### PR TITLE
feat: autopilot observability, stall detection, and abort-on-reset

### DIFF
--- a/src/app/api/autopilot/scan-stalls/route.ts
+++ b/src/app/api/autopilot/scan-stalls/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { scanStalledCycles } from '@/lib/autopilot/stall-detection';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/autopilot/scan-stalls
+ *
+ * Manual trigger for the autopilot cycle stall scanner. The scanner also
+ * runs automatically every 2 minutes as part of runHealthCheckCycle
+ * (alongside the task-side scanStalledTasks). Use this endpoint for an
+ * immediate pass — e.g. from an external cron, or when debugging an
+ * autopilot cycle that's stuck in `running`.
+ *
+ * Response:
+ *   {
+ *     scanned: number,
+ *     flagged: Array<{ cycle_id, cycle_type, product_id, current_phase, minutes_idle }>
+ *   }
+ */
+export async function POST(_request: NextRequest) {
+  try {
+    const report = await scanStalledCycles();
+    return NextResponse.json(report);
+  } catch (error) {
+    console.error('[AutopilotScanStalls] failed:', error);
+    return NextResponse.json(
+      { error: `Autopilot cycle stall scan failed: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/openclaw/sessions/route.ts
+++ b/src/app/api/openclaw/sessions/route.ts
@@ -4,7 +4,8 @@ import { queryAll, queryOne, run, transaction } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { logDebugEvent } from '@/lib/debug-log';
 import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
-import type { Agent, OpenClawSession } from '@/lib/types';
+import { emitAutopilotActivity } from '@/lib/autopilot/activity';
+import type { Agent, OpenClawSession, ResearchCycle, IdeationCycle } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 // GET /api/openclaw/sessions - List OpenClaw sessions
@@ -103,14 +104,18 @@ export async function POST(request: Request) {
 // edits (SOUL.md / AGENTS.md / MESSAGING-PROTOCOL.md) that need agents to
 // reload, or when sessionKey routing has drifted.
 //
-// Two phases:
+// Three phases:
+//   0. Abort any in-flight Product Autopilot research / ideation cycles
+//      (status='running') so their runners can't overwrite a cycle after
+//      the reset with a late 'completed' / 'failed'. Marked 'interrupted'
+//      with error_message='aborted_by_reset: ...'.
 //   1. Wipe MC's `openclaw_sessions` table + clean up legacy Sub-Agent rows.
 //   2. Send `/reset` via chat.send to each gateway-synced agent's main
 //      session, which forces the gateway to re-init that session — the
 //      agent's next message reloads SOUL.md/AGENTS.md/etc. `/reset` and
 //      `/new` are OpenClaw's built-in session-init commands.
 //
-// Either phase can fail independently; the response reports both so the
+// Any phase can fail independently; the response reports all three so the
 // operator can see what landed. `agents_reset` entries with `ok: false`
 // usually mean the gateway didn't route the command (agent offline,
 // allow-list restriction, etc.) — operator can fall back to `/reset` in
@@ -119,6 +124,58 @@ export async function DELETE() {
   try {
     const sessions = queryAll<OpenClawSession>('SELECT * FROM openclaw_sessions');
     const count = sessions.length;
+
+    // Phase 0: abort in-flight autopilot cycles. Without this, a research or
+    // ideation cycle whose LLM fetch is mid-flight when the operator hits
+    // "Reset all sessions" sits in status='running' until its async runner
+    // completes (then overwrites to 'completed'/'failed' — but the guard in
+    // research.ts/ideation.ts now blocks that) or until the cycle scanner
+    // catches it ~15 minutes later. Explicit abort here makes the reset
+    // semantics match the operator's intent: "stop everything in flight".
+    const inflightResearch = queryAll<ResearchCycle>(
+      `SELECT * FROM research_cycles WHERE status = 'running'`
+    );
+    const inflightIdeation = queryAll<IdeationCycle>(
+      `SELECT * FROM ideation_cycles WHERE status = 'running'`
+    );
+    const abortedCycles: Array<{ cycle_id: string; cycle_type: 'research' | 'ideation'; product_id: string; phase: string }> = [];
+    const cycleAbortNow = new Date().toISOString();
+    const cycleAbortReason = `aborted_by_reset: operator triggered bulk session reset at ${cycleAbortNow}`;
+    for (const cycle of inflightResearch) {
+      run(
+        `UPDATE research_cycles SET status = 'interrupted', error_message = ?, completed_at = ? WHERE id = ? AND status = 'running'`,
+        [cycleAbortReason, cycleAbortNow, cycle.id]
+      );
+      abortedCycles.push({ cycle_id: cycle.id, cycle_type: 'research', product_id: cycle.product_id, phase: cycle.current_phase || 'init' });
+    }
+    for (const cycle of inflightIdeation) {
+      run(
+        `UPDATE ideation_cycles SET status = 'interrupted', error_message = ?, completed_at = ? WHERE id = ? AND status = 'running'`,
+        [cycleAbortReason, cycleAbortNow, cycle.id]
+      );
+      abortedCycles.push({ cycle_id: cycle.id, cycle_type: 'ideation', product_id: cycle.product_id, phase: cycle.current_phase || 'init' });
+    }
+    for (const c of abortedCycles) {
+      emitAutopilotActivity({
+        productId: c.product_id,
+        cycleId: c.cycle_id,
+        cycleType: c.cycle_type,
+        eventType: 'cycle_aborted',
+        message: `${c.cycle_type} cycle aborted by session reset`,
+        detail: `Phase was ${c.phase}`,
+      });
+      logDebugEvent({
+        type: 'autopilot.cycle_aborted',
+        direction: 'internal',
+        metadata: {
+          cycle_id: c.cycle_id,
+          cycle_type: c.cycle_type,
+          product_id: c.product_id,
+          current_phase: c.phase,
+          trigger: 'session_reset',
+        },
+      });
+    }
 
     transaction(() => {
       // Same cleanup as the per-session DELETE in [id]/route.ts: remove
@@ -179,6 +236,7 @@ export async function DELETE() {
           success: true,
           deleted: count,
           agents_reset: [],
+          aborted_cycles: abortedCycles,
           gateway_error: (err as Error).message,
         });
       }
@@ -207,13 +265,14 @@ export async function DELETE() {
 
     broadcast({
       type: 'agent_completed',
-      payload: { reset: true, count, agents_reset: agentsReset.length, deleted: true },
+      payload: { reset: true, count, agents_reset: agentsReset.length, aborted_cycles: abortedCycles.length, deleted: true },
     });
 
     return NextResponse.json({
       success: true,
       deleted: count,
       agents_reset: agentsReset,
+      aborted_cycles: abortedCycles,
     });
   } catch (error) {
     console.error('Failed to reset OpenClaw sessions:', error);

--- a/src/app/api/products/[id]/cycles/[cycleId]/admin/release/route.ts
+++ b/src/app/api/products/[id]/cycles/[cycleId]/admin/release/route.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { queryOne, run } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import { logDebugEvent } from '@/lib/debug-log';
+import { emitAutopilotActivity } from '@/lib/autopilot/activity';
+import { ReleaseCycleSchema } from '@/lib/validation';
+import type { ResearchCycle, IdeationCycle } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/products/[id]/cycles/[cycleId]/admin/release
+ *
+ * Admin escape hatch for autopilot cycles stuck in status='running'. Flips
+ * the cycle to 'interrupted' (the shared vocabulary used by recovery.ts)
+ * with a descriptive error_message and writes an autopilot activity row so
+ * the operator sees the action in the Activity panel. Mirrors the shape of
+ * /api/tasks/[id]/admin/release-stall.
+ *
+ * Auth: bearer-token check via middleware (same as other admin routes).
+ *
+ * Body:
+ *   reason:       required, 1..500 chars
+ *   released_by:  optional audit string
+ *
+ * Accepts either a research_cycle id or an ideation_cycle id — we look
+ * both tables up by id and dispatch based on which one matches.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; cycleId: string }> }
+) {
+  const { id: productId, cycleId } = await params;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const validation = ReleaseCycleSchema.safeParse(body);
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: validation.error.issues },
+        { status: 400 }
+      );
+    }
+
+    const { reason, released_by } = validation.data;
+
+    // Find the cycle in either table. Cycle IDs are UUIDs so collisions are
+    // effectively zero; we still check both in case an operator passes the
+    // wrong kind of id.
+    const research = queryOne<ResearchCycle>(
+      'SELECT * FROM research_cycles WHERE id = ? AND product_id = ?',
+      [cycleId, productId]
+    );
+    const ideation = research
+      ? null
+      : queryOne<IdeationCycle>(
+          'SELECT * FROM ideation_cycles WHERE id = ? AND product_id = ?',
+          [cycleId, productId]
+        );
+
+    if (!research && !ideation) {
+      return NextResponse.json({ error: 'Cycle not found for this product' }, { status: 404 });
+    }
+
+    const cycleType: 'research' | 'ideation' = research ? 'research' : 'ideation';
+    const table = research ? 'research_cycles' : 'ideation_cycles';
+    const priorStatus = (research || ideation)!.status;
+    const currentPhase = (research || ideation)!.current_phase || 'init';
+
+    if (priorStatus !== 'running') {
+      return NextResponse.json(
+        {
+          error: `Cycle is not in a releasable state`,
+          hint: `Status is '${priorStatus}'; release only flips running → interrupted.`,
+        },
+        { status: 409 }
+      );
+    }
+
+    const now = new Date().toISOString();
+    const errorMessage = `released_by_admin: ${reason}${released_by ? ` (by ${released_by})` : ''}`;
+
+    // Guard the UPDATE on status='running' so a racing runner can't resurrect
+    // the cycle after we release it.
+    run(
+      `UPDATE ${table}
+         SET status = 'interrupted', error_message = ?, completed_at = ?
+       WHERE id = ? AND status = 'running'`,
+      [errorMessage, now, cycleId]
+    );
+
+    emitAutopilotActivity({
+      productId,
+      cycleId,
+      cycleType,
+      eventType: 'cycle_released',
+      message: `${cycleType} cycle released by admin`,
+      detail: `Phase was ${currentPhase}; reason: ${reason}`,
+    });
+
+    logDebugEvent({
+      type: 'autopilot.cycle_aborted',
+      direction: 'internal',
+      metadata: {
+        table,
+        cycle_id: cycleId,
+        cycle_type: cycleType,
+        product_id: productId,
+        current_phase: currentPhase,
+        prior_status: priorStatus,
+        reason,
+        released_by: released_by || null,
+        trigger: 'admin_release',
+      },
+    });
+
+    broadcast({
+      type: cycleType === 'research' ? 'research_phase' : 'ideation_phase',
+      payload: {
+        productId,
+        cycleId,
+        phase: 'interrupted',
+        reason: errorMessage,
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      cycle_id: cycleId,
+      cycle_type: cycleType,
+      prior_status: priorStatus,
+      prior_phase: currentPhase,
+      new_status: 'interrupted',
+    });
+  } catch (error) {
+    console.error('Failed to release autopilot cycle:', error);
+    return NextResponse.json(
+      { error: `Failed to release cycle: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -31,6 +31,11 @@ const EVENT_TYPE_OPTIONS: Array<{ value: '' | DebugEventType; label: string }> =
   { value: 'stall.flagged', label: '• stall.flagged' },
   { value: 'stall.cleared', label: '• stall.cleared' },
   { value: 'diagnostic.step', label: '• diagnostic.step' },
+  // Product Autopilot
+  { value: 'autopilot.research_llm', label: '↕ autopilot.research_llm' },
+  { value: 'autopilot.ideation_llm', label: '↕ autopilot.ideation_llm' },
+  { value: 'autopilot.cycle_stalled', label: '• autopilot.cycle_stalled' },
+  { value: 'autopilot.cycle_aborted', label: '• autopilot.cycle_aborted' },
 ];
 
 const DIRECTION_OPTIONS: Array<{ value: '' | DebugEventDirection; label: string }> = [

--- a/src/components/AgentsSidebar.tsx
+++ b/src/components/AgentsSidebar.tsx
@@ -215,9 +215,10 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
   const resetAllSessions = async () => {
     if (!confirm(
       'Reset ALL agent sessions?\n\n' +
-      'This does two things:\n' +
-      '  1. Wipes Mission Control\'s session tracking (the "OpenClaw Connected" badges).\n' +
-      '  2. Sends `/reset` to every active gateway-synced agent\'s main session, which forces OpenClaw to re-initialize the session and reload the agent\'s SOUL.md / AGENTS.md / MESSAGING-PROTOCOL.md on its next turn.\n\n' +
+      'This does three things:\n' +
+      '  1. Aborts any in-flight Product Autopilot research/ideation cycles (marks them interrupted).\n' +
+      '  2. Wipes Mission Control\'s session tracking (the "OpenClaw Connected" badges).\n' +
+      '  3. Sends `/reset` to every active gateway-synced agent\'s main session, which forces OpenClaw to re-initialize the session and reload the agent\'s SOUL.md / AGENTS.md / MESSAGING-PROTOCOL.md on its next turn.\n\n' +
       'Use this after editing agent persona files, or when sessionKey routing has drifted.'
     )) return;
     setResetSessionsBusy(true);
@@ -238,9 +239,18 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
       const resets: Array<{ name: string; ok: boolean; error?: string }> = data.agents_reset || [];
       const ok = resets.filter(r => r.ok).map(r => r.name);
       const failed = resets.filter(r => !r.ok);
+      const aborted: Array<{ cycle_id: string; cycle_type: string }> = data.aborted_cycles || [];
       const lines: string[] = [
         `Cleared ${data.deleted} MC session record(s).`,
       ];
+      if (aborted.length) {
+        const researchCount = aborted.filter(c => c.cycle_type === 'research').length;
+        const ideationCount = aborted.filter(c => c.cycle_type === 'ideation').length;
+        const parts: string[] = [];
+        if (researchCount) parts.push(`${researchCount} research`);
+        if (ideationCount) parts.push(`${ideationCount} ideation`);
+        lines.push(`Aborted ${aborted.length} in-flight autopilot cycle(s): ${parts.join(', ')}.`);
+      }
       if (ok.length) lines.push(`Sent /reset to: ${ok.join(', ')}`);
       if (failed.length) {
         lines.push(`Failed to /reset: ${failed.map(f => `${f.name} (${f.error || 'unknown'})`).join('; ')}`);

--- a/src/lib/agent-health.ts
+++ b/src/lib/agent-health.ts
@@ -5,6 +5,7 @@ import { getMissionControlUrl } from '@/lib/config';
 import { buildCheckpointContext } from '@/lib/checkpoint';
 import { logTaskActivityThrottled } from '@/lib/activity-log';
 import { scanStalledTasks } from '@/lib/stall-detection';
+import { scanStalledCycles } from '@/lib/autopilot/stall-detection';
 import type { Agent, AgentHealth, AgentHealthState, Task } from '@/lib/types';
 
 // Heartbeat rows are throttled so the activity feed stays readable. 5 min
@@ -239,6 +240,16 @@ export async function runHealthCheckCycle(): Promise<AgentHealth[]> {
     await scanStalledTasks();
   } catch (err) {
     console.error('[Health] scanStalledTasks failed:', err);
+  }
+
+  // Autopilot cycle scanner. Same rationale as scanStalledTasks: piggyback
+  // on the existing cadence. research_cycles / ideation_cycles live in
+  // separate tables and have their own heartbeat fields, so task scan
+  // doesn't see them.
+  try {
+    await scanStalledCycles();
+  } catch (err) {
+    console.error('[Health] scanStalledCycles failed:', err);
   }
 
   return results;

--- a/src/lib/autopilot/ideation.ts
+++ b/src/lib/autopilot/ideation.ts
@@ -172,6 +172,7 @@ export async function runIdeationCycle(productId: string, cycleId?: string, exis
         const { data: rawIdeas, model: responseModel, usage } = await completeJSON<unknown[]>(prompt, {
           systemPrompt: 'You are a product ideation agent. Respond with a JSON array of idea objects only.',
           timeoutMs: 300_000,
+          debug: { productId, cycleId: ideationId, cycleType: 'ideation' },
         });
 
         // Normalize: handle { ideas: [...] } wrapper
@@ -217,8 +218,10 @@ export async function runIdeationCycle(productId: string, cycleId?: string, exis
       console.log(`[Ideation] Cycle ${ideationId} completed: ${totalIdeasCount} ideas (tokens: ${totalTokensUsed})`);
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
+      // Guard on status='running' so a release-stall / bulk-reset that
+      // interrupted the cycle while we were mid-fetch isn't overwritten.
       run(
-        `UPDATE ideation_cycles SET status = 'failed', error_message = ?, completed_at = ? WHERE id = ?`,
+        `UPDATE ideation_cycles SET status = 'failed', error_message = ?, completed_at = ? WHERE id = ? AND status = 'running'`,
         [errMsg, new Date().toISOString(), ideationId]
       );
       emitAutopilotActivity({
@@ -396,7 +399,7 @@ export async function storeIdeasFromPhaseData(
   }
 
   run(
-    `UPDATE ideation_cycles SET status = 'completed', completed_at = ?, current_phase = 'completed' WHERE id = ?`,
+    `UPDATE ideation_cycles SET status = 'completed', completed_at = ?, current_phase = 'completed' WHERE id = ? AND status = 'running'`,
     [new Date().toISOString(), ideationId]
   );
   emitAutopilotActivity({

--- a/src/lib/autopilot/llm.ts
+++ b/src/lib/autopilot/llm.ts
@@ -3,10 +3,18 @@
  * Uses /v1/chat/completions for stateless prompt→response (no agent sessions).
  */
 
+import { logDebugEvent, type DebugEventType } from '@/lib/debug-log';
+
 const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
 const MAX_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 5_000; // 5s, 10s, 20s exponential backoff
 const OPENCLAW_GATEWAY_MODEL = 'openclaw/default';
+
+export interface AutopilotDebugContext {
+  productId: string;
+  cycleId: string;
+  cycleType: 'research' | 'ideation';
+}
 
 function getGatewayUrl(): string {
   return process.env.OPENCLAW_GATEWAY_URL?.replace('ws://', 'http://').replace('wss://', 'https://') || 'http://127.0.0.1:18789';
@@ -34,6 +42,15 @@ export interface CompletionOptions {
   temperature?: number;
   maxTokens?: number;
   timeoutMs?: number;
+  /**
+   * When provided, the call is mirrored into the /debug event log as a pair
+   * of autopilot.{research,ideation}_llm events. The outbound entry carries
+   * the prompt and request body; the inbound entry carries the response (or
+   * error) and total duration across retries. Without this, the call is
+   * silent to the debug console — which is fine for tests and scripts but
+   * hides operator-relevant autopilot traffic.
+   */
+  debug?: AutopilotDebugContext;
 }
 
 export interface CompletionResult {
@@ -57,6 +74,7 @@ export async function complete(prompt: string, options: CompletionOptions = {}):
     temperature = 0.7,
     maxTokens = 8192,
     timeoutMs = DEFAULT_TIMEOUT_MS,
+    debug,
   } = options;
   const { gatewayModel, modelOverride } = resolveGatewayModel(model);
 
@@ -65,6 +83,38 @@ export async function complete(prompt: string, options: CompletionOptions = {}):
     messages.push({ role: 'system', content: systemPrompt });
   }
   messages.push({ role: 'user', content: prompt });
+
+  const requestBody = {
+    model: gatewayModel,
+    messages,
+    temperature,
+    max_tokens: maxTokens,
+  };
+
+  // Log one outbound event per call (not per attempt) — operators care about
+  // "this cycle made a research LLM call at time T", not the internal retry
+  // bookkeeping. Retry count ends up on the inbound event as metadata.
+  const debugEventType: DebugEventType | null = debug
+    ? debug.cycleType === 'research' ? 'autopilot.research_llm' : 'autopilot.ideation_llm'
+    : null;
+  const callStartedAt = Date.now();
+
+  if (debug && debugEventType) {
+    logDebugEvent({
+      type: debugEventType,
+      direction: 'outbound',
+      metadata: {
+        product_id: debug.productId,
+        cycle_id: debug.cycleId,
+        cycle_type: debug.cycleType,
+        model,
+        gateway_model: gatewayModel,
+        prompt_chars: prompt.length,
+        system_prompt_chars: systemPrompt?.length || 0,
+      },
+      requestBody,
+    });
+  }
 
   let lastError: Error | null = null;
 
@@ -86,12 +136,7 @@ export async function complete(prompt: string, options: CompletionOptions = {}):
           'Authorization': `Bearer ${getGatewayToken()}`,
           ...(modelOverride ? { 'x-openclaw-model': modelOverride } : {}),
         },
-        body: JSON.stringify({
-          model: gatewayModel,
-          messages,
-          temperature,
-          max_tokens: maxTokens,
-        }),
+        body: JSON.stringify(requestBody),
         signal: controller.signal,
       });
 
@@ -110,6 +155,25 @@ export async function complete(prompt: string, options: CompletionOptions = {}):
       const resolvedModel = modelOverride || data.model || gatewayModel;
 
       console.log(`[LLM] Response usage:`, JSON.stringify(data.usage || null), `model: ${resolvedModel}`);
+
+      if (debug && debugEventType) {
+        logDebugEvent({
+          type: debugEventType,
+          direction: 'inbound',
+          durationMs: Date.now() - callStartedAt,
+          metadata: {
+            product_id: debug.productId,
+            cycle_id: debug.cycleId,
+            cycle_type: debug.cycleType,
+            model: resolvedModel,
+            attempts: attempt + 1,
+            prompt_tokens: data.usage?.prompt_tokens || 0,
+            completion_tokens: data.usage?.completion_tokens || 0,
+            total_tokens: data.usage?.total_tokens || 0,
+          },
+          responseBody: data,
+        });
+      }
 
       return {
         content,
@@ -132,12 +196,43 @@ export async function complete(prompt: string, options: CompletionOptions = {}):
       }
 
       // Non-retryable error (e.g. 400 bad request, parse error)
+      if (debug && debugEventType) {
+        logDebugEvent({
+          type: debugEventType,
+          direction: 'inbound',
+          durationMs: Date.now() - callStartedAt,
+          error: lastError.message,
+          metadata: {
+            product_id: debug.productId,
+            cycle_id: debug.cycleId,
+            cycle_type: debug.cycleType,
+            attempts: attempt + 1,
+            retryable: false,
+          },
+        });
+      }
       throw lastError;
     } finally {
       clearTimeout(timeout);
     }
   }
 
+  if (debug && debugEventType) {
+    logDebugEvent({
+      type: debugEventType,
+      direction: 'inbound',
+      durationMs: Date.now() - callStartedAt,
+      error: lastError?.message || 'LLM completion failed after retries',
+      metadata: {
+        product_id: debug.productId,
+        cycle_id: debug.cycleId,
+        cycle_type: debug.cycleType,
+        attempts: MAX_RETRIES + 1,
+        retryable: true,
+        exhausted: true,
+      },
+    });
+  }
   throw lastError || new Error('LLM completion failed after retries');
 }
 

--- a/src/lib/autopilot/research.ts
+++ b/src/lib/autopilot/research.ts
@@ -128,6 +128,7 @@ export async function runResearchCycle(productId: string, existingCycleId?: stri
         const { data: report, model: responseModel, usage } = await completeJSON(prompt, {
           systemPrompt: 'You are a product research agent. Analyze the product and respond with a JSON research report only.',
           timeoutMs: 300_000,
+          debug: { productId, cycleId, cycleType: 'research' },
         });
 
         allReports.push({ report, variantId: programEntry.variantId, variantName: programEntry.variantName });
@@ -163,9 +164,11 @@ export async function runResearchCycle(productId: string, existingCycleId?: stri
       });
       broadcast({ type: 'research_phase', payload: { productId, cycleId, phase: 'report_received' } });
 
-      // Phase: completed
+      // Phase: completed. Guard on status='running' so a release-stall or
+      // bulk-reset that interrupted this cycle while the fetch was in flight
+      // cannot be overwritten by a late-arriving success.
       run(
-        `UPDATE research_cycles SET status = 'completed', report = ?, completed_at = ?, current_phase = 'completed' WHERE id = ?`,
+        `UPDATE research_cycles SET status = 'completed', report = ?, completed_at = ?, current_phase = 'completed' WHERE id = ? AND status = 'running'`,
         [JSON.stringify(combinedReport), new Date().toISOString(), cycleId]
       );
 
@@ -199,8 +202,9 @@ export async function runResearchCycle(productId: string, existingCycleId?: stri
       }
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
+      // Same guard as the success path — don't resurrect an interrupted cycle.
       run(
-        `UPDATE research_cycles SET status = 'failed', error_message = ?, completed_at = ? WHERE id = ?`,
+        `UPDATE research_cycles SET status = 'failed', error_message = ?, completed_at = ? WHERE id = ? AND status = 'running'`,
         [errMsg, new Date().toISOString(), cycleId]
       );
       emitAutopilotActivity({

--- a/src/lib/autopilot/stall-detection.ts
+++ b/src/lib/autopilot/stall-detection.ts
@@ -1,0 +1,142 @@
+import { queryAll, run } from '@/lib/db';
+import { logDebugEvent } from '@/lib/debug-log';
+import { emitAutopilotActivity } from './activity';
+import type { ResearchCycle, IdeationCycle } from '@/lib/types';
+
+/**
+ * Stall scanner for Product Autopilot cycles.
+ *
+ * The task-side scanner in src/lib/stall-detection.ts only scans `tasks`.
+ * Research and ideation cycles live in their own tables with their own
+ * `status='running'` + `last_heartbeat` fields. Without a scanner, a cycle
+ * whose LLM call hangs past the fetch timeout (gateway crash, socket death,
+ * Node aborting mid-read) sits in `running` forever — recovery.ts only fires
+ * at app startup, which only catches cycles that survived a process restart.
+ *
+ * This scanner runs on the same 2-minute cadence as scanStalledTasks and
+ * flips any cycle whose heartbeat is older than CYCLE_STALL_MINUTES to
+ * `status='interrupted'` with a descriptive error_message. Marking
+ * interrupted removes the cycle from the `running` set — next scan is a
+ * no-op for the same row.
+ */
+
+/** Default threshold. Override via AUTOPILOT_CYCLE_STALL_MINUTES env var. */
+const DEFAULT_CYCLE_STALL_MINUTES = 15;
+
+export interface CycleStallReport {
+  scanned: number;
+  flagged: Array<{
+    cycle_id: string;
+    cycle_type: 'research' | 'ideation';
+    product_id: string;
+    current_phase: string;
+    minutes_idle: number;
+  }>;
+}
+
+function getThresholdMinutes(): number {
+  const raw = process.env.AUTOPILOT_CYCLE_STALL_MINUTES;
+  if (!raw) return DEFAULT_CYCLE_STALL_MINUTES;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_CYCLE_STALL_MINUTES;
+}
+
+export async function scanStalledCycles(): Promise<CycleStallReport> {
+  const thresholdMinutes = getThresholdMinutes();
+  const nowMs = Date.now();
+
+  const report: CycleStallReport = { scanned: 0, flagged: [] };
+
+  const researchRunning = queryAll<ResearchCycle>(
+    `SELECT * FROM research_cycles WHERE status = 'running'`
+  );
+  report.scanned += researchRunning.length;
+
+  for (const cycle of researchRunning) {
+    // Cycles with no heartbeat at all are suspicious — they never made it
+    // past the INSERT. Use `started_at` as the fallback freshness signal.
+    const tick = cycle.last_heartbeat || cycle.started_at;
+    if (!tick) continue;
+
+    const minutesIdle = (nowMs - new Date(tick).getTime()) / 60000;
+    if (minutesIdle < thresholdMinutes) continue;
+
+    markInterrupted('research_cycles', cycle.id, cycle.product_id, 'research', minutesIdle, cycle.current_phase || 'init', thresholdMinutes);
+    report.flagged.push({
+      cycle_id: cycle.id,
+      cycle_type: 'research',
+      product_id: cycle.product_id,
+      current_phase: cycle.current_phase || 'init',
+      minutes_idle: Math.round(minutesIdle),
+    });
+  }
+
+  const ideationRunning = queryAll<IdeationCycle>(
+    `SELECT * FROM ideation_cycles WHERE status = 'running'`
+  );
+  report.scanned += ideationRunning.length;
+
+  for (const cycle of ideationRunning) {
+    const tick = cycle.last_heartbeat || cycle.started_at;
+    if (!tick) continue;
+
+    const minutesIdle = (nowMs - new Date(tick).getTime()) / 60000;
+    if (minutesIdle < thresholdMinutes) continue;
+
+    markInterrupted('ideation_cycles', cycle.id, cycle.product_id, 'ideation', minutesIdle, cycle.current_phase || 'init', thresholdMinutes);
+    report.flagged.push({
+      cycle_id: cycle.id,
+      cycle_type: 'ideation',
+      product_id: cycle.product_id,
+      current_phase: cycle.current_phase || 'init',
+      minutes_idle: Math.round(minutesIdle),
+    });
+  }
+
+  return report;
+}
+
+function markInterrupted(
+  table: 'research_cycles' | 'ideation_cycles',
+  cycleId: string,
+  productId: string,
+  cycleType: 'research' | 'ideation',
+  minutesIdle: number,
+  currentPhase: string,
+  thresholdMinutes: number,
+): void {
+  const now = new Date().toISOString();
+  const reason = `stalled_no_heartbeat (idle ${Math.round(minutesIdle)}m in ${currentPhase}, threshold ${thresholdMinutes}m, detected ${now})`;
+
+  // Guard on status='running' so a late completion from the in-flight runner
+  // can't flip us back — once we mark interrupted, we stay interrupted.
+  run(
+    `UPDATE ${table}
+       SET status = 'interrupted', error_message = ?, completed_at = ?
+     WHERE id = ? AND status = 'running'`,
+    [reason, now, cycleId]
+  );
+
+  emitAutopilotActivity({
+    productId,
+    cycleId,
+    cycleType,
+    eventType: 'cycle_stalled',
+    message: `${cycleType} cycle auto-marked interrupted after ${Math.round(minutesIdle)}m without heartbeat`,
+    detail: `Phase was ${currentPhase}; threshold ${thresholdMinutes}m`,
+  });
+
+  logDebugEvent({
+    type: 'autopilot.cycle_stalled',
+    direction: 'internal',
+    metadata: {
+      table,
+      cycle_id: cycleId,
+      cycle_type: cycleType,
+      product_id: productId,
+      current_phase: currentPhase,
+      minutes_idle: Math.round(minutesIdle),
+      threshold_minutes: thresholdMinutes,
+    },
+  });
+}

--- a/src/lib/debug-log.ts
+++ b/src/lib/debug-log.ts
@@ -42,7 +42,14 @@ export type DebugEventType =
   | 'stall.flagged'
   | 'stall.cleared'
   // Diagnostic flow (internal)
-  | 'diagnostic.step';
+  | 'diagnostic.step'
+  // Product Autopilot — stateless LLM calls via Gateway /v1/chat/completions
+  // (distinct from chat.send which targets agent sessions) plus cycle
+  // lifecycle events for research / ideation.
+  | 'autopilot.research_llm'
+  | 'autopilot.ideation_llm'
+  | 'autopilot.cycle_stalled'
+  | 'autopilot.cycle_aborted';
 
 export type DebugEventDirection = 'outbound' | 'inbound' | 'internal';
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -72,6 +72,18 @@ export const ReleaseStallSchema = z.object({
   released_by: z.string().max(200).optional(),
 });
 
+// Admin release-cycle schema — equivalent for autopilot cycles stuck in
+// status='running'. Only one terminal state (`interrupted`) because
+// research_cycles / ideation_cycles have no notion of "completed but
+// cancelled by operator"; the CHECK constraint already enforces
+// running|completed|failed|interrupted|cancelled (research) and
+// running|completed|failed|interrupted (ideation), and `interrupted` is
+// the shared vocabulary used by recovery.ts.
+export const ReleaseCycleSchema = z.object({
+  reason: z.string().min(1, 'reason is required').max(500),
+  released_by: z.string().max(200).optional(),
+});
+
 // Activity validation schema
 export const CreateActivitySchema = z.object({
   activity_type: ActivityType,


### PR DESCRIPTION
Follow-up to the gap analysis on PRs #2–#10: autopilot cycles shared the tasks pipeline downstream but not the observability / recovery primitives those PRs added. Three fixes.

## Summary

- **`/debug` now sees autopilot LLM traffic.** Every Gateway `/v1/chat/completions` call from a research or ideation cycle is mirrored into the debug event log as a pair of `autopilot.research_llm` / `autopilot.ideation_llm` events (outbound with the prompt + request body, inbound with the response + duration + token usage, or inbound with the error string on final failure — retry count stays on the inbound event as metadata). Before this, the debug console was literally blind to autopilot traffic (`rg logDebugEvent src/lib/autopilot` returned zero hits), so a silent LLM hang and a healthy idle system looked identical.

- **Cycle stall scanner.** New `scanStalledCycles()` in [src/lib/autopilot/stall-detection.ts](https://github.com/smb209/mission-control/blob/feat/autopilot-observability-and-recovery/src/lib/autopilot/stall-detection.ts) — finds `research_cycles` / `ideation_cycles` in `status='running'` whose `last_heartbeat` is older than `AUTOPILOT_CYCLE_STALL_MINUTES` (default 15), flips them to `interrupted` with a descriptive `error_message`, emits an `autopilot_activity_log` row and an `autopilot.cycle_stalled` debug event. Wired into `runHealthCheckCycle` alongside the existing `scanStalledTasks`. Manual trigger at `POST /api/autopilot/scan-stalls`. Recovery.ts (from the original spec) only runs at app startup; this catches hung cycles during a live session.

- **Admin release for cycles.** `POST /api/products/:id/cycles/:cycleId/admin/release` — mirrors `/api/tasks/:id/admin/release-stall` from #2. Flips `running → interrupted` only (returns 409 for any other status); uses the existing `interrupted` value, so no migration. Body: `{ reason, released_by? }`. Response includes prior status + prior phase for audit.

- **Reset all sessions aborts in-flight cycles.** `DELETE /api/openclaw/sessions` (the sidebar's "Reset all sessions") now has a phase 0 that marks every in-flight research/ideation cycle as `interrupted` with `error_message='aborted_by_reset: ...'`, emits activity + `autopilot.cycle_aborted` events, and includes `aborted_cycles` in the response. The sidebar alert surfaces the new phase alongside the existing MC + gateway phases.

- **Race guard on terminal UPDATEs.** The success and failure `UPDATE ... SET status = 'completed' | 'failed'` statements in [research.ts](https://github.com/smb209/mission-control/blob/feat/autopilot-observability-and-recovery/src/lib/autopilot/research.ts) and [ideation.ts](https://github.com/smb209/mission-control/blob/feat/autopilot-observability-and-recovery/src/lib/autopilot/ideation.ts) now carry `AND status = 'running'`. Without this, an async runner that finishes after a release-stall or bulk-reset would resurrect the interrupted cycle. The scanner and the release endpoint use the same guard.

## Why

The three items called out in the gap analysis as the ones that actually hurt visibility/recovery — autopilot LLM traffic invisible to `/debug`, hung cycles never scanned, and "Reset all sessions" leaving them dangling. Lower-priority items from that analysis (deliverable/archive asymmetry, `suggested_role` propagation from ideation to convoy routing) are explicitly out of scope.

## Schema

None. Uses existing `interrupted` status on both `research_cycles` and `ideation_cycles` CHECK constraints. No migration.

## Env vars

- `AUTOPILOT_CYCLE_STALL_MINUTES` — cycle stall threshold (default 15). Deliberately higher than the 5-min `/v1/chat/completions` fetch timeout so a legitimately-slow LLM isn't flagged.

## Test plan

Smoke tested end-to-end against the dev DB with fabricated rows:

- [x] `tsc --noEmit` clean
- [x] `next build` clean; new routes registered (`/api/autopilot/scan-stalls`, `/api/products/[id]/cycles/[cycleId]/admin/release`)
- [x] `next lint` — no new warnings
- [x] `scanStalledCycles()` with 3 seeded cycles (fresh research, 30m stale research, 40m stale ideation): flags the two stale rows, leaves fresh one running, writes `error_message = 'stalled_no_heartbeat (idle Nm in ..., threshold 15m, detected ...)'`
- [x] Admin release endpoint flips running → interrupted with `error_message = 'released_by_admin: test-release (by smoke-test)'`; returns 409 on a non-running cycle
- [x] `DELETE /api/openclaw/sessions` aborts both seeded cycles with `error_message='aborted_by_reset: ...'`, response includes `aborted_cycles: [...]` with `cycle_id` / `cycle_type` / `product_id` / `phase`
- [x] UPDATE guard: a late `status = 'completed'` attempt on an already `interrupted` row is a no-op — row stays interrupted
- [ ] Browser smoke test of `/debug` page with collection on during a live research cycle — recommend reviewer verify the two new event types appear in the filter dropdown and in the live tail (requires a working gateway, which this test env doesn't have)

## Files

### New

- `src/lib/autopilot/stall-detection.ts` — cycle scanner
- `src/app/api/autopilot/scan-stalls/route.ts` — manual trigger
- `src/app/api/products/[id]/cycles/[cycleId]/admin/release/route.ts` — admin release

### Modified

- `src/lib/debug-log.ts` — 4 new `DebugEventType` values
- `src/lib/autopilot/llm.ts` — thread `debug` context through `complete()` / `completeJSON()`
- `src/lib/autopilot/research.ts`, `src/lib/autopilot/ideation.ts` — pass debug context, guard terminal UPDATEs
- `src/lib/agent-health.ts` — invoke `scanStalledCycles` after `scanStalledTasks`
- `src/app/api/openclaw/sessions/route.ts` — phase 0 abort
- `src/components/AgentsSidebar.tsx` — confirm copy + alert summary include cycles
- `src/app/debug/page.tsx` — filter dropdown entries
- `src/lib/validation.ts` — `ReleaseCycleSchema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)