### PR TITLE
feat: agent active toggle, roll-call, correct sessionKey routing

### DIFF
--- a/src/app/api/agents/[id]/mail/route.ts
+++ b/src/app/api/agents/[id]/mail/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getUnreadMail, markAsRead } from '@/lib/mailbox';
+import { queryOne } from '@/lib/db';
+import { getUnreadMail, markAsRead, sendMail } from '@/lib/mailbox';
+import { recordRollCallReplyIfMatch } from '@/lib/rollcall';
+import type { Agent } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,6 +18,87 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(messages);
   } catch (error) {
     return NextResponse.json({ error: 'Failed to fetch mail' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/agents/[id]/mail — Send mail to this agent from another.
+ *
+ * Body: {
+ *   from_agent_id: string,
+ *   subject?: string,
+ *   body: string,
+ *   convoy_id?: string,    // optional scope
+ *   task_id?: string,      // optional scope
+ *   push?: boolean         // if true, also deliver via chat.send immediately
+ * }
+ *
+ * Counterpart to /api/convoy/[convoyId]/mail — this one handles mail that
+ * lives outside a convoy (roll-call, help-requests to the master
+ * orchestrator, ad-hoc inter-agent messages). Agents reply to mail by
+ * POSTing back the other direction.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id: toAgentId } = await params;
+    const body = await request.json() as {
+      from_agent_id?: string;
+      subject?: string;
+      body?: string;
+      convoy_id?: string;
+      task_id?: string;
+      push?: boolean;
+    };
+
+    if (!body.from_agent_id || !body.body) {
+      return NextResponse.json(
+        { error: 'from_agent_id and body are required' },
+        { status: 400 }
+      );
+    }
+
+    // Sanity-check both agents exist so FK errors surface as clean 4xx.
+    const recipient = queryOne<Agent>('SELECT id FROM agents WHERE id = ?', [toAgentId]);
+    if (!recipient) {
+      return NextResponse.json({ error: `Recipient agent ${toAgentId} not found` }, { status: 404 });
+    }
+    const sender = queryOne<Agent>('SELECT id FROM agents WHERE id = ?', [body.from_agent_id]);
+    if (!sender) {
+      return NextResponse.json({ error: `Sender agent ${body.from_agent_id} not found` }, { status: 400 });
+    }
+
+    const result = await sendMail({
+      convoyId: body.convoy_id || null,
+      taskId: body.task_id || null,
+      fromAgentId: body.from_agent_id,
+      toAgentId,
+      subject: body.subject,
+      body: body.body,
+      push: Boolean(body.push),
+    });
+
+    // If this mail looks like a reply to an open roll-call, record it
+    // against the matching rollcall_entries row so the UI's live status
+    // view flips from "waiting" to "responded" for this agent. No-op if
+    // there's no match — stray replies are just regular mail.
+    const rollcallMatch = recordRollCallReplyIfMatch({
+      mailId: result.message.id,
+      fromAgentId: body.from_agent_id,
+      toAgentId,
+      subject: body.subject,
+      body: body.body,
+    });
+
+    return NextResponse.json(
+      { ...result, rollcall_matched: rollcallMatch.matched, rollcall_id: rollcallMatch.rollcallId },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error('[POST /api/agents/[id]/mail] failed:', error);
+    return NextResponse.json(
+      { error: `Failed to send mail: ${(error as Error).message}` },
+      { status: 500 }
+    );
   }
 }
 

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -94,6 +94,14 @@ export async function PATCH(
       const trimmed = body.session_key_prefix?.trim();
       values.push(!trimmed ? null : trimmed.endsWith(':') ? trimmed : trimmed + ':');
     }
+    if ((body as { is_active?: unknown }).is_active !== undefined) {
+      // Operator-set flag that excludes this agent from routing / convoy /
+      // roll-call consideration regardless of real-time status. Nothing in
+      // the DB row is destructive — flipping is_active back to 1 restores
+      // candidacy immediately.
+      updates.push('is_active = ?');
+      values.push((body as { is_active?: boolean }).is_active ? 1 : 0);
+    }
 
     if (updates.length === 0) {
       return NextResponse.json({ error: 'No updates provided' }, { status: 400 });

--- a/src/app/api/agents/rollcall/[id]/route.ts
+++ b/src/app/api/agents/rollcall/[id]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getRollCallStatus } from '@/lib/rollcall';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/agents/rollcall/[id]
+ *
+ * Return the current state of a roll-call — per-target delivery status,
+ * whether each agent has replied, and the reply body if so. The UI polls
+ * this (or subscribes to SSE `rollcall_entry_updated` events) to update
+ * the live results panel.
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const status = getRollCallStatus(id);
+    if (!status) {
+      return NextResponse.json({ error: 'Roll-call not found' }, { status: 404 });
+    }
+
+    const now = Date.now();
+    const expiresMs = new Date(status.rollcall.expires_at).getTime();
+    const expired = now > expiresMs;
+
+    // Aggregate summary for quick glance.
+    const summary = {
+      total: status.entries.length,
+      delivered: status.entries.filter(e => e.delivery_status === 'sent').length,
+      delivery_failed: status.entries.filter(e => e.delivery_status === 'failed' || e.delivery_status === 'skipped').length,
+      replied: status.entries.filter(e => e.replied_at).length,
+      pending_reply: status.entries.filter(
+        e => e.delivery_status === 'sent' && !e.replied_at
+      ).length,
+      expired,
+      seconds_remaining: Math.max(0, Math.floor((expiresMs - now) / 1000)),
+    };
+
+    return NextResponse.json({
+      rollcall: status.rollcall,
+      entries: status.entries,
+      summary,
+    });
+  } catch (error) {
+    console.error('[GET /api/agents/rollcall/[id]] failed:', error);
+    return NextResponse.json(
+      { error: `Failed to fetch roll-call status: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/agents/rollcall/route.ts
+++ b/src/app/api/agents/rollcall/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { initiateRollCall } from '@/lib/rollcall';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/agents/rollcall
+ *
+ * Kick off a roll-call across all active agents in a workspace.
+ *
+ * Body: {
+ *   workspace_id?: string,                  // defaults to 'default'
+ *   mode?: 'direct' | 'coordinator',        // defaults to 'direct'
+ *   timeout_seconds?: number                // defaults to 30
+ * }
+ *
+ * Returns 200 with the created rollcall + per-target entries (with
+ * delivery status) on success. Returns 409 if no master orchestrator
+ * exists or more than one does — operator must resolve that first via
+ * `PATCH /api/agents/[id]` setting `is_master`. Returns 400 if there
+ * are no active non-master agents to call.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({})) as {
+      workspace_id?: string;
+      mode?: 'direct' | 'coordinator';
+      timeout_seconds?: number;
+    };
+
+    const workspaceId = body.workspace_id || 'default';
+    const mode = body.mode === 'coordinator' ? 'coordinator' : 'direct';
+    const timeoutSeconds = Math.max(5, Math.min(body.timeout_seconds ?? 30, 300));
+
+    const result = await initiateRollCall({ workspaceId, mode, timeoutSeconds });
+
+    if (!result.ok) {
+      // no_master / multiple_masters → 409 Conflict (operator must fix),
+      // no_active_agents → 400 Bad Request (no one to call).
+      const status =
+        result.reason === 'no_active_agents'
+          ? 400
+          : 409;
+      return NextResponse.json(
+        {
+          error: result.detail,
+          reason: result.reason,
+          candidates: result.candidates?.map(a => ({ id: a.id, name: a.name, role: a.role })),
+        },
+        { status }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      rollcall_id: result.rollcall.id,
+      rollcall: result.rollcall,
+      entries: result.entries,
+    });
+  } catch (error) {
+    console.error('[POST /api/agents/rollcall] failed:', error);
+    return NextResponse.json(
+      { error: `Failed to initiate roll-call: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/convoy/[convoyId]/mail/route.ts
+++ b/src/app/api/convoy/[convoyId]/mail/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const message = sendMail({
+    const result = await sendMail({
       convoyId,
       fromAgentId: from_agent_id,
       toAgentId: to_agent_id,
@@ -34,7 +34,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       body: messageBody,
     });
 
-    return NextResponse.json(message, { status: 201 });
+    return NextResponse.json(result.message, { status: 201 });
   } catch (error) {
     const msg = error instanceof Error ? error.message : 'Failed to send mail';
     return NextResponse.json({ error: msg }, { status: 400 });

--- a/src/app/api/tasks/[id]/convoy/route.ts
+++ b/src/app/api/tasks/[id]/convoy/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createConvoy, getConvoy, updateConvoyStatus, deleteConvoy } from '@/lib/convoy';
 import { queryOne, queryAll } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
 import { extractJSON, getMessagesFromOpenClaw } from '@/lib/planning-utils';
 import {
   getAgentRoster,
@@ -172,8 +173,10 @@ async function runAIDecomposition(task: Task): Promise<{
     await client.connect();
   }
 
-  // Create a unique session key for this decomposition
-  const prefix = masterAgent.session_key_prefix || 'agent:main:';
+  // Create a unique session key for this decomposition. Uses the agent's
+  // own namespace (gateway_agent_id or name) rather than the old `agent:main:`
+  // default that misrouted messages to the gateway's main agent.
+  const prefix = resolveAgentSessionKeyPrefix(masterAgent);
   const sessionKey = `${prefix}decompose:${task.id}`;
 
   const prompt = buildDecompositionPrompt(task, roster);

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -340,6 +340,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           WHERE gateway_agent_id IS NOT NULL
             AND id != ?
             AND COALESCE(status, 'standby') != 'offline'
+            AND COALESCE(is_active, 1) = 1
           ORDER BY role ASC, name ASC`,
         [agent.id]
       );
@@ -515,9 +516,15 @@ If you need help or clarification, ask the orchestrator.`;
 
     // Send message to agent's session using chat.send
     try {
-      // Use sessionKey for routing to the agent's session
-      // Format: {prefix}{openclaw_session_id} where prefix defaults to 'agent:main:'
-      const prefix = agent.session_key_prefix || 'agent:main:';
+      // Use sessionKey for routing to the agent's session.
+      // Prefix defaults (via resolveAgentSessionKeyPrefix) are:
+      //   1. Explicit `agent.session_key_prefix` if set
+      //   2. `agent:<gateway_agent_id>:` for gateway-synced agents
+      //   3. `agent:<name-slug>:` as last resort
+      // The old hard-coded `agent:main:` catchall silently misrouted
+      // every MC→agent chat.send to the gateway's "main" agent.
+      const { resolveAgentSessionKeyPrefix } = await import('@/lib/openclaw/session-key');
+      const prefix = resolveAgentSessionKeyPrefix(agent);
       const sessionKey = `${prefix}${session.openclaw_session_id}`;
       const idempotencyKey = `dispatch-${task.id}-${Date.now()}`;
       const chatSendStart = Date.now();

--- a/src/app/api/tasks/[id]/planning/force-complete/route.ts
+++ b/src/app/api/tasks/[id]/planning/force-complete/route.ts
@@ -82,11 +82,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     let firstAgentId: string | null = null;
 
     if (allowDynamicAgents && completionParsed.agents?.length > 0) {
+      // Mirrors the planning poll path: null-preferred default. New agents
+      // inherit the master's explicit prefix only if one is set; otherwise
+      // leave it null so the runtime resolver picks the agent's own
+      // namespace instead of the `agent:main:` catchall.
       const masterAgent = queryOne<{ session_key_prefix?: string }>(
         `SELECT session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
         [task.workspace_id]
       );
-      const sessionKeyPrefix = masterAgent?.session_key_prefix || 'agent:main:';
+      const sessionKeyPrefix = masterAgent?.session_key_prefix || null;
 
       for (const agent of completionParsed.agents) {
         const agentId = crypto.randomUUID();

--- a/src/app/api/tasks/[id]/planning/poll/route.ts
+++ b/src/app/api/tasks/[id]/planning/poll/route.ts
@@ -39,7 +39,13 @@ async function handlePlanningCompletion(taskId: string, parsed: any, messages: a
         `SELECT session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`
       ).get(task.workspace_id) as { session_key_prefix?: string } | undefined : undefined;
 
-      const sessionKeyPrefix = masterAgent?.session_key_prefix || 'agent:main:';
+      // Only inherit an explicit prefix if the master has one set. When it's
+      // null we leave the new agent's prefix null too — the runtime
+      // resolver (resolveAgentSessionKeyPrefix) will default to the new
+      // agent's own namespace at send time instead of baking in the
+      // `agent:main:` catchall that misrouted everything to the gateway's
+      // main agent.
+      const sessionKeyPrefix = masterAgent?.session_key_prefix || null;
 
       const insertAgent = db.prepare(`
         INSERT INTO agents (id, workspace_id, name, role, description, avatar_emoji, status, soul_md, session_key_prefix, created_at, updated_at)

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -8,9 +8,12 @@ import { getAgentRoster, formatRosterForPrompt } from '@/lib/agent-resolver';
 
 export const dynamic = 'force-dynamic';
 
-// Default planning session prefix for OpenClaw
-// Can be overridden per-agent via the session_key_prefix column on agents table
-const DEFAULT_SESSION_KEY_PREFIX = 'agent:main:';
+// Last-resort fallback when no agent context is available. Normally the
+// per-agent prefix resolver (resolveAgentSessionKeyPrefix) picks the
+// gateway-id or name-slug based prefix for the specific target agent.
+// The old `agent:main:` default silently routed every planning session
+// to the gateway's "main" agent regardless of which agent was planning.
+const FALLBACK_SESSION_KEY_PREFIX = 'agent:main:';
 
 // GET /api/tasks/[id]/planning - Get planning state
 export async function GET(
@@ -99,20 +102,22 @@ export async function POST(
       return NextResponse.json({ error: 'Planning already started', sessionKey: task.planning_session_key }, { status: 400 });
     }
 
-    // Check if there are other orchestrators available before starting planning with the default master agent
-    // Get the default master agent for this workspace
-    const defaultMaster = queryOne<{ id: string; session_key_prefix?: string }>(
-      `SELECT id, session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
+    // Check if there are other orchestrators available before starting planning with the default master agent.
+    // Fetch the full master agent so we can feed it to resolveAgentSessionKeyPrefix
+    // instead of reading session_key_prefix directly — the resolver falls
+    // back to the agent's own gateway namespace when no explicit prefix is set.
+    const defaultMaster = queryOne<import('@/lib/types').Agent>(
+      `SELECT * FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
       [task.workspace_id]
     );
 
-    // Get assigned agent if any (for session_key_prefix)
+    // Get assigned agent (for session_key_prefix via the resolver).
     const taskWithAgent = getDb().prepare(`
-      SELECT a.session_key_prefix 
-      FROM tasks t 
-      LEFT JOIN agents a ON t.assigned_agent_id = a.id 
+      SELECT a.session_key_prefix, a.gateway_agent_id, a.name
+      FROM tasks t
+      LEFT JOIN agents a ON t.assigned_agent_id = a.id
       WHERE t.id = ?
-    `).get(taskId) as { session_key_prefix?: string } | undefined;
+    `).get(taskId) as { session_key_prefix?: string; gateway_agent_id?: string; name?: string } | undefined;
 
     const otherOrchestrators = queryAll<{
       id: string;
@@ -136,9 +141,26 @@ export async function POST(
       }, { status: 409 }); // 409 Conflict
     }
 
-    // Create session key for this planning task
-    // Priority: custom prefix > assigned agent's prefix > master agent's prefix > default prefix
-    const basePrefix = customSessionKeyPrefix || taskWithAgent?.session_key_prefix || defaultMaster?.session_key_prefix || DEFAULT_SESSION_KEY_PREFIX;
+    // Create session key for this planning task.
+    // Priority: custom prefix > assigned agent (via resolver) > master agent
+    // (via resolver) > fallback. The resolver picks `agent:<gateway_id>:`
+    // or `agent:<name>:` when the column is null, keeping messages in the
+    // specific agent's namespace.
+    const { resolveAgentSessionKeyPrefix } = await import('@/lib/openclaw/session-key');
+    let basePrefix: string;
+    if (customSessionKeyPrefix) {
+      basePrefix = customSessionKeyPrefix.endsWith(':') ? customSessionKeyPrefix : customSessionKeyPrefix + ':';
+    } else if (taskWithAgent?.name) {
+      basePrefix = resolveAgentSessionKeyPrefix({
+        session_key_prefix: taskWithAgent.session_key_prefix,
+        gateway_agent_id: taskWithAgent.gateway_agent_id,
+        name: taskWithAgent.name,
+      } as import('@/lib/types').Agent);
+    } else if (defaultMaster) {
+      basePrefix = resolveAgentSessionKeyPrefix(defaultMaster);
+    } else {
+      basePrefix = FALLBACK_SESSION_KEY_PREFIX;
+    }
     const planningPrefix = basePrefix + 'planning:';
     const sessionKey = `${planningPrefix}${taskId}`;
 

--- a/src/components/AgentModal.tsx
+++ b/src/components/AgentModal.tsx
@@ -305,10 +305,11 @@ export function AgentModal({ agent, onClose, workspaceId, onAgentCreated }: Agen
                   value={form.session_key_prefix}
                   onChange={(e) => setForm({ ...form, session_key_prefix: e.target.value })}
                   className="w-full min-h-11 bg-mc-bg border border-mc-border rounded px-3 py-2 text-sm focus:outline-none focus:border-mc-accent"
-                  placeholder="agent:main:"
+                  placeholder="agent:<name>:"
                 />
                 <p className="text-xs text-mc-text-secondary mt-1">
-                  OpenClaw session routing prefix. Defaults to &quot;agent:main:&quot; if not set.
+                  OpenClaw session routing prefix. Leave empty to default to
+                  &quot;agent:&lt;gateway_agent_id&gt;:&quot; (or &quot;agent:&lt;name&gt;:&quot; for local agents).
                 </p>
               </div>
             </div>

--- a/src/components/AgentsSidebar.tsx
+++ b/src/components/AgentsSidebar.tsx
@@ -1,12 +1,32 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Plus, ChevronRight, ChevronLeft, Zap, ZapOff, Loader2, Search } from 'lucide-react';
+import { Plus, ChevronRight, ChevronLeft, Zap, ZapOff, Loader2, Search, Power, Megaphone, X, MoreVertical } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import type { Agent, AgentStatus, AgentHealthState, OpenClawSession } from '@/lib/types';
 import { AgentModal } from './AgentModal';
 import { DiscoverAgentsModal } from './DiscoverAgentsModal';
 import { HealthIndicator } from './HealthIndicator';
+
+interface RollCallEntryView {
+  id: string;
+  target_agent_id: string;
+  target_agent_name?: string;
+  target_agent_role?: string;
+  delivery_status: 'pending' | 'sent' | 'failed' | 'skipped';
+  delivery_error: string | null;
+  replied_at: string | null;
+  reply_body: string | null;
+}
+
+interface RollCallResultView {
+  rollcall_id: string;
+  mode: 'direct' | 'coordinator';
+  seconds_remaining: number;
+  entries: RollCallEntryView[];
+  error?: string;
+  reason?: 'no_master' | 'multiple_masters' | 'no_active_agents';
+}
 
 type FilterTab = 'all' | 'working' | 'standby';
 
@@ -17,7 +37,7 @@ interface AgentsSidebarProps {
 }
 
 export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = true }: AgentsSidebarProps) {
-  const { agents, selectedAgent, setSelectedAgent, agentOpenClawSessions, setAgentOpenClawSession } = useMissionControl();
+  const { agents, selectedAgent, setSelectedAgent, agentOpenClawSessions, setAgentOpenClawSession, updateAgent } = useMissionControl();
   const [filter, setFilter] = useState<FilterTab>('all');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingAgent, setEditingAgent] = useState<Agent | null>(null);
@@ -26,6 +46,24 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
   const [activeSubAgents, setActiveSubAgents] = useState(0);
   const [agentHealth, setAgentHealth] = useState<Record<string, AgentHealthState>>({});
   const [isMinimized, setIsMinimized] = useState(false);
+  const [togglingAgentId, setTogglingAgentId] = useState<string | null>(null);
+  const [rollCallBusy, setRollCallBusy] = useState(false);
+  const [rollCallResult, setRollCallResult] = useState<RollCallResultView | null>(null);
+  const [showActionMenu, setShowActionMenu] = useState(false);
+
+  // Close the action menu when clicking outside it. We watch document mousedown
+  // and check that the target isn't inside the menu or the trigger button.
+  useEffect(() => {
+    if (!showActionMenu) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest('[data-agents-action-menu]')) {
+        setShowActionMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, [showActionMenu]);
 
   const effectiveMinimized = mobileMode ? false : isMinimized;
   const toggleMinimize = () => setIsMinimized(!isMinimized);
@@ -91,6 +129,108 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
     return () => clearInterval(interval);
   }, []);
 
+  // Toggle is_active for an agent. Optimistic update — on failure we roll
+  // back and surface the error.
+  const toggleAgentActive = async (agent: Agent, e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const nextActive = !(Number(agent.is_active ?? 1) === 1);
+    setTogglingAgentId(agent.id);
+    const optimistic: Agent = { ...agent, is_active: nextActive ? 1 : 0 };
+    updateAgent(optimistic);
+    try {
+      const res = await fetch(`/api/agents/${agent.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ is_active: nextActive }),
+      });
+      if (!res.ok) {
+        updateAgent(agent); // rollback
+        const err = await res.json().catch(() => ({}));
+        alert(err.error || 'Failed to toggle agent');
+      } else {
+        const fresh = await res.json();
+        updateAgent(fresh as Agent);
+      }
+    } catch (err) {
+      updateAgent(agent); // rollback
+      alert(`Failed to toggle agent: ${(err as Error).message}`);
+    } finally {
+      setTogglingAgentId(null);
+    }
+  };
+
+  // Kick off a roll-call and open the results panel. Failures
+  // (no/multiple master orchestrators) are surfaced in the same panel so
+  // the operator can act on the alert without leaving the sidebar.
+  const runRollCall = async () => {
+    setRollCallBusy(true);
+    setRollCallResult(null);
+    try {
+      const res = await fetch('/api/agents/rollcall', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          workspace_id: workspaceId || 'default',
+          mode: 'direct',
+          timeout_seconds: 30,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setRollCallResult({
+          rollcall_id: '',
+          mode: 'direct',
+          seconds_remaining: 0,
+          entries: [],
+          error: data.error,
+          reason: data.reason,
+        });
+        return;
+      }
+      setRollCallResult({
+        rollcall_id: data.rollcall_id,
+        mode: data.rollcall.mode,
+        seconds_remaining: 30,
+        entries: data.entries,
+      });
+    } catch (err) {
+      setRollCallResult({
+        rollcall_id: '',
+        mode: 'direct',
+        seconds_remaining: 0,
+        entries: [],
+        error: (err as Error).message,
+      });
+    } finally {
+      setRollCallBusy(false);
+    }
+  };
+
+  // Poll roll-call status while panel is open and timer hasn't expired.
+  // SSE would be nicer; polling is simpler and fine for the small entry
+  // counts this feature fans out to.
+  useEffect(() => {
+    if (!rollCallResult?.rollcall_id) return;
+    const rid = rollCallResult.rollcall_id;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/agents/rollcall/${rid}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        setRollCallResult(prev => prev && prev.rollcall_id === rid
+          ? { ...prev, entries: data.entries, seconds_remaining: data.summary.seconds_remaining }
+          : prev
+        );
+      } catch {}
+    };
+    tick();
+    const interval = setInterval(tick, 2000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [rollCallResult?.rollcall_id]);
+
   const handleConnectToOpenClaw = async (agent: Agent, e: React.MouseEvent) => {
     e.stopPropagation();
     setConnectingAgentId(agent.id);
@@ -138,7 +278,7 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
   return (
     <aside
       className={`bg-mc-bg-secondary ${mobileMode ? 'border border-mc-border rounded-lg h-full' : 'border-r border-mc-border'} flex flex-col transition-all duration-300 ease-in-out ${
-        effectiveMinimized ? 'w-12' : mobileMode ? 'w-full' : 'w-64'
+        effectiveMinimized ? 'w-12' : mobileMode ? 'w-full' : 'w-80'
       }`}
     >
       <div className="p-3 border-b border-mc-border">
@@ -156,6 +296,43 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
             <>
               <span className="text-sm font-medium uppercase tracking-wider">Agents</span>
               <span className="bg-mc-bg-tertiary text-mc-text-secondary text-xs px-2 py-0.5 rounded ml-2">{agents.length}</span>
+              <div className="relative ml-auto" data-agents-action-menu>
+                <button
+                  onClick={() => setShowActionMenu(v => !v)}
+                  className="p-1.5 rounded hover:bg-mc-bg-tertiary text-mc-text-secondary hover:text-mc-text transition-colors"
+                  aria-label="Agent actions"
+                  title="Agent actions"
+                >
+                  <MoreVertical className="w-4 h-4" />
+                </button>
+                {showActionMenu && (
+                  <div className="absolute right-0 top-full mt-1 w-56 rounded-lg border border-mc-border bg-mc-bg shadow-lg z-30 py-1">
+                    <button
+                      onClick={() => { setShowActionMenu(false); runRollCall(); }}
+                      disabled={rollCallBusy}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-purple-300 hover:bg-purple-500/10 disabled:opacity-50 disabled:cursor-not-allowed text-left"
+                    >
+                      {rollCallBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Megaphone className="w-4 h-4" />}
+                      {rollCallBusy ? 'Calling…' : 'Roll Call'}
+                    </button>
+                    <div className="h-px bg-mc-border my-1" />
+                    <button
+                      onClick={() => { setShowActionMenu(false); setShowCreateModal(true); }}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-mc-text hover:bg-mc-bg-tertiary text-left"
+                    >
+                      <Plus className="w-4 h-4" />
+                      Add Agent
+                    </button>
+                    <button
+                      onClick={() => { setShowActionMenu(false); setShowDiscoverModal(true); }}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-blue-300 hover:bg-blue-500/10 text-left"
+                    >
+                      <Search className="w-4 h-4" />
+                      Import from Gateway
+                    </button>
+                  </div>
+                )}
+              </div>
             </>
           )}
         </div>
@@ -221,8 +398,10 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
           }
 
           const isConnecting = connectingAgentId === agent.id;
+          const isActive = Number(agent.is_active ?? 1) === 1;
+          const isToggling = togglingAgentId === agent.id;
           return (
-            <div key={agent.id} className={`w-full rounded hover:bg-mc-bg-tertiary transition-colors ${selectedAgent?.id === agent.id ? 'bg-mc-bg-tertiary' : ''}`}>
+            <div key={agent.id} className={`w-full rounded hover:bg-mc-bg-tertiary transition-colors ${selectedAgent?.id === agent.id ? 'bg-mc-bg-tertiary' : ''} ${!isActive ? 'opacity-50' : ''}`}>
               <button
                 onClick={() => {
                   setSelectedAgent(agent);
@@ -239,6 +418,11 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
                   <div className="flex items-center gap-2">
                     <span className="font-medium text-sm truncate">{agent.name}</span>
                     {!!agent.is_master && <span className="text-xs text-mc-accent-yellow">★</span>}
+                    {!isActive && (
+                      <span className="text-[9px] px-1 py-0 bg-amber-500/20 text-amber-400 rounded uppercase tracking-wider" title="Excluded from routing + roll-call">
+                        paused
+                      </span>
+                    )}
                   </div>
                   <div className="text-xs text-mc-text-secondary truncate flex items-center gap-1">
                     {agent.role}
@@ -251,6 +435,22 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
                 </div>
 
                 <div className="flex items-center gap-1.5">
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => toggleAgentActive(agent, e)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleAgentActive(agent, e as unknown as React.MouseEvent); }
+                    }}
+                    title={isActive ? 'Active — click to pause (excludes from routing + roll-call)' : 'Paused — click to activate'}
+                    className={`p-1.5 rounded transition-colors cursor-pointer ${
+                      isActive
+                        ? 'text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary'
+                        : 'text-amber-400 hover:bg-amber-500/20'
+                    } ${isToggling ? 'opacity-50 pointer-events-none' : ''}`}
+                  >
+                    <Power className="w-3.5 h-3.5" />
+                  </span>
                   {agentHealth[agent.id] && agentHealth[agent.id] !== 'idle' && (
                     <HealthIndicator state={agentHealth[agent.id]} size="sm" />
                   )}
@@ -293,28 +493,104 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
         })}
       </div>
 
-      {!effectiveMinimized && (
-        <div className="p-3 border-t border-mc-border space-y-2">
-          <button
-            onClick={() => setShowCreateModal(true)}
-            className="w-full min-h-11 flex items-center justify-center gap-2 px-3 bg-mc-bg-tertiary hover:bg-mc-border rounded text-sm text-mc-text-secondary hover:text-mc-text transition-colors"
-          >
-            <Plus className="w-4 h-4" />
-            Add Agent
-          </button>
-          <button
-            onClick={() => setShowDiscoverModal(true)}
-            className="w-full min-h-11 flex items-center justify-center gap-2 px-3 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/20 rounded text-sm text-blue-400 hover:text-blue-300 transition-colors"
-          >
-            <Search className="w-4 h-4" />
-            Import from Gateway
-          </button>
+      {!effectiveMinimized && rollCallResult && (
+        <div className="border-t border-mc-border bg-mc-bg-secondary">
+          <RollCallResultsPanel
+            result={rollCallResult}
+            onClose={() => setRollCallResult(null)}
+          />
         </div>
       )}
+
 
       {showCreateModal && <AgentModal onClose={() => setShowCreateModal(false)} workspaceId={workspaceId} />}
       {editingAgent && <AgentModal agent={editingAgent} onClose={() => setEditingAgent(null)} workspaceId={workspaceId} />}
       {showDiscoverModal && <DiscoverAgentsModal onClose={() => setShowDiscoverModal(false)} workspaceId={workspaceId} />}
     </aside>
+  );
+}
+
+/**
+ * Inline panel that shows the live roll-call results. Renders above the
+ * action buttons so the operator can watch replies land without leaving
+ * the sidebar context. Also surfaces alert-level errors (no master
+ * orchestrator / multiple master orchestrators) in the same surface.
+ */
+function RollCallResultsPanel({
+  result,
+  onClose,
+}: {
+  result: RollCallResultView;
+  onClose: () => void;
+}) {
+  // Error state: no master, multiple masters, or other failure.
+  if (result.error) {
+    const alertTitle =
+      result.reason === 'no_master'
+        ? '⚠️ No Master Orchestrator'
+        : result.reason === 'multiple_masters'
+          ? '⚠️ Multiple Master Orchestrators'
+          : '⚠️ Roll-call Failed';
+    return (
+      <div className="p-3 border-l-4 border-amber-500 bg-amber-500/10">
+        <div className="flex items-start justify-between gap-2 mb-1">
+          <span className="text-sm font-semibold text-amber-300">{alertTitle}</span>
+          <button onClick={onClose} className="text-mc-text-secondary hover:text-mc-text p-0.5">
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+        <p className="text-xs text-mc-text-secondary">{result.error}</p>
+      </div>
+    );
+  }
+
+  const delivered = result.entries.filter(e => e.delivery_status === 'sent').length;
+  const skipped = result.entries.filter(e => e.delivery_status === 'skipped').length;
+  const failed = result.entries.filter(e => e.delivery_status === 'failed').length;
+  const replied = result.entries.filter(e => e.replied_at).length;
+  const expired = result.seconds_remaining <= 0;
+
+  return (
+    <div className="p-3">
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs">
+          <div className="font-semibold text-mc-text flex items-center gap-2">
+            📢 Roll Call ({expired ? 'complete' : `${result.seconds_remaining}s left`})
+          </div>
+          <div className="text-mc-text-secondary mt-0.5">
+            {replied}/{result.entries.length} replied · {delivered} delivered · {skipped + failed} undelivered
+          </div>
+        </div>
+        <button onClick={onClose} className="text-mc-text-secondary hover:text-mc-text p-0.5" title="Close">
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      <div className="space-y-1 max-h-40 overflow-auto">
+        {result.entries.map(e => {
+          const replyGlyph = e.replied_at ? '✓' : expired ? '✗' : '⏳';
+          const replyColor = e.replied_at
+            ? 'text-green-400'
+            : expired
+              ? 'text-red-400'
+              : 'text-mc-text-secondary';
+          const deliveryBadge = e.delivery_status === 'sent'
+            ? null
+            : e.delivery_status === 'skipped'
+              ? <span className="text-[9px] px-1 bg-mc-text-secondary/20 text-mc-text-secondary rounded" title={e.delivery_error || ''}>no session</span>
+              : e.delivery_status === 'failed'
+                ? <span className="text-[9px] px-1 bg-red-500/20 text-red-400 rounded" title={e.delivery_error || ''}>fail</span>
+                : null;
+          return (
+            <div key={e.id} className="flex items-center gap-2 text-xs">
+              <span className={`w-4 text-center ${replyColor}`}>{replyGlyph}</span>
+              <span className="flex-1 truncate">
+                {e.target_agent_name} <span className="text-mc-text-secondary">({e.target_agent_role})</span>
+              </span>
+              {deliveryBadge}
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,69 @@ import Link from 'next/link';
 import { Zap, Settings, ChevronLeft, LayoutGrid, Rocket } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import { format } from 'date-fns';
-import type { Workspace } from '@/lib/types';
+import type { Workspace, Agent, Task, TaskStatus } from '@/lib/types';
+
+// Label + colour map for the "Tasks in Queue" stage breakdown. Kept in
+// Header so the tooltip can render a stable order regardless of hash-map
+// iteration; counts at zero are hidden.
+const STAGE_LABELS: Array<{ status: TaskStatus; label: string; color: string }> = [
+  { status: 'inbox', label: 'Inbox', color: 'text-mc-text-secondary' },
+  { status: 'pending_dispatch', label: 'Pending dispatch', color: 'text-mc-text-secondary' },
+  { status: 'planning', label: 'Planning', color: 'text-blue-400' },
+  { status: 'assigned', label: 'Assigned', color: 'text-cyan-400' },
+  { status: 'in_progress', label: 'In progress', color: 'text-cyan-400' },
+  { status: 'convoy_active', label: 'Convoy active', color: 'text-purple-400' },
+  { status: 'testing', label: 'Testing', color: 'text-amber-400' },
+  { status: 'verification', label: 'Verification', color: 'text-orange-400' },
+];
+
+function ActiveAgentsTooltip({ activeAgents, activeSubAgents }: { activeAgents: Agent[]; activeSubAgents: number }) {
+  if (activeAgents.length === 0 && activeSubAgents === 0) {
+    return <span className="text-mc-text-secondary">Nothing currently working.</span>;
+  }
+  return (
+    <div className="space-y-1">
+      {activeAgents.map(a => (
+        <div key={a.id} className="flex items-center gap-2 text-xs">
+          <span className="text-base">{a.avatar_emoji}</span>
+          <span className="flex-1 truncate">{a.name}</span>
+          <span className="text-mc-text-secondary">{a.role}</span>
+        </div>
+      ))}
+      {activeSubAgents > 0 && (
+        <div className="text-xs text-mc-text-secondary pt-1 border-t border-mc-border">
+          + {activeSubAgents} sub-agent{activeSubAgents === 1 ? '' : 's'}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function QueuedTasksTooltip({ tasks }: { tasks: Task[] }) {
+  const queued = tasks.filter(t => t.status !== 'done' && t.status !== 'review' && t.status !== 'cancelled');
+  if (queued.length === 0) {
+    return <span className="text-mc-text-secondary">No tasks in queue.</span>;
+  }
+  const counts: Record<string, number> = {};
+  for (const t of queued) counts[t.status] = (counts[t.status] || 0) + 1;
+  const rows = STAGE_LABELS
+    .map(s => ({ ...s, count: counts[s.status] || 0 }))
+    .filter(s => s.count > 0);
+  return (
+    <div className="space-y-1">
+      {rows.map(r => (
+        <div key={r.status} className="flex items-center justify-between gap-3 text-xs">
+          <span className={r.color}>{r.label}</span>
+          <span className="font-mono text-mc-text">{r.count}</span>
+        </div>
+      ))}
+      <div className="text-xs text-mc-text-secondary pt-1 border-t border-mc-border flex justify-between">
+        <span>Total</span>
+        <span className="font-mono">{queued.length}</span>
+      </div>
+    </div>
+  );
+}
 
 interface HeaderProps {
   workspace?: Workspace;
@@ -42,8 +104,14 @@ export function Header({ workspace, isPortrait = true }: HeaderProps) {
     return () => clearInterval(interval);
   }, []);
 
-  const workingAgents = agents.filter((a) => a.status === 'working').length;
-  const activeAgents = workingAgents + activeSubAgents;
+  // "Agents active" counts persistent agents currently assigned to a live
+  // task. Sub-agent sessions used to be summed in too, but with the new
+  // routing model (Coordinator → sessions_send → persistent agents) a
+  // sub-agent session is a child of an existing agent, not an additional
+  // worker — adding it double-counts. The sub-agent count is still
+  // surfaced separately in the sidebar when >0.
+  const workingAgentsList = agents.filter((a) => a.status === 'working');
+  const activeAgents = workingAgentsList.length;
   const tasksInQueue = tasks.filter((t) => t.status !== 'done' && t.status !== 'review').length;
 
   const portraitWorkspaceHeader = !!workspace && isPortrait;
@@ -89,13 +157,21 @@ export function Header({ workspace, isPortrait = true }: HeaderProps) {
             </div>
 
             <div className="flex-1 grid grid-cols-2 gap-2">
-              <div className="min-h-11 rounded border border-mc-border bg-mc-bg-tertiary px-2 flex items-center justify-center gap-1.5 text-xs">
+              <div className="relative group min-h-11 rounded border border-mc-border bg-mc-bg-tertiary px-2 flex items-center justify-center gap-1.5 text-xs cursor-help">
                 <span className="text-mc-accent-cyan font-semibold">{activeAgents}</span>
                 <span className="text-mc-text-secondary">active</span>
+                <div className="hidden group-hover:block absolute top-full mt-1 left-0 right-0 md:left-auto md:right-auto md:w-64 z-40 p-2 rounded-lg border border-mc-border bg-mc-bg shadow-lg">
+                  <div className="text-[11px] uppercase tracking-wider text-mc-text-secondary mb-1.5">Agents active</div>
+                  <ActiveAgentsTooltip activeAgents={workingAgentsList} activeSubAgents={activeSubAgents} />
+                </div>
               </div>
-              <div className="min-h-11 rounded border border-mc-border bg-mc-bg-tertiary px-2 flex items-center justify-center gap-1.5 text-xs">
+              <div className="relative group min-h-11 rounded border border-mc-border bg-mc-bg-tertiary px-2 flex items-center justify-center gap-1.5 text-xs cursor-help">
                 <span className="text-mc-accent-purple font-semibold">{tasksInQueue}</span>
                 <span className="text-mc-text-secondary">queued</span>
+                <div className="hidden group-hover:block absolute top-full mt-1 left-0 right-0 md:left-auto md:right-auto md:w-64 z-40 p-2 rounded-lg border border-mc-border bg-mc-bg shadow-lg">
+                  <div className="text-[11px] uppercase tracking-wider text-mc-text-secondary mb-1.5">Tasks in queue</div>
+                  <QueuedTasksTooltip tasks={tasks} />
+                </div>
               </div>
             </div>
           </div>
@@ -130,13 +206,21 @@ export function Header({ workspace, isPortrait = true }: HeaderProps) {
 
           {workspace && (
             <div className="hidden lg:flex items-center gap-8">
-              <div className="text-center">
+              <div className="relative group text-center cursor-help">
                 <div className="text-2xl font-bold text-mc-accent-cyan">{activeAgents}</div>
                 <div className="text-xs text-mc-text-secondary uppercase">Agents Active</div>
+                <div className="hidden group-hover:block absolute top-full mt-1 left-1/2 -translate-x-1/2 w-64 z-40 p-2 rounded-lg border border-mc-border bg-mc-bg shadow-lg text-left">
+                  <div className="text-[11px] uppercase tracking-wider text-mc-text-secondary mb-1.5">Agents active</div>
+                  <ActiveAgentsTooltip activeAgents={workingAgentsList} activeSubAgents={activeSubAgents} />
+                </div>
               </div>
-              <div className="text-center">
+              <div className="relative group text-center cursor-help">
                 <div className="text-2xl font-bold text-mc-accent-purple">{tasksInQueue}</div>
                 <div className="text-xs text-mc-text-secondary uppercase">Tasks in Queue</div>
+                <div className="hidden group-hover:block absolute top-full mt-1 left-1/2 -translate-x-1/2 w-64 z-40 p-2 rounded-lg border border-mc-border bg-mc-bg shadow-lg text-left">
+                  <div className="text-[11px] uppercase tracking-wider text-mc-text-secondary mb-1.5">Tasks in queue</div>
+                  <QueuedTasksTooltip tasks={tasks} />
+                </div>
               </div>
             </div>
           )}

--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -146,19 +146,25 @@ export function ensureCatalogSyncScheduled(): void {
 }
 
 export function getAgentByPreferredRoles(taskId: string, preferredRoles: string[]): { id: string; name: string } | null {
+  // Filter out operator-disabled agents (is_active=0). COALESCE(is_active, 1)
+  // guards rows created before the column existed.
   for (const role of preferredRoles) {
     const byTaskRole = queryOne<{ id: string; name: string }>(
       `SELECT a.id, a.name
        FROM task_roles tr
        JOIN agents a ON a.id = tr.agent_id
-       WHERE tr.task_id = ? AND tr.role = ? AND a.status != 'offline'
+       WHERE tr.task_id = ? AND tr.role = ?
+         AND a.status != 'offline'
+         AND COALESCE(a.is_active, 1) = 1
        LIMIT 1`,
       [taskId, role]
     );
     if (byTaskRole) return byTaskRole;
 
     const byGlobalRole = queryOne<{ id: string; name: string }>(
-      `SELECT id, name FROM agents WHERE role = ? AND status != 'offline' ORDER BY updated_at DESC LIMIT 1`,
+      `SELECT id, name FROM agents
+       WHERE role = ? AND status != 'offline' AND COALESCE(is_active, 1) = 1
+       ORDER BY updated_at DESC LIMIT 1`,
       [role]
     );
     if (byGlobalRole) return byGlobalRole;

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1730,6 +1730,90 @@ const migrations: Migration[] = [
 
       console.log('[Migration 031] debug_events + debug_config created (collection_enabled=0 by default)');
     }
+  },
+  {
+    id: '032',
+    name: 'active_flag_and_general_mailbox_and_rollcall',
+    up: (db) => {
+      console.log('[Migration 032] Adding agents.is_active, generalizing agent_mailbox, creating rollcall tables...');
+
+      // --- 1. agents.is_active (default 1 so every existing agent is active) ---
+      const agentsInfo = db.prepare("PRAGMA table_info(agents)").all() as { name: string }[];
+      if (!agentsInfo.some(c => c.name === 'is_active')) {
+        db.exec(`ALTER TABLE agents ADD COLUMN is_active INTEGER DEFAULT 1`);
+        db.exec(`UPDATE agents SET is_active = 1 WHERE is_active IS NULL`);
+      }
+
+      // --- 2. agent_mailbox: make convoy_id nullable + add task_id ---
+      // SQLite can't drop NOT NULL on an existing column, so rebuild the
+      // table. PRAGMA foreign_keys must stay ON at commit; we use the
+      // documented 12-step table-rebuild pattern (inside a transaction we
+      // run outside this migration's wrapper — see runMigrations).
+      const mailboxInfo = db.prepare("PRAGMA table_info(agent_mailbox)").all() as { name: string; notnull: number }[];
+      const convoyCol = mailboxInfo.find(c => c.name === 'convoy_id');
+      const hasTaskId = mailboxInfo.some(c => c.name === 'task_id');
+      const needsRebuild = Boolean(convoyCol && convoyCol.notnull === 1) || !hasTaskId;
+
+      if (needsRebuild) {
+        db.exec(`
+          CREATE TABLE agent_mailbox_new (
+            id TEXT PRIMARY KEY,
+            convoy_id TEXT REFERENCES convoys(id) ON DELETE CASCADE,
+            task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+            from_agent_id TEXT NOT NULL REFERENCES agents(id),
+            to_agent_id TEXT NOT NULL REFERENCES agents(id),
+            subject TEXT,
+            body TEXT NOT NULL,
+            read_at TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+          )
+        `);
+        db.exec(`
+          INSERT INTO agent_mailbox_new (id, convoy_id, task_id, from_agent_id, to_agent_id, subject, body, read_at, created_at)
+          SELECT id, convoy_id, NULL as task_id, from_agent_id, to_agent_id, subject, body, read_at, created_at
+          FROM agent_mailbox
+        `);
+        db.exec(`DROP TABLE agent_mailbox`);
+        db.exec(`ALTER TABLE agent_mailbox_new RENAME TO agent_mailbox`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_mailbox_to ON agent_mailbox(to_agent_id, read_at)`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_mailbox_convoy ON agent_mailbox(convoy_id) WHERE convoy_id IS NOT NULL`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_mailbox_task ON agent_mailbox(task_id) WHERE task_id IS NOT NULL`);
+      }
+
+      // --- 3. rollcall + rollcall_entries ---
+      // One roll-call session can fan out to N agents; we track delivery
+      // and reply independently (the two failure modes are different:
+      // "couldn't deliver the prompt" vs "delivered but agent didn't reply").
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS rollcall_sessions (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+          initiator_agent_id TEXT NOT NULL REFERENCES agents(id),
+          mode TEXT NOT NULL CHECK (mode IN ('direct', 'coordinator')),
+          timeout_seconds INTEGER NOT NULL DEFAULT 30,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          expires_at TEXT NOT NULL
+        )
+      `);
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS rollcall_entries (
+          id TEXT PRIMARY KEY,
+          rollcall_id TEXT NOT NULL REFERENCES rollcall_sessions(id) ON DELETE CASCADE,
+          target_agent_id TEXT NOT NULL REFERENCES agents(id),
+          delivery_status TEXT NOT NULL DEFAULT 'pending' CHECK (delivery_status IN ('pending', 'sent', 'failed', 'skipped')),
+          delivery_error TEXT,
+          delivered_at TEXT,
+          reply_mail_id TEXT REFERENCES agent_mailbox(id) ON DELETE SET NULL,
+          reply_body TEXT,
+          replied_at TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_rollcall_entries_session ON rollcall_entries(rollcall_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_rollcall_entries_target ON rollcall_entries(target_agent_id, replied_at)`);
+
+      console.log('[Migration 032] Complete: is_active flag, mailbox generalized, rollcall tables created.');
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -38,6 +38,7 @@ CREATE TABLE IF NOT EXISTS agents (
   source TEXT DEFAULT 'local',
   gateway_agent_id TEXT,
   session_key_prefix TEXT,
+  is_active INTEGER DEFAULT 1,
   total_cost_usd REAL DEFAULT 0,
   total_tokens_used INTEGER DEFAULT 0,
   created_at TEXT DEFAULT (datetime('now')),
@@ -309,10 +310,13 @@ CREATE TABLE IF NOT EXISTS work_checkpoints (
   created_at TEXT DEFAULT (datetime('now'))
 );
 
--- Agent mailbox: inter-agent communication within a convoy
+-- Agent mailbox: inter-agent communication. Optionally scoped to a convoy
+-- or a task. Both scope columns may be NULL for ad-hoc mail (e.g. roll-call,
+-- help-requests to the master orchestrator).
 CREATE TABLE IF NOT EXISTS agent_mailbox (
   id TEXT PRIMARY KEY,
-  convoy_id TEXT NOT NULL REFERENCES convoys(id) ON DELETE CASCADE,
+  convoy_id TEXT REFERENCES convoys(id) ON DELETE CASCADE,
+  task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
   from_agent_id TEXT NOT NULL REFERENCES agents(id),
   to_agent_id TEXT NOT NULL REFERENCES agents(id),
   subject TEXT,
@@ -320,6 +324,36 @@ CREATE TABLE IF NOT EXISTS agent_mailbox (
   read_at TEXT,
   created_at TEXT DEFAULT (datetime('now'))
 );
+CREATE INDEX IF NOT EXISTS idx_agent_mailbox_to ON agent_mailbox(to_agent_id, read_at);
+CREATE INDEX IF NOT EXISTS idx_agent_mailbox_convoy ON agent_mailbox(convoy_id) WHERE convoy_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_agent_mailbox_task ON agent_mailbox(task_id) WHERE task_id IS NOT NULL;
+
+-- Roll-call sessions: a master orchestrator asks each active agent to
+-- check in; we track delivery and reply independently so the UI can
+-- surface two distinct failure modes (couldn't deliver vs. agent silent).
+CREATE TABLE IF NOT EXISTS rollcall_sessions (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+  initiator_agent_id TEXT NOT NULL REFERENCES agents(id),
+  mode TEXT NOT NULL CHECK (mode IN ('direct', 'coordinator')),
+  timeout_seconds INTEGER NOT NULL DEFAULT 30,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS rollcall_entries (
+  id TEXT PRIMARY KEY,
+  rollcall_id TEXT NOT NULL REFERENCES rollcall_sessions(id) ON DELETE CASCADE,
+  target_agent_id TEXT NOT NULL REFERENCES agents(id),
+  delivery_status TEXT NOT NULL DEFAULT 'pending' CHECK (delivery_status IN ('pending', 'sent', 'failed', 'skipped')),
+  delivery_error TEXT,
+  delivered_at TEXT,
+  reply_mail_id TEXT REFERENCES agent_mailbox(id) ON DELETE SET NULL,
+  reply_body TEXT,
+  replied_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_rollcall_entries_session ON rollcall_entries(rollcall_id);
+CREATE INDEX IF NOT EXISTS idx_rollcall_entries_target ON rollcall_entries(target_agent_id, replied_at);
 
 -- Products table (Product Autopilot)
 CREATE TABLE IF NOT EXISTS products (

--- a/src/lib/learner.ts
+++ b/src/lib/learner.ts
@@ -8,6 +8,7 @@
 import { queryOne, queryAll, run } from '@/lib/db';
 import { getMissionControlUrl } from '@/lib/config';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
 import type { KnowledgeEntry, TaskRole, OpenClawSession } from '@/lib/types';
 
 /**
@@ -98,7 +99,16 @@ Focus on:
     }
 
     if (session) {
-      const prefix = learnerRole.session_key_prefix || 'agent:main:';
+      // learnerRole has name/session_key_prefix but not gateway_agent_id;
+      // fetch the full agent row so the prefix resolver can choose the
+      // gateway namespace when appropriate instead of the old main catchall.
+      const learnerAgent = queryOne<import('@/lib/types').Agent>(
+        'SELECT * FROM agents WHERE id = ?',
+        [learnerRole.agent_id]
+      );
+      const prefix = learnerAgent
+        ? resolveAgentSessionKeyPrefix(learnerAgent)
+        : `agent:${learnerRole.agent_id}:`;
       const sessionKey = `${prefix}${session.openclaw_session_id}`;
       await client.call('chat.send', {
         sessionKey,

--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -1,40 +1,134 @@
 import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
-import type { AgentMailMessage } from '@/lib/types';
+import type { Agent, AgentMailMessage, OpenClawSession } from '@/lib/types';
 
 interface SendMailInput {
-  convoyId: string;
+  /** Optional convoy scope (original convoy mail flow). */
+  convoyId?: string | null;
+  /** Optional task scope — mail is associated with this task for context injection. */
+  taskId?: string | null;
   fromAgentId: string;
   toAgentId: string;
   subject?: string;
   body: string;
+  /**
+   * If true, also push-deliver the mail via chat.send to the target's
+   * active OpenClaw session so the target sees it immediately (rather
+   * than on their next dispatch via formatMailForDispatch). Used for
+   * roll-call and urgent help-requests.
+   */
+  push?: boolean;
+}
+
+export interface SendMailResult {
+  message: AgentMailMessage;
+  /** Only set when push=true. */
+  delivery?: {
+    status: 'sent' | 'failed' | 'skipped';
+    error?: string;
+    sessionKey?: string;
+  };
 }
 
 /**
- * Send a message from one agent to another within a convoy.
+ * Send mail from one agent to another. Scope is optional — both convoy_id
+ * and task_id may be null for ad-hoc mail (roll-call, general questions
+ * to the master orchestrator, etc.). When `push=true`, the mail is also
+ * delivered immediately via the target's active session so the target
+ * doesn't have to wait for a dispatch to receive it.
  */
-export function sendMail(input: SendMailInput): AgentMailMessage {
-  const { convoyId, fromAgentId, toAgentId, subject, body } = input;
+export async function sendMail(input: SendMailInput): Promise<SendMailResult> {
+  const { convoyId, taskId, fromAgentId, toAgentId, subject, body, push } = input;
 
-  // Verify convoy exists
-  const convoy = queryOne<{ id: string }>('SELECT id FROM convoys WHERE id = ?', [convoyId]);
-  if (!convoy) throw new Error(`Convoy ${convoyId} not found`);
+  // If a convoy is specified, verify it exists — matches the old strict
+  // behavior for the existing convoy mail API. Non-convoy mail skips this
+  // check, which is what makes the roll-call/help-request paths work.
+  if (convoyId) {
+    const convoy = queryOne<{ id: string }>('SELECT id FROM convoys WHERE id = ?', [convoyId]);
+    if (!convoy) throw new Error(`Convoy ${convoyId} not found`);
+  }
 
   const id = uuidv4();
   const now = new Date().toISOString();
 
   run(
-    `INSERT INTO agent_mailbox (id, convoy_id, from_agent_id, to_agent_id, subject, body, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    [id, convoyId, fromAgentId, toAgentId, subject || null, body, now]
+    `INSERT INTO agent_mailbox (id, convoy_id, task_id, from_agent_id, to_agent_id, subject, body, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, convoyId ?? null, taskId ?? null, fromAgentId, toAgentId, subject || null, body, now]
   );
 
   const message = queryOne<AgentMailMessage>('SELECT * FROM agent_mailbox WHERE id = ?', [id])!;
 
   broadcast({ type: 'mail_received', payload: message });
 
-  return message;
+  if (!push) return { message };
+
+  // Push delivery. We frame the mail body so the receiving agent can
+  // distinguish mail from a regular task dispatch, and include the
+  // message_id so the operator can trace the mail row through the debug
+  // feed. If delivery fails, the DB row is still there — a later
+  // dispatch will pick it up via formatMailForDispatch. We surface the
+  // failure in the return value so roll-call can record it accurately.
+  try {
+    // Lazy-import to avoid pulling the openclaw client into non-push callers.
+    const { getOpenClawClient } = await import('@/lib/openclaw/client');
+    const client = getOpenClawClient();
+    if (!client.isConnected()) {
+      await client.connect();
+    }
+
+    // Build a sessionKey that targets the agent's own namespace. The prefix
+    // resolver prefers an explicit `session_key_prefix`, then the gateway
+    // agent id, then a name-slug fallback — anything but the old
+    // `agent:main:` catchall that misrouted to the gateway's main agent.
+    // We append a mail-scoped suffix so each mail occupies its own
+    // session bucket (the gateway creates it on receipt if needed — no
+    // pre-existing openclaw_sessions row required).
+    const { resolveAgentSessionKeyPrefix } = await import('@/lib/openclaw/session-key');
+    const target = queryOne<Pick<OpenClawSession, 'id'> & { name: string; session_key_prefix: string | null; gateway_agent_id: string | null }>(
+      'SELECT id, name, session_key_prefix, gateway_agent_id FROM agents WHERE id = ?',
+      [toAgentId]
+    );
+    if (!target) {
+      return {
+        message,
+        delivery: { status: 'skipped', error: `Target agent ${toAgentId} not found` },
+      };
+    }
+    const fromAgent = queryOne<{ name: string }>('SELECT name FROM agents WHERE id = ?', [fromAgentId]);
+    const prefix = resolveAgentSessionKeyPrefix({
+      session_key_prefix: target.session_key_prefix ?? undefined,
+      gateway_agent_id: target.gateway_agent_id ?? undefined,
+      name: target.name,
+    } as Agent);
+    const sessionKey = `${prefix}mc-mail-${id}`;
+
+    const framedMessage = `📬 **MAIL from ${fromAgent?.name || fromAgentId}** (mail_id=${id})
+${subject ? `**Subject:** ${subject}\n` : ''}
+${body}
+
+---
+This mail has also been stored in your mailbox. Reply by POSTing to:
+\`POST /api/agents/${fromAgentId}/mail\`
+Body: \`{"from_agent_id": "<your-id>", "subject": "re: ${subject || 'mail'}", "body": "<your reply>"}\``;
+
+    await client.call('chat.send', {
+      sessionKey,
+      message: framedMessage,
+      idempotencyKey: `mail-${id}`,
+    });
+
+    return {
+      message,
+      delivery: { status: 'sent', sessionKey },
+    };
+  } catch (err) {
+    return {
+      message,
+      delivery: { status: 'failed', error: (err as Error).message },
+    };
+  }
 }
 
 /**

--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -104,14 +104,16 @@ export async function sendMail(input: SendMailInput): Promise<SendMailResult> {
     } as Agent);
     const sessionKey = `${prefix}mc-mail-${id}`;
 
+    // Frame the mail so the agent recognises it as MC→agent mail (not a
+    // regular task dispatch). We deliberately don't append a generic
+    // "reply by POST" footer here — callers know the exact reply shape
+    // they want (roll-call needs a specific subject format; help-request
+    // flows may not need a reply at all), and appending a generic footer
+    // caused agents to guess URLs / methods / body shapes rather than
+    // follow the caller's explicit instructions.
     const framedMessage = `📬 **MAIL from ${fromAgent?.name || fromAgentId}** (mail_id=${id})
 ${subject ? `**Subject:** ${subject}\n` : ''}
-${body}
-
----
-This mail has also been stored in your mailbox. Reply by POSTing to:
-\`POST /api/agents/${fromAgentId}/mail\`
-Body: \`{"from_agent_id": "<your-id>", "subject": "re: ${subject || 'mail'}", "body": "<your reply>"}\``;
+${body}`;
 
     await client.call('chat.send', {
       sessionKey,

--- a/src/lib/master-orchestrator.ts
+++ b/src/lib/master-orchestrator.ts
@@ -1,0 +1,40 @@
+import { queryAll } from '@/lib/db';
+import type { Agent } from '@/lib/types';
+
+export type MasterOrchestratorResult =
+  | { ok: true; agent: Agent }
+  | { ok: false; reason: 'none' | 'multiple'; candidates: Agent[] };
+
+/**
+ * Resolve the single master orchestrator for a workspace.
+ *
+ * The roll-call feature (and any future feature that needs a workspace-wide
+ * "governing" agent) requires exactly one agent marked `is_master=1`. We
+ * return a tagged union so callers can raise the right alert:
+ *   - `none`: no master exists → operator must mark one via
+ *     `PATCH /api/agents/[id]` with { is_master: true }
+ *   - `multiple`: more than one → operator must pick by un-marking the others
+ *
+ * Non-active agents (`is_active = 0`) and offline agents are excluded from
+ * consideration — a disabled orchestrator doesn't count even if its
+ * `is_master` flag is still set in the DB.
+ */
+export function resolveMasterOrchestrator(workspaceId: string): MasterOrchestratorResult {
+  const candidates = queryAll<Agent>(
+    `SELECT * FROM agents
+       WHERE is_master = 1
+         AND workspace_id = ?
+         AND COALESCE(is_active, 1) = 1
+         AND COALESCE(status, 'standby') != 'offline'
+       ORDER BY updated_at DESC`,
+    [workspaceId]
+  );
+
+  if (candidates.length === 0) {
+    return { ok: false, reason: 'none', candidates: [] };
+  }
+  if (candidates.length > 1) {
+    return { ok: false, reason: 'multiple', candidates };
+  }
+  return { ok: true, agent: candidates[0] };
+}

--- a/src/lib/openclaw/session-key.ts
+++ b/src/lib/openclaw/session-key.ts
@@ -1,0 +1,33 @@
+import type { Agent } from '@/lib/types';
+
+/**
+ * Resolve the OpenClaw sessionKey prefix for a target agent.
+ *
+ * Priority:
+ *   1. `agent.session_key_prefix` if explicitly set (operator override).
+ *   2. `agent:<gateway_agent_id>:` — preferred for gateway-synced agents,
+ *      because the gateway treats `agent:<agentId>:<...>` as the agent's
+ *      own namespace (see OpenClaw session-routing docs).
+ *   3. `agent:<slugified_name>:` — last-resort fallback for local/manual
+ *      agents that have never been linked to a gateway agent.
+ *
+ * Previously the default was a hard-coded `agent:main:` which silently
+ * routed every MC→agent chat.send to the gateway's "main" agent
+ * regardless of which agent MC intended to reach. That masked test
+ * failures (e.g. roll-call's "no session" results) and misrouted real
+ * dispatches. Every call site that builds a sessionKey should use this
+ * helper so the change lands uniformly.
+ */
+export function resolveAgentSessionKeyPrefix(
+  agent: Pick<Agent, 'session_key_prefix' | 'gateway_agent_id' | 'name'>
+): string {
+  const explicit = agent.session_key_prefix?.trim();
+  if (explicit) {
+    return explicit.endsWith(':') ? explicit : `${explicit}:`;
+  }
+  if (agent.gateway_agent_id) {
+    return `agent:${agent.gateway_agent_id}:`;
+  }
+  const slug = agent.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return `agent:${slug || 'unknown'}:`;
+}

--- a/src/lib/rollcall.ts
+++ b/src/lib/rollcall.ts
@@ -3,6 +3,7 @@ import { queryAll, queryOne, run, transaction } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { sendMail } from '@/lib/mailbox';
 import { resolveMasterOrchestrator } from '@/lib/master-orchestrator';
+import { getMissionControlUrl } from '@/lib/config';
 import type { Agent } from '@/lib/types';
 
 export interface RollCallSession {
@@ -134,13 +135,51 @@ export async function initiateRollCall(params: {
   // — parallel fire would interleave RPC requests but gain little given
   // the typical target count (<10). Keeping it sequential also gives us
   // deterministic ordering in the debug feed.
-  const body =
-    'ROLL CALL — please reply briefly with your current status.\n\n' +
-    'Format: `CHECKED_IN: <your role>, status=<ok|busy|blocked>, note=<optional one-liner>`\n\n' +
-    `Reply by POSTing to /api/agents/${master.agent.id}/mail with subject="roll_call_reply".\n` +
-    `This roll-call times out in ${timeoutSeconds}s.`;
+  //
+  // Each target gets a personalized mail body that hard-codes:
+  //   - their own MC agent_id (they don't need to guess / introspect)
+  //   - the fully-qualified MC URL (no "localhost:3120?" probing)
+  //   - a bearer-token hint (the middleware rejects agent POSTs without
+  //     the MC_API_TOKEN in prod; dev without a token omits the header)
+  //   - a ready-to-paste curl command so there's one unambiguous shape
+  //     to mimic
+  // Prior versions of this prompt showed agents trying every port from
+  // 3000 upward, probing with PUT when POST was right, and filling
+  // `from_agent_id` with whatever random uuid they could scrape off
+  // their own session. Being explicit here eliminates all of that.
+  const missionControlUrl = getMissionControlUrl();
+  const token = process.env.MC_API_TOKEN;
+  const authHeaderLine = token
+    ? `  -H "Authorization: Bearer ${token}" \\\n`
+    : '';
+  const authNote = token
+    ? `The Authorization header above is required — Mission Control runs with MC_API_TOKEN set and rejects unauthenticated agent callbacks with 403.`
+    : `No Authorization header is required in this dev environment (MC_API_TOKEN is not set).`;
 
   for (const target of targets) {
+    const replyEndpoint = `${missionControlUrl}/api/agents/${master.agent.id}/mail`;
+    const body = `ROLL CALL — please reply briefly with your current status.
+
+**Your Mission Control agent_id:** \`${target.id}\`
+**Your role:** ${target.role}
+**Reply within:** ${timeoutSeconds}s
+
+**REPLY FORMAT** — copy and run this exact curl, substituting your short status note:
+
+\`\`\`bash
+curl -sS -X POST '${replyEndpoint}' \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{
+    "from_agent_id": "${target.id}",
+    "subject": "roll_call_reply:${rollcallId}",
+    "body": "CHECKED_IN: ${target.role}, status=ok, note=<your short note>"
+  }'
+\`\`\`
+
+${authNote}
+
+Keep the reply brief — a single \`CHECKED_IN:\` line is enough.`;
+
     let deliveryStatus: 'sent' | 'failed' | 'skipped' = 'failed';
     let deliveryError: string | null = null;
     try {

--- a/src/lib/rollcall.ts
+++ b/src/lib/rollcall.ts
@@ -149,6 +149,21 @@ export async function initiateRollCall(params: {
   // their own session. Being explicit here eliminates all of that.
   const missionControlUrl = getMissionControlUrl();
   const token = process.env.MC_API_TOKEN;
+
+  // Sanity check: roll-call replies must be reachable from whichever host
+  // the target agent is running on. If MISSION_CONTROL_URL points to
+  // localhost / 127.0.0.1 / ::1, agents on any other host will see
+  // "connection refused" when they try to reply. We don't block — the
+  // operator may legitimately be running a single-host dev setup — but
+  // log loudly so misconfiguration surfaces before the first 30s timeout.
+  if (/^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/.test(missionControlUrl)) {
+    console.warn(
+      `[RollCall] MISSION_CONTROL_URL is set to ${missionControlUrl}. ` +
+      `If any target agent runs on a different host it will not be able ` +
+      `to reach this URL to reply. Set MISSION_CONTROL_URL to an address ` +
+      `reachable from the agent host (e.g. your LAN IP) and restart MC.`
+    );
+  }
   const authHeaderLine = token
     ? `  -H "Authorization: Bearer ${token}" \\\n`
     : '';

--- a/src/lib/rollcall.ts
+++ b/src/lib/rollcall.ts
@@ -1,0 +1,267 @@
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run, transaction } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import { sendMail } from '@/lib/mailbox';
+import { resolveMasterOrchestrator } from '@/lib/master-orchestrator';
+import type { Agent } from '@/lib/types';
+
+export interface RollCallSession {
+  id: string;
+  workspace_id: string;
+  initiator_agent_id: string;
+  mode: 'direct' | 'coordinator';
+  timeout_seconds: number;
+  created_at: string;
+  expires_at: string;
+}
+
+export interface RollCallEntry {
+  id: string;
+  rollcall_id: string;
+  target_agent_id: string;
+  delivery_status: 'pending' | 'sent' | 'failed' | 'skipped';
+  delivery_error: string | null;
+  delivered_at: string | null;
+  reply_mail_id: string | null;
+  reply_body: string | null;
+  replied_at: string | null;
+  created_at: string;
+  // Joined on read
+  target_agent_name?: string;
+  target_agent_role?: string;
+}
+
+export type InitiateRollCallResult =
+  | {
+      ok: true;
+      rollcall: RollCallSession;
+      entries: RollCallEntry[];
+    }
+  | {
+      ok: false;
+      reason: 'no_master' | 'multiple_masters' | 'no_active_agents';
+      detail: string;
+      candidates?: Agent[];
+    };
+
+/**
+ * Start a roll-call: ask every active agent in the workspace (except the
+ * initiator) to check in. Delivery happens via mail push (chat.send to
+ * the target's active session). Replies are captured when agents POST
+ * back to `/api/agents/<initiator>/mail`.
+ *
+ * Modes:
+ *   - 'direct'      : MC push-delivers the mail itself from the master
+ *                     orchestrator to each target.
+ *   - 'coordinator' : MC dispatches a task to the master orchestrator
+ *                     and the master uses sessions_send / mail to
+ *                     fan-out. Currently both modes use the same direct
+ *                     push path underneath — coordinator mode just also
+ *                     creates the orchestrator-visible task so the master
+ *                     can follow up.
+ */
+export async function initiateRollCall(params: {
+  workspaceId: string;
+  mode: 'direct' | 'coordinator';
+  timeoutSeconds?: number;
+}): Promise<InitiateRollCallResult> {
+  const { workspaceId, mode, timeoutSeconds = 30 } = params;
+
+  // Resolve the master orchestrator (exactly one, else error).
+  const master = resolveMasterOrchestrator(workspaceId);
+  if (!master.ok) {
+    return {
+      ok: false,
+      reason: master.reason === 'none' ? 'no_master' : 'multiple_masters',
+      detail:
+        master.reason === 'none'
+          ? `No master orchestrator found in workspace "${workspaceId}". Mark one agent with is_master=1 via PATCH /api/agents/[id].`
+          : `${master.candidates.length} agents are marked as master orchestrators in workspace "${workspaceId}": ${master.candidates
+              .map(a => a.name)
+              .join(', ')}. Exactly one is required — un-mark the others via PATCH.`,
+      candidates: master.reason === 'multiple' ? master.candidates : undefined,
+    };
+  }
+
+  // Active agents in the workspace, excluding the master itself.
+  const targets = queryAll<Agent>(
+    `SELECT * FROM agents
+       WHERE workspace_id = ?
+         AND id != ?
+         AND COALESCE(is_active, 1) = 1
+         AND COALESCE(status, 'standby') != 'offline'
+       ORDER BY role ASC, name ASC`,
+    [workspaceId, master.agent.id]
+  );
+
+  if (targets.length === 0) {
+    return {
+      ok: false,
+      reason: 'no_active_agents',
+      detail: `No other active agents in workspace "${workspaceId}". Mark at least one agent as is_active=1.`,
+    };
+  }
+
+  const rollcallId = uuidv4();
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const expiresAt = new Date(now.getTime() + timeoutSeconds * 1000).toISOString();
+
+  // Insert session + entries in one transaction so the UI can subscribe
+  // to a single rollcall_id and pick up a complete roster on first read.
+  transaction(() => {
+    run(
+      `INSERT INTO rollcall_sessions (id, workspace_id, initiator_agent_id, mode, timeout_seconds, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [rollcallId, workspaceId, master.agent.id, mode, timeoutSeconds, nowIso, expiresAt]
+    );
+    for (const t of targets) {
+      run(
+        `INSERT INTO rollcall_entries (id, rollcall_id, target_agent_id, created_at)
+         VALUES (?, ?, ?, ?)`,
+        [uuidv4(), rollcallId, t.id, nowIso]
+      );
+    }
+  });
+
+  broadcast({
+    type: 'rollcall_started',
+    payload: { rollcall_id: rollcallId, workspace_id: workspaceId, mode, target_count: targets.length },
+  });
+
+  // Deliver mail to each target. We do this sequentially (not in parallel)
+  // because our OpenClawClient singleton serializes via a single WebSocket
+  // — parallel fire would interleave RPC requests but gain little given
+  // the typical target count (<10). Keeping it sequential also gives us
+  // deterministic ordering in the debug feed.
+  const body =
+    'ROLL CALL — please reply briefly with your current status.\n\n' +
+    'Format: `CHECKED_IN: <your role>, status=<ok|busy|blocked>, note=<optional one-liner>`\n\n' +
+    `Reply by POSTing to /api/agents/${master.agent.id}/mail with subject="roll_call_reply".\n` +
+    `This roll-call times out in ${timeoutSeconds}s.`;
+
+  for (const target of targets) {
+    let deliveryStatus: 'sent' | 'failed' | 'skipped' = 'failed';
+    let deliveryError: string | null = null;
+    try {
+      const result = await sendMail({
+        fromAgentId: master.agent.id,
+        toAgentId: target.id,
+        subject: `roll_call:${rollcallId}`,
+        body,
+        push: true,
+      });
+      deliveryStatus = result.delivery?.status ?? 'failed';
+      deliveryError = result.delivery?.error ?? null;
+    } catch (err) {
+      deliveryStatus = 'failed';
+      deliveryError = (err as Error).message;
+    }
+
+    run(
+      `UPDATE rollcall_entries
+         SET delivery_status = ?, delivery_error = ?, delivered_at = ?
+       WHERE rollcall_id = ? AND target_agent_id = ?`,
+      [deliveryStatus, deliveryError, new Date().toISOString(), rollcallId, target.id]
+    );
+  }
+
+  // Return the assembled roster. The caller will poll GET for updates as
+  // replies come in — or subscribe to the `rollcall_entry_updated` SSE
+  // event stream we'll emit when replies land.
+  const rollcall = queryOne<RollCallSession>('SELECT * FROM rollcall_sessions WHERE id = ?', [rollcallId])!;
+  const entries = queryAll<RollCallEntry>(
+    `SELECT e.*, a.name as target_agent_name, a.role as target_agent_role
+       FROM rollcall_entries e
+       JOIN agents a ON a.id = e.target_agent_id
+       WHERE e.rollcall_id = ?
+       ORDER BY a.role ASC, a.name ASC`,
+    [rollcallId]
+  );
+
+  broadcast({
+    type: 'rollcall_delivered',
+    payload: { rollcall_id: rollcallId, entries },
+  });
+
+  return { ok: true, rollcall, entries };
+}
+
+/**
+ * Fetch current status of a roll-call, including any replies that have
+ * arrived since delivery.
+ */
+export function getRollCallStatus(rollcallId: string): {
+  rollcall: RollCallSession;
+  entries: RollCallEntry[];
+} | null {
+  const rollcall = queryOne<RollCallSession>(
+    'SELECT * FROM rollcall_sessions WHERE id = ?',
+    [rollcallId]
+  );
+  if (!rollcall) return null;
+
+  const entries = queryAll<RollCallEntry>(
+    `SELECT e.*, a.name as target_agent_name, a.role as target_agent_role
+       FROM rollcall_entries e
+       JOIN agents a ON a.id = e.target_agent_id
+       WHERE e.rollcall_id = ?
+       ORDER BY a.role ASC, a.name ASC`,
+    [rollcallId]
+  );
+
+  return { rollcall, entries };
+}
+
+/**
+ * Try to record a mail message as the reply to an open roll-call entry.
+ * Called from the mail POST handler when `subject` starts with
+ * "roll_call_reply" or "roll_call:<id>" — matches by (rollcall_id,
+ * from_agent_id). No-op if no matching entry is found (e.g. late reply
+ * after expiry or stray mail).
+ */
+export function recordRollCallReplyIfMatch(params: {
+  mailId: string;
+  fromAgentId: string;
+  toAgentId: string;
+  subject: string | null | undefined;
+  body: string;
+}): { matched: boolean; rollcallId?: string } {
+  const { mailId, fromAgentId, toAgentId, subject, body } = params;
+  if (!subject) return { matched: false };
+
+  // Accept either "roll_call_reply:<uuid>" or "roll_call:<uuid>"
+  const match = subject.match(/^roll_call(?:_reply)?:([\w-]+)/i);
+  const rollcallId = match?.[1];
+  if (!rollcallId) return { matched: false };
+
+  const rollcall = queryOne<RollCallSession>(
+    'SELECT * FROM rollcall_sessions WHERE id = ? AND initiator_agent_id = ?',
+    [rollcallId, toAgentId]
+  );
+  if (!rollcall) return { matched: false };
+
+  const entry = queryOne<{ id: string; replied_at: string | null }>(
+    'SELECT id, replied_at FROM rollcall_entries WHERE rollcall_id = ? AND target_agent_id = ?',
+    [rollcallId, fromAgentId]
+  );
+  if (!entry || entry.replied_at) return { matched: false };
+
+  run(
+    `UPDATE rollcall_entries
+       SET reply_mail_id = ?, reply_body = ?, replied_at = ?
+     WHERE id = ?`,
+    [mailId, body, new Date().toISOString(), entry.id]
+  );
+
+  broadcast({
+    type: 'rollcall_entry_updated',
+    payload: {
+      rollcall_id: rollcallId,
+      target_agent_id: fromAgentId,
+      reply_received: true,
+    },
+  });
+
+  return { matched: true, rollcallId };
+}

--- a/src/lib/stall-detection.ts
+++ b/src/lib/stall-detection.ts
@@ -269,7 +269,7 @@ async function notifyForStall(
   // the FK check doesn't fail when the stalled task never had an assignee.
   const fromAgentId = task.assigned_agent_id || convoy.coordinatorAgentId;
   try {
-    sendMail({
+    await sendMail({
       convoyId: convoy.convoyId,
       fromAgentId,
       toAgentId: convoy.coordinatorAgentId,

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -126,13 +126,16 @@ export function pickDynamicAgent(taskId: string, stageRole?: string | null): { i
     } catch {}
   }
 
+  // All role/fallback lookups filter on is_active=1 (COALESCE for rows
+  // created before the column existed — default to active). An operator-
+  // marked inactive agent is excluded from every routing decision.
   const checked = new Set<string>();
   for (const candidateId of plannerCandidates) {
-    const candidate = queryOne<{ id: string; name: string; is_master: number; status: string }>(
-      'SELECT id, name, is_master, status FROM agents WHERE id = ? LIMIT 1',
+    const candidate = queryOne<{ id: string; name: string; is_master: number; status: string; is_active: number }>(
+      'SELECT id, name, is_master, status, is_active FROM agents WHERE id = ? LIMIT 1',
       [candidateId]
     );
-    if (!candidate || candidate.status === 'offline') continue;
+    if (!candidate || candidate.status === 'offline' || Number(candidate.is_active ?? 1) !== 1) continue;
     checked.add(candidate.id);
     return { id: candidate.id, name: candidate.name };
   }
@@ -143,7 +146,7 @@ export function pickDynamicAgent(taskId: string, stageRole?: string | null): { i
     // via OpenClaw, so picking one silently breaks the dispatch.
     const byRole = queryOne<{ id: string; name: string }>(
       `SELECT id, name FROM agents
-       WHERE role = ? AND status != 'offline'
+       WHERE role = ? AND status != 'offline' AND COALESCE(is_active, 1) = 1
        ORDER BY
          (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL) DESC,
          status = 'standby' DESC,
@@ -156,7 +159,7 @@ export function pickDynamicAgent(taskId: string, stageRole?: string | null): { i
 
   const fallback = queryOne<{ id: string; name: string }>(
     `SELECT id, name FROM agents
-     WHERE status != 'offline'
+     WHERE status != 'offline' AND COALESCE(is_active, 1) = 1
      ORDER BY
        (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL) DESC,
        is_master ASC,

--- a/src/lib/task-notes.ts
+++ b/src/lib/task-notes.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
 import type { TaskNote, OpenClawSession, Agent } from '@/lib/types';
 
 /**
@@ -98,7 +99,7 @@ export async function deliverPendingNotesAtCheckpoint(taskId: string): Promise<n
 
     // Get the agent's session key prefix
     const agent = queryOne<Agent>('SELECT * FROM agents WHERE id = ?', [activeSession.agent_id]);
-    const prefix = agent?.session_key_prefix || 'agent:main:';
+    const prefix = agent ? resolveAgentSessionKeyPrefix(agent) : 'agent:main:';
     const sessionKey = `${prefix}${activeSession.openclaw_session_id}`;
 
     // Build the message

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,7 @@ export interface Agent {
   source: AgentSource;
   gateway_agent_id?: string;
   session_key_prefix?: string;
+  is_active?: number;
   total_cost_usd?: number;
   total_tokens_used?: number;
   created_at: string;
@@ -329,6 +330,7 @@ export interface CreateAgentRequest {
 
 export interface UpdateAgentRequest extends Partial<CreateAgentRequest> {
   status?: AgentStatus;
+  is_active?: boolean;
 }
 
 export interface CreateTaskRequest {
@@ -856,7 +858,10 @@ export type SSEEventType =
   | 'debug_collection_toggled'
   | 'debug_events_cleared'
   | 'agents_cleared'
-  | 'tasks_cleared';
+  | 'tasks_cleared'
+  | 'rollcall_started'
+  | 'rollcall_delivered'
+  | 'rollcall_entry_updated';
 
 export interface SSEEvent {
   type: SSEEventType;


### PR DESCRIPTION
## Summary
Three related changes that together move MC fully onto the persistent-agent routing model and add operator controls for it:

1. **Agent active/inactive toggle** — operator-controlled `is_active` flag, filtered by every routing decision.
2. **Roll-call** — master orchestrator can ping every active agent for a live check-in via the generalized mailbox.
3. **sessionKey routing fix** — replaces the hard-coded `agent:main:` default that silently misrouted every MC→agent chat.send to the gateway's ""main"" agent.

## What changed

### Agent toggle
- New `agents.is_active` column (default 1), filtered by `pickDynamicAgent`, `getAgentByPreferredRoles`, coordinator delegation roster, and roll-call target list.
- `PATCH /api/agents/[id]` accepts `is_active`.
- Per-row Power toggle in AgentsSidebar with optimistic update + ""paused"" badge.

### Roll-call
- `POST /api/agents/rollcall` — master orchestrator sends push-delivered mail to every other active agent. Returns delivery status + rollcall_id.
- `GET /api/agents/rollcall/[id]` — polled by the UI to show live per-agent reply status.
- `resolveMasterOrchestrator` returns structured `none` / `multiple` errors with candidate lists so the UI can surface actionable alerts.
- Reply matching: mail POSTed back with subject `roll_call:<id>` auto-flips the entry from ""waiting"" to ""responded"".
- AgentsSidebar: kebab menu (top-right) replaces the bottom button block — Roll Call / Add Agent / Import from Gateway all live there. Sidebar widened to `w-80` so names stop truncating.

### sessionKey correctness
- New `resolveAgentSessionKeyPrefix(agent)` helper: explicit prefix → `agent:<gateway_agent_id>:` → `agent:<name-slug>:`
- Replaces `agent:main:` defaults in **dispatch, mailbox, task-notes, learner, convoy decomposition, planning, planning-poll, planning-force-complete**. Previously every MC→agent message was silently routed to the gateway's ""main"" agent regardless of target.
- Dynamic-agent-creation paths now store `null` for `session_key_prefix` so the runtime resolver picks per-agent prefixes at send time.
- AgentModal placeholder + help text updated to reflect the new defaulting.

### Generalized mailbox
- `agent_mailbox.convoy_id` relaxed to nullable; new `task_id` column.
- `sendMail` gains optional `taskId` and `push` flag. push=true delivers via chat.send; otherwise pull-delivered on next dispatch (existing behavior).
- New `POST /api/agents/[id]/mail` for general inter-agent mail outside convoys — also the mechanism for agents to send help-requests to the master orchestrator.

### Header stats + tooltips
- `Agents Active` no longer double-counts sub-agent sessions (children of existing agents under the new model).
- Hover tooltips: list of working agents (name + role) on the Active card; per-stage task breakdown on the Queue card.

### Schema (migration 032)
- `agents.is_active INTEGER DEFAULT 1`
- `agent_mailbox.convoy_id` → nullable, add `task_id`
- `rollcall_sessions` + `rollcall_entries` tables

## Verification
- `tsc --noEmit` clean
- Roll-call happy path: 6/6 agents `delivery=sent`, sub-10ms RPCs (before this PR: 0/6 ""no session"")
- Alert paths return 409 with structured detail: `no_master` / `multiple_masters` + candidate list
- is_active filter excludes paused agents from `pickDynamicAgent` and the roll-call roster (verified with Builder paused)
- Ghost subagent rows no longer auto-created (`ALLOW_DYNAMIC_AGENTS=false`, verified)

## Test plan
- [x] Migration 032 applies cleanly on an existing DB (auto-backup created in db-backups/)
- [x] Run diagnostic / roll-call from the sidebar — 6 non-master agents reached
- [x] Pause an agent via the Power icon → immediately excluded from next roll-call
- [x] Toggle `is_master` off all agents → roll-call returns 409 `no_master`
- [x] Set two agents `is_master=1` → roll-call returns 409 `multiple_masters` with both names
- [ ] Browser smoke test of the new sidebar layout / tooltips / kebab menu (recommend reviewer verify UI visually)

## Notes for follow-up
- Agents that have an **explicit** `session_key_prefix='agent:main:'` still use it. The resolver only switches to the new default when the column is null. Run `UPDATE agents SET session_key_prefix=NULL WHERE session_key_prefix='agent:main:'` if you want existing agents to cut over to the correct per-agent namespace.
- Whether agents actually *reply* to roll-call is now a function of their OpenClaw-side system prompt. MC sends to the right address; agent-side config determines response behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)