### PR TITLE
feat: web-downloadable deliverables + task archiving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1014.0",
         "@hello-pangea/dnd": "^17.0.0",
+        "@types/archiver": "^7.0.0",
+        "archiver": "^7.0.1",
         "better-sqlite3": "^12.6.2",
         "clsx": "^2.1.1",
         "css-tree": "^3.1.0",
@@ -1514,7 +1516,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1532,7 +1533,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1545,7 +1545,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -1821,7 +1820,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2602,6 +2600,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/archiver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
+      "integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -2630,7 +2637,6 @@
       "version": "20.19.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2662,6 +2668,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/use-sync-external-store": {
@@ -3222,6 +3237,18 @@
         "win32"
       ]
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3266,7 +3293,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3276,7 +3302,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3307,6 +3332,148 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/archiver/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/arg": {
@@ -3500,6 +3667,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3587,8 +3760,98 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.1.tgz",
+      "integrity": "sha512-fZapLWNB25gS+etK27NV9KgBNXgo2yeYHuj+OyPblQd6GYAE3JVy6aKxszMV5jhGGFwraXQKA5fldvf3lMyEqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3753,6 +4016,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/busboy": {
@@ -3936,7 +4208,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3949,7 +4220,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -3962,6 +4232,62 @@
         "node": ">= 6"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3969,11 +4295,81 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4237,7 +4633,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/echarts": {
@@ -4267,7 +4662,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -4969,6 +5363,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -4983,6 +5404,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5165,7 +5592,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -5351,7 +5777,6 @@
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
       "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -5387,7 +5812,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5397,7 +5821,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -5846,7 +6269,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5996,6 +6418,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -6104,7 +6538,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -6129,7 +6562,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
       "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -6253,6 +6685,54 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -6303,6 +6783,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6326,7 +6812,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -6422,7 +6907,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6602,7 +7086,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6870,7 +7353,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6887,7 +7369,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -7192,6 +7673,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7352,6 +7848,36 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -7681,7 +8207,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7694,7 +8219,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7780,7 +8304,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -7872,6 +8395,17 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -7885,7 +8419,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -7904,7 +8437,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7919,14 +8451,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7939,7 +8469,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -8068,7 +8597,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8082,7 +8610,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8262,6 +8789,38 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/text-table": {
@@ -8573,7 +9132,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8693,7 +9251,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8808,7 +9365,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -8827,7 +9383,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -8845,14 +9400,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8867,7 +9420,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8880,7 +9432,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8893,7 +9444,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -8922,6 +9472,60 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1014.0",
     "@hello-pangea/dnd": "^17.0.0",
+    "@types/archiver": "^7.0.0",
+    "archiver": "^7.0.1",
     "better-sqlite3": "^12.6.2",
     "clsx": "^2.1.1",
     "css-tree": "^3.1.0",

--- a/src/app/api/deliverables/[id]/download/route.ts
+++ b/src/app/api/deliverables/[id]/download/route.ts
@@ -1,0 +1,68 @@
+/**
+ * Download a single task deliverable as a file.
+ *
+ * Only works for file-type deliverables. URL and artifact types are not
+ * downloadable. Legacy 'host' rows are served too, provided MC can read the
+ * path (i.e. same-host or shared mount) — otherwise 404.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createReadStream } from 'fs';
+import { Readable } from 'stream';
+import path from 'path';
+import { getDb } from '@/lib/db';
+import {
+  resolveDeliverableReadPath,
+  mimeTypeForPath,
+  fileSizeBytes,
+  DeliverableReadError,
+} from '@/lib/deliverables/storage';
+import type { TaskDeliverable } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const db = getDb();
+  const deliverable = db.prepare(`SELECT * FROM task_deliverables WHERE id = ?`).get(params.id) as
+    | TaskDeliverable
+    | undefined;
+
+  if (!deliverable) {
+    return NextResponse.json({ error: 'Deliverable not found' }, { status: 404 });
+  }
+  if (deliverable.deliverable_type !== 'file') {
+    return NextResponse.json(
+      { error: 'Only file deliverables can be downloaded' },
+      { status: 400 }
+    );
+  }
+
+  let absPath: string;
+  try {
+    absPath = resolveDeliverableReadPath(deliverable);
+  } catch (e) {
+    if (e instanceof DeliverableReadError) {
+      return NextResponse.json({ error: e.message }, { status: e.status });
+    }
+    throw e;
+  }
+
+  const size = fileSizeBytes(absPath);
+  const contentType = mimeTypeForPath(absPath);
+  const downloadName = path.basename(absPath);
+
+  const nodeStream = createReadStream(absPath);
+  // Next.js accepts a Web ReadableStream for the body; convert Node → Web.
+  const webStream = Readable.toWeb(nodeStream) as unknown as ReadableStream;
+
+  const headers: Record<string, string> = {
+    'Content-Type': contentType,
+    'Content-Disposition': `attachment; filename="${encodeURIComponent(downloadName)}"`,
+  };
+  if (size !== undefined) headers['Content-Length'] = String(size);
+
+  return new NextResponse(webStream, { status: 200, headers });
+}

--- a/src/app/api/deliverables/tasks-with-deliverables/route.ts
+++ b/src/app/api/deliverables/tasks-with-deliverables/route.ts
@@ -1,0 +1,52 @@
+/**
+ * Summary list of every task that has at least one deliverable, used by the
+ * right-rail "Ready deliverables" panel.
+ *
+ * Returns a row per task with total count, mc-managed count (i.e. how many are
+ * downloadable), status, archived flag, and last_added_at for sorting.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+interface Row {
+  task_id: string;
+  task_title: string;
+  status: string;
+  is_archived: number;
+  file_count: number;
+  mc_count: number;
+  last_added_at: string;
+}
+
+export async function GET(request: NextRequest) {
+  const db = getDb();
+  const workspaceId = request.nextUrl.searchParams.get('workspace_id');
+
+  const params: string[] = [];
+  let where = 'WHERE td.deliverable_type = \'file\'';
+  if (workspaceId) {
+    where += ' AND t.workspace_id = ?';
+    params.push(workspaceId);
+  }
+
+  const rows = db.prepare(`
+    SELECT
+      t.id AS task_id,
+      t.title AS task_title,
+      t.status AS status,
+      COALESCE(t.is_archived, 0) AS is_archived,
+      COUNT(td.id) AS file_count,
+      SUM(CASE WHEN COALESCE(td.storage_scheme, 'host') = 'mc' THEN 1 ELSE 0 END) AS mc_count,
+      MAX(td.created_at) AS last_added_at
+    FROM task_deliverables td
+    JOIN tasks t ON t.id = td.task_id
+    ${where}
+    GROUP BY t.id
+    ORDER BY MAX(td.created_at) DESC
+  `).all(...params) as Row[];
+
+  return NextResponse.json(rows);
+}

--- a/src/app/api/tasks/[id]/archive/route.ts
+++ b/src/app/api/tasks/[id]/archive/route.ts
@@ -1,0 +1,64 @@
+/**
+ * Archive / unarchive a task.
+ *
+ * Archive is orthogonal to status: any task can be archived and its status is
+ * untouched. The board hides is_archived=1 by default. Deliverables stay put,
+ * so an archived task can still be revisited and re-downloaded.
+ *
+ * POST body: { archived: true | false } (defaults to true)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import type { Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const db = getDb();
+  const existing = db.prepare(`SELECT id FROM tasks WHERE id = ?`).get(params.id) as
+    | { id: string }
+    | undefined;
+  if (!existing) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+  }
+
+  let archived = true;
+  try {
+    const body = await request.json().catch(() => ({}));
+    if (body && typeof body.archived === 'boolean') archived = body.archived;
+  } catch {
+    // empty/invalid body is fine — default to archiving
+  }
+
+  if (archived) {
+    db.prepare(`
+      UPDATE tasks
+         SET is_archived = 1,
+             archived_at = datetime('now'),
+             updated_at = datetime('now')
+       WHERE id = ?
+    `).run(params.id);
+  } else {
+    db.prepare(`
+      UPDATE tasks
+         SET is_archived = 0,
+             archived_at = NULL,
+             updated_at = datetime('now')
+       WHERE id = ?
+    `).run(params.id);
+  }
+
+  const task = db.prepare(`SELECT * FROM tasks WHERE id = ?`).get(params.id) as Task;
+
+  broadcast({
+    type: archived ? 'task_archived' : 'task_unarchived',
+    payload: task,
+  });
+
+  return NextResponse.json(task);
+}

--- a/src/app/api/tasks/[id]/deliverables/download/route.ts
+++ b/src/app/api/tasks/[id]/deliverables/download/route.ts
@@ -1,0 +1,92 @@
+/**
+ * Download all file deliverables for a task as a zip.
+ *
+ * Skips URL/artifact types. Skips file deliverables that can't be read (404
+ * from the storage helper) — the rest still go into the archive.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { PassThrough } from 'stream';
+import { Readable } from 'stream';
+import path from 'path';
+import archiver from 'archiver';
+import { getDb } from '@/lib/db';
+import {
+  resolveDeliverableReadPath,
+  DeliverableReadError,
+} from '@/lib/deliverables/storage';
+import type { Task, TaskDeliverable } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const db = getDb();
+  const task = db.prepare(`SELECT id, title FROM tasks WHERE id = ?`).get(params.id) as
+    | Pick<Task, 'id' | 'title'>
+    | undefined;
+
+  if (!task) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+  }
+
+  const deliverables = db.prepare(`
+    SELECT * FROM task_deliverables
+    WHERE task_id = ? AND deliverable_type = 'file'
+    ORDER BY created_at ASC
+  `).all(params.id) as TaskDeliverable[];
+
+  const entries: { absPath: string; name: string }[] = [];
+  for (const d of deliverables) {
+    try {
+      const absPath = resolveDeliverableReadPath(d);
+      // Entry name is suffixed with the deliverable id to keep archive entries
+      // unique even when two deliverables share a filename.
+      const ext = path.extname(absPath);
+      const base = path.basename(absPath, ext);
+      entries.push({ absPath, name: `${base}-${d.id}${ext}` });
+    } catch (e) {
+      if (e instanceof DeliverableReadError) {
+        // Silently skip unreadable rows — don't fail the whole zip.
+        console.warn(`[deliverables zip] Skipping ${d.id}: ${e.message}`);
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  if (entries.length === 0) {
+    return NextResponse.json(
+      { error: 'No downloadable deliverables for this task' },
+      { status: 404 }
+    );
+  }
+
+  const archive = archiver('zip', { zlib: { level: 6 } });
+  const pass = new PassThrough();
+  archive.pipe(pass);
+
+  for (const entry of entries) {
+    archive.file(entry.absPath, { name: entry.name });
+  }
+  archive.finalize();
+
+  archive.on('error', (err) => {
+    console.error('[deliverables zip] archive error', err);
+    pass.destroy(err);
+  });
+
+  const slug = (task.title || 'task').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'task';
+  const zipName = `${slug}-deliverables.zip`;
+
+  const webStream = Readable.toWeb(pass) as unknown as ReadableStream;
+  return new NextResponse(webStream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="${encodeURIComponent(zipName)}"`,
+    },
+  });
+}

--- a/src/app/api/tasks/[id]/deliverables/route.ts
+++ b/src/app/api/tasks/[id]/deliverables/route.ts
@@ -9,8 +9,13 @@ import { broadcast } from '@/lib/events';
 import { CreateDeliverableSchema } from '@/lib/validation';
 import { logDebugEvent } from '@/lib/debug-log';
 import { existsSync } from 'fs';
+import {
+  isUnderDeliverablesHostRoot,
+  hostPathToContainerPath,
+  fileSizeBytes,
+} from '@/lib/deliverables/storage';
 
-import type { TaskDeliverable } from '@/lib/types';
+import type { TaskDeliverable, DeliverableStorageScheme } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 /**
@@ -65,13 +70,35 @@ export async function POST(
 
     const { deliverable_type, title, path, description } = validation.data;
 
-    // Validate file existence for file deliverables
+    // Reject the reserved ssh:// prefix — the column is widened for future
+    // remote storage, but nothing reads it yet. Failing here avoids half-wired
+    // deliverables accumulating.
+    if (path && path.startsWith('ssh://')) {
+      return NextResponse.json(
+        { error: 'Remote (ssh://) deliverable storage is not yet supported' },
+        { status: 501 }
+      );
+    }
+
+    // Decide storage_scheme + capture file metadata.
+    let storageScheme: DeliverableStorageScheme = 'host';
+    let sizeBytes: number | undefined;
     let fileExists = true;
     let normalizedPath = path;
+
     if (deliverable_type === 'file' && path) {
-      // Expand tilde
       normalizedPath = path.replace(/^~/, process.env.HOME || '');
-      fileExists = existsSync(normalizedPath);
+      if (isUnderDeliverablesHostRoot(path)) {
+        storageScheme = 'mc';
+        // Existence + size measured against the container-perspective path
+        // (MC reads from there; the path the agent wrote is host-perspective).
+        const containerPath = hostPathToContainerPath(path);
+        fileExists = existsSync(containerPath);
+        if (fileExists) sizeBytes = fileSizeBytes(containerPath);
+      } else {
+        // Legacy host-path: just use as-given (tilde-expanded).
+        fileExists = existsSync(normalizedPath);
+      }
       if (!fileExists) {
         console.warn(`[DELIVERABLE] Warning: File does not exist: ${normalizedPath}`);
       }
@@ -82,15 +109,17 @@ export async function POST(
 
     // Insert deliverable
     db.prepare(`
-      INSERT INTO task_deliverables (id, task_id, deliverable_type, title, path, description)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO task_deliverables (id, task_id, deliverable_type, title, path, description, storage_scheme, size_bytes)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       taskId,
       deliverable_type,
       title,
       path || null,
-      description || null
+      description || null,
+      storageScheme,
+      sizeBytes ?? null
     );
 
     // Get the created deliverable

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -4,6 +4,7 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
 import { getProjectsPath, getMissionControlUrl } from '@/lib/config';
+import { getTaskDeliverableDir } from '@/lib/deliverables/storage';
 import { getRelevantKnowledge, formatKnowledgeForDispatch } from '@/lib/learner';
 import { getTaskWorkflow } from '@/lib/workflow-engine';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
@@ -203,11 +204,16 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       urgent: '🔴'
     }[task.priority] || '⚪';
 
-    // Get project path for deliverables — with workspace isolation if needed
+    // Get project path for working files — with workspace isolation if needed
     const projectsPath = getProjectsPath();
     const projectDir = task.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
     let taskProjectDir = `${projectsPath}/${projectDir}`;
     const missionControlUrl = getMissionControlUrl();
+
+    // Deliverables directory: MC-managed location the agent writes FINAL
+    // deliverables into so they become web-downloadable. Separate from
+    // taskProjectDir, which may be an isolated worktree the agent codes in.
+    const deliverablesDir = getTaskDeliverableDir(task.id, 'host');
 
     // Create isolated workspace if parallel builds are possible
     // Only for builder dispatches (assigned/in_progress), not tester/reviewer
@@ -396,9 +402,10 @@ curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
 ${authHeaderLine}  -d '{"activity_type":"updated","message":"Delegated <slice> to <agent name>"}'
 
 # Register aggregated deliverable (after all peers report in)
+# Save the file to the **DELIVERABLES DIR** below so it becomes web-downloadable.
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/deliverables" \\
   -H "Content-Type: application/json" \\
-${authHeaderLine}  -d '{"deliverable_type":"file","title":"<title>","path":"${taskProjectDir}/<filename>"}'
+${authHeaderLine}  -d '{"deliverable_type":"file","title":"<title>","path":"${deliverablesDir}/<filename>"}'
 
 # Close the task
 curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
@@ -413,9 +420,10 @@ When complete, reply with:
 
 \`\`\`bash
 # 1. Register deliverable
+# Save the file to the **DELIVERABLES DIR** below so it becomes web-downloadable.
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/deliverables" \\
   -H "Content-Type: application/json" \\
-${authHeaderLine}  -d '{"deliverable_type":"file","title":"<file name>","path":"${taskProjectDir}/<filename>"}'
+${authHeaderLine}  -d '{"deliverable_type":"file","title":"<file name>","path":"${deliverablesDir}/<filename>"}'
 
 # 2. Log activity (must have both a deliverable AND an activity before step 3 will pass the evidence gate)
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
@@ -566,9 +574,9 @@ ${task.due_date ? `**Due:** ${task.due_date}\n` : ''}
 **Task ID:** ${task.id}
 ${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}${delegationRosterSection}
 ${isBuilder ? (workspaceIsolated
-  ? `**\u{1F512} ISOLATED WORKSPACE:** ${taskProjectDir}\n- **Port:** ${workspacePort || 'default'} (use this for dev server, NOT the default)\n${workspaceBranchName ? `- **Branch:** ${workspaceBranchName}\n` : ''}- **IMPORTANT:** Do NOT modify files outside this workspace directory. Other agents may be working on the same project in parallel. All your work must stay within: ${taskProjectDir}\nCreate this directory if needed and save all deliverables there.\n`
-  : `**OUTPUT DIRECTORY:** ${taskProjectDir}\nCreate this directory and save all deliverables there.\n`)
-: isCoordinator ? '' : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n`}
+  ? `**\u{1F512} ISOLATED WORKSPACE:** ${taskProjectDir}\n- **Port:** ${workspacePort || 'default'} (use this for dev server, NOT the default)\n${workspaceBranchName ? `- **Branch:** ${workspaceBranchName}\n` : ''}- **IMPORTANT:** Do NOT modify files outside this workspace directory. Other agents may be working on the same project in parallel. All your work must stay within: ${taskProjectDir}\n**DELIVERABLES DIR (separate):** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`
+  : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n**DELIVERABLES DIR:** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`)
+: isCoordinator ? `**DELIVERABLES DIR:** ${deliverablesDir}\nAggregated deliverables registered via the deliverables endpoint should be written to this directory so they become web-downloadable.\n` : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n**DELIVERABLES DIR:** ${deliverablesDir}\nFinal deliverables should be saved to ${deliverablesDir} so they become web-downloadable.\n`}
 ${completionInstructions}
 
 If you need help or clarification, ask the orchestrator.`;

--- a/src/app/workspace/[slug]/page.tsx
+++ b/src/app/workspace/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Header } from '@/components/Header';
 import { AgentsSidebar } from '@/components/AgentsSidebar';
 import { MissionQueue } from '@/components/MissionQueue';
 import { LiveFeed } from '@/components/LiveFeed';
+import { ReadyDeliverablesPanel } from '@/components/ReadyDeliverablesPanel';
 import { SSEDebugPanel } from '@/components/SSEDebugPanel';
 import { useMissionControl } from '@/lib/store';
 import { useSSE } from '@/hooks/useSSE';
@@ -211,7 +212,7 @@ export default function WorkspacePage() {
       <div className="hidden lg:flex flex-1 overflow-hidden">
         <AgentsSidebar workspaceId={workspace.id} />
         <MissionQueue workspaceId={workspace.id} />
-        <LiveFeed />
+        <LiveFeed topSlot={<ReadyDeliverablesPanel workspaceId={workspace.id} />} />
       </div>
 
       <div

--- a/src/components/DeliverablesList.tsx
+++ b/src/components/DeliverablesList.tsx
@@ -6,7 +6,7 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import { FileText, Link as LinkIcon, Package, ExternalLink, Eye } from 'lucide-react';
+import { FileText, Link as LinkIcon, Package, ExternalLink, Eye, Download, Archive } from 'lucide-react';
 import { debug } from '@/lib/debug';
 import type { TaskDeliverable } from '@/lib/types';
 
@@ -101,6 +101,13 @@ export function DeliverablesList({ taskId }: DeliverablesListProps) {
     }
   };
 
+  const formatBytes = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+    return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+  };
+
   const formatTimestamp = (timestamp: string) => {
     const date = new Date(timestamp);
     return date.toLocaleDateString('en-US', {
@@ -128,8 +135,24 @@ export function DeliverablesList({ taskId }: DeliverablesListProps) {
     );
   }
 
+  const mcFileCount = deliverables.filter(
+    d => d.deliverable_type === 'file' && d.storage_scheme === 'mc'
+  ).length;
+
   return (
     <div className="space-y-3">
+      {mcFileCount > 0 && (
+        <div className="flex items-center justify-end">
+          <a
+            href={`/api/tasks/${taskId}/deliverables/download`}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded bg-mc-accent text-white hover:bg-mc-accent/90"
+            title={`Download ${mcFileCount} file${mcFileCount === 1 ? '' : 's'} as a zip`}
+          >
+            <Archive className="w-4 h-4" />
+            Download all ({mcFileCount})
+          </a>
+        </div>
+      )}
       {deliverables.map((deliverable) => (
         <div
           key={deliverable.id}
@@ -158,6 +181,16 @@ export function DeliverablesList({ taskId }: DeliverablesListProps) {
                 <h4 className="font-medium text-mc-text">{deliverable.title}</h4>
               )}
               <div className="flex items-center gap-1">
+                {/* Download button (MC-managed file deliverables only) */}
+                {deliverable.deliverable_type === 'file' && deliverable.storage_scheme === 'mc' && (
+                  <a
+                    href={`/api/deliverables/${deliverable.id}/download`}
+                    className="flex-shrink-0 p-1.5 hover:bg-mc-bg-tertiary rounded text-mc-accent"
+                    title="Download file"
+                  >
+                    <Download className="w-4 h-4" />
+                  </a>
+                )}
                 {/* Preview button for HTML files */}
                 {deliverable.deliverable_type === 'file' && deliverable.path?.endsWith('.html') && (
                   <button
@@ -207,10 +240,24 @@ export function DeliverablesList({ taskId }: DeliverablesListProps) {
             )}
 
             {/* Metadata */}
-            <div className="flex items-center gap-4 mt-2 text-xs text-mc-text-secondary">
+            <div className="flex items-center gap-2 mt-2 text-xs text-mc-text-secondary flex-wrap">
               <span className="capitalize">{deliverable.deliverable_type}</span>
               <span>•</span>
               <span>{formatTimestamp(deliverable.created_at)}</span>
+              {deliverable.size_bytes != null && (
+                <>
+                  <span>•</span>
+                  <span>{formatBytes(deliverable.size_bytes)}</span>
+                </>
+              )}
+              {deliverable.deliverable_type === 'file' && deliverable.storage_scheme !== 'mc' && (
+                <span
+                  className="px-1.5 py-0.5 rounded bg-mc-bg-tertiary text-mc-text-secondary"
+                  title="Stored on host filesystem; not downloadable from the web UI"
+                >
+                  host-only
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronRight, ChevronLeft, Clock } from 'lucide-react';
+import { ChevronUp, ChevronDown, Clock, PanelRightClose, PanelRightOpen } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import type { Event } from '@/lib/types';
 import { formatDistanceToNow } from 'date-fns';
@@ -11,15 +11,21 @@ type FeedFilter = 'all' | 'tasks' | 'agents';
 interface LiveFeedProps {
   mobileMode?: boolean;
   isPortrait?: boolean;
+  // Optional content rendered at the top of the rail, above the filter tabs.
+  // Used by the desktop layout to stack the Ready Deliverables panel above
+  // the feed without creating a competing w-80 wrapper.
+  topSlot?: React.ReactNode;
 }
 
-export function LiveFeed({ mobileMode = false, isPortrait = true }: LiveFeedProps) {
+export function LiveFeed({ mobileMode = false, isPortrait = true, topSlot }: LiveFeedProps) {
   const { events } = useMissionControl();
   const [filter, setFilter] = useState<FeedFilter>('all');
-  const [isMinimized, setIsMinimized] = useState(false);
+  const [isMinimized, setIsMinimized] = useState(false); // whole-rail collapse
+  const [feedCollapsed, setFeedCollapsed] = useState(false); // only hide feed content
 
   const effectiveMinimized = mobileMode ? false : isMinimized;
   const toggleMinimize = () => setIsMinimized(!isMinimized);
+  const toggleFeed = () => setFeedCollapsed(v => !v);
 
   const filteredEvents = events.filter((event) => {
     if (filter === 'all') return true;
@@ -28,28 +34,58 @@ export function LiveFeed({ mobileMode = false, isPortrait = true }: LiveFeedProp
     return true;
   });
 
+  // Whole-rail collapsed view: a slim 12px-wide column with just the expand button.
+  if (effectiveMinimized) {
+    return (
+      <aside className="w-12 bg-mc-bg-secondary border-l border-mc-border flex flex-col items-center py-2 transition-all duration-300 ease-in-out">
+        <button
+          onClick={toggleMinimize}
+          className="p-1 rounded hover:bg-mc-bg-tertiary text-mc-text-secondary hover:text-mc-text transition-colors"
+          aria-label="Expand right panel"
+          title="Expand right panel"
+        >
+          <PanelRightOpen className="w-4 h-4" />
+        </button>
+      </aside>
+    );
+  }
+
   return (
     <aside
       className={`bg-mc-bg-secondary ${mobileMode ? 'border border-mc-border rounded-lg h-full' : 'border-l border-mc-border'} flex flex-col transition-all duration-300 ease-in-out ${
-        effectiveMinimized ? 'w-12' : mobileMode ? 'w-full' : 'w-80'
+        mobileMode ? 'w-full' : 'w-80'
       }`}
     >
-      <div className="p-3 border-b border-mc-border">
-        <div className="flex items-center">
-          {!mobileMode && (
-            <button
-              onClick={toggleMinimize}
-              className="p-1 rounded hover:bg-mc-bg-tertiary text-mc-text-secondary hover:text-mc-text transition-colors"
-              aria-label={effectiveMinimized ? 'Expand feed' : 'Minimize feed'}
-            >
-              {effectiveMinimized ? <ChevronLeft className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-            </button>
-          )}
-          {!effectiveMinimized && <span className="text-sm font-medium uppercase tracking-wider">Live Feed</span>}
+      {/* Rail toolbar — whole-panel minimize lives here, independent of the
+          LIVE FEED section header so it's always reachable even when the feed
+          (or deliverables) is collapsed. */}
+      {!mobileMode && (
+        <div className="flex items-center justify-end px-2 py-1 border-b border-mc-border/60">
+          <button
+            onClick={toggleMinimize}
+            className="p-1 rounded hover:bg-mc-bg-tertiary text-mc-text-secondary hover:text-mc-text transition-colors"
+            aria-label="Minimize right panel"
+            title="Minimize right panel"
+          >
+            <PanelRightClose className="w-4 h-4" />
+          </button>
         </div>
+      )}
 
-        {!effectiveMinimized && (
-          <div className={`mt-3 ${mobileMode && isPortrait ? 'grid grid-cols-3 gap-2' : 'flex gap-1'}`}>
+      {topSlot && <div className="flex-shrink-0">{topSlot}</div>}
+
+      {/* LIVE FEED section — the header itself is a button that collapses the
+          section independently of the deliverables panel and the whole rail. */}
+      <div className={`border-b border-mc-border flex-shrink-0 ${feedCollapsed ? '' : ''}`}>
+        <button
+          onClick={toggleFeed}
+          className="w-full flex items-center justify-between px-3 py-2 hover:bg-mc-bg-tertiary"
+        >
+          <span className="text-sm font-medium uppercase tracking-wider">Live Feed</span>
+          {feedCollapsed ? <ChevronDown className="w-4 h-4 text-mc-text-secondary" /> : <ChevronUp className="w-4 h-4 text-mc-text-secondary" />}
+        </button>
+        {!feedCollapsed && (
+          <div className={`px-3 pb-3 ${mobileMode && isPortrait ? 'grid grid-cols-3 gap-2' : 'flex gap-1'}`}>
             {(['all', 'tasks', 'agents'] as FeedFilter[]).map((tab) => (
               <button
                 key={tab}
@@ -65,7 +101,7 @@ export function LiveFeed({ mobileMode = false, isPortrait = true }: LiveFeedProp
         )}
       </div>
 
-      {!effectiveMinimized && (
+      {!feedCollapsed && (
         <div className="flex-1 overflow-y-auto p-2 space-y-1 pb-[calc(0.5rem+env(safe-area-inset-bottom))]">
           {filteredEvents.length === 0 ? (
             <div className="text-center py-8 text-mc-text-secondary text-sm">No events yet</div>
@@ -103,6 +139,10 @@ function EventItem({ event }: { event: Event }) {
         return '🚚';
       case 'convoy_completed':
         return '🏁';
+      case 'task_archived':
+        return '📦';
+      case 'task_unarchived':
+        return '📤';
       default:
         return '📌';
     }

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Plus, ChevronRight, GripVertical, ArrowRightLeft, AlertTriangle, MessageSquare } from 'lucide-react';
+import { Plus, ChevronRight, GripVertical, ArrowRightLeft, AlertTriangle, MessageSquare, Archive, ChevronsLeft } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import { triggerAutoDispatch, shouldTriggerAutoDispatch } from '@/lib/auto-dispatch';
 import { getConfig } from '@/lib/config';
@@ -32,7 +32,25 @@ const COLUMNS: { id: TaskStatus; label: string; color: string }[] = [
 export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = true }: MissionQueueProps) {
   const { tasks, updateTaskStatus, addEvent } = useMissionControl();
   const [compactEmptyColumns, setCompactEmptyColumns] = useState(true);
+  const [showArchived, setShowArchived] = useState(false);
+  // Per-column manual override. Without an entry, the column uses the default
+  // (empty = collapsed to a vertical rail, non-empty = expanded).
+  const [columnOverride, setColumnOverride] = useState<Record<string, 'expanded' | 'collapsed'>>({});
   const unreadCounts = useUnreadCounts();
+
+  const isColumnCollapsed = (id: TaskStatus, count: number): boolean => {
+    const override = columnOverride[id];
+    if (override === 'expanded') return false;
+    if (override === 'collapsed') return true;
+    return count === 0;
+  };
+
+  const toggleColumn = (id: TaskStatus, currentlyCollapsed: boolean) => {
+    setColumnOverride(prev => ({
+      ...prev,
+      [id]: currentlyCollapsed ? 'expanded' : 'collapsed',
+    }));
+  };
 
   useEffect(() => {
     const cfg = getConfig();
@@ -53,7 +71,8 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
   const [statusMoveTask, setStatusMoveTask] = useState<Task | null>(null);
   const [pendingMove, setPendingMove] = useState<{ task: Task; targetStatus: TaskStatus } | null>(null);
 
-  const getTasksByStatus = (status: TaskStatus) => tasks.filter((task) => task.status === status);
+  const getTasksByStatus = (status: TaskStatus) =>
+    tasks.filter((task) => task.status === status && (showArchived || !task.is_archived));
 
   // Active pipeline states where manual moves are dangerous
   const ACTIVE_PIPELINE_STATES: TaskStatus[] = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification'];
@@ -167,13 +186,28 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
           <ChevronRight className="w-4 h-4 text-mc-text-secondary" />
           <span className="text-sm font-medium uppercase tracking-wider">Mission Queue</span>
         </div>
-        <button
-          onClick={() => setShowCreateModal(true)}
-          className="flex items-center gap-2 px-4 min-h-11 bg-mc-accent-pink text-mc-bg rounded text-sm font-medium hover:bg-mc-accent-pink/90"
-        >
-          <Plus className="w-4 h-4" />
-          New Task
-        </button>
+        <div className="flex items-center gap-2">
+          <label
+            className="flex items-center gap-1.5 text-xs text-mc-text-secondary cursor-pointer select-none"
+            title="Include archived tasks in the board"
+          >
+            <input
+              type="checkbox"
+              checked={showArchived}
+              onChange={e => setShowArchived(e.target.checked)}
+              className="accent-mc-accent"
+            />
+            <Archive className="w-3.5 h-3.5" />
+            Archived
+          </label>
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="flex items-center gap-2 px-4 min-h-11 bg-mc-accent-pink text-mc-bg rounded text-sm font-medium hover:bg-mc-accent-pink/90"
+          >
+            <Plus className="w-4 h-4" />
+            New Task
+          </button>
+        </div>
       </div>
 
       {!mobileMode ? (
@@ -181,6 +215,35 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
           {COLUMNS.map((column) => {
             const columnTasks = getTasksByStatus(column.id);
             const hasTasks = columnTasks.length > 0;
+            const collapsed = isColumnCollapsed(column.id, columnTasks.length);
+
+            if (collapsed) {
+              // Vertical rail — narrow column with rotated label. Still acts as
+              // a drop target. Whole body is a button that expands the column
+              // back to horizontal.
+              return (
+                <button
+                  key={column.id}
+                  type="button"
+                  onClick={() => toggleColumn(column.id, true)}
+                  onDragOver={handleDragOver}
+                  onDrop={(e) => handleDrop(e, column.id)}
+                  className={`flex-none w-10 flex flex-col items-center py-2 gap-2 bg-mc-bg rounded-lg border border-mc-border/50 border-t-2 transition-[width] duration-200 hover:bg-mc-bg-tertiary ${column.color}`}
+                  title={`${column.label} (${columnTasks.length}) — click to expand`}
+                >
+                  <span className="text-[10px] bg-mc-bg-tertiary px-1.5 py-0.5 rounded text-mc-text-secondary">
+                    {columnTasks.length}
+                  </span>
+                  <span
+                    className="text-xs font-medium uppercase text-mc-text-secondary tracking-wider"
+                    style={{ writingMode: 'vertical-rl' }}
+                  >
+                    {column.label}
+                  </span>
+                </button>
+              );
+            }
+
             return (
               <div
                 key={column.id}
@@ -191,7 +254,17 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
               >
                 <div className="p-2 border-b border-mc-border flex items-center justify-between gap-2">
                   <span className="text-xs font-medium uppercase text-mc-text-secondary whitespace-nowrap">{column.label}</span>
-                  <span className="text-xs bg-mc-bg-tertiary px-2 py-0.5 rounded text-mc-text-secondary">{columnTasks.length}</span>
+                  <div className="flex items-center gap-1">
+                    <span className="text-xs bg-mc-bg-tertiary px-2 py-0.5 rounded text-mc-text-secondary">{columnTasks.length}</span>
+                    <button
+                      type="button"
+                      onClick={() => toggleColumn(column.id, false)}
+                      className="p-0.5 rounded text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary"
+                      title="Collapse column"
+                    >
+                      <ChevronsLeft className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
                 </div>
 
                 <div className={`flex-1 overflow-y-auto p-2 ${hasTasks ? 'space-y-2' : ''}`}>
@@ -417,6 +490,8 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
   const isAssigned = task.status === 'assigned';
   const dispatchError = task.planning_dispatch_error;
 
+  const isArchived = task.is_archived === 1;
+
   return (
     <div
       draggable={!mobileMode}
@@ -424,7 +499,7 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
       onClick={onClick}
       className={`group bg-mc-bg-secondary border rounded-lg cursor-pointer transition-all hover:shadow-lg hover:shadow-black/20 ${
         isDragging ? 'opacity-50 scale-95' : ''
-      } ${isPlanning ? 'border-purple-500/40 hover:border-purple-500' : 'border-mc-border/50 hover:border-mc-accent/40'}`}
+      } ${isArchived ? 'opacity-60 border-dashed' : ''} ${isPlanning ? 'border-purple-500/40 hover:border-purple-500' : 'border-mc-border/50 hover:border-mc-accent/40'}`}
     >
       {!mobileMode && (
         <div className="flex items-center justify-center py-1.5 border-b border-mc-border/30 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -434,7 +509,18 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
 
       <div className={portraitMode ? 'p-4' : 'p-3'}>
         <div className="flex items-start justify-between gap-1.5">
-          <h4 className={`font-medium leading-snug line-clamp-2 ${portraitMode ? 'text-sm mb-3' : 'text-xs mb-2'}`}>{task.title}</h4>
+          <h4 className={`font-medium leading-snug line-clamp-2 ${portraitMode ? 'text-sm mb-3' : 'text-xs mb-2'}`}>
+            {isArchived && (
+              <span
+                className="inline-flex items-center gap-0.5 mr-1.5 px-1.5 py-0.5 rounded bg-mc-bg-tertiary text-[10px] text-mc-text-secondary align-middle"
+                title="Archived"
+              >
+                <Archive className="w-2.5 h-2.5" />
+                Archived
+              </span>
+            )}
+            {task.title}
+          </h4>
           {unreadCount > 0 && (
             <span className="flex-shrink-0 flex items-center gap-1 px-1.5 py-0.5 bg-mc-accent/15 text-mc-accent rounded text-[10px] font-medium" title={`${unreadCount} unread message${unreadCount !== 1 ? 's' : ''}`}>
               <MessageSquare className="w-2.5 h-2.5" />

--- a/src/components/ReadyDeliverablesPanel.tsx
+++ b/src/components/ReadyDeliverablesPanel.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+/**
+ * Right-rail panel that surfaces every task with at least one deliverable.
+ * Persistent (state view), not event-stream. Separate from LiveFeed so deliverable
+ * rows don't churn when unrelated events arrive.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp, Archive, Download, Package } from 'lucide-react';
+import { useMissionControl } from '@/lib/store';
+
+const RELEVANT_EVENT_TYPES = [
+  'deliverable_added',
+  'task_status_changed',
+  'task_archived',
+  'task_unarchived',
+  'task_deleted',
+  'task_completed',
+];
+
+interface Row {
+  task_id: string;
+  task_title: string;
+  status: string;
+  is_archived: number;
+  file_count: number;
+  mc_count: number;
+  last_added_at: string;
+}
+
+interface Props {
+  workspaceId?: string;
+}
+
+export function ReadyDeliverablesPanel({ workspaceId }: Props) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState(true);
+  const [showArchived, setShowArchived] = useState(false);
+  const { events } = useMissionControl();
+
+  const load = useCallback(async () => {
+    try {
+      const qs = workspaceId ? `?workspace_id=${encodeURIComponent(workspaceId)}` : '';
+      const res = await fetch(`/api/deliverables/tasks-with-deliverables${qs}`);
+      if (res.ok) {
+        setRows(await res.json());
+      }
+    } catch (e) {
+      console.error('[ReadyDeliverablesPanel] load failed', e);
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Refetch when a relevant event arrives. We can't subscribe to the SSE stream
+  // directly from here, but the store holds the last 100 events — so re-running
+  // when a matching one lands at the head is good enough. Comparing the
+  // string-typed column rather than the narrower EventType keeps this in sync
+  // with the broader set of types that actually flow into the store.
+  const latestRelevantId = useMemo(() => {
+    const match = events.find(e => RELEVANT_EVENT_TYPES.includes(e.type as string));
+    return match?.id;
+  }, [events]);
+  useEffect(() => {
+    if (latestRelevantId) load();
+  }, [latestRelevantId, load]);
+
+  const visible = rows.filter(r => showArchived || r.is_archived === 0);
+
+  const statusClass = (s: string) => {
+    if (s === 'done') return 'bg-green-700/30 text-green-300';
+    if (s === 'cancelled') return 'bg-red-700/30 text-red-300';
+    if (s === 'in_progress' || s === 'testing' || s === 'review' || s === 'verification') {
+      return 'bg-yellow-700/30 text-yellow-300';
+    }
+    return 'bg-mc-bg-tertiary text-mc-text-secondary';
+  };
+
+  return (
+    <div className="border-b border-mc-border bg-mc-bg-secondary">
+      <button
+        onClick={() => setExpanded(v => !v)}
+        className="w-full flex items-center justify-between px-3 py-2 hover:bg-mc-bg-tertiary"
+      >
+        <div className="flex items-center gap-2">
+          <Package className="w-4 h-4 text-mc-accent" />
+          <span className="text-sm font-medium uppercase tracking-wider">Deliverables</span>
+          {visible.length > 0 && (
+            <span className="text-xs px-1.5 py-0.5 rounded bg-mc-bg-tertiary text-mc-text-secondary">
+              {visible.length}
+            </span>
+          )}
+        </div>
+        {expanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-3">
+          <label className="flex items-center gap-2 text-xs text-mc-text-secondary mb-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showArchived}
+              onChange={e => setShowArchived(e.target.checked)}
+              className="accent-mc-accent"
+            />
+            Show archived
+          </label>
+
+          {loading ? (
+            <div className="text-xs text-mc-text-secondary py-2">Loading...</div>
+          ) : visible.length === 0 ? (
+            <div className="text-xs text-mc-text-secondary py-2">No deliverables yet</div>
+          ) : (
+            <div className="space-y-2 max-h-64 overflow-y-auto">
+              {visible.map(row => (
+                <div
+                  key={row.task_id}
+                  className={`p-2 rounded border border-mc-border bg-mc-bg ${row.is_archived ? 'opacity-60' : ''}`}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <span
+                      className="flex-1 min-w-0 text-sm text-mc-text truncate"
+                      title={row.task_title}
+                    >
+                      {row.task_title}
+                    </span>
+                    {row.mc_count > 0 && (
+                      <a
+                        href={`/api/tasks/${row.task_id}/deliverables/download`}
+                        className="flex-shrink-0 p-1 rounded text-mc-accent hover:bg-mc-bg-tertiary"
+                        title={`Download ${row.mc_count} file${row.mc_count === 1 ? '' : 's'}`}
+                      >
+                        <Download className="w-3.5 h-3.5" />
+                      </a>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 mt-1 text-xs">
+                    <span className={`px-1.5 py-0.5 rounded capitalize ${statusClass(row.status)}`}>
+                      {row.status.replace(/_/g, ' ')}
+                    </span>
+                    <span className="text-mc-text-secondary">
+                      {row.file_count} file{row.file_count === 1 ? '' : 's'}
+                    </span>
+                    {row.mc_count < row.file_count && (
+                      <span className="text-mc-text-secondary" title="Some deliverables are host-only">
+                        ({row.mc_count} web)
+                      </span>
+                    )}
+                    {row.is_archived === 1 && (
+                      <span className="flex items-center gap-0.5 text-mc-text-secondary">
+                        <Archive className="w-3 h-3" />
+                        archived
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { X, Save, Trash2, Activity, Package, Bot, ClipboardList, Plus, Users, ImageIcon, Truck, Radio, MessageSquare, ExternalLink, HardDrive } from 'lucide-react';
+import { X, Save, Trash2, Activity, Package, Bot, ClipboardList, Plus, Users, ImageIcon, Truck, Radio, MessageSquare, ExternalLink, HardDrive, Archive, ArchiveRestore } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import { triggerAutoDispatch, shouldTriggerAutoDispatch } from '@/lib/auto-dispatch';
 import { ActivityLog } from './ActivityLog';
@@ -66,6 +66,7 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isArchiving, setIsArchiving] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent, keepOpen = false) => {
     e.preventDefault();
@@ -168,6 +169,30 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
       setSaveError(error instanceof Error ? error.message : 'Network error — please try again');
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleArchiveToggle = async () => {
+    if (!task) return;
+    const shouldArchive = !task.is_archived;
+    setIsArchiving(true);
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/archive`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ archived: shouldArchive }),
+      });
+      if (res.ok) {
+        const updated = await res.json();
+        useMissionControl.setState((state) => ({
+          tasks: state.tasks.map((t) => (t.id === updated.id ? { ...t, ...updated } : t)),
+        }));
+        onClose();
+      }
+    } catch (error) {
+      console.error('Failed to toggle archive:', error);
+    } finally {
+      setIsArchiving(false);
     }
   };
 
@@ -464,9 +489,20 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
                 <>
                   <button
                     type="button"
+                    onClick={handleArchiveToggle}
+                    disabled={isArchiving}
+                    className="min-h-11 flex items-center gap-2 px-3 py-2 text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary rounded text-sm disabled:opacity-50"
+                    title={task.is_archived ? 'Restore from archive' : 'Archive (preserves deliverables)'}
+                  >
+                    {task.is_archived ? <ArchiveRestore className="w-4 h-4" /> : <Archive className="w-4 h-4" />}
+                    {isArchiving ? '...' : task.is_archived ? 'Unarchive' : 'Archive'}
+                  </button>
+                  <button
+                    type="button"
                     onClick={handleDelete}
                     disabled={isDeleting}
                     className="min-h-11 flex items-center gap-2 px-3 py-2 text-mc-accent-red hover:bg-mc-accent-red/10 rounded text-sm disabled:opacity-50"
+                    title="Permanently delete this task and its deliverables"
                   >
                     <Trash2 className="w-4 h-4" />
                     {isDeleting ? 'Deleting...' : 'Delete'}

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1814,6 +1814,36 @@ const migrations: Migration[] = [
 
       console.log('[Migration 032] Complete: is_active flag, mailbox generalized, rollcall tables created.');
     }
+  },
+  {
+    id: '033',
+    name: 'deliverable_storage_and_task_archive',
+    up: (db) => {
+      console.log('[Migration 033] Adding task archive flags and deliverable storage metadata...');
+
+      const tasksInfo = db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[];
+      if (!tasksInfo.some(c => c.name === 'is_archived')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN is_archived INTEGER DEFAULT 0`);
+        db.exec(`UPDATE tasks SET is_archived = 0 WHERE is_archived IS NULL`);
+      }
+      if (!tasksInfo.some(c => c.name === 'archived_at')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN archived_at TEXT`);
+      }
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_archived ON tasks(is_archived, status)`);
+
+      const delivInfo = db.prepare("PRAGMA table_info(task_deliverables)").all() as { name: string }[];
+      if (!delivInfo.some(c => c.name === 'storage_scheme')) {
+        db.exec(`ALTER TABLE task_deliverables ADD COLUMN storage_scheme TEXT DEFAULT 'host'`);
+        // Existing rows: they reference host paths, so 'host' is correct. URL/artifact
+        // rows also get 'host' but the UI keys off deliverable_type, not scheme.
+        db.exec(`UPDATE task_deliverables SET storage_scheme = 'host' WHERE storage_scheme IS NULL`);
+      }
+      if (!delivInfo.some(c => c.name === 'size_bytes')) {
+        db.exec(`ALTER TABLE task_deliverables ADD COLUMN size_bytes INTEGER`);
+      }
+
+      console.log('[Migration 033] Complete: tasks.is_archived/archived_at and task_deliverables.storage_scheme/size_bytes added.');
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -82,6 +82,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   workspace_base_commit TEXT,
   merge_status TEXT,
   merge_pr_url TEXT,
+  is_archived INTEGER DEFAULT 0,
+  archived_at TEXT,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -255,6 +257,8 @@ CREATE TABLE IF NOT EXISTS task_deliverables (
   title TEXT NOT NULL,
   path TEXT,
   description TEXT,
+  storage_scheme TEXT DEFAULT 'host',
+  size_bytes INTEGER,
   created_at TEXT DEFAULT (datetime('now'))
 );
 
@@ -797,6 +801,7 @@ CREATE TABLE IF NOT EXISTS debug_config (
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_assigned ON tasks(assigned_agent_id);
 CREATE INDEX IF NOT EXISTS idx_tasks_workspace ON tasks(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_archived ON tasks(is_archived, status);
 CREATE INDEX IF NOT EXISTS idx_agents_workspace ON agents(workspace_id);
 CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id);
 CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at DESC);

--- a/src/lib/deliverables/storage.ts
+++ b/src/lib/deliverables/storage.ts
@@ -1,0 +1,179 @@
+/**
+ * Deliverable storage resolution.
+ *
+ * Two paths matter:
+ *   - HOST path: what the agent (running on the host OS) sees. Injected into
+ *     dispatch prompts so agents write deliverables to the right place.
+ *   - CONTAINER path: what MC (possibly running inside a Docker container)
+ *     sees when reading the same bytes via a mounted volume.
+ *
+ * In local dev the two collapse to one value. In Docker compose a volume
+ * mount makes host → container translation.
+ *
+ * On-disk layout for MC-managed deliverables:
+ *   <root>/<task_id>/<filename>
+ *
+ * (The agent writes the file before it knows the deliverable_id, so we don't
+ * prefix with it at write-time. Collisions between deliverables in the same
+ * task are the agent's responsibility — typically distinct titles produce
+ * distinct filenames.)
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { getProjectsPath } from '@/lib/config';
+import type { TaskDeliverable } from '@/lib/types';
+
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.xml': 'application/xml',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.pdf': 'application/pdf',
+  '.zip': 'application/zip',
+  '.csv': 'text/csv',
+  '.yaml': 'application/x-yaml',
+  '.yml': 'application/x-yaml',
+};
+
+function expandTilde(p: string): string {
+  if (p.startsWith('~')) {
+    return p.replace(/^~/, process.env.HOME || '');
+  }
+  return p;
+}
+
+export function getDeliverablesHostPath(): string {
+  // Agent-perspective. Defaults to the existing projects location so today's
+  // flow keeps working when the env vars aren't set.
+  return expandTilde(process.env.MC_DELIVERABLES_HOST_PATH || getProjectsPath());
+}
+
+export function getDeliverablesContainerPath(): string {
+  // MC-perspective. In local mode this is identical to the host path.
+  return expandTilde(
+    process.env.MC_DELIVERABLES_CONTAINER_PATH ||
+    process.env.MC_DELIVERABLES_HOST_PATH ||
+    getProjectsPath()
+  );
+}
+
+export function getTaskDeliverableDir(taskId: string, perspective: 'host' | 'container'): string {
+  const root = perspective === 'host' ? getDeliverablesHostPath() : getDeliverablesContainerPath();
+  return path.join(root, taskId);
+}
+
+/**
+ * Given a submitted absolute host path, decide if it lives under the
+ * deliverables root. Used at register-time to tag storage_scheme.
+ */
+export function isUnderDeliverablesHostRoot(submittedPath: string): boolean {
+  if (!submittedPath) return false;
+  const expanded = expandTilde(submittedPath);
+  const root = path.resolve(getDeliverablesHostPath());
+  const abs = path.resolve(expanded);
+  return abs === root || abs.startsWith(root + path.sep);
+}
+
+/**
+ * Translate a host-perspective absolute path to a container-perspective
+ * absolute path by swapping the roots. Used when MC needs to read a file
+ * the agent wrote.
+ */
+export function hostPathToContainerPath(hostPath: string): string {
+  const expanded = expandTilde(hostPath);
+  const hostRoot = path.resolve(getDeliverablesHostPath());
+  const containerRoot = path.resolve(getDeliverablesContainerPath());
+  if (hostRoot === containerRoot) return expanded;
+
+  const abs = path.resolve(expanded);
+  if (abs === hostRoot) return containerRoot;
+  if (abs.startsWith(hostRoot + path.sep)) {
+    return path.join(containerRoot, abs.slice(hostRoot.length + 1));
+  }
+  // Path is outside the deliverables root — can't translate, return as-is and
+  // let the caller's safety check reject it if applicable.
+  return expanded;
+}
+
+export class DeliverableReadError extends Error {
+  status: number;
+  constructor(message: string, status = 500) {
+    super(message);
+    this.status = status;
+  }
+}
+
+/**
+ * Resolve a deliverable record to an absolute, readable path in the MC
+ * (container) filesystem. Validates:
+ *   - scheme is supported (ssh:// is reserved but not yet implemented)
+ *   - real path stays under the configured deliverables container root
+ *     (for MC-managed rows) — this blocks path-traversal / symlink attacks
+ *   - for legacy 'host' rows the stored path is used as-is (this is pre-existing
+ *     behavior we preserve for deliverables created before this feature)
+ */
+export function resolveDeliverableReadPath(deliverable: TaskDeliverable): string {
+  if (!deliverable.path) {
+    throw new DeliverableReadError('Deliverable has no path', 400);
+  }
+  if (deliverable.path.startsWith('ssh://')) {
+    throw new DeliverableReadError('Remote (ssh) deliverable storage is not yet supported', 501);
+  }
+
+  const scheme = deliverable.storage_scheme || 'host';
+
+  if (scheme === 'mc') {
+    // Rebuild from (container_root, task_id, basename(path)). We trust only
+    // the basename of the stored path — the directory part is host-perspective
+    // and not meaningful for reads. The on-disk layout is canonical.
+    const containerDir = getTaskDeliverableDir(deliverable.task_id, 'container');
+    const filename = path.basename(deliverable.path);
+    const candidate = path.join(containerDir, filename);
+
+    // Safety: real path must stay within the container root.
+    const root = path.resolve(getDeliverablesContainerPath());
+    let resolved: string;
+    try {
+      resolved = fs.realpathSync(candidate);
+    } catch {
+      throw new DeliverableReadError('Deliverable file not found', 404);
+    }
+    if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+      throw new DeliverableReadError('Deliverable path escaped storage root', 403);
+    }
+    return resolved;
+  }
+
+  // Legacy host-only row. We still do a basic existence check so callers get
+  // a 404 instead of a 500 when the file has been moved or the host path is
+  // not reachable from the MC process (e.g. MC in Docker without the mount).
+  const translated = hostPathToContainerPath(deliverable.path);
+  if (!fs.existsSync(translated)) {
+    throw new DeliverableReadError('Deliverable file not found', 404);
+  }
+  return translated;
+}
+
+export function mimeTypeForPath(p: string): string {
+  const ext = path.extname(p).toLowerCase();
+  return MIME_TYPES[ext] || 'application/octet-stream';
+}
+
+export function fileSizeBytes(absPath: string): number | undefined {
+  try {
+    return fs.statSync(absPath).size;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,8 @@ export type EventType =
   | 'task_assigned'
   | 'task_status_changed'
   | 'task_completed'
+  | 'task_archived'
+  | 'task_unarchived'
   | 'message_sent'
   | 'agent_status_changed'
   | 'agent_joined'
@@ -92,6 +94,8 @@ export interface Task {
   workspace_base_commit?: string;
   merge_status?: 'pending' | 'merged' | 'conflict' | 'pr_created' | 'abandoned';
   merge_pr_url?: string;
+  is_archived?: number;
+  archived_at?: string;
   created_at: string;
   updated_at: string;
   // Joined fields
@@ -253,6 +257,8 @@ export interface TaskActivity {
 
 export type DeliverableType = 'file' | 'url' | 'artifact';
 
+export type DeliverableStorageScheme = 'mc' | 'host' | 'ssh';
+
 export interface TaskDeliverable {
   id: string;
   task_id: string;
@@ -260,6 +266,8 @@ export interface TaskDeliverable {
   title: string;
   path?: string;
   description?: string;
+  storage_scheme?: DeliverableStorageScheme;
+  size_bytes?: number;
   created_at: string;
 }
 
@@ -822,6 +830,8 @@ export type SSEEventType =
   | 'task_updated'
   | 'task_created'
   | 'task_deleted'
+  | 'task_archived'
+  | 'task_unarchived'
   | 'activity_logged'
   | 'deliverable_added'
   | 'agent_spawned'


### PR DESCRIPTION
## Summary
- Deliverables written to `MC_DELIVERABLES_HOST_PATH/<task_id>/` are now web-downloadable: per-file and per-task zip. Host/container path split keeps it working when MC runs in Docker; `ssh://` prefix is reserved for future remote hosts.
- New **Ready Deliverables** right-rail panel lists every task that has produced output (persistent state view, not event stream). Each row has an inline zip download.
- **Task archiving** via an orthogonal `is_archived` flag — any task can be archived with deliverables preserved. Board hides archived by default, toggle on the header to show. Archive/Unarchive button in TaskModal.
- **Mission Queue** empty columns collapse to a narrow vertical rail (still a drop target); each column has manual collapse/expand.
- **Right rail** has three independent collapses: whole panel, Live Feed section, Deliverables section.

## Why
Agents and MC may run on different hosts (or MC in a container), so reveal-in-Finder and host-path deliverables stop being reachable from the operator. Web download is the one reliable access pattern. Archive keeps tasks with deliverables accessible without cluttering the board.

## Schema (migration 033)
- `tasks`: `is_archived INTEGER DEFAULT 0`, `archived_at TEXT`
- `task_deliverables`: `storage_scheme TEXT DEFAULT 'host'` (values: `mc` | `host` | `ssh`), `size_bytes INTEGER`
- Existing deliverables default to `'host'` — they remain reveal-only (shown with a "host-only" pill) so nothing pre-existing breaks.

## Env vars
- `MC_DELIVERABLES_HOST_PATH` — path agents see (injected into dispatch prompts)
- `MC_DELIVERABLES_CONTAINER_PATH` — path MC reads via
- Both default to existing `getProjectsPath()` when unset, so local dev is unchanged.

## Test plan
- [ ] Start app against an existing DB, confirm migration 033 runs, backup is created, existing deliverables get `storage_scheme='host'`
- [ ] Dispatch a builder task, confirm the prompt shows `DELIVERABLES DIR: <host>/<task_id>/`
- [ ] Have an agent drop a file in that dir and POST to `/api/tasks/:id/deliverables` — row gets `storage_scheme='mc'` and `size_bytes`
- [ ] Click per-item Download in the Deliverables tab — file downloads with correct MIME + filename
- [ ] Click "Download all" on the tab — zip arrives with one entry per MC-managed file
- [ ] Legacy pre-migration row shows "host-only" pill, Reveal still works, no Download button
- [ ] Ready Deliverables panel populates; SSE `deliverable_added` / `task_archived` updates it without reload
- [ ] Archive a done task — disappears from board, reappears with "Show archived" toggle, still listed in Ready Deliverables. Unarchive restores.
- [ ] \`ssh://\` path submission is rejected with 501
- [ ] Empty board columns render as vertical rails; dragging a card onto a rail still drops into that status
- [ ] Right-rail: whole-panel minimize, Live Feed collapse, and Deliverables collapse all work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)