### PR TITLE
Fix convoy sub-task routing — respect suggested_role, not hardcoded builder

### DIFF
--- a/src/app/api/tasks/[id]/convoy/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/convoy/dispatch/route.ts
@@ -58,10 +58,16 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [subtask.task_id]);
       if (!task) continue;
 
-      // Auto-assign agent if not assigned
+      // Auto-assign agent if not assigned. Use the decomposition's role hint
+      // so researcher/writer/reviewer sub-tasks reach their own agent;
+      // `pickDynamicAgent` falls back to any non-offline agent if no match
+      // for the role exists (see src/lib/task-governance.ts). Prior to this,
+      // every sub-task passed 'builder' here — which is why every sub-task
+      // in a convoy landed on the single builder agent.
       let agentId = task.assigned_agent_id;
       if (!agentId) {
-        const picked = pickDynamicAgent(subtask.task_id, 'builder');
+        const roleHint = subtask.suggested_role || 'builder';
+        const picked = pickDynamicAgent(subtask.task_id, roleHint);
         if (picked) {
           agentId = picked.id;
           run('UPDATE tasks SET assigned_agent_id = ?, updated_at = datetime(\'now\') WHERE id = ?', [agentId, subtask.task_id]);

--- a/src/app/api/tasks/[id]/convoy/route.ts
+++ b/src/app/api/tasks/[id]/convoy/route.ts
@@ -63,7 +63,7 @@ Respond with ONLY valid JSON in this exact format:
  * Run AI decomposition via OpenClaw: send prompt, poll for response, parse sub-tasks.
  */
 async function runAIDecomposition(task: Task): Promise<{
-  subtasks: Array<{ title: string; description?: string; depends_on?: string[] }>;
+  subtasks: Array<{ title: string; description?: string; depends_on?: string[]; suggested_role?: string }>;
   reasoning: string;
 }> {
   // Find master agent for this workspace
@@ -125,6 +125,12 @@ async function runAIDecomposition(task: Task): Promise<{
             title: st.title,
             description: st.description,
             depends_on: st.depends_on,
+            // Preserve the AI's per-sub-task role hint so convoy dispatch can
+            // route researcher/writer/reviewer work to the right agent. Before
+            // this, the role was dropped here and dispatch fell back to the
+            // hardcoded 'builder' in convoy/dispatch/route.ts — every sub-task
+            // landed on whichever agent had role='builder'.
+            suggested_role: st.suggested_role,
           })),
           reasoning: parsed.reasoning || 'AI decomposition',
         };
@@ -143,7 +149,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const { strategy = 'manual', name, subtasks, decomposition_spec } = body as {
       strategy?: DecompositionStrategy;
       name?: string;
-      subtasks?: Array<{ title: string; description?: string; agent_id?: string; depends_on?: string[] }>;
+      subtasks?: Array<{ title: string; description?: string; agent_id?: string; depends_on?: string[]; suggested_role?: string }>;
       decomposition_spec?: string;
     };
 

--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -24,11 +24,20 @@ let syncing: Promise<number> | null = null;
 
 function normalizeRole(name: string): string {
   const n = name.toLowerCase();
+  // Order matters: more-specific patterns first. Without the research /
+  // write / coord branches below, gateway-synced agents named "Researcher",
+  // "Writer", or "Coordinator" all fell through to 'builder', which hid
+  // them from pickDynamicAgent's role-based lookup and caused every
+  // convoy sub-task to route to the single `role='builder'` agent.
   if (n.includes('learn')) return 'learner';
   if (n.includes('test')) return 'tester';
   if (n.includes('review') || n.includes('verif')) return 'reviewer';
   if (n.includes('fix')) return 'fixer';
   if (n.includes('senior')) return 'senior';
+  if (n.includes('research')) return 'researcher';
+  if (n.includes('writ')) return 'writer';
+  if (n.includes('design')) return 'designer';
+  if (n.includes('coord')) return 'coordinator';
   if (n.includes('plan') || n.includes('orch')) return 'orchestrator';
   return 'builder';
 }

--- a/src/lib/convoy.ts
+++ b/src/lib/convoy.ts
@@ -9,6 +9,8 @@ interface CreateSubtaskInput {
   description?: string;
   agent_id?: string;
   depends_on?: string[];
+  /** Role hint for dispatch. If omitted, convoy dispatch falls back to 'builder'. */
+  suggested_role?: string;
 }
 
 interface CreateConvoyInput {
@@ -64,9 +66,9 @@ export function createConvoy(input: CreateConvoyInput): Convoy {
 
       // Create the convoy_subtasks relationship
       run(
-        `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, depends_on, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-        [convoySubtaskId, convoyId, subtaskId, i, sub.depends_on ? JSON.stringify(sub.depends_on) : null, now]
+        `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, depends_on, suggested_role, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [convoySubtaskId, convoyId, subtaskId, i, sub.depends_on ? JSON.stringify(sub.depends_on) : null, sub.suggested_role || null, now]
       );
     }
 
@@ -281,12 +283,12 @@ export function addSubtasks(convoyId: string, subtasks: CreateSubtaskInput[]): C
       );
 
       run(
-        `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, depends_on, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-        [convoySubtaskId, convoyId, subtaskId, maxOrder + i + 1, sub.depends_on ? JSON.stringify(sub.depends_on) : null, now]
+        `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, depends_on, suggested_role, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [convoySubtaskId, convoyId, subtaskId, maxOrder + i + 1, sub.depends_on ? JSON.stringify(sub.depends_on) : null, sub.suggested_role || null, now]
       );
 
-      created.push({ id: convoySubtaskId, convoy_id: convoyId, task_id: subtaskId, sort_order: maxOrder + i + 1, depends_on: sub.depends_on, created_at: now });
+      created.push({ id: convoySubtaskId, convoy_id: convoyId, task_id: subtaskId, sort_order: maxOrder + i + 1, depends_on: sub.depends_on, suggested_role: sub.suggested_role || null, created_at: now });
     }
 
     // Update total count

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1676,6 +1676,20 @@ const migrations: Migration[] = [
 
       console.log('[Migration 029] Tasks table recreated with cancelled status');
     }
+  },
+  {
+    id: '030',
+    name: 'add_suggested_role_to_convoy_subtasks',
+    up: (db) => {
+      console.log('[Migration 030] Adding suggested_role to convoy_subtasks...');
+      const cols = db.prepare("PRAGMA table_info(convoy_subtasks)").all() as { name: string }[];
+      if (cols.some(c => c.name === 'suggested_role')) {
+        console.log('[Migration 030] suggested_role already present — skipping');
+        return;
+      }
+      db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN suggested_role TEXT`);
+      console.log('[Migration 030] convoy_subtasks.suggested_role added');
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -279,6 +279,7 @@ CREATE TABLE IF NOT EXISTS convoy_subtasks (
   task_id TEXT NOT NULL UNIQUE REFERENCES tasks(id) ON DELETE CASCADE,
   sort_order INTEGER DEFAULT 0,
   depends_on TEXT,
+  suggested_role TEXT,
   created_at TEXT DEFAULT (datetime('now'))
 );
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -766,6 +766,10 @@ export interface ConvoySubtask {
   task_id: string;
   sort_order: number;
   depends_on?: string[];
+  /** Role hint produced by decomposition (e.g. 'researcher', 'writer').
+   *  Read by convoy dispatch to route each sub-task to an agent whose
+   *  `agents.role` matches. NULL means "no hint — pick a builder". */
+  suggested_role?: string | null;
   created_at: string;
   // Joined
   task?: Task;


### PR DESCRIPTION
Fixes the convoy routing bug: every sub-task was landing on the single `role='builder'` agent regardless of decomposition intent.

**Stacked on top of [#2](https://github.com/smb209/mission-control/pull/2)** — base will auto-retarget to `main` once that merges. Review after #2 or treat as a preview.

## Root causes (two compound bugs)

1. **Role hint dropped between AI and DB.** [`src/app/api/tasks/[id]/convoy/route.ts:124`](src/app/api/tasks/[id]/convoy/route.ts) mapped the decomposition response and silently discarded `suggested_role`. The `convoy_subtasks` table had no column for it anyway. Then [`src/app/api/tasks/[id]/convoy/dispatch/route.ts:64`](src/app/api/tasks/[id]/convoy/dispatch/route.ts) hardcoded `'builder'` as the role passed to `pickDynamicAgent`.

2. **`normalizeRole()` collapses most names to `'builder'`.** [`src/lib/agent-catalog-sync.ts:25-34`](src/lib/agent-catalog-sync.ts) only recognised `learn / test / review / verif / fix / senior / plan / orch`. Any gateway agent named "Researcher", "Writer", or "Coordinator" got `role='builder'`, which hid them from the role-based lookup even if bug #1 were fixed.

## Summary

- Migration `030` adds `suggested_role TEXT` to `convoy_subtasks`.
- `CreateSubtaskInput` + `ConvoySubtask` gain an optional `suggested_role`; `createConvoy()` and `addSubtasks()` persist it; `getDispatchableSubtasks` returns it via `SELECT cs.*`.
- `runAIDecomposition()` forwards `suggested_role` from the AI response (the prompt already asks for it at [convoy/route.ts:40](src/app/api/tasks/[id]/convoy/route.ts); it was being thrown away).
- Manual `POST /api/tasks/:id/convoy` body accepts per-sub-task `suggested_role`.
- Convoy dispatch reads `subtask.suggested_role` and falls back to `'builder'` only when the hint is missing.
- `normalizeRole()` gains `researcher` / `writer` / `designer` / `coordinator` branches before the `'builder'` fallback.

## Test plan

Smoke tested end-to-end against `next dev` with a freshly migrated DB:

- [x] Migration `030` applies; `convoy_subtasks.suggested_role` present
- [x] `npm run build` / `tsc --noEmit` clean
- [x] 4-sub-task convoy with explicit role hints (`researcher`, `writer`, `reviewer`, `tester`) → each sub-task routes to the matching agent:
  ```
  sort_order  suggested_role  picked_agent      role        match
  0           researcher      Researcher Agent  researcher  OK
  1           writer          Writer Agent      writer      OK
  2           reviewer        Reviewer Agent    reviewer    OK
  3           tester          Tester Agent      tester      OK
  ```
- [x] Convoy with no hints → both sub-tasks still route to the builder agent (backwards compatible)

## Files

- `src/lib/db/migrations.ts` (migration 030), `src/lib/db/schema.ts`, `src/lib/types.ts`
- `src/lib/convoy.ts` (INSERTs + interface)
- `src/app/api/tasks/[id]/convoy/route.ts` (AI response mapping + manual body type)
- `src/app/api/tasks/[id]/convoy/dispatch/route.ts` (role hint read)
- `src/lib/agent-catalog-sync.ts` (`normalizeRole` expansion)

## Notes

- Migration `030` is a pure `ALTER TABLE ADD COLUMN` — non-destructive, no table recreate.
- Existing convoys (with `NULL` `suggested_role`) keep their original behaviour: fall back to builder.
- `pickDynamicAgent` was already correct — it does an exact role match on `agents.role` and falls back to any non-offline agent when there's no match. No change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)