### PR TITLE
fix: dispatch auth + Reset all sessions button

### DIFF
--- a/src/app/api/openclaw/sessions/route.ts
+++ b/src/app/api/openclaw/sessions/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getOpenClawClient } from '@/lib/openclaw/client';
-import { queryAll } from '@/lib/db';
-import type { OpenClawSession } from '@/lib/types';
+import { queryAll, queryOne, run, transaction } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import { logDebugEvent } from '@/lib/debug-log';
+import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
+import type { Agent, OpenClawSession } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 // GET /api/openclaw/sessions - List OpenClaw sessions
@@ -89,6 +92,133 @@ export async function POST(request: Request) {
     console.error('Failed to create OpenClaw session:', error);
     return NextResponse.json(
       { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE /api/openclaw/sessions - Reset all sessions, both MC-side and gateway-side.
+// Used by the sidebar's "Reset all sessions" action so the operator can
+// clear stale/zombie sessions in one click — typically after persona-file
+// edits (SOUL.md / AGENTS.md / MESSAGING-PROTOCOL.md) that need agents to
+// reload, or when sessionKey routing has drifted.
+//
+// Two phases:
+//   1. Wipe MC's `openclaw_sessions` table + clean up legacy Sub-Agent rows.
+//   2. Send `/reset` via chat.send to each gateway-synced agent's main
+//      session, which forces the gateway to re-init that session — the
+//      agent's next message reloads SOUL.md/AGENTS.md/etc. `/reset` and
+//      `/new` are OpenClaw's built-in session-init commands.
+//
+// Either phase can fail independently; the response reports both so the
+// operator can see what landed. `agents_reset` entries with `ok: false`
+// usually mean the gateway didn't route the command (agent offline,
+// allow-list restriction, etc.) — operator can fall back to `/reset` in
+// that agent's chat manually.
+export async function DELETE() {
+  try {
+    const sessions = queryAll<OpenClawSession>('SELECT * FROM openclaw_sessions');
+    const count = sessions.length;
+
+    transaction(() => {
+      // Same cleanup as the per-session DELETE in [id]/route.ts: remove
+      // any auto-created Sub-Agent rows whose session is being dropped.
+      // With ALLOW_DYNAMIC_AGENTS=false this is a no-op, but we keep the
+      // cleanup so resets stay safe in legacy workspaces where ghost
+      // Sub-Agent rows may still exist.
+      for (const s of sessions) {
+        if (s.agent_id) {
+          const agent = queryOne<{ id: string; role: string }>(
+            'SELECT id, role FROM agents WHERE id = ?',
+            [s.agent_id]
+          );
+          if (agent?.role === 'Sub-Agent') {
+            run('DELETE FROM agents WHERE id = ?', [agent.id]);
+          } else if (agent) {
+            run('UPDATE agents SET status = ? WHERE id = ?', ['standby', agent.id]);
+          }
+        }
+      }
+      run('DELETE FROM openclaw_sessions');
+    });
+
+    for (const s of sessions) {
+      logDebugEvent({
+        type: 'session.end',
+        direction: 'internal',
+        agentId: s.agent_id,
+        taskId: s.task_id,
+        sessionKey: s.openclaw_session_id,
+        metadata: { reason: 'bulk_reset' },
+      });
+    }
+
+    // Phase 2: tell each gateway-synced agent to re-init its session so
+    // SOUL.md / AGENTS.md / MESSAGING-PROTOCOL.md get re-injected on the
+    // next turn. Done sequentially because the OpenClawClient serializes
+    // on a single WebSocket — parallel would interleave but gain little
+    // at the typical roster size.
+    const gatewayAgents = queryAll<Agent>(
+      `SELECT * FROM agents
+         WHERE gateway_agent_id IS NOT NULL
+           AND COALESCE(is_active, 1) = 1
+           AND COALESCE(status, 'standby') != 'offline'`
+    );
+
+    const agentsReset: Array<{ agent_id: string; name: string; sessionKey: string; ok: boolean; error?: string }> = [];
+
+    if (gatewayAgents.length > 0) {
+      const client = getOpenClawClient();
+      try {
+        if (!client.isConnected()) await client.connect();
+      } catch (err) {
+        // If we can't even connect, return what we have and let the
+        // operator fall back to `/reset` in the chat. MC-side phase 1
+        // already succeeded.
+        return NextResponse.json({
+          success: true,
+          deleted: count,
+          agents_reset: [],
+          gateway_error: (err as Error).message,
+        });
+      }
+
+      for (const agent of gatewayAgents) {
+        const prefix = resolveAgentSessionKeyPrefix(agent);
+        const sessionKey = `${prefix}main`;
+        try {
+          await client.call('chat.send', {
+            sessionKey,
+            message: '/reset',
+            idempotencyKey: `reset-${agent.id}-${Date.now()}`,
+          });
+          agentsReset.push({ agent_id: agent.id, name: agent.name, sessionKey, ok: true });
+        } catch (err) {
+          agentsReset.push({
+            agent_id: agent.id,
+            name: agent.name,
+            sessionKey,
+            ok: false,
+            error: (err as Error).message,
+          });
+        }
+      }
+    }
+
+    broadcast({
+      type: 'agent_completed',
+      payload: { reset: true, count, agents_reset: agentsReset.length, deleted: true },
+    });
+
+    return NextResponse.json({
+      success: true,
+      deleted: count,
+      agents_reset: agentsReset,
+    });
+  } catch (error) {
+    console.error('Failed to reset OpenClaw sessions:', error);
+    return NextResponse.json(
+      { error: `Failed to reset sessions: ${(error as Error).message}` },
       { status: 500 }
     );
   }

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -359,6 +359,17 @@ their persona, memory, and channel bindings.
       }
     }
 
+    // Every /api/tasks/* and /api/agents/* callback requires the MC bearer
+    // token when MC_API_TOKEN is set — which is always in practice, since
+    // unauthenticated dev mode is only for local experiments. Every
+    // completion-instruction branch embeds this header line so agents
+    // paste a ready-to-use curl rather than being told to POST to a URL
+    // and silently 401-ing.
+    const mcAuthToken = process.env.MC_API_TOKEN || '';
+    const authHeaderLine = mcAuthToken
+      ? `  -H "Authorization: Bearer ${mcAuthToken}" \\\n`
+      : '';
+
     let completionInstructions: string;
     if (isCoordinator) {
       completionInstructions = `**YOUR ROLE: COORDINATOR** — Break this task down and delegate to the persistent agents above. Track their progress and roll the results up to Mission Control.
@@ -369,25 +380,53 @@ their persona, memory, and channel bindings.
   - \`message\`: include the task id (\`${task.id}\`), the specific slice of work you want them to do, and any context they need. Prefix each message with \"You are the <role> for this task\" so they receive the role framing they would get from Mission Control directly.
   - \`timeoutSeconds\`: use \`0\` (fire-and-forget) for parallel work; use a positive value only when you need a synchronous reply.
 - **DO NOT use \`sessions_spawn\`** for this workflow. Spawned subagents inherit a stripped context (no SOUL.md/IDENTITY.md) and won't know the role they're meant to play. We want the pinned persona of the persistent agents.
-- If \`sessions_send\` is rejected with a permissions/allow-list error, surface that by calling \`${failEndpoint}\` with the error details — it means the OpenClaw allow-list needs to be updated for this coordinator.
+- If \`sessions_send\` is rejected with a permissions/allow-list error (e.g. *"Session send visibility is restricted"*), the OpenClaw allow-list on this coordinator needs \`tools.sessions.visibility: "all"\` — or an explicit list of peer agent ids. Surface the blocker via:
+  \`\`\`bash
+  curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/fail" \\
+    -H "Content-Type: application/json" \\
+${authHeaderLine}    -d '{"reason":"sessions_send blocked by allow-list: <error text>"}'
+  \`\`\`
 
-**TRACKING & REPORTING:**
-1. Log activity whenever you delegate or receive results: POST ${missionControlUrl}/api/tasks/${task.id}/activities
-   Body: {"activity_type": "updated", "message": "Delegated <slice> to <agent name>"}
-2. Register any deliverables the agents produce: POST ${missionControlUrl}/api/tasks/${task.id}/deliverables
-3. When the whole task is complete, update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}
+**TRACKING & REPORTING** (all calls require the Authorization header):
+
+\`\`\`bash
+# Log each delegation / receipt
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"activity_type":"updated","message":"Delegated <slice> to <agent name>"}'
+
+# Register aggregated deliverable (after all peers report in)
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/deliverables" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"deliverable_type":"file","title":"<title>","path":"${taskProjectDir}/<filename>"}'
+
+# Close the task
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\`
 
 When complete, reply with:
 \`TASK_COMPLETE: [summary of what was delegated, to whom, and the aggregate outcome]\``;
     } else if (isBuilder) {
-      completionInstructions = `**IMPORTANT:** After completing work, you MUST call these APIs:
-1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
-   Body: {"activity_type": "completed", "message": "Description of what was done"}
-2. Register deliverable: POST ${missionControlUrl}/api/tasks/${task.id}/deliverables
-   Body: {"deliverable_type": "file", "title": "File name", "path": "${taskProjectDir}/filename.html"}
-3. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}
+      completionInstructions = `**IMPORTANT:** After completing work, you MUST make these three calls in order — all require the Authorization header:
+
+\`\`\`bash
+# 1. Register deliverable
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/deliverables" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"deliverable_type":"file","title":"<file name>","path":"${taskProjectDir}/<filename>"}'
+
+# 2. Log activity (must have both a deliverable AND an activity before step 3 will pass the evidence gate)
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"activity_type":"completed","message":"<what you built in one line>"}'
+
+# 3. Transition status
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\`
 
 When complete, reply with:
 \`TASK_COMPLETE: [brief summary of what you did]\``;
@@ -396,15 +435,25 @@ When complete, reply with:
 
 Review the output directory for deliverables and run any applicable tests.
 
-**If tests PASS:**
-1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
-   Body: {"activity_type": "completed", "message": "Tests passed: [summary]"}
-2. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}
+**If tests PASS** — all calls require the Authorization header:
+
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"activity_type":"completed","message":"Tests passed: <summary>"}'
+
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\`
 
 **If tests FAIL:**
-1. ${failEndpoint}
-   Body: {"reason": "Detailed description of what failed and what needs fixing"}
+
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/fail" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"reason":"<detailed description of what failed and what needs fixing>"}'
+\`\`\`
 
 Reply with: \`TEST_PASS: [summary]\` or \`TEST_FAIL: [what failed]\``;
     } else if (isVerifier) {
@@ -412,22 +461,36 @@ Reply with: \`TEST_PASS: [summary]\` or \`TEST_FAIL: [what failed]\``;
 
 Review deliverables, test results, and task requirements.
 
-**If verification PASSES:**
-1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
-   Body: {"activity_type": "completed", "message": "Verification passed: [summary]"}
-2. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}
+**If verification PASSES** — all calls require the Authorization header:
+
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"activity_type":"completed","message":"Verification passed: <summary>"}'
+
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\`
 
 **If verification FAILS:**
-1. ${failEndpoint}
-   Body: {"reason": "Detailed description of what failed and what needs fixing"}
+
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/fail" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"reason":"<detailed description of what failed and what needs fixing>"}'
+\`\`\`
 
 Reply with: \`VERIFY_PASS: [summary]\` or \`VERIFY_FAIL: [what failed]\``;
     } else {
       // Fallback for unknown roles
-      completionInstructions = `**IMPORTANT:** After completing work:
-1. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}`;
+      completionInstructions = `**IMPORTANT:** After completing work, update status — the call requires the Authorization header:
+
+\`\`\`bash
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\``;
     }
 
     // Build image references section

--- a/src/components/AgentsSidebar.tsx
+++ b/src/components/AgentsSidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Plus, ChevronRight, ChevronLeft, Zap, ZapOff, Loader2, Search, Power, Megaphone, X, MoreVertical } from 'lucide-react';
+import { Plus, ChevronRight, ChevronLeft, Zap, ZapOff, Loader2, Search, Power, Megaphone, X, MoreVertical, RotateCcw } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import type { Agent, AgentStatus, AgentHealthState, OpenClawSession } from '@/lib/types';
 import { AgentModal } from './AgentModal';
@@ -50,6 +50,7 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
   const [rollCallBusy, setRollCallBusy] = useState(false);
   const [rollCallResult, setRollCallResult] = useState<RollCallResultView | null>(null);
   const [showActionMenu, setShowActionMenu] = useState(false);
+  const [resetSessionsBusy, setResetSessionsBusy] = useState(false);
 
   // Close the action menu when clicking outside it. We watch document mousedown
   // and check that the target isn't inside the menu or the trigger button.
@@ -207,6 +208,53 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
     }
   };
 
+  // Reset all OpenClaw sessions — both MC-side (session rows) and
+  // gateway-side (via `/reset` sent to each active gateway-synced agent's
+  // main session, which forces the gateway to re-init and reload the
+  // agent's persona files on its next turn). One click, two phases.
+  const resetAllSessions = async () => {
+    if (!confirm(
+      'Reset ALL agent sessions?\n\n' +
+      'This does two things:\n' +
+      '  1. Wipes Mission Control\'s session tracking (the "OpenClaw Connected" badges).\n' +
+      '  2. Sends `/reset` to every active gateway-synced agent\'s main session, which forces OpenClaw to re-initialize the session and reload the agent\'s SOUL.md / AGENTS.md / MESSAGING-PROTOCOL.md on its next turn.\n\n' +
+      'Use this after editing agent persona files, or when sessionKey routing has drifted.'
+    )) return;
+    setResetSessionsBusy(true);
+    try {
+      const res = await fetch('/api/openclaw/sessions', { method: 'DELETE' });
+      const data = await res.json();
+      if (!res.ok) {
+        alert(data.error || 'Failed to reset sessions');
+        return;
+      }
+      // Drop in-memory OpenClaw session state so badges update immediately.
+      for (const agent of agents) {
+        setAgentOpenClawSession(agent.id, null);
+      }
+      // Summarise both phases. Gateway /reset can fail per-agent (allow-list,
+      // offline, etc.) — surface those in the alert so the operator knows
+      // which ones to hit manually in the chat.
+      const resets: Array<{ name: string; ok: boolean; error?: string }> = data.agents_reset || [];
+      const ok = resets.filter(r => r.ok).map(r => r.name);
+      const failed = resets.filter(r => !r.ok);
+      const lines: string[] = [
+        `Cleared ${data.deleted} MC session record(s).`,
+      ];
+      if (ok.length) lines.push(`Sent /reset to: ${ok.join(', ')}`);
+      if (failed.length) {
+        lines.push(`Failed to /reset: ${failed.map(f => `${f.name} (${f.error || 'unknown'})`).join('; ')}`);
+        lines.push('Fall back: run `/reset` in those agents\' OpenClaw chats directly.');
+      }
+      if (data.gateway_error) lines.push(`Gateway unreachable: ${data.gateway_error}`);
+      alert(lines.join('\n'));
+    } catch (err) {
+      alert(`Failed to reset sessions: ${(err as Error).message}`);
+    } finally {
+      setResetSessionsBusy(false);
+    }
+  };
+
   // Poll roll-call status while panel is open and timer hasn't expired.
   // SSE would be nicer; polling is simpler and fine for the small entry
   // counts this feature fans out to.
@@ -314,6 +362,15 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
                     >
                       {rollCallBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Megaphone className="w-4 h-4" />}
                       {rollCallBusy ? 'Calling…' : 'Roll Call'}
+                    </button>
+                    <button
+                      onClick={() => { setShowActionMenu(false); resetAllSessions(); }}
+                      disabled={resetSessionsBusy}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-amber-300 hover:bg-amber-500/10 disabled:opacity-50 disabled:cursor-not-allowed text-left"
+                      title="Clear all OpenClaw session records so next dispatch starts fresh"
+                    >
+                      {resetSessionsBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <RotateCcw className="w-4 h-4" />}
+                      {resetSessionsBusy ? 'Resetting…' : 'Reset all sessions'}
                     </button>
                     <div className="h-px bg-mc-border my-1" />
                     <button


### PR DESCRIPTION
## Dispatch auth fix

Observed: Coordinator received a dispatch, correctly called \`sessions_send\` (routing fix from #8 working as intended), got rejected by the gateway allow-list, tried to surface the blocker via \`POST /api/tasks/<id>/fail\` — and got **Unauthorized** on every MC callback.

Root cause: the dispatch prompt's TRACKING & REPORTING / completion instructions listed raw \`POST /api/tasks/...\` and \`PATCH /api/tasks/...\` URLs without the Authorization header. When \`MC_API_TOKEN\` is set (always in practice), the middleware returns 401.

**Fix:** every completion-instruction branch (coordinator / builder / tester / verifier / fallback) now embeds ready-to-paste curl commands with the bearer header. \`MC_API_TOKEN\` is read at dispatch time and interpolated into the prompt, so different deployments pick up the right token automatically. The Coordinator's allow-list-error handling is now also a full curl example instead of a bare URL.

## Reset all sessions

New dropdown item in AgentsSidebar that:

1. **MC phase** — \`DELETE /api/openclaw/sessions\` wipes MC's session rows, clears \"OpenClaw Connected\" badges, cleans up any legacy Sub-Agent ghost rows, emits \`session.end\` debug events.
2. **Gateway phase** — sends \`/reset\` via \`chat.send\` to every active gateway-synced agent's main session, forcing the gateway to re-init and reload each agent's \`SOUL.md\` / \`AGENTS.md\` / \`MESSAGING-PROTOCOL.md\` on its next turn.

Per-agent success/failure is reported in the response; the UI alert summarises both phases. Filters: \`is_active=0\` agents are excluded (consistent with routing + roll-call); offline agents are excluded; gateway-unreachable case reports the network error but leaves MC phase 1 successful.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Coordinator dispatch prompt now shows full curl with bearer in TRACKING & REPORTING block (verified via /debug feed — chat.send body contains the Authorization header line)
- [x] \`DELETE /api/openclaw/sessions\` wipes MC rows + sends \`/reset\` to 4 active gateway agents, skips 4 inactive
- [x] Per-agent result reporting shows sessionKey and ok=true/false per entry

## Not covered here (gateway-side config)

The other blocker in the user's dispatch trace — **\"Session send visibility is restricted. Set tools.sessions.visibility=all\"** — is OpenClaw gateway config on the Coordinator agent, not an MC issue. The dispatch prompt's error-handling section now gives explicit curl to surface that blocker via \`/fail\`, but fixing it requires adding \`tools.sessions.visibility: \"all\"\` (or an explicit allow-list of peer agent ids) to the Coordinator's gateway config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)