### PR TITLE
feat: /debug console — opt-in capture of MC↔agent traffic

### DIFF
--- a/src/app/api/debug/events/route.ts
+++ b/src/app/api/debug/events/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { broadcast } from '@/lib/events';
+import {
+  getDebugEvents,
+  getDebugEventCount,
+  clearDebugEvents,
+  type DebugEventFilter,
+  type DebugEventType,
+  type DebugEventDirection,
+} from '@/lib/debug-log';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/debug/events
+ *
+ * Query params (all optional):
+ *   task_id, agent_id, event_type, direction, after_id, limit
+ *
+ * Returns `{ events, total }`. `total` is the unfiltered count so the UI
+ * can show "N / M" even when the current filter is narrow.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+
+  const filter: DebugEventFilter = {
+    taskId: searchParams.get('task_id') || undefined,
+    agentId: searchParams.get('agent_id') || undefined,
+    eventType: (searchParams.get('event_type') as DebugEventType | null) || undefined,
+    direction: (searchParams.get('direction') as DebugEventDirection | null) || undefined,
+    afterId: searchParams.get('after_id') || undefined,
+    limit: searchParams.get('limit') ? Number(searchParams.get('limit')) : undefined,
+  };
+
+  const events = getDebugEvents(filter);
+  const total = getDebugEventCount();
+
+  return NextResponse.json({ events, total });
+}
+
+/**
+ * DELETE /api/debug/events — wipe all captured rows. Operator-invoked from
+ * the /debug UI. Intentionally not soft-delete; debug data has no
+ * auditing value after the operator says "clear".
+ */
+export async function DELETE() {
+  const cleared = clearDebugEvents();
+  broadcast({ type: 'debug_events_cleared', payload: { cleared } });
+  return NextResponse.json({ cleared });
+}

--- a/src/app/api/debug/settings/route.ts
+++ b/src/app/api/debug/settings/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { broadcast } from '@/lib/events';
+import { isDebugCollectionEnabled, setDebugCollectionEnabled } from '@/lib/debug-log';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/debug/settings — returns { collection_enabled } */
+export async function GET() {
+  return NextResponse.json({ collection_enabled: isDebugCollectionEnabled() });
+}
+
+/**
+ * POST /api/debug/settings — body: { collection_enabled: boolean }
+ *
+ * Toggles capture. When turning OFF, existing rows are preserved so the
+ * operator can still inspect them; use DELETE /api/debug/events to wipe.
+ */
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => ({}));
+  if (typeof body.collection_enabled !== 'boolean') {
+    return NextResponse.json(
+      { error: 'collection_enabled must be a boolean' },
+      { status: 400 }
+    );
+  }
+
+  setDebugCollectionEnabled(body.collection_enabled);
+  broadcast({
+    type: 'debug_collection_toggled',
+    payload: { collection_enabled: body.collection_enabled },
+  });
+  return NextResponse.json({ collection_enabled: body.collection_enabled });
+}

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -10,6 +10,7 @@ import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { pickDynamicAgent } from '@/lib/task-governance';
 import { buildCheckpointContext, saveCheckpoint, getLatestCheckpoint } from '@/lib/checkpoint';
 import { clearStallFlag } from '@/lib/stall-detection';
+import { logDebugEvent } from '@/lib/debug-log';
 import { formatMailForDispatch } from '@/lib/mailbox';
 import { getPendingNotesForDispatch } from '@/lib/task-notes';
 import { createTaskWorkspace, determineIsolationStrategy } from '@/lib/workspace-isolation';
@@ -440,11 +441,42 @@ If you need help or clarification, ask the orchestrator.`;
       // Format: {prefix}{openclaw_session_id} where prefix defaults to 'agent:main:'
       const prefix = agent.session_key_prefix || 'agent:main:';
       const sessionKey = `${prefix}${session.openclaw_session_id}`;
-      await client.call('chat.send', {
-        sessionKey,
-        message: finalMessage,
-        idempotencyKey: `dispatch-${task.id}-${Date.now()}`
-      });
+      const idempotencyKey = `dispatch-${task.id}-${Date.now()}`;
+      const chatSendStart = Date.now();
+      let chatSendResponse: unknown;
+      let chatSendError: string | null = null;
+      try {
+        chatSendResponse = await client.call('chat.send', {
+          sessionKey,
+          message: finalMessage,
+          idempotencyKey,
+        });
+      } catch (err) {
+        chatSendError = (err as Error).message;
+        throw err; // preserve existing error-path behavior below
+      } finally {
+        // Debug console capture. No-op unless collection is enabled. Stores
+        // the full dispatch payload so operators can see exactly what the
+        // agent was asked to do — including injected knowledge, checkpoint
+        // context, and planning spec.
+        logDebugEvent({
+          type: 'chat.send',
+          direction: 'outbound',
+          taskId: task.id,
+          agentId: agent.id,
+          sessionKey,
+          durationMs: Date.now() - chatSendStart,
+          requestBody: { sessionKey, message: finalMessage, idempotencyKey },
+          responseBody: chatSendResponse,
+          error: chatSendError,
+          metadata: {
+            agent_name: agent.name,
+            agent_role: (agent as { role?: string }).role ?? null,
+            message_length: finalMessage.length,
+            task_status: task.status,
+          },
+        });
+      }
 
       // Only move to in_progress for builder dispatch (task is in 'assigned' status)
       // For tester/reviewer/verifier, the task status is already correct

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -1,0 +1,329 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Trash2, Play, Pause, ChevronDown, ChevronRight } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import type { DebugEvent, DebugEventType, DebugEventDirection } from '@/lib/debug-log';
+
+const EVENT_TYPE_OPTIONS: Array<{ value: '' | DebugEventType; label: string }> = [
+  { value: '', label: 'All event types' },
+  { value: 'chat.send', label: 'chat.send (outbound)' },
+  { value: 'chat.response', label: 'chat.response' },
+  { value: 'session.create', label: 'session.create' },
+  { value: 'session.end', label: 'session.end' },
+];
+
+const DIRECTION_OPTIONS: Array<{ value: '' | DebugEventDirection; label: string }> = [
+  { value: '', label: 'All directions' },
+  { value: 'outbound', label: 'Outbound (MC → agent)' },
+  { value: 'inbound', label: 'Inbound (agent → MC)' },
+  { value: 'internal', label: 'Internal' },
+];
+
+export default function DebugConsolePage() {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [events, setEvents] = useState<DebugEvent[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState({
+    taskId: '',
+    agentId: '',
+    eventType: '' as '' | DebugEventType,
+    direction: '' as '' | DebugEventDirection,
+  });
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  // Keep the latest filter in a ref so the SSE handler (which is stable
+  // across renders) reads the current value without having to re-register.
+  const filterRef = useRef(filter);
+  filterRef.current = filter;
+
+  const refetch = async () => {
+    const qs = new URLSearchParams();
+    if (filter.taskId) qs.set('task_id', filter.taskId);
+    if (filter.agentId) qs.set('agent_id', filter.agentId);
+    if (filter.eventType) qs.set('event_type', filter.eventType);
+    if (filter.direction) qs.set('direction', filter.direction);
+    qs.set('limit', '200');
+    const res = await fetch(`/api/debug/events?${qs.toString()}`);
+    const data = await res.json();
+    setEvents(data.events || []);
+    setTotal(data.total || 0);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetch('/api/debug/settings').then(r => r.json()).then(d => setEnabled(Boolean(d.collection_enabled)));
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    refetch();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filter.taskId, filter.agentId, filter.eventType, filter.direction]);
+
+  // Live tail — subscribe to SSE, react only to debug-specific events.
+  useEffect(() => {
+    const es = new EventSource('/api/events/stream');
+    es.onmessage = (event) => {
+      if (event.data.startsWith(':')) return;
+      try {
+        const parsed = JSON.parse(event.data) as { type: string; payload: unknown };
+        if (parsed.type === 'debug_event_logged') {
+          const incoming = parsed.payload as DebugEvent;
+          // Respect active filters — if the incoming row doesn't match, skip.
+          const f = filterRef.current;
+          if (f.taskId && incoming.task_id !== f.taskId) return;
+          if (f.agentId && incoming.agent_id !== f.agentId) return;
+          if (f.eventType && incoming.event_type !== f.eventType) return;
+          if (f.direction && incoming.direction !== f.direction) return;
+          setEvents(prev => [incoming, ...prev].slice(0, 200));
+          setTotal(prev => prev + 1);
+        } else if (parsed.type === 'debug_events_cleared') {
+          setEvents([]);
+          setTotal(0);
+        } else if (parsed.type === 'debug_collection_toggled') {
+          const p = parsed.payload as { collection_enabled: boolean };
+          setEnabled(p.collection_enabled);
+        }
+      } catch { /* ignore malformed */ }
+    };
+    return () => es.close();
+  }, []);
+
+  const toggleCollection = async () => {
+    const next = !enabled;
+    setEnabled(next);
+    await fetch('/api/debug/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ collection_enabled: next }),
+    });
+  };
+
+  const clearAll = async () => {
+    if (!confirm(`Delete all ${total} debug event(s)?`)) return;
+    await fetch('/api/debug/events', { method: 'DELETE' });
+    setEvents([]);
+    setTotal(0);
+    setExpandedIds(new Set());
+  };
+
+  const toggleExpanded = (id: string) => {
+    setExpandedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-mc-bg text-mc-text">
+      <header className="border-b border-mc-border bg-mc-bg-secondary">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <Link href="/" className="text-mc-text-secondary hover:text-mc-text">
+              <ArrowLeft className="w-5 h-5" />
+            </Link>
+            <span className="text-2xl">🔬</span>
+            <div>
+              <h1 className="text-xl font-bold">Debug Console</h1>
+              <p className="text-xs text-mc-text-secondary">
+                Raw capture of Mission Control ↔ agent traffic
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={toggleCollection}
+              disabled={enabled === null}
+              className={`min-h-11 px-4 rounded-lg border flex items-center gap-2 text-sm font-medium transition-colors ${
+                enabled
+                  ? 'bg-red-500/15 border-red-500/40 text-red-300 hover:bg-red-500/25'
+                  : 'bg-green-500/15 border-green-500/40 text-green-300 hover:bg-green-500/25'
+              }`}
+            >
+              {enabled ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+              {enabled === null ? '...' : enabled ? 'Stop collection' : 'Start collection'}
+            </button>
+            <button
+              onClick={clearAll}
+              disabled={total === 0}
+              className="min-h-11 px-4 rounded-lg border border-mc-border bg-mc-bg text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary flex items-center gap-2 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <Trash2 className="w-4 h-4" />
+              Clear ({total})
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+        {/* Status banner */}
+        <div className={`mb-4 px-4 py-3 rounded-lg border text-sm ${
+          enabled
+            ? 'bg-green-500/10 border-green-500/30 text-green-300'
+            : 'bg-mc-bg-tertiary border-mc-border text-mc-text-secondary'
+        }`}>
+          {enabled === null
+            ? 'Loading collection state...'
+            : enabled
+            ? `Collection is ON — capturing every outbound chat.send. ${total} event(s) stored.`
+            : `Collection is OFF. ${total} event(s) stored from previous sessions. Click "Start collection" to capture new traffic.`}
+        </div>
+
+        {/* Filters */}
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-3 mb-4">
+          <input
+            type="text"
+            placeholder="Filter by task_id"
+            value={filter.taskId}
+            onChange={e => setFilter(f => ({ ...f, taskId: e.target.value }))}
+            className="min-h-11 px-3 rounded-lg border border-mc-border bg-mc-bg-secondary text-sm"
+          />
+          <input
+            type="text"
+            placeholder="Filter by agent_id"
+            value={filter.agentId}
+            onChange={e => setFilter(f => ({ ...f, agentId: e.target.value }))}
+            className="min-h-11 px-3 rounded-lg border border-mc-border bg-mc-bg-secondary text-sm"
+          />
+          <select
+            value={filter.eventType}
+            onChange={e => setFilter(f => ({ ...f, eventType: e.target.value as '' | DebugEventType }))}
+            className="min-h-11 px-3 rounded-lg border border-mc-border bg-mc-bg-secondary text-sm"
+          >
+            {EVENT_TYPE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+          </select>
+          <select
+            value={filter.direction}
+            onChange={e => setFilter(f => ({ ...f, direction: e.target.value as '' | DebugEventDirection }))}
+            className="min-h-11 px-3 rounded-lg border border-mc-border bg-mc-bg-secondary text-sm"
+          >
+            {DIRECTION_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+          </select>
+        </div>
+
+        {/* Event list */}
+        {loading ? (
+          <div className="text-center py-12 text-mc-text-secondary">Loading...</div>
+        ) : events.length === 0 ? (
+          <div className="text-center py-12 text-mc-text-secondary border border-mc-border rounded-lg bg-mc-bg-secondary">
+            No events match the current filter.
+            {!enabled && total === 0 && (
+              <div className="mt-2 text-xs">Turn collection ON and dispatch a task to see traffic here.</div>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {events.map(event => (
+              <DebugEventRow
+                key={event.id}
+                event={event}
+                expanded={expandedIds.has(event.id)}
+                onToggle={() => toggleExpanded(event.id)}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function DebugEventRow({
+  event,
+  expanded,
+  onToggle,
+}: {
+  event: DebugEvent;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const directionBadge = useMemo(() => {
+    const m = {
+      outbound: { label: 'OUT', cls: 'bg-blue-500/15 text-blue-300 border-blue-500/30' },
+      inbound: { label: 'IN', cls: 'bg-purple-500/15 text-purple-300 border-purple-500/30' },
+      internal: { label: 'INT', cls: 'bg-mc-text-secondary/10 text-mc-text-secondary border-mc-border' },
+    }[event.direction];
+    return m || { label: event.direction, cls: '' };
+  }, [event.direction]);
+
+  const hasError = Boolean(event.error);
+
+  return (
+    <div className={`rounded-lg border ${hasError ? 'border-red-500/40 bg-red-500/5' : 'border-mc-border bg-mc-bg-secondary'}`}>
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-mc-bg-tertiary/40 rounded-lg"
+      >
+        {expanded ? <ChevronDown className="w-4 h-4 flex-shrink-0" /> : <ChevronRight className="w-4 h-4 flex-shrink-0" />}
+        <span className={`text-[10px] font-mono px-1.5 py-0.5 rounded border ${directionBadge.cls} flex-shrink-0`}>
+          {directionBadge.label}
+        </span>
+        <span className="font-mono text-sm flex-shrink-0">{event.event_type}</span>
+        <span className="text-xs text-mc-text-secondary truncate flex-1">
+          {event.task_id && <span className="mr-3">task={event.task_id.slice(0, 8)}</span>}
+          {event.agent_id && <span className="mr-3">agent={event.agent_id.slice(0, 8)}</span>}
+          {event.duration_ms != null && <span className="mr-3">{event.duration_ms}ms</span>}
+          {hasError && <span className="text-red-300">error</span>}
+        </span>
+        <span className="text-[11px] text-mc-text-secondary/70 flex-shrink-0">
+          {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-mc-border px-4 py-3 text-xs font-mono space-y-3">
+          <DebugField label="created_at" value={event.created_at} />
+          {event.session_key && <DebugField label="session_key" value={event.session_key} />}
+          {event.task_id && <DebugField label="task_id" value={event.task_id} />}
+          {event.agent_id && <DebugField label="agent_id" value={event.agent_id} />}
+          {event.duration_ms != null && <DebugField label="duration_ms" value={String(event.duration_ms)} />}
+          {event.error && <DebugField label="error" value={event.error} tone="error" />}
+          {event.metadata && <DebugField label="metadata" value={prettyJson(event.metadata)} block />}
+          {event.request_body && <DebugField label="request_body" value={prettyJson(event.request_body)} block />}
+          {event.response_body && <DebugField label="response_body" value={prettyJson(event.response_body)} block />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DebugField({
+  label,
+  value,
+  block = false,
+  tone,
+}: {
+  label: string;
+  value: string;
+  block?: boolean;
+  tone?: 'error';
+}) {
+  const toneCls = tone === 'error' ? 'text-red-300' : 'text-mc-text';
+  if (block) {
+    return (
+      <div>
+        <div className="text-mc-text-secondary mb-1">{label}</div>
+        <pre className={`whitespace-pre-wrap break-all bg-mc-bg px-3 py-2 rounded border border-mc-border max-h-96 overflow-auto ${toneCls}`}>{value}</pre>
+      </div>
+    );
+  }
+  return (
+    <div className="flex gap-3">
+      <span className="text-mc-text-secondary w-28 flex-shrink-0">{label}</span>
+      <span className={`break-all ${toneCls}`}>{value}</span>
+    </div>
+  );
+}
+
+function prettyJson(value: string | null): string {
+  if (value == null) return '';
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return value;
+  }
+}

--- a/src/components/WorkspaceDashboard.tsx
+++ b/src/components/WorkspaceDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Plus, ArrowRight, Folder, Users, CheckSquare, Trash2, AlertTriangle, Activity, Rocket } from 'lucide-react';
+import { Plus, ArrowRight, Folder, Users, CheckSquare, Trash2, AlertTriangle, Activity, Rocket, Bug } from 'lucide-react';
 import Link from 'next/link';
 import type { WorkspaceStats } from '@/lib/types';
 
@@ -63,6 +63,14 @@ export function WorkspaceDashboard() {
               >
                 <Activity className="w-4 h-4" />
                 Activity Dashboard
+              </Link>
+              <Link
+                href="/debug"
+                className="min-h-11 px-4 rounded-lg border border-mc-border bg-mc-bg text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary flex items-center gap-2 text-sm"
+                title="Verbose debugging — capture MC↔agent traffic"
+              >
+                <Bug className="w-4 h-4" />
+                Debug
               </Link>
               <button
                 onClick={() => setShowCreateModal(true)}

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1690,6 +1690,46 @@ const migrations: Migration[] = [
       db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN suggested_role TEXT`);
       console.log('[Migration 030] convoy_subtasks.suggested_role added');
     }
+  },
+  {
+    id: '031',
+    name: 'add_debug_console_tables',
+    up: (db) => {
+      console.log('[Migration 031] Adding debug_events + debug_config tables...');
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS debug_events (
+          id TEXT PRIMARY KEY,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          event_type TEXT NOT NULL,
+          direction TEXT NOT NULL CHECK (direction IN ('outbound', 'inbound', 'internal')),
+          task_id TEXT,
+          agent_id TEXT,
+          session_key TEXT,
+          duration_ms INTEGER,
+          request_body TEXT,
+          response_body TEXT,
+          error TEXT,
+          metadata TEXT
+        )
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_debug_events_created ON debug_events(created_at DESC)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_debug_events_task ON debug_events(task_id, created_at DESC)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_debug_events_agent ON debug_events(agent_id, created_at DESC)`);
+
+      // Single-row config table. Enforced via CHECK so app code doesn't have
+      // to worry about multi-row races — there is exactly one row at id=1.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS debug_config (
+          id INTEGER PRIMARY KEY CHECK (id = 1),
+          collection_enabled INTEGER NOT NULL DEFAULT 0,
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+      db.exec(`INSERT OR IGNORE INTO debug_config (id, collection_enabled) VALUES (1, 0)`);
+
+      console.log('[Migration 031] debug_events + debug_config created (collection_enabled=0 by default)');
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -736,6 +736,29 @@ CREATE TABLE IF NOT EXISTS skill_reports (
   created_at TEXT DEFAULT (datetime('now'))
 );
 
+-- Debug console: opt-in capture of MC↔agent traffic (dispatch payloads).
+-- Gated by debug_config.collection_enabled; operator toggles from /debug UI.
+CREATE TABLE IF NOT EXISTS debug_events (
+  id TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  event_type TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK (direction IN ('outbound', 'inbound', 'internal')),
+  task_id TEXT,
+  agent_id TEXT,
+  session_key TEXT,
+  duration_ms INTEGER,
+  request_body TEXT,
+  response_body TEXT,
+  error TEXT,
+  metadata TEXT
+);
+
+CREATE TABLE IF NOT EXISTS debug_config (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  collection_enabled INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_assigned ON tasks(assigned_agent_id);
@@ -798,4 +821,7 @@ CREATE INDEX IF NOT EXISTS idx_user_task_reads_user_task ON user_task_reads(user
 CREATE INDEX IF NOT EXISTS idx_product_skills_product ON product_skills(product_id, skill_type, status);
 CREATE INDEX IF NOT EXISTS idx_product_skills_confidence ON product_skills(confidence DESC);
 CREATE INDEX IF NOT EXISTS idx_skill_reports_skill ON skill_reports(skill_id);
+CREATE INDEX IF NOT EXISTS idx_debug_events_created ON debug_events(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_debug_events_task ON debug_events(task_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_debug_events_agent ON debug_events(agent_id, created_at DESC);
 `;

--- a/src/lib/debug-log.ts
+++ b/src/lib/debug-log.ts
@@ -1,0 +1,205 @@
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, queryAll, run } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+
+/**
+ * Debug console — opt-in verbose capture of everything that travels
+ * between Mission Control and an agent. Operator toggles collection via
+ * `/debug` UI or `POST /api/debug/settings`. Off by default; stored rows
+ * grow indefinitely until explicitly cleared.
+ *
+ * Current instrumented surfaces:
+ *   - dispatch/route.ts chat.send (outbound)
+ *
+ * Future expansions (stubs already reserved via `event_type`):
+ *   - inbound POST /activities, /deliverables, PATCH /tasks, /fail
+ *   - openclaw session lifecycle + chat response polling
+ *   - gateway catalog sync + health cycle
+ */
+
+export type DebugEventType =
+  // Outbound
+  | 'chat.send'
+  // Reserved for future instrumentation
+  | 'chat.response'
+  | 'session.create'
+  | 'session.end'
+  | 'agent.activity_post'
+  | 'agent.deliverable_post'
+  | 'agent.status_patch'
+  | 'agent.fail_post'
+  | 'gateway.list_agents'
+  | 'gateway.health_ping';
+
+export type DebugEventDirection = 'outbound' | 'inbound' | 'internal';
+
+export interface DebugEvent {
+  id: string;
+  created_at: string;
+  event_type: DebugEventType;
+  direction: DebugEventDirection;
+  task_id: string | null;
+  agent_id: string | null;
+  session_key: string | null;
+  duration_ms: number | null;
+  request_body: string | null;
+  response_body: string | null;
+  error: string | null;
+  metadata: string | null;
+}
+
+interface LogInput {
+  type: DebugEventType;
+  direction: DebugEventDirection;
+  taskId?: string | null;
+  agentId?: string | null;
+  sessionKey?: string | null;
+  durationMs?: number;
+  requestBody?: unknown;
+  responseBody?: unknown;
+  error?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+function stringifyBody(body: unknown): string | null {
+  if (body === undefined || body === null) return null;
+  if (typeof body === 'string') return body;
+  try {
+    return JSON.stringify(body);
+  } catch {
+    return String(body);
+  }
+}
+
+/**
+ * Check whether debug collection is currently enabled. Reads the single
+ * `debug_config` row; cached in-process for 2 seconds so `isEnabled()`
+ * calls at hot sites (per-dispatch) don't hammer SQLite.
+ */
+let cachedEnabled: { value: boolean; expires: number } | null = null;
+
+export function isDebugCollectionEnabled(): boolean {
+  const now = Date.now();
+  if (cachedEnabled && cachedEnabled.expires > now) return cachedEnabled.value;
+
+  const row = queryOne<{ collection_enabled: number }>(
+    'SELECT collection_enabled FROM debug_config WHERE id = 1'
+  );
+  const value = Boolean(row?.collection_enabled);
+  cachedEnabled = { value, expires: now + 2000 };
+  return value;
+}
+
+export function setDebugCollectionEnabled(enabled: boolean): void {
+  run(
+    `UPDATE debug_config SET collection_enabled = ?, updated_at = ? WHERE id = 1`,
+    [enabled ? 1 : 0, new Date().toISOString()]
+  );
+  cachedEnabled = { value: enabled, expires: Date.now() + 2000 };
+}
+
+export function clearDebugEvents(): number {
+  const before = queryOne<{ cnt: number }>('SELECT COUNT(*) as cnt FROM debug_events')?.cnt ?? 0;
+  run('DELETE FROM debug_events');
+  return before;
+}
+
+/**
+ * Append a debug event. No-op when collection is disabled. Call sites can
+ * invoke this unconditionally — the gate is enforced here so instrumentation
+ * code stays clean.
+ */
+export function logDebugEvent(input: LogInput): void {
+  if (!isDebugCollectionEnabled()) return;
+
+  const id = uuidv4();
+  const now = new Date().toISOString();
+  const row = {
+    id,
+    created_at: now,
+    event_type: input.type,
+    direction: input.direction,
+    task_id: input.taskId ?? null,
+    agent_id: input.agentId ?? null,
+    session_key: input.sessionKey ?? null,
+    duration_ms: input.durationMs ?? null,
+    request_body: stringifyBody(input.requestBody),
+    response_body: stringifyBody(input.responseBody),
+    error: input.error ?? null,
+    metadata: input.metadata ? stringifyBody(input.metadata) : null,
+  };
+
+  try {
+    run(
+      `INSERT INTO debug_events
+         (id, created_at, event_type, direction, task_id, agent_id, session_key, duration_ms, request_body, response_body, error, metadata)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [row.id, row.created_at, row.event_type, row.direction, row.task_id, row.agent_id, row.session_key, row.duration_ms, row.request_body, row.response_body, row.error, row.metadata]
+    );
+
+    // Broadcast for live tail in /debug UI. We emit a generic
+    // autopilot_activity-style payload rather than adding a typed
+    // Payload — SSEEvent.payload permits Record<string, unknown>.
+    broadcast({ type: 'debug_event_logged', payload: row as unknown as Record<string, unknown> });
+  } catch (err) {
+    // Logging must never break the thing it observes. If the INSERT fails,
+    // record it to stderr and carry on. The caller's dispatch/PATCH/etc
+    // continues unaffected.
+    console.error('[DebugLog] insert failed:', err);
+  }
+}
+
+export interface DebugEventFilter {
+  taskId?: string;
+  agentId?: string;
+  eventType?: DebugEventType;
+  direction?: DebugEventDirection;
+  afterId?: string; // for live tail cursor
+  limit?: number;
+}
+
+export function getDebugEvents(filter: DebugEventFilter = {}): DebugEvent[] {
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+
+  if (filter.taskId) {
+    clauses.push('task_id = ?');
+    params.push(filter.taskId);
+  }
+  if (filter.agentId) {
+    clauses.push('agent_id = ?');
+    params.push(filter.agentId);
+  }
+  if (filter.eventType) {
+    clauses.push('event_type = ?');
+    params.push(filter.eventType);
+  }
+  if (filter.direction) {
+    clauses.push('direction = ?');
+    params.push(filter.direction);
+  }
+  if (filter.afterId) {
+    // `afterId` is a cursor — rows with created_at > the created_at of afterId.
+    // Used by the UI's live-tail to fetch only new rows on reconnect.
+    const cursor = queryOne<{ created_at: string }>(
+      'SELECT created_at FROM debug_events WHERE id = ?',
+      [filter.afterId]
+    );
+    if (cursor) {
+      clauses.push('created_at > ?');
+      params.push(cursor.created_at);
+    }
+  }
+
+  const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+  const limit = Math.max(1, Math.min(filter.limit ?? 200, 1000));
+
+  return queryAll<DebugEvent>(
+    `SELECT * FROM debug_events ${where} ORDER BY created_at DESC LIMIT ?`,
+    [...params, limit]
+  );
+}
+
+export function getDebugEventCount(): number {
+  return queryOne<{ cnt: number }>('SELECT COUNT(*) as cnt FROM debug_events')?.cnt ?? 0;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -851,7 +851,10 @@ export type SSEEventType =
   | 'ab_test_cancelled'
   | 'skill_created'
   | 'skill_promoted'
-  | 'skills_extracted';
+  | 'skills_extracted'
+  | 'debug_event_logged'
+  | 'debug_collection_toggled'
+  | 'debug_events_cleared';
 
 export interface SSEEvent {
   type: SSEEventType;


### PR DESCRIPTION
**Stacked** on [#4](https://github.com/smb209/mission-control/pull/4) → [#3](https://github.com/smb209/mission-control/pull/3) → [#2](https://github.com/smb209/mission-control/pull/2). Base auto-retargets as each merges.

## What it is

A new `/debug` page that gives you a firehose view of everything Mission Control sends to agents. Starts with the biggest single signal — outbound `chat.send` dispatch payloads — and leaves room for inbound agent calls, session lifecycle, and gateway traffic as follow-ups (event-type values are already reserved).

Per our convo: **off by default**, no retention policy, just a Start/Stop toggle and a Clear button. Full bodies stored; no redaction.

## UI

- **Header**: Start/Stop collection, Clear (N), back link.
- **Status banner**: current state + total row count.
- **Filters**: `task_id`, `agent_id`, event type dropdown, direction dropdown.
- **List**: each row is a collapsed summary (direction chip OUT/IN/INT, event type, task/agent cursor, duration, error flag, relative time). Click to expand into formatted JSON for `request_body`, `response_body`, `metadata`, plus the error string.
- **Live tail**: new events prepend via SSE, respecting active filters. Clear and toggle also react over SSE so multiple tabs stay in sync.
- Link added to the workspace dashboard header (Bug icon).

## Backend

- **Migration `031`** adds `debug_events` (append-only log) and `debug_config` (single-row toggle, `collection_enabled=0` by default).
- **[src/lib/debug-log.ts](src/lib/debug-log.ts)** — `isDebugCollectionEnabled`, `setDebugCollectionEnabled`, `logDebugEvent`, `getDebugEvents`, `getDebugEventCount`, `clearDebugEvents`. `logDebugEvent` is a no-op when collection is off so instrumentation call sites don't have to gate themselves. The `enabled` flag is cached 2s in-process so the hot path doesn't re-query SQLite per call.
- **API**: `GET`/`DELETE` `/api/debug/events`, `GET`/`POST` `/api/debug/settings`.
- **Instrumentation**: [dispatch/route.ts](src/app/api/tasks/[id]/dispatch/route.ts) chat.send is wrapped to log the full payload (sessionKey + message body + idempotencyKey), response, duration, and any error — capture happens whether dispatch succeeds or fails.
- **SSE event types added**: `debug_event_logged`, `debug_collection_toggled`, `debug_events_cleared`.

## Test plan

Smoke tested end-to-end against `next dev`:

- [x] `tsc --noEmit` + `next build` clean; `/debug` and both API routes registered
- [x] Migration `031` applies; `debug_config` seeds with `collection_enabled=0`
- [x] `GET /api/debug/settings` returns the current flag
- [x] `logDebugEvent()` persists rows + broadcasts SSE (verified via direct lib call — the dispatch-site instrumentation itself requires a live gateway connection to exercise, which this dev env doesn't have)
- [x] `GET /api/debug/events` with `task_id` / `agent_id` filters narrows correctly
- [x] `POST /api/debug/settings` toggles collection; subsequent `logDebugEvent()` calls become no-ops
- [x] `DELETE /api/debug/events` clears everything
- [x] `/debug` page renders (HTTP 200)

## Follow-ups reserved (not in this PR)

`DebugEventType` already includes `chat.response`, `session.create`, `session.end`, `agent.activity_post`, `agent.deliverable_post`, `agent.status_patch`, `agent.fail_post`, `gateway.list_agents`, `gateway.health_ping`. When you want those surfaces instrumented, just add `logDebugEvent({ type: '...' })` at the call site — no schema or UI changes needed.

## Security note

Dispatch payloads include the full planning spec, any injected knowledge, checkpoint context, and mail from convoy teammates — so captured rows can contain sensitive context. Safe for local dev; don't enable on multi-tenant deploys without thinking about access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)