### PR TITLE
Fix stalled-task deadlock — admin release-stall, stall scanner, auto-checkpoints (#1)

### DIFF
--- a/docs/ISSUE-01-LOCAL-GUIDE.md
+++ b/docs/ISSUE-01-LOCAL-GUIDE.md
@@ -1,0 +1,240 @@
+# Issue #1: Stalled Tasks Deadlock — Local Worker Guide
+
+**Source:** <https://github.com/smb209/mission-control/issues/1>
+**Status:** FIXED (pending release)
+**Summary:** Tasks used to become permanently deadlocked when they had no
+properly-typed activities and no deliverables — the evidence gate blocked
+every forward transition AND `POST /fail` returned 500, so operators had no
+supported path to release, cancel, or delete the task.
+
+Resolved by migration `029` + the endpoints documented under **Operator
+escape hatch** below. The original write-up is preserved in
+*Historical context* for provenance.
+
+---
+
+## Operator escape hatch
+
+### 1. Cancel a stalled task (primary tool)
+
+```bash
+MC="http://localhost:4000"; AUTH="Authorization: Bearer $TOK"
+
+curl -s -X POST "$MC/api/tasks/$TASK_ID/admin/release-stall" \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  -d '{"reason":"agent_stalled_no_activity","terminal_state":"cancelled"}'
+```
+
+- Bypasses the evidence gate.
+- Terminates `openclaw_sessions` for the task AND every convoy sub-task.
+- Unassigns the agent, sets `status = 'cancelled'`, writes
+  `status_reason = 'released_by_admin: <reason>'`.
+- Dissolves the convoy (sets `convoys.status = 'failed'`) if the task is
+  a convoy parent.
+- Audit trail in both `task_activities` (`activity_type: admin_release`)
+  and `events`.
+- Terminal: cancelled tasks cannot transition back to active. Use `DELETE
+  /api/tasks/:id` to remove, or create a fresh task.
+
+Accepts `terminal_state: 'done'` if the operator considers the work
+effectively complete; default is `'cancelled'`.
+
+### 2. Fail a task with a real error (now 400, not 500)
+
+`POST /api/tasks/:id/fail` used to return a bare 500 when
+`handleStageFailure` couldn't resolve a `fail_target`. It now returns a
+400 with a structured error and a hint pointing to `release-stall` when
+recovery isn't possible. Use this when a testing/review/verification
+stage should bounce back for rework; use `release-stall` when nothing
+can bring the task back.
+
+### 3. Scan for stalled tasks on demand
+
+```bash
+curl -s -X POST "$MC/api/tasks/scan-stalls" -H "$AUTH"
+```
+
+Returns `{ scanned, flagged: [...] }`. The scanner also runs automatically
+every 2 minutes as part of `runHealthCheckCycle` (piggybacks on the SSE
+stream). Flagged convoy sub-tasks message the coordinator agent via
+`agent_mailbox`; non-convoy tasks fall through to
+`MC_STALL_WEBHOOK_URL` if that env var is set. Threshold defaults to
+30 min idle — override via `STALL_DETECTION_MINUTES`.
+
+---
+
+## What was broken (historical context)
+
+---
+
+## What Happens
+
+1. Task is created and dispatched to an agent
+2. Agent runs heartbeat pings (~every 2 min) but logs them as `type: null` instead of real activity types ("progress", "deliverable", etc.)
+3. Agent stalls without producing a deliverable
+4. Task stuck in `in_progress`, `verification`, or `convoy_active`
+5. All API operations fail:
+   - `POST /api/tasks/{id}/fail` → Internal server error
+   - `PATCH /api/tasks/{id}` with `status: completed` → "Evidence gate failed"
+   - `DELETE /api/tasks/{id}` → "Failed to delete task"
+
+### Root Causes
+
+- **No automatic activity logging** — agents must manually POST activities with proper types; heartbeat timestamps alone don't satisfy the evidence gate
+- **No admin bypass for the evidence gate** — no endpoint to override quality gates for stalled tasks
+- **No stall detection** — tasks can remain idle indefinitely with no alerting
+- **Checkpoints not working** — `checkpoint/restore` returns "No checkpoint to restore from" even after hours of activity
+
+---
+
+## Proposed Fixes
+
+### Priority 1 — Admin escape hatch
+
+Add an admin-only endpoint to bypass the evidence gate:
+
+```
+POST /api/tasks/{id}/admin/release-stall
+{
+  "reason": "agent_stalled_no_activity",
+  "released_by": "admin-token-or-api-key"
+}
+```
+
+This allows transitioning any task to a terminal state regardless of evidence requirements.
+
+### Priority 2 — Server-side activity logging
+
+The server should automatically record meaningful interactions as activities with proper types:
+- Agent health check responses → `type: "heartbeat"`
+- Deliverable registration attempts → `type: "deliverable_attempt"`
+- Dispatch events → `type: "dispatched"`
+- Planning events → `type: "planning_*"`
+
+### Priority 3 — Stall detection + alerting
+
+Periodic health checks flagging tasks that:
+- Same status for > X minutes (configurable, default 30 min)
+- No deliverables registered
+- No activities with non-null `type`
+
+When flagged: set `status_reason`, send notification via Discord/webhook, optionally auto-create a cleanup task.
+
+### Priority 4 — Fix checkpoint system
+
+Ensure checkpoints are created during normal task lifecycle so `checkpoint/restore` is viable recovery. Currently returns empty even for long-running tasks.
+
+---
+
+## Current Workaround
+
+```bash
+MC="http://localhost:4001"
+TOK="<token>"
+AUTH="Authorization: Bearer $TOK"
+
+# 1. Force-complete planning (moves to inbox)
+curl -X POST "$MC/api/tasks/{id}/planning/force-complete" \
+  -H "$AUTH" -H "Content-Type: application/json" -d '{}'
+
+# 2. Unassign agent (bypasses evidence gate)
+curl -X PATCH "$MC/api/tasks/{id}" \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  -d '{"assigned_agent_id":null}'
+
+# 3. Delete
+curl -X DELETE "$MC/api/tasks/{id}" -H "$AUTH"
+```
+
+---
+
+## Local Machine Resources
+
+### Repo & Checkout
+| Resource | Path / URL |
+|----------|-----------|
+| Fork (active source) | <https://github.com/smb209/mission-control> |
+| Local checkout | `/Users/snappytwo/snappytwo-sandbox/mission-control` |
+| GitHub access | `research-sc` has **owner** access |
+| Upstream remote | Removed — only work with our fork |
+
+### Running Container
+| Resource | Detail |
+|----------|--------|
+| Container name | `mission-control` |
+| Image | `mission-control:latest` |
+| Host port | `4000` → container `4000` |
+| Internal API base | `http://localhost:4001` (proxied) |
+| DB path (in container) | `/app/data/mission-control.db` |
+| Workspace volume | `/app/workspace/` |
+
+### Docker Compose
+- **Compose file:** `/Users/snappytwo/snappytwo-sandbox/mission-control/docker-compose.yml`
+- **Dockerfile:** `/Users/snappytwo/snappytwo-sandbox/mission-control/Dockerfile`
+- **Volumes:** Named volumes `mission-control-data` (DB) + `mission-control-workspace` (deliverables)
+- **Host data bind:** `/Users/snappytwo/docker/mission-control/` maps to container paths
+
+### OpenClaw Gateway Connection
+- **Gateway URL:** `ws://host.docker.internal:18789` (set in container environment)
+- **Gateway Token:** Stored in container env (`OPENCLAW_GATEWAY_TOKEN`)
+- **Gateway local:** `http://localhost:18789`
+
+### Build & Run
+```bash
+# Build the Docker image from fork
+cd /Users/snappytwo/snappytwo-sandbox/mission-control
+docker compose build
+
+# Start (volumes persist DB + workspace)
+docker compose up -d
+
+# Rebuild after code changes
+docker compose up -d --build
+
+# View logs
+docker logs mission-control -f
+
+# Exec into running container
+docker exec -it mission-control sh
+
+# Stop
+docker compose down
+```
+
+### Local Dev (non-Docker)
+```bash
+cd /Users/snappytwo/snappytwo-sandbox/mission-control
+npm install
+npm run build          # Next.js production build
+npm run db:seed         # Seed database (creates default agents like "Charlie")
+npm start               # Start on port 4000
+```
+
+### Database
+- **SQLite DB location (host):** `/Users/snappytwo/docker/mission-control/mission-control.db`
+- **Backups:** `/Users/snappytwo/docker/mission-control/data/db-backups/`
+- **NEVER mutate SQLite directly.** Use the REST API or `docker exec` to run seed scripts.
+
+### Workspace / Deliverables
+- **Host path:** `/Users/snappytwo/docker/mission-control/workspace/`
+- Files saved here are readable by agents at `/app/workspace/<filename>` inside container
+
+---
+
+## Key Files to Modify for This Fix
+
+| File | Purpose |
+|------|---------|
+| `src/app/api/tasks/[id]/fail/route.ts` | Where `POST /api/tasks/{id}/fail` fails with internal error |
+| `src/app/api/tasks/[id]/route.ts` (PATCH) | Evidence gate validation logic |
+| `src/app/api/tasks/[id]/delete/route.ts` | Deletion blocking |
+| `src/models/task.ts` or similar | Evidence gate model/validation |
+| `src/lib/checkpoints.ts` | Checkpoint creation logic (currently broken) |
+| New file: `src/app/api/tasks/[id]/admin/release-stall/route.ts` | Admin escape hatch endpoint |
+
+## Notes for Future Workers
+
+- This fork (`smb209/mission-control`) is our source of truth. Do NOT push to or file issues against upstream.
+- The running Docker image is built from this fork. Any fixes should be made here first.
+- If agents don't show up in the UI after a rebuild: check gateway connectivity, run `/api/agents/discover`, verify `openclaw_session_id` linkage via `/api/agents/{id}`.
+- Database resets (`db:seed`) will wipe custom agents. Always back up before reseeding.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mission-control",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mission-control",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1014.0",
         "@hello-pangea/dnd": "^17.0.0",

--- a/src/app/api/tasks/[id]/admin/release-stall/route.ts
+++ b/src/app/api/tasks/[id]/admin/release-stall/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, queryAll, run, transaction } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import { ReleaseStallSchema } from '@/lib/validation';
+import type { Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/tasks/[id]/admin/release-stall
+ *
+ * Admin escape hatch for stalled tasks that cannot clear the evidence gate.
+ * Terminates the task (default: cancelled), ends all OpenClaw sessions for
+ * the task and — if this is a convoy parent — for every convoy sub-task too,
+ * unassigns the agent, and writes audit trail to both task_activities and
+ * events.
+ *
+ * Auth: relies on the middleware bearer-token check (same as other admin
+ * endpoints — see src/middleware.ts). No additional role logic.
+ *
+ * Body:
+ *   reason:           required, 1..500 chars
+ *   terminal_state:   'cancelled' (default) | 'done'
+ *   released_by:      optional audit string (operator name, token hint, etc)
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: taskId } = await params;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const validation = ReleaseStallSchema.safeParse(body);
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: validation.error.issues },
+        { status: 400 }
+      );
+    }
+
+    const { reason, terminal_state = 'cancelled', released_by } = validation.data;
+
+    const existing = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!existing) {
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    }
+
+    const now = new Date().toISOString();
+    const statusReason = `released_by_admin: ${reason}`;
+
+    // If this task is a convoy parent, collect sub-task ids so we can end
+    // sessions for every convoy member, not just the primary assignee.
+    const convoy = queryOne<{ id: string }>(
+      'SELECT id FROM convoys WHERE parent_task_id = ?',
+      [taskId]
+    );
+    const convoySubtaskIds = convoy
+      ? queryAll<{ task_id: string }>(
+          'SELECT task_id FROM convoy_subtasks WHERE convoy_id = ?',
+          [convoy.id]
+        ).map(r => r.task_id)
+      : [];
+    const sessionTaskIds = [taskId, ...convoySubtaskIds];
+
+    transaction(() => {
+      // 1. End all active OpenClaw sessions bound to this task or any
+      //    convoy sub-task. Matches the session-end shape used by
+      //    nudgeAgent() in src/lib/agent-health.ts.
+      const placeholders = sessionTaskIds.map(() => '?').join(',');
+      run(
+        `UPDATE openclaw_sessions
+         SET status = 'ended', ended_at = ?, updated_at = ?
+         WHERE task_id IN (${placeholders}) AND status = 'active'`,
+        [now, now, ...sessionTaskIds]
+      );
+
+      // 2. Flip the parent task to the terminal state. Clear the assignee
+      //    so the ex-agent can pick up other work via the standby sweep.
+      run(
+        `UPDATE tasks
+         SET status = ?, status_reason = ?, assigned_agent_id = NULL,
+             planning_dispatch_error = NULL, updated_at = ?
+         WHERE id = ?`,
+        [terminal_state, statusReason, now, taskId]
+      );
+
+      // 3. Audit row inside the task so it shows up in the Activity tab.
+      run(
+        `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, created_at)
+         VALUES (?, ?, ?, 'admin_release', ?, ?)`,
+        [
+          uuidv4(),
+          taskId,
+          existing.assigned_agent_id || null,
+          `Admin release-stall → ${terminal_state}: ${reason}${released_by ? ` (by ${released_by})` : ''}`,
+          now,
+        ]
+      );
+
+      // 4. System-level audit event. Mirrors the shape used by
+      //    auditBoardOverride() in src/lib/task-governance.ts.
+      run(
+        `INSERT INTO events (id, type, task_id, message, metadata, created_at)
+         VALUES (?, 'system', ?, ?, ?, ?)`,
+        [
+          uuidv4(),
+          taskId,
+          `Admin release-stall: ${existing.status} → ${terminal_state}`,
+          JSON.stringify({ adminRelease: true, reason, released_by: released_by || null, convoy_dissolved: Boolean(convoy) }),
+          now,
+        ]
+      );
+
+      // 5. If this was a convoy parent, mark the convoy as failed so the
+      //    coordinator UI reflects the dissolution. We don't touch the
+      //    sub-tasks — they'll be DELETEd / released individually if needed.
+      if (convoy) {
+        run(
+          `UPDATE convoys SET status = 'failed', updated_at = ? WHERE id = ?`,
+          [now, convoy.id]
+        );
+      }
+
+      // 6. Return the previously-assigned agent to standby if they have no
+      //    other active work. Same shape as in DELETE + PATCH handlers.
+      if (existing.assigned_agent_id) {
+        const otherActive = queryOne<{ count: number }>(
+          `SELECT COUNT(*) as count FROM tasks
+           WHERE assigned_agent_id = ?
+             AND status IN ('assigned', 'in_progress', 'testing', 'verification')
+             AND id != ?`,
+          [existing.assigned_agent_id, taskId]
+        );
+        if (!otherActive || otherActive.count === 0) {
+          run(
+            `UPDATE agents SET status = 'standby', updated_at = ?
+             WHERE id = ? AND status = 'working'`,
+            [now, existing.assigned_agent_id]
+          );
+        }
+      }
+    });
+
+    const updated = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (updated) {
+      broadcast({ type: 'task_updated', payload: updated });
+    }
+
+    return NextResponse.json({
+      success: true,
+      task: updated,
+      previous_status: existing.status,
+      sessions_ended: sessionTaskIds.length,
+      convoy_dissolved: Boolean(convoy),
+    });
+  } catch (error) {
+    console.error('Failed to release-stall task:', error);
+    return NextResponse.json(
+      { error: `Failed to release-stall task: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -8,7 +8,8 @@ import { getRelevantKnowledge, formatKnowledgeForDispatch } from '@/lib/learner'
 import { getTaskWorkflow } from '@/lib/workflow-engine';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { pickDynamicAgent } from '@/lib/task-governance';
-import { buildCheckpointContext } from '@/lib/checkpoint';
+import { buildCheckpointContext, saveCheckpoint, getLatestCheckpoint } from '@/lib/checkpoint';
+import { clearStallFlag } from '@/lib/stall-detection';
 import { formatMailForDispatch } from '@/lib/mailbox';
 import { getPendingNotesForDispatch } from '@/lib/task-notes';
 import { createTaskWorkspace, determineIsolationStrategy } from '@/lib/workspace-isolation';
@@ -484,6 +485,37 @@ If you need help or clarification, ask the orchestrator.`;
          VALUES (?, ?, ?, ?, ?, ?)`,
         [activityId, task.id, agent.id, 'status_changed', `Task dispatched to ${agent.name} - Agent is now working on this task`, now]
       );
+
+      // A successful dispatch is the canonical "coordinator (or operator)
+      // has acted" signal. Clear any stalled_* status_reason so the
+      // scanner doesn't re-flag the task on its next pass.
+      clearStallFlag(task.id);
+
+      // Auto-checkpoint on dispatch. Throttled to 60s so rapid re-dispatch
+      // during nudge/recovery doesn't write duplicate rows. Gives
+      // checkpoint/restore a viable starting point even before the agent
+      // writes any of its own checkpoints — previously the restore route
+      // returned 404 for long-running tasks because nothing ever called
+      // saveCheckpoint().
+      try {
+        const latestCheckpoint = getLatestCheckpoint(task.id);
+        const recent = latestCheckpoint
+          && (Date.now() - new Date(latestCheckpoint.created_at).getTime()) / 1000 < 60;
+        if (!recent) {
+          saveCheckpoint({
+            taskId: task.id,
+            agentId: agent.id,
+            checkpointType: 'auto',
+            stateSummary: `Dispatched to ${agent.name} (status=${task.status}, role=${currentStage?.role || 'unknown'})`,
+            contextData: {
+              stage: currentStage?.label,
+              dispatch_message_length: finalMessage.length,
+            },
+          });
+        }
+      } catch (err) {
+        console.warn('[Dispatch] saveCheckpoint failed:', err);
+      }
 
       return NextResponse.json({
         success: true,

--- a/src/app/api/tasks/[id]/fail/route.ts
+++ b/src/app/api/tasks/[id]/fail/route.ts
@@ -50,8 +50,26 @@ export async function POST(
       failReason: reason,
     }).catch(err => console.error('[Learner] notification failed:', err));
 
-    // Trigger the fail-loopback via the workflow engine
-    const result = await handleStageFailure(taskId, task.status, reason);
+    // Trigger the fail-loopback via the workflow engine. Wrap in try/catch so
+    // an internal throw (e.g. DB error, dispatch timeout) returns a clean 400
+    // instead of the bare 500 "Internal server error" that masked the real
+    // problem before. Operators hitting this endpoint for stalled tasks got
+    // the opaque 500 and had no path forward — the admin release-stall
+    // endpoint now covers the "can't recover" case.
+    let result: Awaited<ReturnType<typeof handleStageFailure>>;
+    try {
+      result = await handleStageFailure(taskId, task.status, reason);
+    } catch (err) {
+      const message = (err as Error).message || 'handleStageFailure threw';
+      console.error('[Fail] handleStageFailure threw:', err);
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Stage failure could not be processed: ${message}. If the task is stuck, use POST /api/tasks/${taskId}/admin/release-stall.`,
+        },
+        { status: 400 }
+      );
+    }
 
     if (result.success) {
       // Fail-loopback freed a slot (testing/verification) — drain the queue
@@ -64,14 +82,28 @@ export async function POST(
         message: `Task returned to ${result.newAgentName ? result.newAgentName : 'previous stage'} for rework`,
         newAgent: result.newAgentName,
       });
-    } else {
-      return NextResponse.json({
+    }
+
+    // result.success === false with a structured error — return 400, not 500.
+    // A 500 implies the server is broken; the server is fine, the transition
+    // is just rejected. This was the original bug: callers saw 500 and
+    // assumed the server had crashed when the real issue was a missing
+    // workflow template or fail_target.
+    return NextResponse.json(
+      {
         success: false,
         error: result.error || 'Failed to process stage failure',
-      }, { status: 500 });
-    }
+        hint: result.error?.includes('No workflow template') || result.error?.includes('No fail target')
+          ? `Task has no recovery path. Use POST /api/tasks/${taskId}/admin/release-stall to cancel it.`
+          : undefined,
+      },
+      { status: 400 }
+    );
   } catch (error) {
     console.error('Failed to process stage failure:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return NextResponse.json(
+      { error: `Failed to process stage failure: ${(error as Error).message}` },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -4,7 +4,7 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { handleStageTransition, handleStageFailure, getTaskWorkflow, drainQueue, populateTaskRolesFromAgents } from '@/lib/workflow-engine';
-import { hasStageEvidence, canUseBoardOverride, auditBoardOverride, taskCanBeDone, recordLearnerOnTransition } from '@/lib/task-governance';
+import { hasStageEvidence, canUseBoardOverride, auditBoardOverride, taskCanBeDone, recordLearnerOnTransition, isTerminalStatus } from '@/lib/task-governance';
 import { updateConvoyProgress, checkConvoyCompletion } from '@/lib/convoy';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
@@ -174,6 +174,16 @@ export async function PATCH(
     if (nextStatus !== undefined && nextStatus !== existing.status) {
       const boardOverrideRequested = Boolean(body.board_override);
       const boardOverrideAllowed = boardOverrideRequested && canUseBoardOverride(request);
+
+      // Cancelled is terminal: PATCH cannot move a cancelled task back into an
+      // active state. Use /admin/release-stall to un-cancel via a deliberate
+      // administrative action (which re-dispatches separately).
+      if (isTerminalStatus(existing.status) && existing.status === 'cancelled' && !boardOverrideAllowed) {
+        return NextResponse.json(
+          { error: `Cannot transition cancelled task to ${nextStatus}. Create a new task or use board_override.` },
+          { status: 400 }
+        );
+      }
 
       // Hard evidence gate for forward-stage transitions and completion
       const enteringQualityStage = ['testing', 'review', 'verification', 'done'].includes(nextStatus);
@@ -520,14 +530,31 @@ export async function DELETE(
       run('DELETE FROM convoys WHERE id = ?', [convoy.id]);
     }
 
-    // Delete or nullify related records first (foreign key constraints)
-    // Note: task_activities and task_deliverables have ON DELETE CASCADE
+    // Delete or nullify related records first (foreign key constraints).
+    // Tables with ON DELETE CASCADE: task_activities, task_deliverables,
+    // task_roles, task_notes, planning_questions, planning_specs,
+    // user_task_reads — these handle themselves.
+    //
+    // Tables with a plain REFERENCES (no cascade) to tasks(id) will block
+    // the delete with an FK error unless we handle them here. These were
+    // the silent "Failed to delete task" cause for stalled tasks that had
+    // agent_health / workspace_ports rows.
     run('DELETE FROM work_checkpoints WHERE task_id = ?', [id]);
     run('DELETE FROM openclaw_sessions WHERE task_id = ?', [id]);
     run('DELETE FROM events WHERE task_id = ?', [id]);
-    // Conversations and Knowledge reference tasks - nullify or delete
+    run('DELETE FROM agent_health WHERE task_id = ?', [id]);
+    run('DELETE FROM workspace_ports WHERE task_id = ?', [id]);
+    run('DELETE FROM workspace_merges WHERE task_id = ?', [id]);
+    // Product-autopilot tables: null out rather than cascade-delete so the
+    // parent product/idea/skill history is preserved across task deletion.
     run('UPDATE conversations SET task_id = NULL WHERE task_id = ?', [id]);
     run('UPDATE knowledge_entries SET task_id = NULL WHERE task_id = ?', [id]);
+    run('UPDATE ideas SET task_id = NULL WHERE task_id = ?', [id]);
+    run('UPDATE content_inventory SET task_id = NULL WHERE task_id = ?', [id]);
+    run('UPDATE cost_events SET task_id = NULL WHERE task_id = ?', [id]);
+    run('UPDATE product_skills SET created_by_task_id = NULL WHERE created_by_task_id = ?', [id]);
+    // skill_reports.task_id is NOT NULL — drop the rows rather than null them.
+    run('DELETE FROM skill_reports WHERE task_id = ?', [id]);
 
     // Now delete the task (cascades to task_activities and task_deliverables)
     run('DELETE FROM tasks WHERE id = ?', [id]);

--- a/src/app/api/tasks/scan-stalls/route.ts
+++ b/src/app/api/tasks/scan-stalls/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { scanStalledTasks } from '@/lib/stall-detection';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/tasks/scan-stalls
+ *
+ * Manual trigger for the stall scanner. The scanner also runs automatically
+ * every 2 minutes as part of runHealthCheckCycle (invoked from the SSE
+ * stream while at least one client is connected). Use this endpoint when
+ * you want an immediate pass — e.g. from an external cron, or when
+ * debugging a stuck task.
+ *
+ * Response:
+ *   {
+ *     scanned: number,
+ *     flagged: Array<{ task_id, title, status, minutes_idle, mode, notified }>
+ *   }
+ */
+export async function POST(_request: NextRequest) {
+  try {
+    const report = await scanStalledTasks();
+    return NextResponse.json(report);
+  } catch (error) {
+    console.error('[ScanStalls] failed:', error);
+    return NextResponse.json(
+      { error: `Stall scan failed: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -44,6 +44,7 @@ export async function GET(request: NextRequest) {
           review: 0,
           verification: 0,
           done: 0,
+          cancelled: 0,
           total: 0
         };
         

--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -1,0 +1,71 @@
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, run } from '@/lib/db';
+
+/**
+ * Typed server-side activity types. NONE of these satisfy the evidence gate
+ * at src/lib/task-governance.ts:hasStageEvidence — that gate deliberately
+ * accepts only ('completed','file_created','updated') and this module must
+ * not broaden it. These types exist for visibility, audit, and stall
+ * detection — they fill in the gap where agent heartbeats used to land as
+ * `activity_type = null`.
+ */
+export type ServerActivityType =
+  | 'heartbeat'        // throttled proof-of-life from runHealthCheckCycle
+  | 'dispatched'       // reserved; dispatch/route.ts still uses status_changed
+  | 'admin_release'    // written by /admin/release-stall
+  | 'stall_detected'   // stall scanner flags a deadlocked task
+  | 'stall_notified'   // stall scanner messaged coordinator / webhook
+  | 'stall_recovered'  // coordinator / dispatch clears a stall flag
+  | 'coordinator_stalled'   // convoy coordinator itself can't be reached
+  | 'coordinator_missing';  // convoy has no live coordinator
+
+interface LogActivityInput {
+  taskId: string;
+  type: ServerActivityType;
+  message: string;
+  agentId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export function logTaskActivity(input: LogActivityInput): string {
+  const id = uuidv4();
+  const now = new Date().toISOString();
+  run(
+    `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, metadata, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [
+      id,
+      input.taskId,
+      input.agentId ?? null,
+      input.type,
+      input.message,
+      input.metadata ? JSON.stringify(input.metadata) : null,
+      now,
+    ]
+  );
+  return id;
+}
+
+/**
+ * Log an activity row only if the most recent activity of the same type for
+ * this task is older than `thresholdSeconds`. Keeps high-frequency signals
+ * (heartbeats, re-scans) from flooding the activity feed.
+ *
+ * Returns the new activity id, or null if throttled.
+ */
+export function logTaskActivityThrottled(
+  input: LogActivityInput,
+  thresholdSeconds: number
+): string | null {
+  const latest = queryOne<{ created_at: string }>(
+    `SELECT created_at FROM task_activities
+     WHERE task_id = ? AND activity_type = ?
+     ORDER BY created_at DESC LIMIT 1`,
+    [input.taskId, input.type]
+  );
+  if (latest) {
+    const ageSeconds = (Date.now() - new Date(latest.created_at).getTime()) / 1000;
+    if (ageSeconds < thresholdSeconds) return null;
+  }
+  return logTaskActivity(input);
+}

--- a/src/lib/agent-health.ts
+++ b/src/lib/agent-health.ts
@@ -3,7 +3,14 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { buildCheckpointContext } from '@/lib/checkpoint';
+import { logTaskActivityThrottled } from '@/lib/activity-log';
+import { scanStalledTasks } from '@/lib/stall-detection';
 import type { Agent, AgentHealth, AgentHealthState, Task } from '@/lib/types';
+
+// Heartbeat rows are throttled so the activity feed stays readable. 5 min
+// is a good default: runHealthCheckCycle fires every 2 min (see the SSE
+// stream route), so every 2nd-3rd pulse lands a row.
+const HEARTBEAT_THROTTLE_SECONDS = 300;
 
 const STALL_THRESHOLD_MINUTES = 5;
 const STUCK_THRESHOLD_MINUTES = 15;
@@ -130,6 +137,23 @@ export async function runHealthCheckCycle(): Promise<AgentHealth[]> {
       );
     }
 
+    // Healthy heartbeats were previously not logged at all — agents' 2-minute
+    // pings landed as `activity_type = null` elsewhere, so a task could look
+    // idle (no typed activity rows) even while its agent was alive. The stall
+    // scanner (Phase 3) trusts `task_activities` as the source of truth, so
+    // we need a typed row here. Throttled to 5 min to avoid feed noise.
+    if (activeTask && healthState === 'working') {
+      logTaskActivityThrottled(
+        {
+          taskId: activeTask.id,
+          type: 'heartbeat',
+          agentId,
+          message: `Agent alive — last real activity confirmed by health pulse`,
+        },
+        HEARTBEAT_THROTTLE_SECONDS
+      );
+    }
+
     // Auto-nudge after consecutive stall checks
     const updatedHealth = queryOne<AgentHealth>('SELECT * FROM agent_health WHERE agent_id = ?', [agentId]);
     if (updatedHealth) {
@@ -204,6 +228,17 @@ export async function runHealthCheckCycle(): Promise<AgentHealth[]> {
         [uuidv4(), agentId, now]
       );
     }
+  }
+
+  // Run the stall scanner after the per-agent pass. This is the natural
+  // place for it: both share the same 2-minute cadence from the SSE
+  // stream, and the scanner's throttle windows (NOTIFY_THROTTLE_MINUTES,
+  // STALL_DETECTION_MINUTES) make repeated calls cheap. A scanner failure
+  // should never break the health cycle — so we catch and log.
+  try {
+    await scanStalledTasks();
+  } catch (err) {
+    console.error('[Health] scanStalledTasks failed:', err);
   }
 
   return results;

--- a/src/lib/checkpoint.ts
+++ b/src/lib/checkpoint.ts
@@ -13,6 +13,24 @@ interface SaveCheckpointInput {
 }
 
 /**
+ * Save a checkpoint only if no checkpoint has been saved for this task in
+ * the last `thresholdSeconds`. Used by dispatch / stage-transition /
+ * stall-detection call sites to avoid duplicate rows when recovery loops
+ * hammer the task in quick succession.
+ */
+export function saveCheckpointThrottled(
+  input: SaveCheckpointInput,
+  thresholdSeconds: number
+): WorkCheckpoint | null {
+  const latest = getLatestCheckpoint(input.taskId);
+  if (latest) {
+    const ageSeconds = (Date.now() - new Date(latest.created_at).getTime()) / 1000;
+    if (ageSeconds < thresholdSeconds) return null;
+  }
+  return saveCheckpoint(input);
+}
+
+/**
  * Save a work checkpoint for a task.
  */
 export function saveCheckpoint(input: SaveCheckpointInput): WorkCheckpoint {

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1595,6 +1595,87 @@ const migrations: Migration[] = [
 
       console.log('[Migration 028] product_skills and skill_reports tables created');
     }
+  },
+  {
+    id: '029',
+    name: 'add_cancelled_task_status',
+    up: (db) => {
+      console.log('[Migration 029] Adding cancelled status to tasks CHECK constraint...');
+
+      const taskSchema = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'").get() as { sql: string } | undefined;
+      if (!taskSchema || taskSchema.sql.includes("'cancelled'")) {
+        console.log('[Migration 029] cancelled already present — skipping');
+        return;
+      }
+
+      // SQLite can't ALTER a CHECK constraint — recreate the tasks table.
+      // legacy_alter_table is ON during migrations (see runMigrations), so the
+      // RENAME below will NOT rewrite FKs in other tables to point at the
+      // temporary name — the gotcha that migration 011 had to clean up.
+      const oldCols = (db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[]).map(c => c.name);
+
+      db.exec(`ALTER TABLE tasks RENAME TO _tasks_old_029`);
+      db.exec(`
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL,
+          description TEXT,
+          status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done', 'cancelled')),
+          priority TEXT DEFAULT 'normal' CHECK (priority IN ('low', 'normal', 'high', 'urgent')),
+          assigned_agent_id TEXT REFERENCES agents(id),
+          created_by_agent_id TEXT REFERENCES agents(id),
+          workspace_id TEXT DEFAULT 'default' REFERENCES workspaces(id),
+          business_id TEXT DEFAULT 'default',
+          due_date TEXT,
+          workflow_template_id TEXT REFERENCES workflow_templates(id),
+          planning_session_key TEXT,
+          planning_messages TEXT,
+          planning_complete INTEGER DEFAULT 0,
+          planning_spec TEXT,
+          planning_agents TEXT,
+          planning_dispatch_error TEXT,
+          status_reason TEXT,
+          images TEXT,
+          convoy_id TEXT,
+          is_subtask INTEGER DEFAULT 0,
+          product_id TEXT REFERENCES products(id),
+          idea_id TEXT REFERENCES ideas(id),
+          estimated_cost_usd REAL,
+          actual_cost_usd REAL DEFAULT 0,
+          repo_url TEXT,
+          repo_branch TEXT,
+          pr_url TEXT,
+          pr_status TEXT CHECK (pr_status IN ('pending', 'open', 'merged', 'closed')),
+          workspace_path TEXT,
+          workspace_strategy TEXT,
+          workspace_port INTEGER,
+          workspace_base_commit TEXT,
+          merge_status TEXT,
+          merge_pr_url TEXT,
+          retry_count INTEGER DEFAULT 0,
+          next_retry_at TEXT,
+          dispatch_lock TEXT,
+          created_at TEXT DEFAULT (datetime('now')),
+          updated_at TEXT DEFAULT (datetime('now'))
+        )
+      `);
+
+      // Copy data — only columns present in BOTH old and new tables. This is
+      // forward-compatible: any column the old schema has that the new one
+      // doesn't is silently dropped; any new column gets its default.
+      const newCols = new Set(
+        (db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[]).map(c => c.name)
+      );
+      const safeCols = oldCols.filter(c => newCols.has(c)).join(', ');
+      db.exec(`INSERT INTO tasks (${safeCols}) SELECT ${safeCols} FROM _tasks_old_029`);
+      db.exec(`DROP TABLE _tasks_old_029`);
+
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_assigned ON tasks(assigned_agent_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_workspace ON tasks(workspace_id)`);
+
+      console.log('[Migration 029] Tasks table recreated with cancelled status');
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS tasks (
   id TEXT PRIMARY KEY,
   title TEXT NOT NULL,
   description TEXT,
-  status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done')),
+  status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done', 'cancelled')),
   priority TEXT DEFAULT 'normal' CHECK (priority IN ('low', 'normal', 'high', 'urgent')),
   assigned_agent_id TEXT REFERENCES agents(id),
   created_by_agent_id TEXT REFERENCES agents(id),

--- a/src/lib/stall-detection.ts
+++ b/src/lib/stall-detection.ts
@@ -1,0 +1,337 @@
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, queryAll, run } from '@/lib/db';
+import { sendMail } from '@/lib/mailbox';
+import { logTaskActivity } from '@/lib/activity-log';
+import { saveCheckpointThrottled } from '@/lib/checkpoint';
+import type { Task } from '@/lib/types';
+
+// Active statuses that can go stale. Kept in sync with
+// src/lib/task-governance.ts — not imported so this module remains a thin
+// leaf dependency; a drift test in Phase 9 pins the list.
+const ACTIVE_STATUSES = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification'] as const;
+
+/** Default threshold. Override via STALL_DETECTION_MINUTES env var. */
+const DEFAULT_STALL_MINUTES = 30;
+
+/** Consider the coordinator itself stalled if its last heartbeat is older than this. */
+const COORDINATOR_STALL_MINUTES = 10;
+
+/** Don't re-notify for the same stall within this window. */
+const NOTIFY_THROTTLE_MINUTES = 60;
+
+export interface StallReport {
+  scanned: number;
+  flagged: Array<{
+    task_id: string;
+    title: string;
+    status: string;
+    minutes_idle: number;
+    mode: 'convoy' | 'solo';
+    notified: 'coordinator' | 'webhook' | 'coordinator_stalled' | 'coordinator_missing' | 'throttled' | 'none';
+  }>;
+}
+
+function getThresholdMinutes(): number {
+  const raw = process.env.STALL_DETECTION_MINUTES;
+  if (!raw) return DEFAULT_STALL_MINUTES;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_STALL_MINUTES;
+}
+
+/**
+ * Stall scanner. Flags tasks in an active status whose last typed activity
+ * is older than the threshold AND which have no deliverables. Notifies via
+ * the convoy coordinator (if this is a convoy sub-task) or via webhook.
+ *
+ * Called from `runHealthCheckCycle` in agent-health.ts and also available
+ * as a manual trigger at POST /api/tasks/scan-stalls.
+ *
+ * This function must be idempotent: calling it repeatedly within
+ * NOTIFY_THROTTLE_MINUTES should not re-flag or re-notify the same task.
+ */
+export async function scanStalledTasks(): Promise<StallReport> {
+  const thresholdMinutes = getThresholdMinutes();
+
+  // Join with the max activity timestamp so we rank by freshness. Anything
+  // older than the threshold AND with zero deliverables is a candidate.
+  // `task_activities` is the source of truth — it's task-scoped so convoy
+  // members writing to it count toward the parent's freshness.
+  const placeholders = ACTIVE_STATUSES.map(() => '?').join(',');
+  const candidates = queryAll<Task & { last_activity_at: string | null; deliverable_count: number }>(
+    `SELECT
+       t.*,
+       (SELECT MAX(created_at) FROM task_activities WHERE task_id = t.id) as last_activity_at,
+       (SELECT COUNT(*) FROM task_deliverables WHERE task_id = t.id) as deliverable_count
+     FROM tasks t
+     WHERE t.status IN (${placeholders})`,
+    [...ACTIVE_STATUSES]
+  );
+
+  const report: StallReport = { scanned: candidates.length, flagged: [] };
+  const nowMs = Date.now();
+
+  for (const task of candidates) {
+    if (task.deliverable_count > 0) continue;
+
+    const lastTick = task.last_activity_at || task.updated_at;
+    const minutesIdle = (nowMs - new Date(lastTick).getTime()) / 60000;
+    if (minutesIdle < thresholdMinutes) continue;
+
+    // Skip if we already raced through and flagged this task recently. The
+    // coordinator may be mid-handoff, or a nudge may be in-flight — both
+    // show up as a fresh `status_changed` activity which would bump
+    // `last_activity_at` above. Defense in depth: also skip if we already
+    // wrote a stall_detected row within the throttle window.
+    const lastDetected = queryOne<{ created_at: string }>(
+      `SELECT created_at FROM task_activities
+       WHERE task_id = ? AND activity_type = 'stall_detected'
+       ORDER BY created_at DESC LIMIT 1`,
+      [task.id]
+    );
+    const alreadyFlagged = lastDetected
+      && (nowMs - new Date(lastDetected.created_at).getTime()) / 60000 < NOTIFY_THROTTLE_MINUTES;
+
+    // 1. Mark the task. status_reason is cleared by Phase 3.5
+    //    (recovery-guard) when the coordinator does anything real.
+    if (!alreadyFlagged) {
+      run(
+        `UPDATE tasks SET status_reason = ?, updated_at = ? WHERE id = ?`,
+        [
+          `stalled_no_activity (idle ${Math.round(minutesIdle)}m, detected ${new Date().toISOString()})`,
+          new Date().toISOString(),
+          task.id,
+        ]
+      );
+      logTaskActivity({
+        taskId: task.id,
+        type: 'stall_detected',
+        message: `Task idle for ${Math.round(minutesIdle)}m with no deliverables`,
+        metadata: { minutes_idle: Math.round(minutesIdle), threshold: thresholdMinutes },
+      });
+
+      // Snapshot a checkpoint so a subsequent /checkpoint/restore has
+      // something to resume from. Throttled at 300s (same as the scan
+      // cadence floor) to avoid piling rows on re-flagged tasks.
+      if (task.assigned_agent_id) {
+        try {
+          saveCheckpointThrottled(
+            {
+              taskId: task.id,
+              agentId: task.assigned_agent_id,
+              checkpointType: 'auto',
+              stateSummary: `Stall snapshot — idle ${Math.round(minutesIdle)}m in ${task.status}`,
+              contextData: {
+                minutes_idle: Math.round(minutesIdle),
+                status_at_snapshot: task.status,
+                detected_at: new Date().toISOString(),
+              },
+            },
+            300
+          );
+        } catch (err) {
+          console.warn('[Stall] saveCheckpoint on stall_detected failed:', err);
+        }
+      }
+    }
+
+    // 2. Decide who to notify.
+    const convoyMembership = resolveConvoyMembership(task);
+    const notifyDecision = alreadyFlagged
+      ? 'throttled' as const
+      : await notifyForStall(task, convoyMembership, minutesIdle);
+
+    report.flagged.push({
+      task_id: task.id,
+      title: task.title,
+      status: task.status,
+      minutes_idle: Math.round(minutesIdle),
+      mode: convoyMembership ? 'convoy' : 'solo',
+      notified: notifyDecision,
+    });
+  }
+
+  return report;
+}
+
+interface ConvoyMembership {
+  convoyId: string;
+  parentTaskId: string;
+  coordinatorAgentId: string | null;
+}
+
+/**
+ * Resolve the convoy this task belongs to, if any. Three shapes to handle:
+ *   (a) task is a convoy sub-task  → tasks.convoy_id + convoy_subtasks row
+ *   (b) task is a convoy parent    → convoys.parent_task_id = task.id
+ *   (c) neither                    → null (solo task, webhook path)
+ * In every convoy case, the "coordinator" is the agent assigned to the
+ * convoy's parent task. The schema doesn't model a separate coordinator,
+ * so we synthesize it here — see src/lib/convoy.ts for the idiom.
+ */
+function resolveConvoyMembership(task: Task): ConvoyMembership | null {
+  // Case (b): this task IS the convoy parent
+  const convoyAsParent = queryOne<{ id: string }>(
+    'SELECT id FROM convoys WHERE parent_task_id = ?',
+    [task.id]
+  );
+  if (convoyAsParent) {
+    return {
+      convoyId: convoyAsParent.id,
+      parentTaskId: task.id,
+      coordinatorAgentId: task.assigned_agent_id || null,
+    };
+  }
+
+  // Case (a): this task is a convoy sub-task
+  if (task.convoy_id) {
+    const convoy = queryOne<{ id: string; parent_task_id: string }>(
+      'SELECT id, parent_task_id FROM convoys WHERE id = ?',
+      [task.convoy_id]
+    );
+    if (convoy) {
+      const parent = queryOne<{ assigned_agent_id: string | null }>(
+        'SELECT assigned_agent_id FROM tasks WHERE id = ?',
+        [convoy.parent_task_id]
+      );
+      return {
+        convoyId: convoy.id,
+        parentTaskId: convoy.parent_task_id,
+        coordinatorAgentId: parent?.assigned_agent_id || null,
+      };
+    }
+  }
+
+  return null;
+}
+
+async function notifyForStall(
+  task: Task,
+  convoy: ConvoyMembership | null,
+  minutesIdle: number
+): Promise<StallReport['flagged'][number]['notified']> {
+  if (!convoy) {
+    await fireWebhook(task, minutesIdle);
+    logTaskActivity({
+      taskId: task.id,
+      type: 'stall_notified',
+      message: `Notified via webhook (solo task)`,
+    });
+    return 'webhook';
+  }
+
+  // Convoy path. Coordinator may be missing (agent deleted) or itself
+  // stalled (its own most-recent activity older than COORDINATOR_STALL_MINUTES).
+  if (!convoy.coordinatorAgentId) {
+    logTaskActivity({
+      taskId: task.id,
+      type: 'coordinator_missing',
+      message: `Convoy ${convoy.convoyId} has no assigned coordinator — falling back to webhook`,
+    });
+    await fireWebhook(task, minutesIdle);
+    return 'coordinator_missing';
+  }
+
+  const coordinatorLast = queryOne<{ last_activity_at: string }>(
+    `SELECT MAX(created_at) as last_activity_at FROM task_activities
+     WHERE agent_id = ?`,
+    [convoy.coordinatorAgentId]
+  );
+  const coordinatorIdleMinutes = coordinatorLast?.last_activity_at
+    ? (Date.now() - new Date(coordinatorLast.last_activity_at).getTime()) / 60000
+    : Infinity;
+
+  if (coordinatorIdleMinutes > COORDINATOR_STALL_MINUTES) {
+    logTaskActivity({
+      taskId: task.id,
+      type: 'coordinator_stalled',
+      message: `Coordinator ${convoy.coordinatorAgentId} also stalled (${Math.round(coordinatorIdleMinutes)}m idle) — escalating via webhook`,
+    });
+    await fireWebhook(task, minutesIdle);
+    return 'coordinator_stalled';
+  }
+
+  // Send mail. sendMail requires a from_agent_id — we use the task's
+  // originally-assigned agent as the nominal "from" (the agent that
+  // stalled), falling back to the coordinator itself (self-message) so
+  // the FK check doesn't fail when the stalled task never had an assignee.
+  const fromAgentId = task.assigned_agent_id || convoy.coordinatorAgentId;
+  try {
+    sendMail({
+      convoyId: convoy.convoyId,
+      fromAgentId,
+      toAgentId: convoy.coordinatorAgentId,
+      subject: `Stall on "${task.title}"`,
+      body: [
+        `Sub-task ${task.id} has been idle for ${Math.round(minutesIdle)} minutes in status "${task.status}".`,
+        `No deliverables registered. You can:`,
+        `- Revise the spec and re-dispatch via POST /api/tasks/${task.id}/dispatch`,
+        `- Reassign to another agent via PATCH /api/tasks/${task.id}`,
+        `- Cancel via POST /api/tasks/${task.id}/admin/release-stall`,
+      ].join('\n'),
+    });
+    logTaskActivity({
+      taskId: task.id,
+      type: 'stall_notified',
+      message: `Notified coordinator (agent ${convoy.coordinatorAgentId})`,
+      metadata: { convoy_id: convoy.convoyId, coordinator_agent_id: convoy.coordinatorAgentId },
+    });
+    return 'coordinator';
+  } catch (err) {
+    // sendMail throws if the convoy vanished between the SELECT above and
+    // here — extremely rare but possible. Fall back to webhook so the
+    // operator still gets a signal.
+    console.warn('[Stall] Coordinator sendMail failed, falling back to webhook:', err);
+    await fireWebhook(task, minutesIdle);
+    return 'webhook';
+  }
+}
+
+async function fireWebhook(task: Task, minutesIdle: number): Promise<void> {
+  const url = process.env.MC_STALL_WEBHOOK_URL;
+  if (!url) return;
+
+  const payload = {
+    text: `🚨 Stalled task: "${task.title}" (${task.id}) idle ${Math.round(minutesIdle)}m in status "${task.status}"`,
+    task_id: task.id,
+    title: task.title,
+    status: task.status,
+    minutes_idle: Math.round(minutesIdle),
+    assigned_agent_id: task.assigned_agent_id || null,
+  };
+
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(5_000),
+    });
+  } catch (err) {
+    // Webhook failures are best-effort — a failing webhook shouldn't block
+    // the rest of the scan from processing other stalled tasks.
+    console.warn('[Stall] Webhook POST failed:', (err as Error).message);
+  }
+}
+
+/**
+ * Called by dispatch / reassign / plan-revision paths to clear the
+ * stalled flag when the coordinator (or an operator) takes a real action.
+ * Without this the next scan would re-flag the same task and re-notify.
+ */
+export function clearStallFlag(taskId: string): void {
+  const task = queryOne<{ status_reason: string | null }>(
+    'SELECT status_reason FROM tasks WHERE id = ?',
+    [taskId]
+  );
+  if (!task?.status_reason?.startsWith('stalled_')) return;
+
+  run(
+    `UPDATE tasks SET status_reason = NULL, updated_at = ? WHERE id = ?`,
+    [new Date().toISOString(), taskId]
+  );
+  logTaskActivity({
+    taskId,
+    type: 'stall_recovered',
+    message: 'Stall cleared by subsequent action (dispatch / reassign / mail from coordinator)',
+  });
+}

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -3,6 +3,11 @@ import { notifyLearner } from '@/lib/learner';
 import type { Task } from '@/lib/types';
 
 const ACTIVE_STATUSES = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification'];
+const TERMINAL_STATUSES = ['done', 'cancelled'];
+
+export function isTerminalStatus(status: string): boolean {
+  return TERMINAL_STATUSES.includes(status);
+}
 
 export function hasStageEvidence(taskId: string): boolean {
   const deliverable = queryOne<{ count: number }>('SELECT COUNT(*) as count FROM task_deliverables WHERE task_id = ?', [taskId]);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@
 
 export type AgentStatus = 'standby' | 'working' | 'offline';
 
-export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'done';
+export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'done' | 'cancelled';
 
 export type TaskPriority = 'low' | 'normal' | 'high' | 'urgent';
 
@@ -174,6 +174,7 @@ export interface WorkspaceStats {
     review: number;
     verification: number;
     done: number;
+    cancelled: number;
     total: number;
   };
   agentCount: number;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -18,7 +18,8 @@ const TaskStatus = z.enum([
   'testing',
   'review',
   'verification',
-  'done'
+  'done',
+  'cancelled'
 ]);
 
 const TaskPriority = z.enum(['low', 'normal', 'high', 'urgent']);
@@ -60,6 +61,15 @@ export const UpdateTaskSchema = z.object({
   override_reason: z.string().max(2000).optional(),
   pr_url: z.string().url().optional().nullable(),
   pr_status: z.enum(['pending', 'open', 'merged', 'closed']).optional(),
+});
+
+// Admin release-stall schema — escape hatch for deadlocked tasks that
+// cannot clear the evidence gate. Deliberately restricted to the two
+// terminal statuses so operators can't use it to bypass normal workflow.
+export const ReleaseStallSchema = z.object({
+  reason: z.string().min(1, 'reason is required').max(500),
+  terminal_state: z.enum(['cancelled', 'done']).optional(),
+  released_by: z.string().max(200).optional(),
 });
 
 // Activity validation schema

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -9,6 +9,7 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { pickDynamicAgent, escalateFailureIfNeeded, recordLearnerOnTransition } from '@/lib/task-governance';
 import { getMissionControlUrl } from '@/lib/config';
 import { broadcast } from '@/lib/events';
+import { saveCheckpointThrottled } from '@/lib/checkpoint';
 import type { Task, WorkflowTemplate, WorkflowStage, TaskRole } from '@/lib/types';
 
 interface StageTransitionResult {
@@ -203,6 +204,39 @@ export async function handleStageTransition(
       now
     ]
   );
+
+  // Auto-checkpoint on every stage transition. Counts + status are cheap
+  // to compute and give checkpoint/restore a reliable recovery point even
+  // if the agent never saves one itself. Throttled to 60s so a rapid
+  // handoff chain doesn't bloat work_checkpoints.
+  try {
+    const counts = queryOne<{ act: number; del: number }>(
+      `SELECT
+         (SELECT COUNT(*) FROM task_activities WHERE task_id = ?) as act,
+         (SELECT COUNT(*) FROM task_deliverables WHERE task_id = ?) as del`,
+      [taskId, taskId]
+    );
+    saveCheckpointThrottled(
+      {
+        taskId,
+        agentId: roleAgent.id,
+        checkpointType: 'auto',
+        stateSummary: `Stage handoff to "${targetStage.label}" (role=${targetStage.role})`,
+        contextData: {
+          previous_status: options?.previousStatus,
+          new_status: newStatus,
+          stage_label: targetStage.label,
+          activity_count: counts?.act ?? 0,
+          deliverable_count: counts?.del ?? 0,
+          fail_reason: options?.failReason,
+        },
+      },
+      60
+    );
+  } catch (err) {
+    // Non-fatal: checkpoint failures shouldn't block a stage transition.
+    console.warn('[Workflow] saveCheckpoint on transition failed:', err);
+  }
 
   recordLearnerOnTransition(taskId, options?.previousStatus || newStatus, newStatus, true).catch(err =>
     console.error('[Learner] transition record failed:', err)


### PR DESCRIPTION
Closes #1.

## Summary

- Adds `cancelled` terminal status (migration `029`) + admin escape hatch at `POST /api/tasks/:id/admin/release-stall` that bypasses the evidence gate, ends OpenClaw sessions for the task and every convoy sub-task, and writes an audit trail to both `task_activities` and `events`.
- Fixes `POST /api/tasks/:id/fail` returning a bare 500 — now returns 400 with a structured error + hint when no recovery path exists.
- Hardens DELETE: unwinds the non-cascading FKs (`agent_health`, `workspace_ports`, `workspace_merges`, `skill_reports`) and nulls `task_id` on product-autopilot tables — the silent cause of "Failed to delete task" on active tasks.
- New stall scanner (`src/lib/stall-detection.ts`) piggybacks on the existing 2-minute `runHealthCheckCycle`. Convoy sub-tasks notify the coordinator via `agent_mailbox`; solo tasks fall through to `MC_STALL_WEBHOOK_URL`. Handles coordinator-stalled, coordinator-missing, and mid-handoff races. `clearStallFlag()` on successful dispatch prevents re-flagging recovered tasks.
- Throttled `heartbeat` activities give the scanner a real proof-of-life signal without flooding the feed.
- `saveCheckpointThrottled` auto-snapshots on dispatch, every stage transition, and stall detection — `checkpoint/restore` was returning 404 because nothing ever called `saveCheckpoint()`.
- PATCH blocks transitions out of `cancelled` (use release-stall or create a fresh task).
- Manual trigger at `POST /api/tasks/scan-stalls` for cron / debug.

The evidence gate's accepted activity types (`completed`, `file_created`, `updated`) are deliberately unchanged — new auto-logged types are for visibility only.

## Test plan

Smoke tested end-to-end against `next dev` with a backdated task:

- [x] `npm run build` clean, `tsc --noEmit` clean
- [x] Migration `029` applies; `'cancelled'` appears in the `tasks.status` CHECK constraint
- [x] `POST /api/tasks/scan-stalls` flags a 120m-idle task as `{ mode: 'solo', notified: 'webhook' }`
- [x] Second scan is throttled (no re-flag within 60m window)
- [x] `POST /fail` on a non-failable status returns **400** with a clear message (was 500)
- [x] `POST /admin/release-stall` → task → `cancelled`, `assigned_agent_id` nulled, `sessions_ended: 1`, audit event written
- [x] `PATCH { status: 'in_progress' }` on a cancelled task → **400**
- [x] `DELETE` on a cancelled task → **200**, row removed, no FK errors

## Files

- Migration: `src/lib/db/migrations.ts` (migration 029), `src/lib/db/schema.ts`, `src/lib/types.ts`, `src/lib/validation.ts`
- Admin endpoint: `src/app/api/tasks/[id]/admin/release-stall/route.ts`
- Fail fix: `src/app/api/tasks/[id]/fail/route.ts`
- DELETE hardening: `src/app/api/tasks/[id]/route.ts`
- Stall scanner: `src/lib/stall-detection.ts`, `src/app/api/tasks/scan-stalls/route.ts`
- Activity helper: `src/lib/activity-log.ts`
- Auto-checkpoints: `src/lib/checkpoint.ts`, `src/lib/workflow-engine.ts`, `src/app/api/tasks/[id]/dispatch/route.ts`
- Heartbeat + scanner scheduling: `src/lib/agent-health.ts`
- Docs: `docs/ISSUE-01-LOCAL-GUIDE.md`

## Notes

- New env vars: `STALL_DETECTION_MINUTES` (default 30), `MC_STALL_WEBHOOK_URL` (optional).
- Existing `board_override` header path remains untouched — still a valid per-request bypass for the PATCH evidence gate.
- The migration is destructive at the table level (SQLite can't `ALTER CHECK`, so tasks is recreate+copy+rename). The migration runner already takes a timestamped `VACUUM INTO` backup before any migration runs, so no extra operator step required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)