### PR TITLE
fix: stop convoy planner from duplicating gateway agents

### DIFF
--- a/src/app/api/tasks/[id]/convoy/route.ts
+++ b/src/app/api/tasks/[id]/convoy/route.ts
@@ -3,6 +3,15 @@ import { createConvoy, getConvoy, updateConvoyStatus, deleteConvoy } from '@/lib
 import { queryOne, queryAll } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { extractJSON, getMessagesFromOpenClaw } from '@/lib/planning-utils';
+import {
+  getAgentRoster,
+  formatRosterForPrompt,
+  verifyAgentInWorkspace,
+  MAX_CONVOY_SUBTASKS,
+  MAX_TASKS_PER_AGENT,
+  MIN_NEW_AGENT_RATIONALE_LENGTH,
+  type RosterAgent,
+} from '@/lib/agent-resolver';
 import type { Task, Agent, ConvoyStatus, DecompositionStrategy } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -14,11 +23,27 @@ interface RouteParams {
   params: Promise<{ id: string }>;
 }
 
+interface ParsedSubtask {
+  title: string;
+  description?: string;
+  suggested_role?: string;
+  agent_id?: string | null;
+  agent_name?: string;
+  rationale?: string;
+  depends_on?: string[];
+}
+
 /**
- * Build the AI decomposition prompt from the task's spec and description.
+ * Build the AI decomposition prompt from the task's spec and description,
+ * injecting the current agent roster so the LLM can assign sub-tasks to
+ * existing agents by id instead of silently producing ghosts.
  */
-function buildDecompositionPrompt(task: Task): string {
+function buildDecompositionPrompt(task: Task, roster: RosterAgent[]): string {
   const specSection = task.description || 'No description provided.';
+  const rosterBlock = formatRosterForPrompt(roster);
+  const createPolicy = roster.length === 0
+    ? 'No existing agents. Set agent_id to null for every sub-task.'
+    : 'Prefer assigning sub-tasks to agents in the roster above. Only set agent_id to null when no listed agent is a reasonable fit; in that case you MUST provide a specific rationale naming the capability or capacity gap.';
 
   return `TASK DECOMPOSITION REQUEST
 
@@ -28,43 +53,107 @@ You are decomposing a task into parallel sub-tasks for a convoy (multi-agent par
 **Description/Spec:**
 ${specSection}
 
-Analyze this task and break it into independent sub-tasks that can be worked on in parallel by different agents. Each sub-task should be a self-contained unit of work.
+AVAILABLE AGENTS (workspace roster):
+${rosterBlock}
+
+${createPolicy}
 
 Rules:
-- Create 2-6 sub-tasks (prefer fewer, larger sub-tasks over many tiny ones)
-- Each sub-task must have a clear, actionable title and description
-- Identify dependencies: if sub-task C requires output from A and B, declare it
-- Dependencies reference other sub-tasks by their zero-based index (e.g. "subtask-0", "subtask-1")
-- Sub-tasks WITHOUT dependencies will run in parallel immediately
-- Sub-tasks WITH dependencies wait until all dependencies complete
-- Suggest a role for each sub-task (e.g. "developer", "designer", "writer")
+- Plan no more than ${MAX_CONVOY_SUBTASKS} sub-tasks. If the task is too big for that, plan the first ${MAX_CONVOY_SUBTASKS} and describe what was left out in "deferred".
+- Each sub-task must have a clear, actionable title and description.
+- Identify dependencies: if sub-task C requires output from A and B, declare it.
+- Dependencies reference other sub-tasks by their zero-based index (e.g. "subtask-0", "subtask-1").
+- Sub-tasks WITHOUT dependencies run in parallel immediately.
+- Do not assign more than ${MAX_TASKS_PER_AGENT} sub-tasks to the same agent_id; if more work exists for a role, prefer creating a new agent over overloading.
+- Prefer agents with status "standby" over "working".
+- For each sub-task include "agent_id" (from the roster above) OR null, plus "suggested_role" (human-readable), and a "rationale" explaining the choice.
+- If agent_id is null, "rationale" must name the specific capability gap — "no suitable agent" is not acceptable.
 
-Respond with ONLY valid JSON in this exact format:
+Respond with ONLY valid JSON — no markdown fences, no commentary — in this exact shape:
 {
   "reasoning": "Brief explanation of how you decomposed this task",
+  "deferred": "optional — what was left out when capped at ${MAX_CONVOY_SUBTASKS} sub-tasks",
   "subtasks": [
     {
       "title": "Sub-task title",
       "description": "Detailed description of what this sub-task should accomplish",
-      "suggested_role": "developer",
+      "suggested_role": "researcher",
+      "agent_id": "<existing agent id from roster, or null>",
+      "agent_name": "<name for new agent, only when agent_id is null>",
+      "rationale": "Why this agent was chosen, or why a new agent is required",
       "depends_on": []
-    },
-    {
-      "title": "Another sub-task",
-      "description": "Description...",
-      "suggested_role": "developer",
-      "depends_on": ["subtask-0"]
     }
   ]
 }`;
 }
 
 /**
+ * Validate the LLM's plan against the guardrails (subtask cap, per-agent load
+ * limit, hallucinated agent ids, required rationale for new agents). Mutates
+ * each subtask's agent_id to null when validation fails for that subtask, so
+ * the caller falls back to creating a new agent rather than assigning to a
+ * non-existent one. Returns any validation problems for logging.
+ */
+function validateConvoyPlan(
+  subtasks: ParsedSubtask[],
+  workspaceId: string,
+): { errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (subtasks.length > MAX_CONVOY_SUBTASKS) {
+    errors.push(`Plan has ${subtasks.length} sub-tasks, exceeds cap of ${MAX_CONVOY_SUBTASKS}`);
+  }
+
+  const assignmentCounts = new Map<string, number>();
+
+  for (const subtask of subtasks) {
+    if (subtask.agent_id) {
+      const agent = verifyAgentInWorkspace(workspaceId, subtask.agent_id);
+      if (!agent) {
+        warnings.push(
+          `LLM returned unknown agent_id ${subtask.agent_id} for sub-task "${subtask.title}" — will fall back to role-based pick`,
+        );
+        subtask.agent_id = null;
+      } else {
+        const next = (assignmentCounts.get(subtask.agent_id) ?? 0) + 1;
+        assignmentCounts.set(subtask.agent_id, next);
+        if (next > MAX_TASKS_PER_AGENT) {
+          warnings.push(
+            `Agent ${agent.name} (${subtask.agent_id}) assigned ${next} sub-tasks, exceeds per-agent load limit of ${MAX_TASKS_PER_AGENT} — dropping this assignment`,
+          );
+          subtask.agent_id = null;
+        }
+      }
+    }
+
+    if (subtask.agent_id == null) {
+      const rationale = (subtask.rationale ?? '').trim();
+      if (rationale.length < MIN_NEW_AGENT_RATIONALE_LENGTH) {
+        warnings.push(
+          `Sub-task "${subtask.title}" requests a new agent without a specific rationale (got "${rationale}") — dispatch will fall back to the role-based pick instead of auto-creating`,
+        );
+      }
+    }
+  }
+
+  return { errors, warnings };
+}
+
+/**
  * Run AI decomposition via OpenClaw: send prompt, poll for response, parse sub-tasks.
  */
 async function runAIDecomposition(task: Task): Promise<{
-  subtasks: Array<{ title: string; description?: string; depends_on?: string[]; suggested_role?: string }>;
+  subtasks: Array<{
+    title: string;
+    description?: string;
+    depends_on?: string[];
+    suggested_role?: string;
+    agent_id?: string | null;
+  }>;
   reasoning: string;
+  deferred?: string;
+  warnings: string[];
 }> {
   // Find master agent for this workspace
   const masterAgent = queryOne<Agent>(
@@ -76,6 +165,8 @@ async function runAIDecomposition(task: Task): Promise<{
     throw new Error('No master agent available for AI decomposition');
   }
 
+  const roster = getAgentRoster(task.workspace_id);
+
   const client = getOpenClawClient();
   if (!client.isConnected()) {
     await client.connect();
@@ -85,7 +176,7 @@ async function runAIDecomposition(task: Task): Promise<{
   const prefix = masterAgent.session_key_prefix || 'agent:main:';
   const sessionKey = `${prefix}decompose:${task.id}`;
 
-  const prompt = buildDecompositionPrompt(task);
+  const prompt = buildDecompositionPrompt(task, roster);
 
   // Send the decomposition prompt
   await client.call('chat.send', {
@@ -109,30 +200,32 @@ async function runAIDecomposition(task: Task): Promise<{
 
       const parsed = extractJSON(msg.content) as {
         reasoning?: string;
-        subtasks?: Array<{
-          title: string;
-          description?: string;
-          suggested_role?: string;
-          depends_on?: string[];
-        }>;
+        deferred?: string;
+        subtasks?: ParsedSubtask[];
       } | null;
 
       if (parsed?.subtasks && Array.isArray(parsed.subtasks) && parsed.subtasks.length > 0) {
-        // Convert subtask index references (e.g. "subtask-0") to task IDs later
-        // For now, keep them as-is — they'll be resolved during convoy creation
+        const subtasks = parsed.subtasks.slice(0, MAX_CONVOY_SUBTASKS);
+        const { errors, warnings } = validateConvoyPlan(subtasks, task.workspace_id);
+        if (errors.length > 0) {
+          throw new Error(`Convoy plan rejected: ${errors.join('; ')}`);
+        }
+        for (const w of warnings) console.warn(`[Convoy Decomposition] ${w}`);
+
         return {
-          subtasks: parsed.subtasks.map(st => ({
+          subtasks: subtasks.map(st => ({
             title: st.title,
             description: st.description,
             depends_on: st.depends_on,
-            // Preserve the AI's per-sub-task role hint so convoy dispatch can
-            // route researcher/writer/reviewer work to the right agent. Before
-            // this, the role was dropped here and dispatch fell back to the
-            // hardcoded 'builder' in convoy/dispatch/route.ts — every sub-task
-            // landed on whichever agent had role='builder'.
             suggested_role: st.suggested_role,
+            // Pass the LLM's validated agent choice through to createConvoy so
+            // the sub-task row is pre-assigned. Null means "let dispatch pick
+            // by role" — which is the non-breaking fallback for empty rosters.
+            agent_id: st.agent_id ?? null,
           })),
           reasoning: parsed.reasoning || 'AI decomposition',
+          deferred: parsed.deferred,
+          warnings,
         };
       }
     }
@@ -167,11 +260,18 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           parentTaskId: id,
           name: name || task.title,
           strategy: 'ai',
-          decompositionSpec: JSON.stringify({ reasoning: result.reasoning }),
+          decompositionSpec: JSON.stringify({
+            reasoning: result.reasoning,
+            deferred: result.deferred,
+            warnings: result.warnings,
+          }),
           subtasks: result.subtasks,
         });
 
-        return NextResponse.json({ ...convoy, ai_reasoning: result.reasoning }, { status: 201 });
+        return NextResponse.json(
+          { ...convoy, ai_reasoning: result.reasoning, ai_deferred: result.deferred, warnings: result.warnings },
+          { status: 201 },
+        );
       } catch (err) {
         const message = err instanceof Error ? err.message : 'AI decomposition failed';
         return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/api/tasks/[id]/planning/poll/route.ts
+++ b/src/app/api/tasks/[id]/planning/poll/route.ts
@@ -4,6 +4,7 @@ import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { extractJSON, getMessagesFromOpenClaw } from '@/lib/planning-utils';
+import { findAgentForRole, verifyAgentInWorkspace } from '@/lib/agent-resolver';
 import { Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -37,7 +38,7 @@ async function handlePlanningCompletion(taskId: string, parsed: any, messages: a
       const masterAgent = task ? db.prepare(
         `SELECT session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`
       ).get(task.workspace_id) as { session_key_prefix?: string } | undefined : undefined;
-      
+
       const sessionKeyPrefix = masterAgent?.session_key_prefix || 'agent:main:';
 
       const insertAgent = db.prepare(`
@@ -45,20 +46,49 @@ async function handlePlanningCompletion(taskId: string, parsed: any, messages: a
         VALUES (?, (SELECT workspace_id FROM tasks WHERE id = ?), ?, ?, ?, ?, 'standby', ?, ?, datetime('now'), datetime('now'))
       `);
 
-      for (const agent of parsed.agents) {
-        const agentId = crypto.randomUUID();
-        if (!firstAgentId) firstAgentId = agentId;
+      const workspaceId = task?.workspace_id;
 
-        insertAgent.run(
-          agentId,
-          taskId,
-          agent.name,
-          agent.role,
-          agent.instructions || '',
-          agent.avatar_emoji || '🤖',
-          agent.soul_md || '',
-          sessionKeyPrefix
-        );
+      // For each agent the planner wants to spin up, first check whether the
+      // workspace already has a gateway-linked (or session-routed) agent that
+      // fills this role. If so, reuse it — this is the core fix for the ghost
+      // agent duplication bug. Only when no existing agent matches (or the
+      // planner gave an explicit agent_id that we've verified) do we create a
+      // new row.
+      for (const agent of parsed.agents) {
+        let resolvedId: string | null = null;
+
+        if (workspaceId && agent.agent_id) {
+          const verified = verifyAgentInWorkspace(workspaceId, agent.agent_id);
+          if (verified) {
+            resolvedId = verified.id;
+          } else {
+            console.warn(`[Planning Poll] Planner returned unknown agent_id ${agent.agent_id} for role "${agent.role}" — falling back to role match`);
+          }
+        }
+
+        if (!resolvedId && workspaceId && agent.role) {
+          const existing = findAgentForRole(workspaceId, agent.role);
+          if (existing) {
+            resolvedId = existing.id;
+            console.log(`[Planning Poll] Reusing existing agent ${existing.name} (${existing.id}) for role "${agent.role}" — skipping insert`);
+          }
+        }
+
+        if (!resolvedId) {
+          resolvedId = crypto.randomUUID();
+          insertAgent.run(
+            resolvedId,
+            taskId,
+            agent.name,
+            agent.role,
+            agent.instructions || '',
+            agent.avatar_emoji || '🤖',
+            agent.soul_md || '',
+            sessionKeyPrefix
+          );
+        }
+
+        if (!firstAgentId) firstAgentId = resolvedId;
       }
     } else if (!allowDynamicAgents && parsed.agents && parsed.agents.length > 0) {
       console.log(`[Planning Poll] Dynamic agent generation disabled (ALLOW_DYNAMIC_AGENTS=false), skipping creation of ${parsed.agents.length} agent(s)`);
@@ -257,6 +287,10 @@ export async function GET(
               avatar_emoji?: string;
               soul_md?: string;
               instructions?: string;
+              /** Optional: planner may reuse an existing workspace agent by id. */
+              agent_id?: string | null;
+              /** Optional: why a new agent is needed vs. reusing one from the roster. */
+              rationale?: string;
             }>;
             execution_plan?: object;
           } | null;

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -3,6 +3,7 @@ import { getDb, queryAll, queryOne, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
 import { extractJSON } from '@/lib/planning-utils';
+import { getAgentRoster, formatRosterForPrompt } from '@/lib/agent-resolver';
 // File system imports removed - using OpenClaw API instead
 
 export const dynamic = 'force-dynamic';
@@ -141,11 +142,26 @@ export async function POST(
     const planningPrefix = basePrefix + 'planning:';
     const sessionKey = `${planningPrefix}${taskId}`;
 
+    // Fetch the gateway-linked agent roster and surface it to the planner.
+    // Without this context the planner invents new agents every run, which is
+    // the root of the ghost-agent duplication bug: the real gateway agents
+    // sit idle while newly-created rows with no session_key_prefix receive
+    // the dispatch. When the planner emits its final `agents` list at status
+    // "complete", it may now return `agent_id` per agent to reuse one of these
+    // existing rows — see the polling handler for reuse/verify logic.
+    const roster = getAgentRoster(task.workspace_id);
+    const rosterBlock = formatRosterForPrompt(roster);
+
     // Build the initial planning prompt
     const planningPrompt = `PLANNING REQUEST
 
 Task Title: ${task.title}
 Task Description: ${task.description || 'No description provided'}
+
+AVAILABLE AGENTS (workspace roster):
+${rosterBlock}
+
+When you later emit the final plan (status: "complete") with an "agents" array, prefer assigning roles to the agents listed above by including their "agent_id" in each entry. Only propose a new agent (agent_id: null) when no listed agent is a suitable fit — and include a "rationale" explaining the specific capability gap.
 
 You are starting a planning session for this task. Read PLANNING.md for your protocol.
 

--- a/src/lib/agent-resolver.ts
+++ b/src/lib/agent-resolver.ts
@@ -1,0 +1,115 @@
+/**
+ * Agent roster + role-to-agent resolution used by the convoy planner and the
+ * planning-session completion handler.
+ *
+ * Background: the convoy planner and the task-planning LLM both historically
+ * invented new agents every run, which produced "ghost" agents — rows with no
+ * gateway_agent_id and no session_key_prefix that received task assignments
+ * but dispatched nowhere. This module gives callers a single place to look up
+ * existing gateway-linked agents and a single policy for reuse-vs-create.
+ */
+import { queryAll, queryOne } from '@/lib/db';
+
+export interface RosterAgent {
+  id: string;
+  name: string;
+  role: string;
+  description: string | null;
+  status: string;
+  session_key_prefix: string | null;
+  gateway_agent_id: string | null;
+  is_master: number;
+  workspace_id: string;
+}
+
+/** Policy caps shared by planning + convoy flows. Keep small and explicit. */
+export const MAX_CONVOY_SUBTASKS = parseInt(process.env.MAX_CONVOY_SUBTASKS || '6', 10);
+export const MAX_TASKS_PER_AGENT = parseInt(process.env.MAX_TASKS_PER_AGENT || '2', 10);
+export const MIN_NEW_AGENT_RATIONALE_LENGTH = 20;
+
+/**
+ * Return all agents that are eligible to be assigned work in this workspace.
+ * Prefers gateway-linked agents (ones that actually map to a live OpenClaw
+ * session) but also includes local agents that carry a session_key_prefix —
+ * those still route correctly. Agents with neither are "ghosts" and are
+ * filtered out.
+ */
+export function getAgentRoster(workspaceId: string): RosterAgent[] {
+  return queryAll<RosterAgent>(
+    `SELECT id, name, role, description, status, session_key_prefix, gateway_agent_id, is_master, workspace_id
+     FROM agents
+     WHERE workspace_id = ?
+       AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
+       AND status != 'offline'
+     ORDER BY is_master DESC, name ASC`,
+    [workspaceId]
+  );
+}
+
+/**
+ * Format the roster as plain-text lines for injection into an LLM prompt.
+ * Empty roster returns a short notice instead of an empty block, so the LLM
+ * handles bootstrap workspaces gracefully ("no existing agents, create new").
+ */
+export function formatRosterForPrompt(roster: RosterAgent[]): string {
+  if (roster.length === 0) {
+    return 'No existing agents are provisioned for this workspace — create whichever roles are needed.';
+  }
+  return roster
+    .map(a => {
+      const linked = a.gateway_agent_id ? ' [gateway]' : '';
+      const master = a.is_master ? ' [orchestrator]' : '';
+      return `- id: ${a.id} | name: ${a.name} | role: ${a.role} | status: ${a.status}${linked}${master}`;
+    })
+    .join('\n');
+}
+
+/**
+ * Look up an existing agent in the workspace whose role matches `role`,
+ * preferring gateway-linked agents. Used by the planning-completion handler
+ * to avoid inserting a duplicate when the LLM proposes an agent for a role
+ * that's already staffed.
+ *
+ * Matching is case-insensitive and also tolerates partial matches (e.g. the
+ * LLM says "Tester" and the roster has role "tester" or "QA Tester"). Exact
+ * matches win over partial matches.
+ */
+export function findAgentForRole(workspaceId: string, role: string): RosterAgent | null {
+  if (!role) return null;
+  const exact = queryOne<RosterAgent>(
+    `SELECT id, name, role, description, status, session_key_prefix, gateway_agent_id, is_master, workspace_id
+     FROM agents
+     WHERE workspace_id = ?
+       AND LOWER(role) = LOWER(?)
+       AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
+       AND status != 'offline'
+     ORDER BY gateway_agent_id IS NOT NULL DESC, status = 'standby' DESC, updated_at DESC
+     LIMIT 1`,
+    [workspaceId, role]
+  );
+  if (exact) return exact;
+
+  return queryOne<RosterAgent>(
+    `SELECT id, name, role, description, status, session_key_prefix, gateway_agent_id, is_master, workspace_id
+     FROM agents
+     WHERE workspace_id = ?
+       AND (LOWER(role) LIKE '%' || LOWER(?) || '%' OR LOWER(?) LIKE '%' || LOWER(role) || '%')
+       AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
+       AND status != 'offline'
+     ORDER BY gateway_agent_id IS NOT NULL DESC, status = 'standby' DESC, updated_at DESC
+     LIMIT 1`,
+    [workspaceId, role, role]
+  ) ?? null;
+}
+
+/**
+ * Verify that `agentId` is a real agent in the given workspace. Guards against
+ * LLM hallucinations where the planner returns an agent id that doesn't exist.
+ */
+export function verifyAgentInWorkspace(workspaceId: string, agentId: string): RosterAgent | null {
+  return queryOne<RosterAgent>(
+    `SELECT id, name, role, description, status, session_key_prefix, gateway_agent_id, is_master, workspace_id
+     FROM agents WHERE id = ? AND workspace_id = ? LIMIT 1`,
+    [agentId, workspaceId]
+  ) ?? null;
+}

--- a/src/lib/convoy.ts
+++ b/src/lib/convoy.ts
@@ -7,7 +7,10 @@ import type { Convoy, ConvoySubtask, Task, ConvoyStatus, DecompositionStrategy }
 interface CreateSubtaskInput {
   title: string;
   description?: string;
-  agent_id?: string;
+  /** Pre-assigned agent from the decomposition LLM (may be null when the planner
+   *  explicitly asks to create a new agent). Dispatch falls back to role-based
+   *  pick when this is null/undefined. */
+  agent_id?: string | null;
   depends_on?: string[];
   /** Role hint for dispatch. If omitted, convoy dispatch falls back to 'builder'. */
   suggested_role?: string;

--- a/src/lib/db/cleanup-ghost-agents.ts
+++ b/src/lib/db/cleanup-ghost-agents.ts
@@ -1,0 +1,147 @@
+/**
+ * One-shot cleanup for "ghost" agents left over from pre-fix convoy runs.
+ *
+ * A ghost is an agent row with no gateway_agent_id AND no session_key_prefix.
+ * Before the convoy duplication fix, every planning run inserted a fresh set
+ * of these for Builder/Tester/Reviewer/Learner even when real gateway agents
+ * already covered those roles. This script merges each ghost into the live
+ * agent sharing its role (preferring gateway-linked) and re-points any task
+ * assignments so no work is lost.
+ *
+ * Usage:
+ *   cp mission-control.db mission-control.db.bak
+ *   npx tsx src/lib/db/cleanup-ghost-agents.ts           # dry-run
+ *   npx tsx src/lib/db/cleanup-ghost-agents.ts --apply   # execute
+ *
+ * Safe to run repeatedly; it's a no-op once no ghosts remain.
+ */
+import { getDb, closeDb } from './index';
+
+interface AgentRow {
+  id: string;
+  name: string;
+  role: string | null;
+  workspace_id: string;
+  gateway_agent_id: string | null;
+  session_key_prefix: string | null;
+}
+
+interface MergePlan {
+  ghost: AgentRow;
+  keeper: AgentRow;
+  taskReassignments: number;
+}
+
+function findKeeperForGhost(
+  db: ReturnType<typeof getDb>,
+  ghost: AgentRow,
+): AgentRow | null {
+  if (!ghost.role) return null;
+
+  const exact = db.prepare(
+    `SELECT id, name, role, workspace_id, gateway_agent_id, session_key_prefix
+     FROM agents
+     WHERE id != ?
+       AND workspace_id = ?
+       AND LOWER(role) = LOWER(?)
+       AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
+     ORDER BY gateway_agent_id IS NOT NULL DESC, updated_at DESC
+     LIMIT 1`,
+  ).get(ghost.id, ghost.workspace_id, ghost.role) as AgentRow | undefined;
+
+  if (exact) return exact;
+
+  const fuzzy = db.prepare(
+    `SELECT id, name, role, workspace_id, gateway_agent_id, session_key_prefix
+     FROM agents
+     WHERE id != ?
+       AND workspace_id = ?
+       AND (LOWER(role) LIKE '%' || LOWER(?) || '%' OR LOWER(?) LIKE '%' || LOWER(role) || '%')
+       AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
+     ORDER BY gateway_agent_id IS NOT NULL DESC, updated_at DESC
+     LIMIT 1`,
+  ).get(ghost.id, ghost.workspace_id, ghost.role, ghost.role) as AgentRow | undefined;
+
+  return fuzzy ?? null;
+}
+
+function main() {
+  const apply = process.argv.includes('--apply');
+  const db = getDb();
+
+  const ghosts = db.prepare(
+    `SELECT id, name, role, workspace_id, gateway_agent_id, session_key_prefix
+     FROM agents
+     WHERE gateway_agent_id IS NULL AND session_key_prefix IS NULL AND is_master = 0`,
+  ).all() as AgentRow[];
+
+  if (ghosts.length === 0) {
+    console.log('✅ No ghost agents found. Nothing to do.');
+    closeDb();
+    return;
+  }
+
+  console.log(`Found ${ghosts.length} ghost agent(s):`);
+  for (const g of ghosts) {
+    console.log(`  - ${g.name} (${g.id}) role=${g.role ?? '<none>'} workspace=${g.workspace_id}`);
+  }
+  console.log('');
+
+  const plans: MergePlan[] = [];
+  const orphans: AgentRow[] = [];
+
+  const countTasks = db.prepare('SELECT COUNT(*) as n FROM tasks WHERE assigned_agent_id = ?');
+
+  for (const ghost of ghosts) {
+    const keeper = findKeeperForGhost(db, ghost);
+    if (!keeper) {
+      orphans.push(ghost);
+      continue;
+    }
+    const taskReassignments = (countTasks.get(ghost.id) as { n: number }).n;
+    plans.push({ ghost, keeper, taskReassignments });
+  }
+
+  console.log(`Planned merges: ${plans.length}`);
+  for (const { ghost, keeper, taskReassignments } of plans) {
+    console.log(
+      `  ${ghost.name} (${ghost.id}) → ${keeper.name} (${keeper.id})  [${taskReassignments} task(s) to re-point]`,
+    );
+  }
+  if (orphans.length > 0) {
+    console.log('');
+    console.log(`Orphans (no matching gateway-linked agent for role — left in place):`);
+    for (const o of orphans) {
+      console.log(`  - ${o.name} (${o.id}) role=${o.role ?? '<none>'}`);
+    }
+  }
+
+  if (!apply) {
+    console.log('');
+    console.log('Dry run complete. Re-run with --apply to execute.');
+    closeDb();
+    return;
+  }
+
+  const tx = db.transaction((ps: MergePlan[]) => {
+    const reassign = db.prepare(
+      `UPDATE tasks SET assigned_agent_id = ?, updated_at = datetime('now') WHERE assigned_agent_id = ?`,
+    );
+    const reassignRoles = db.prepare(
+      `UPDATE task_roles SET agent_id = ? WHERE agent_id = ?`,
+    );
+    const del = db.prepare(`DELETE FROM agents WHERE id = ?`);
+    for (const { ghost, keeper } of ps) {
+      reassign.run(keeper.id, ghost.id);
+      try { reassignRoles.run(keeper.id, ghost.id); } catch { /* table may not exist in older DBs */ }
+      del.run(ghost.id);
+    }
+  });
+
+  tx(plans);
+  console.log('');
+  console.log(`✅ Merged ${plans.length} ghost agent(s). ${orphans.length} orphan(s) left in place.`);
+  closeDb();
+}
+
+main();

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -100,6 +100,21 @@ async function seed() {
     `INSERT OR IGNORE INTO businesses (id, name, description, created_at) VALUES (?, ?, ?, ?)`
   ).run(businessId, 'Mission Control HQ', 'Default workspace for all operations', now);
 
+  // Guard agent seeding: if the DB already has gateway-linked or session-routed
+  // agents (e.g. imported from OpenClaw), do not seed the stock example team.
+  // Overwriting them silently produced ghost duplicates after every reseed.
+  const realAgentCount = db.prepare(
+    `SELECT COUNT(*) as n FROM agents
+     WHERE gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL`
+  ).get() as { n: number };
+
+  if (realAgentCount.n > 0) {
+    console.log(`⏭️  Skipping agent seed — ${realAgentCount.n} gateway-linked agent(s) already exist.`);
+    console.log('✅ Database seed skipped (agents preserved)');
+    closeDb();
+    return;
+  }
+
   // Create master orchestrator agent
   const orchestratorId = uuidv4();
   db.prepare(

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -138,15 +138,30 @@ export function pickDynamicAgent(taskId: string, stageRole?: string | null): { i
   }
 
   if (stageRole) {
+    // Prefer gateway-linked / session-routed agents. A matching-role "ghost"
+    // (no gateway_agent_id, no session_key_prefix) is never actually reachable
+    // via OpenClaw, so picking one silently breaks the dispatch.
     const byRole = queryOne<{ id: string; name: string }>(
-      `SELECT id, name FROM agents WHERE role = ? AND status != 'offline' ORDER BY status = 'standby' DESC, updated_at DESC LIMIT 1`,
+      `SELECT id, name FROM agents
+       WHERE role = ? AND status != 'offline'
+       ORDER BY
+         (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL) DESC,
+         status = 'standby' DESC,
+         updated_at DESC
+       LIMIT 1`,
       [stageRole]
     );
     if (byRole) return byRole;
   }
 
   const fallback = queryOne<{ id: string; name: string }>(
-    `SELECT id, name FROM agents WHERE status != 'offline' ORDER BY is_master ASC, updated_at DESC LIMIT 1`
+    `SELECT id, name FROM agents
+     WHERE status != 'offline'
+     ORDER BY
+       (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL) DESC,
+       is_master ASC,
+       updated_at DESC
+     LIMIT 1`
   );
   if (fallback && !checked.has(fallback.id)) return fallback;
 


### PR DESCRIPTION
## Summary

Stacked on top of `claude/fix-convoy-duplication-bQM25`. Closes the convoy "ghost agent" duplication loop: the planning LLM now sees the existing roster and the completion handler reuses existing rows instead of inserting fresh Builder/Tester/Reviewer/Learner every run.

- **Roster-aware prompts** — convoy decomposition (`convoy/route.ts`) and task planning (`planning/route.ts`) both inject the gateway-linked agent roster and ask for per-sub-task `agent_id` choices (existing id, or `null` with a specific rationale).
- **Structured output + guardrails** — validate `subtasks.length <= MAX_CONVOY_SUBTASKS` (6), per-agent load `<= MAX_TASKS_PER_AGENT` (2), verify every `agent_id` exists, warn when a new-agent request lacks a >=20 char rationale. All configurable via env.
- **Planning-completion dedup** — `planning/poll/route.ts` now looks up an existing matching-role agent before inserting a new row (the actual fix for the duplication).
- **Dispatch hardening** — `pickDynamicAgent` prefers gateway-linked / session-routed agents so a leftover ghost with a matching role can't keep getting picked.
- **Seed protection** — `db:seed` skips the stock example team when any gateway-linked agents already exist.
- **Cleanup utility** — `src/lib/db/cleanup-ghost-agents.ts` is a dry-run-by-default `tsx` script that merges existing ghost rows into their gateway-linked counterparts and re-points task assignments. Run with `--apply` to execute.

## Files

- `src/lib/agent-resolver.ts` (new) — roster fetch, role→agent resolver, hallucination guard, guardrail constants.
- `src/app/api/tasks/[id]/convoy/route.ts` — roster injection, structured schema, server-side validation.
- `src/app/api/tasks/[id]/planning/route.ts` — roster injection into planning session prompt.
- `src/app/api/tasks/[id]/planning/poll/route.ts` — reuse-existing before insert.
- `src/lib/task-governance.ts` — `pickDynamicAgent` prefers gateway-linked.
- `src/lib/convoy.ts` — `agent_id: string | null` to match the LLM schema.
- `src/lib/db/seed.ts` — skip agent seed when real agents exist.
- `src/lib/db/cleanup-ghost-agents.ts` (new) — one-shot merge script.

## Test plan

- [x] `npx tsc --noEmit` — clean on modified files.
- [x] `npx tsx --test src/lib/task-governance.test.ts` — 4/4 pass.
- [x] `npx next lint` — no new warnings introduced.
- [ ] End-to-end in a workspace with gateway agents already imported:
  - [ ] Back up DB: `cp mission-control.db mission-control.db.bak`
  - [ ] Dry-run: `npx tsx src/lib/db/cleanup-ghost-agents.ts` — review planned merges.
  - [ ] Apply: `npx tsx src/lib/db/cleanup-ghost-agents.ts --apply`.
  - [ ] Dispatch a convoy task via the UI; confirm `sqlite3 mission-control.db "SELECT COUNT(*), role FROM agents GROUP BY role;"` count is stable before and after.
  - [ ] Confirm new task assignments point at gateway-linked agents: `SELECT t.title, a.name, a.gateway_agent_id, a.session_key_prefix FROM tasks t JOIN agents a ON t.assigned_agent_id = a.id WHERE t.updated_at > datetime('now', '-10 minutes');`
- [ ] Bootstrap workspace with empty roster: confirm decomposition prompt degrades to "no existing agents" and new agents are still created.

## Out of scope

Per the spec: OpenClaw per-task session construction, `sessions_spawn` vs `sessions_send`, MEMORY.md. Stale-dispatch detection is already in `src/lib/stall-detection.ts` (commit 7018ebb).

https://claude.ai/code/session_018ZMPsqnatNY8C9YjdjLWLR