### PR TITLE
feat: structured Blocked indicator on task cards

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -22,6 +22,8 @@ export async function GET(request: NextRequest) {
         t.*,
         aa.name as assigned_agent_name,
         aa.avatar_emoji as assigned_agent_emoji,
+        aa.status as assigned_agent_status,
+        aa.role as assigned_agent_role,
         ca.name as created_by_agent_name
       FROM tasks t
       LEFT JOIN agents aa ON t.assigned_agent_id = aa.id
@@ -56,9 +58,17 @@ export async function GET(request: NextRequest) {
 
     sql += ' ORDER BY t.created_at DESC';
 
-    const tasks = queryAll<Task & { assigned_agent_name?: string; assigned_agent_emoji?: string; created_by_agent_name?: string }>(sql, params);
+    const tasks = queryAll<Task & {
+      assigned_agent_name?: string;
+      assigned_agent_emoji?: string;
+      assigned_agent_status?: string;
+      assigned_agent_role?: string;
+      created_by_agent_name?: string;
+    }>(sql, params);
 
-    // Transform to include nested agent info
+    // Transform to include nested agent info. `status` and `role` are needed
+    // client-side so the Blocked badge can distinguish "agent went offline
+    // mid-task" from other block conditions — see src/lib/blocked-state.ts.
     const transformedTasks = tasks.map((task) => ({
       ...task,
       assigned_agent: task.assigned_agent_id
@@ -66,6 +76,8 @@ export async function GET(request: NextRequest) {
             id: task.assigned_agent_id,
             name: task.assigned_agent_name,
             avatar_emoji: task.assigned_agent_emoji,
+            status: task.assigned_agent_status,
+            role: task.assigned_agent_role,
           }
         : undefined,
     }));

--- a/src/components/BlockedBadge.tsx
+++ b/src/components/BlockedBadge.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { getBlockedState, type BlockedState } from '@/lib/blocked-state';
+import type { Task } from '@/lib/types';
+
+interface BlockedBadgeProps {
+  task: Task;
+  portraitMode?: boolean;
+}
+
+/**
+ * Rich replacement for the scattered "Assigned, but blocked: {err}" /
+ * "In queue — waiting for verification" / "Needs agent" rows that
+ * previously lived inline in MissionQueue.tsx. Single source of truth
+ * for block detection is src/lib/blocked-state.ts.
+ */
+export function BlockedBadge({ task, portraitMode = true }: BlockedBadgeProps) {
+  const state = getBlockedState(task);
+  if (!state) return null;
+
+  return <BlockedBadgeInner state={state} portraitMode={portraitMode} />;
+}
+
+function BlockedBadgeInner({ state, portraitMode }: { state: BlockedState; portraitMode: boolean }) {
+  const toneClasses =
+    state.tone === 'error'
+      ? 'bg-red-500/10 border-red-500/30 text-red-300'
+      : state.tone === 'warn'
+      ? 'bg-amber-500/10 border-amber-500/30 text-amber-200'
+      : 'bg-cyan-500/10 border-cyan-500/30 text-cyan-200';
+
+  const dotColor =
+    state.tone === 'error' ? 'bg-red-400' : state.tone === 'warn' ? 'bg-amber-400' : 'bg-cyan-400';
+
+  return (
+    <div
+      className={`flex items-start gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} rounded-md border ${toneClasses}`}
+      title={state.tooltip}
+    >
+      <div className={`w-2 h-2 rounded-full mt-1 flex-shrink-0 ${dotColor}`} />
+      <span className="text-xs leading-snug">{state.label}</span>
+    </div>
+  );
+}

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -8,6 +8,7 @@ import { getConfig } from '@/lib/config';
 import { useUnreadCounts } from '@/hooks/useUnreadCounts';
 import type { Task, TaskStatus } from '@/lib/types';
 import { TaskModal } from './TaskModal';
+import { BlockedBadge } from './BlockedBadge';
 import { formatDistanceToNow } from 'date-fns';
 
 interface MissionQueueProps {
@@ -462,36 +463,17 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
           </div>
         )}
 
-        {isAssigned && dispatchError && (
-          <div className={`flex items-start gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-red-500/10 rounded-md border border-red-500/30`}>
-            <div className="w-2 h-2 bg-red-400 rounded-full mt-1 flex-shrink-0" />
-            <span className="text-xs text-red-300">Assigned, but blocked: {dispatchError}</span>
-          </div>
-        )}
+        {/* Single source of truth for all block / queue / offline-agent
+            indicators. Previously spread across four render blocks that
+            each read a different slice of task state — see
+            src/lib/blocked-state.ts for the consolidated logic. */}
+        <BlockedBadge task={task} portraitMode={portraitMode} />
 
+        {/* The dedicated "Assigned and validating" / "Stuck in assigned"
+            badge still shows a retry-dispatch button, so keep it when there
+            is no structured block reason yet. */}
         {isAssigned && !dispatchError && (
           <AssignedStatusBadge task={task} portraitMode={portraitMode} />
-        )}
-
-        {task.status === 'inbox' && !task.assigned_agent_id && (
-          <div className={`flex items-center gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-amber-500/10 rounded-md border border-amber-500/30`}>
-            <div className="w-2 h-2 bg-amber-400 rounded-full flex-shrink-0" />
-            <span className="text-xs text-amber-200">Needs agent — assign to start</span>
-          </div>
-        )}
-
-        {['testing', 'verification'].includes(task.status) && dispatchError && (
-          <div className={`flex items-start gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-red-500/10 rounded-md border border-red-500/30`}>
-            <div className="w-2 h-2 bg-red-400 rounded-full mt-1 flex-shrink-0" />
-            <span className="text-xs text-red-300">{dispatchError}</span>
-          </div>
-        )}
-
-        {task.status === 'review' && !dispatchError && (
-          <div className={`flex items-center gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-cyan-500/10 rounded-md border border-cyan-500/30`}>
-            <div className="w-2 h-2 bg-cyan-400 rounded-full flex-shrink-0" />
-            <span className="text-xs text-cyan-200">In queue — waiting for verification</span>
-          </div>
         )}
 
         {task.assigned_agent && (

--- a/src/lib/blocked-state.ts
+++ b/src/lib/blocked-state.ts
@@ -1,0 +1,126 @@
+import type { Task } from '@/lib/types';
+
+/**
+ * Structured "why is this task blocked" reason. Pure function — no DB, no
+ * fetch, no React. Runs on the client from the `Task` row that the
+ * `/api/tasks` endpoint already returns (with `assigned_agent.status` and
+ * `assigned_agent.role` joined in).
+ *
+ * Mirrors the `blockedAgentIds` logic in AgentActivityDashboard.tsx, but
+ * at the task level so the Kanban board can show WHY each card is stuck
+ * instead of just dumping `planning_dispatch_error` verbatim.
+ */
+export type BlockedKind =
+  | 'offline_agent'     // agent assigned but currently offline
+  | 'dispatch_failed'   // planning_dispatch_error is populated
+  | 'stalled'           // status_reason starts with 'stalled_' (scanner flag)
+  | 'queued_review'     // in review with no reviewer free (handled by drainQueue)
+  | 'queued_testing'    // in testing with no tester free
+  | 'needs_agent';      // inbox with no assignee — needs operator input
+
+export interface BlockedState {
+  kind: BlockedKind;
+  /** Short label shown on the card. */
+  label: string;
+  /** Longer explanation shown on hover / in the task modal. */
+  tooltip: string;
+  /** Tone for styling — 'error' | 'warn' | 'info'. */
+  tone: 'error' | 'warn' | 'info';
+}
+
+const ACTIVE_STATUSES = new Set(['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification']);
+
+/**
+ * Parse a Node-fetch-style dispatch error into something operator-friendly.
+ * workflow-engine.ts now stuffs the real cause ({ECONNREFUSED, timeout, ...})
+ * into the stored error after the "fetch failed" sentinel. Strip the noise
+ * so the badge shows "Gateway unreachable" instead of
+ * "Dispatch error: fetch failed (connect ECONNREFUSED 127.0.0.1:4001)".
+ */
+function summarizeDispatchError(raw: string): string {
+  const lower = raw.toLowerCase();
+  if (lower.includes('econnrefused')) return 'Cannot reach Mission Control API — check URL';
+  if (lower.includes('enotfound') || lower.includes('dns')) return 'Mission Control URL does not resolve';
+  if (lower.includes('timeout') || lower.includes('etimedout')) return 'Dispatch timed out';
+  if (lower.includes('gateway') && lower.includes('connect')) return 'Gateway disconnected';
+  if (lower.includes('no eligible agent')) return 'No agent available for this role';
+  if (lower.includes('no routable agent')) return 'No agent available for this role';
+  if (lower.includes('agent has no session') || lower.includes('session')) return 'Agent has no active session';
+  if (lower.includes('openclaw')) return 'Gateway error';
+  // Fallback: trim leading "Dispatch error: " / "Auto-dispatch ... failed: "
+  return raw.replace(/^(dispatch(?:\s+to\s+\S+)?\s+(?:error|failed)(?:\s*\([^)]*\))?:\s*)/i, '').slice(0, 100);
+}
+
+export function getBlockedState(task: Task): BlockedState | null {
+  const status = task.status;
+  const agent = task.assigned_agent;
+  const dispatchError = task.planning_dispatch_error;
+  const statusReason = task.status_reason;
+
+  // 1. Dispatch error — highest priority because it means the server tried
+  //    and failed. Surface the parsed cause so the user knows what to fix.
+  if (dispatchError && ACTIVE_STATUSES.has(status)) {
+    return {
+      kind: 'dispatch_failed',
+      label: `Blocked — ${summarizeDispatchError(dispatchError)}`,
+      tooltip: dispatchError,
+      tone: 'error',
+    };
+  }
+
+  // 2. Assigned agent is offline but task is active. The agent went away
+  //    after being assigned — the Blocked indicator ships the operator
+  //    straight to "reassign or bring the agent back online".
+  if (agent && agent.status === 'offline' && ACTIVE_STATUSES.has(status)) {
+    return {
+      kind: 'offline_agent',
+      label: `Blocked — ${agent.name} is offline`,
+      tooltip: `Agent "${agent.name}" is offline but still assigned to this task. Reassign or bring the agent back online.`,
+      tone: 'error',
+    };
+  }
+
+  // 3. Scanner-flagged stall (PR #2). Distinct from dispatch_failed because
+  //    dispatch succeeded but the agent then went quiet.
+  if (statusReason?.startsWith('stalled_') && ACTIVE_STATUSES.has(status)) {
+    return {
+      kind: 'stalled',
+      label: 'Blocked — stalled',
+      tooltip: statusReason,
+      tone: 'warn',
+    };
+  }
+
+  // 4. Testing / review with no agent assigned = queued waiting for the
+  //    next stage's role to free up. Not an error — operator just needs
+  //    visibility that it's not forgotten. (drainQueue will advance it.)
+  if (status === 'testing' && !task.assigned_agent_id) {
+    return {
+      kind: 'queued_testing',
+      label: 'In queue — waiting for tester',
+      tooltip: 'No tester available yet. Will auto-advance when one frees up.',
+      tone: 'info',
+    };
+  }
+  if (status === 'review' && !task.assigned_agent_id) {
+    return {
+      kind: 'queued_review',
+      label: 'In queue — waiting for reviewer',
+      tooltip: 'No reviewer available yet. Will auto-advance when one frees up.',
+      tone: 'info',
+    };
+  }
+
+  // 5. Inbox with no agent — needs operator to assign someone. Matches the
+  //    existing "Needs agent — assign to start" row in MissionQueue.
+  if (status === 'inbox' && !task.assigned_agent_id) {
+    return {
+      kind: 'needs_agent',
+      label: 'Needs agent — assign to start',
+      tooltip: 'Task has no assigned agent. Pick one from the agent list.',
+      tone: 'warn',
+    };
+  }
+
+  return null;
+}

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -262,7 +262,14 @@ export async function handleStageTransition(
 
     if (!dispatchRes.ok) {
       const errorText = await dispatchRes.text();
-      const error = `Auto-dispatch to ${roleAgent.name} failed (${dispatchRes.status}): ${errorText}`;
+      // Try to pull a clean message out of the JSON body; many routes return
+      // { error: "..." }. Fall back to the raw text if it isn't JSON.
+      let parsedMessage = errorText;
+      try {
+        const parsed = JSON.parse(errorText);
+        if (parsed?.error) parsedMessage = parsed.error;
+      } catch { /* not JSON — use raw */ }
+      const error = `Dispatch to ${roleAgent.name} failed (HTTP ${dispatchRes.status}): ${parsedMessage}`;
       console.error(`[Workflow] ${error}`);
       run('UPDATE tasks SET planning_dispatch_error = ?, updated_at = ? WHERE id = ?', [error, now, taskId]);
       return { success: false, handedOff: true, newAgentId: roleAgent.id, newAgentName: roleAgent.name, error };
@@ -271,8 +278,17 @@ export async function handleStageTransition(
     console.log(`[Workflow] Dispatched task ${taskId} to ${roleAgent.name} (role: ${targetStage.role})`);
     return { success: true, handedOff: true, newAgentId: roleAgent.id, newAgentName: roleAgent.name };
   } catch (err) {
-    const error = `Dispatch error: ${(err as Error).message}`;
-    console.error(`[Workflow] ${error}`);
+    // Node's global fetch throws `TypeError: fetch failed` and stashes the
+    // real reason on `err.cause` (ECONNREFUSED, DNS, TLS, timeout, etc).
+    // Without this the operator sees "Dispatch error: fetch failed" and has
+    // no idea whether the gateway is down, the MC URL is wrong, or the
+    // internal route is broken. Surface the cause so the card's Blocked
+    // badge can actually diagnose the problem.
+    const e = err as Error & { cause?: { code?: string; message?: string } };
+    const causeMsg = e.cause?.message || e.cause?.code;
+    const reason = causeMsg ? `${e.message} (${causeMsg})` : e.message;
+    const error = `Dispatch error: ${reason}`;
+    console.error(`[Workflow] ${error}`, e.cause || '');
     run('UPDATE tasks SET planning_dispatch_error = ?, updated_at = ? WHERE id = ?', [error, now, taskId]);
     return { success: false, handedOff: true, newAgentId: roleAgent.id, newAgentName: roleAgent.name, error };
   }


### PR DESCRIPTION
**Stacked** on top of [#3](https://github.com/smb209/mission-control/pull/3) (which stacks on [#2](https://github.com/smb209/mission-control/pull/2)). Base auto-retargets as each merges.

## Problem

You reported seeing *"Dispatch error: Failed Fetch"* on cards on the testing board, with no way to tell whether the gateway was down, the Mission Control URL was wrong, the assigned agent had gone offline, or the task was simply waiting in a queue. The raw Node fetch error was leaking straight into the UI via `planning_dispatch_error`.

Inline block rendering was also spread across four separate `<div>`s in [MissionQueue.TaskCard](src/components/MissionQueue.tsx), each reading a different slice of task state — hard to reason about and easy to drift.

## Fix

Single `<BlockedBadge task={task}/>` component backed by a pure `getBlockedState(task)` helper. Six block kinds with operator-readable labels:

| Kind | Trigger | Label |
|---|---|---|
| `offline_agent` | `assigned_agent.status === 'offline'` + active | `Blocked — {agent} is offline` |
| `dispatch_failed` | `planning_dispatch_error` set | `Blocked — {parsed reason}` (see summarizer) |
| `stalled` | `status_reason` starts with `stalled_` (scanner from [#2](https://github.com/smb209/mission-control/pull/2)) | `Blocked — stalled` |
| `queued_testing` | `testing` + no assignee | `In queue — waiting for tester` |
| `queued_review` | `review` + no assignee | `In queue — waiting for reviewer` |
| `needs_agent` | `inbox` + no assignee | `Needs agent — assign to start` |

The `dispatch_failed` summarizer maps raw errors into something actionable:

- `ECONNREFUSED` → *"Cannot reach Mission Control API — check URL"*
- `ENOTFOUND` / DNS → *"Mission Control URL does not resolve"*
- timeout / ETIMEDOUT → *"Dispatch timed out"*
- "Failed to connect to OpenClaw Gateway" → *"Gateway disconnected"*
- "No eligible agent for role" → *"No agent available for this role"*

## Backend support

1. **[src/app/api/tasks/route.ts](src/app/api/tasks/route.ts) GET** joins `agents.status` + `agents.role` into the nested `assigned_agent` object. Previously only `name`/`avatar_emoji` were returned, so the client couldn't detect an offline agent at all.
2. **[src/lib/workflow-engine.ts](src/lib/workflow-engine.ts) fetch catch** now surfaces `err.cause` (ECONNREFUSED / ENOTFOUND / ETIMEDOUT codes) — Node's global fetch throws `TypeError: fetch failed` and stashes the real reason on `err.cause`. Without this, `planning_dispatch_error` was literally "Dispatch error: fetch failed" and the summarizer had nothing to go on. Also parses `{ error: "..." }` JSON bodies from non-2xx dispatch responses so we don't dump the raw JSON on the card.

## Test plan

Smoke tested against `next dev` with fabricated tasks in each block state:

- [x] `npm run build` clean, `tsc --noEmit` clean
- [x] `/api/tasks` GET returns `assigned_agent.status` for tasks with offline agents
- [x] `getBlockedState` returns the expected kind + label for all seven states:
  ```
  offline_agent                kind=offline_agent   label="Blocked — Researcher Agent is offline"
  dispatch_failed              kind=dispatch_failed label="Blocked — Cannot reach Mission Control API — check URL"
  dispatch_failed (gateway)    kind=dispatch_failed label="Blocked — Gateway disconnected"
  queued_review                kind=queued_review   label="In queue — waiting for reviewer"
  queued_testing               kind=queued_testing  label="In queue — waiting for tester"
  needs_agent                  kind=needs_agent     label="Needs agent — assign to start"
  stalled                      kind=stalled         label="Blocked — stalled"
  not blocked (done)           kind=null
  ```
- [x] The existing `AssignedStatusBadge` (with retry-dispatch button) still renders when there is no structured block reason.

## Files

| File | What changes |
|---|---|
| `src/lib/blocked-state.ts` *(new)* | Pure `getBlockedState(task)` helper + error summarizer |
| `src/components/BlockedBadge.tsx` *(new)* | Rich badge with tone/colour + tooltip |
| `src/components/MissionQueue.tsx` | Replaces four inline block renders with a single `<BlockedBadge/>` |
| `src/app/api/tasks/route.ts` | Joins `aa.status`, `aa.role` into response |
| `src/lib/workflow-engine.ts` | Surfaces `err.cause`; parses JSON error bodies |

## Notes

- No toast / alert changes — indicators stay on the cards where they belong.
- The full raw error is still preserved in the tooltip (`title` attr) in case you need it for debugging.
- `AssignedStatusBadge` (the "Assigned and validating" / "Stuck in assigned for Xm" card with the retry button) is untouched — it's a different concern and still renders below the new badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)