### PR TITLE
feat: OpenAPI docs at /api-docs for agent-callback endpoints

### DIFF
--- a/next.openapi.json
+++ b/next.openapi.json
@@ -1,0 +1,111 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Mission Control API",
+    "version": "2.5.0",
+    "description": "HTTP API surface for Mission Control. Agent-facing endpoints authenticate with a bearer token (MC_API_TOKEN) and callback to log activities, register deliverables, report failures, and checkpoint work."
+  },
+  "servers": [
+    {
+      "url": "/api",
+      "description": "Current host (relative)"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "MC_API_TOKEN",
+        "description": "Shared bearer token injected into agent dispatch prompts as Authorization: Bearer <token>. Sourced from the MC_API_TOKEN environment variable."
+      }
+    }
+  },
+  "defaultResponseSet": "auth",
+  "responseSets": {
+    "common": [
+      "400",
+      "500"
+    ],
+    "auth": [
+      "400",
+      "401",
+      "403",
+      "500"
+    ],
+    "public": [
+      "400",
+      "500"
+    ]
+  },
+  "errorConfig": {
+    "template": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string",
+          "example": "{{ERROR_MESSAGE}}"
+        },
+        "code": {
+          "type": "string",
+          "example": "{{ERROR_CODE}}"
+        }
+      }
+    },
+    "codes": {
+      "400": {
+        "description": "Bad Request",
+        "variables": {
+          "ERROR_MESSAGE": "Invalid request parameters",
+          "ERROR_CODE": "BAD_REQUEST"
+        }
+      },
+      "401": {
+        "description": "Unauthorized",
+        "variables": {
+          "ERROR_MESSAGE": "Authentication required",
+          "ERROR_CODE": "UNAUTHORIZED"
+        }
+      },
+      "403": {
+        "description": "Forbidden",
+        "variables": {
+          "ERROR_MESSAGE": "Access denied",
+          "ERROR_CODE": "FORBIDDEN"
+        }
+      },
+      "404": {
+        "description": "Not Found",
+        "variables": {
+          "ERROR_MESSAGE": "Resource not found",
+          "ERROR_CODE": "NOT_FOUND"
+        }
+      },
+      "409": {
+        "description": "Conflict",
+        "variables": {
+          "ERROR_MESSAGE": "Resource already exists",
+          "ERROR_CODE": "CONFLICT"
+        }
+      },
+      "500": {
+        "description": "Internal Server Error",
+        "variables": {
+          "ERROR_MESSAGE": "An unexpected error occurred",
+          "ERROR_CODE": "INTERNAL_ERROR"
+        }
+      }
+    }
+  },
+  "apiDir": "./src/app/api",
+  "schemaDir": "./src",
+  "schemaType": "zod",
+  "schemaFiles": [],
+  "docsUrl": "api-docs",
+  "ui": "scalar",
+  "outputFile": "openapi.json",
+  "outputDir": "./public",
+  "includeOpenApiRoutes": true,
+  "ignoreRoutes": [],
+  "debug": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@types/react-dom": "^19.2.3",
         "eslint": "^9.39.4",
         "eslint-config-next": "16.2.4",
+        "next-openapi-gen": "^0.10.5",
         "postcss": "^8.5.10",
         "tailwindcss": "^4.2.2",
         "tsx": "^4.21.0",
@@ -5043,6 +5044,35 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -5075,6 +5105,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/compress-commons": {
       "version": "6.0.2",
@@ -6325,6 +6365,21 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -6398,6 +6453,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -7004,6 +7072,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -7166,6 +7247,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-weakmap": {
@@ -7335,6 +7429,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -7735,6 +7842,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7815,6 +7965,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -7971,6 +8134,28 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-openapi-gen": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/next-openapi-gen/-/next-openapi-gen-0.10.5.tgz",
+      "integrity": "sha512-69026rPOwE2xwwscAofZPBGeaHRy2/z8Vh+jqJgIAbD4TCo4KqQF0/LXJ9exkf7ICddlQWCMix5uWMg59o927w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/traverse": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "commander": "^14.0.0",
+        "fs-extra": "^11.3.1",
+        "js-yaml": "^4.1.0",
+        "ora": "^8.2.0"
+      },
+      "bin": {
+        "next-openapi-gen": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -8192,6 +8377,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8208,6 +8409,68 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/own-keys": {
@@ -8756,6 +9019,23 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -9158,6 +9438,19 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -9891,6 +10184,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,15 @@
     "db:seed": "tsx src/lib/db/seed.ts",
     "db:backup": "sqlite3 mission-control.db 'PRAGMA wal_checkpoint(TRUNCATE);' && cp mission-control.db mission-control.db.backup && echo 'Backed up to mission-control.db.backup'",
     "db:restore": "cp mission-control.db.backup mission-control.db && echo 'Restored from backup'",
-    "db:reset": "rm -f mission-control.db mission-control.db-* && npm run db:seed"
+    "db:reset": "rm -f mission-control.db mission-control.db-* && npm run db:seed",
+    "openapi:generate": "next-openapi-gen generate"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1032.0",
     "@hello-pangea/dnd": "^18.0.1",
+    "@scalar/api-reference-react": "^0.9.24",
     "@types/archiver": "^7.0.0",
+    "ajv": "^8.18.0",
     "archiver": "^7.0.1",
     "better-sqlite3": "^12.9.0",
     "clsx": "^2.1.1",
@@ -42,6 +45,7 @@
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.4",
     "eslint-config-next": "16.2.4",
+    "next-openapi-gen": "^0.10.5",
     "postcss": "^8.5.10",
     "tailwindcss": "^4.2.2",
     "tsx": "^4.21.0",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,0 +1,1283 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Mission Control API",
+    "version": "2.5.0",
+    "description": "HTTP API surface for Mission Control. Agent-facing endpoints authenticate with a bearer token (MC_API_TOKEN) and callback to log activities, register deliverables, report failures, and checkpoint work."
+  },
+  "servers": [
+    {
+      "url": "/api",
+      "description": "Current host (relative)"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "MC_API_TOKEN",
+        "description": "Shared bearer token injected into agent dispatch prompts as Authorization: Bearer <token>. Sourced from the MC_API_TOKEN environment variable."
+      }
+    },
+    "schemas": {
+      "TaskIdParam": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Task UUID"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "CreateActivitySchema": {
+        "type": "object",
+        "properties": {
+          "activity_type": {
+            "$ref": "#/components/schemas/ActivityType"
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 5000
+          },
+          "agent_id": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/agentId"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "activity_type",
+          "message"
+        ]
+      },
+      "CheckpointSchema": {
+        "type": "object",
+        "properties": {
+          "agent_id": {
+            "$ref": "#/components/schemas/agentId"
+          },
+          "checkpoint_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual",
+              "crash_recovery"
+            ]
+          },
+          "state_summary": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10000
+          },
+          "files_snapshot": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CheckpointFileSnapshot"
+            }
+          },
+          "context_data": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "agent_id",
+          "state_summary"
+        ]
+      },
+      "CreateDeliverableSchema": {
+        "type": "object",
+        "properties": {
+          "deliverable_type": {
+            "$ref": "#/components/schemas/DeliverableType"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "path": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "deliverable_type",
+          "title"
+        ]
+      },
+      "FailTaskSchema": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 5000
+          }
+        },
+        "required": [
+          "reason"
+        ]
+      },
+      "UpdateTaskSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 10000
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskStatus"
+              }
+            ]
+          },
+          "priority": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskPriority"
+              }
+            ]
+          },
+          "assigned_agent_id": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/agentId"
+              }
+            ]
+          },
+          "workflow_template_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "due_date": {
+            "type": "string",
+            "nullable": true
+          },
+          "updated_by_agent_id": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/agentId"
+              }
+            ]
+          },
+          "status_reason": {
+            "type": "string",
+            "maxLength": 2000
+          },
+          "board_override": {
+            "type": "boolean"
+          },
+          "override_reason": {
+            "type": "string",
+            "maxLength": 2000
+          },
+          "pr_url": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true
+          },
+          "pr_status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "open",
+              "merged",
+              "closed"
+            ]
+          }
+        }
+      },
+      "agentId": {
+        "type": "string",
+        "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32})$"
+      },
+      "TaskStatus": {
+        "type": "string",
+        "enum": [
+          "pending_dispatch",
+          "planning",
+          "inbox",
+          "assigned",
+          "in_progress",
+          "convoy_active",
+          "testing",
+          "review",
+          "verification",
+          "done",
+          "cancelled"
+        ]
+      },
+      "TaskPriority": {
+        "type": "string",
+        "enum": [
+          "low",
+          "normal",
+          "high",
+          "urgent"
+        ]
+      },
+      "ActivityType": {
+        "type": "string",
+        "enum": [
+          "spawned",
+          "updated",
+          "completed",
+          "file_created",
+          "status_changed"
+        ]
+      },
+      "DeliverableType": {
+        "type": "string",
+        "enum": [
+          "file",
+          "url",
+          "artifact"
+        ]
+      },
+      "CreateTaskSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 10000
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskStatus"
+              }
+            ]
+          },
+          "priority": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskPriority"
+              }
+            ]
+          },
+          "assigned_agent_id": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/agentId"
+              }
+            ]
+          },
+          "created_by_agent_id": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/agentId"
+              }
+            ]
+          },
+          "business_id": {
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          },
+          "due_date": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
+      "ReleaseStallSchema": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "terminal_state": {
+            "type": "string",
+            "enum": [
+              "cancelled",
+              "done"
+            ]
+          },
+          "released_by": {
+            "type": "string",
+            "maxLength": 200
+          }
+        },
+        "required": [
+          "reason"
+        ]
+      },
+      "ReleaseCycleSchema": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "released_by": {
+            "type": "string",
+            "maxLength": 200
+          }
+        },
+        "required": [
+          "reason"
+        ]
+      },
+      "AgentIdParam": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Agent UUID or 32-char hex gateway ID"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "CheckpointFileSnapshot": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "hash": {
+            "type": "string",
+            "minLength": 1
+          },
+          "size": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "path",
+          "hash",
+          "size"
+        ]
+      },
+      "IdeaCategory": {
+        "type": "string",
+        "enum": [
+          "feature",
+          "improvement",
+          "ux",
+          "performance",
+          "integration",
+          "infrastructure",
+          "content",
+          "growth",
+          "monetization",
+          "operations",
+          "security"
+        ]
+      },
+      "IdeaComplexity": {
+        "type": "string",
+        "enum": [
+          "S",
+          "M",
+          "L",
+          "XL"
+        ]
+      },
+      "SwipeAction": {
+        "type": "string",
+        "enum": [
+          "approve",
+          "reject",
+          "maybe",
+          "fire"
+        ]
+      },
+      "CostCapType": {
+        "type": "string",
+        "enum": [
+          "per_cycle",
+          "per_task",
+          "daily",
+          "monthly",
+          "per_product_monthly"
+        ]
+      },
+      "CostEventType": {
+        "type": "string",
+        "enum": [
+          "agent_dispatch",
+          "research_cycle",
+          "ideation_cycle",
+          "build_task",
+          "content_generation",
+          "seo_analysis",
+          "web_search",
+          "external_api"
+        ]
+      },
+      "ProductStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "paused",
+          "archived"
+        ]
+      },
+      "CreateProductSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 5000
+          },
+          "repo_url": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  ""
+                ]
+              }
+            ]
+          },
+          "live_url": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  ""
+                ]
+              }
+            ]
+          },
+          "product_program": {
+            "type": "string",
+            "maxLength": 50000
+          },
+          "icon": {
+            "type": "string",
+            "maxLength": 10
+          },
+          "workspace_id": {
+            "type": "string"
+          },
+          "settings": {
+            "type": "string"
+          },
+          "build_mode": {
+            "type": "string",
+            "enum": [
+              "auto_build",
+              "plan_first"
+            ]
+          },
+          "default_branch": {
+            "type": "string",
+            "maxLength": 200
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "UpdateProductSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 5000
+          },
+          "repo_url": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "uri",
+                "nullable": true
+              },
+              {
+                "type": "string",
+                "enum": [
+                  ""
+                ]
+              }
+            ]
+          },
+          "live_url": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "uri",
+                "nullable": true
+              },
+              {
+                "type": "string",
+                "enum": [
+                  ""
+                ]
+              }
+            ]
+          },
+          "product_program": {
+            "type": "string",
+            "maxLength": 50000
+          },
+          "icon": {
+            "type": "string",
+            "maxLength": 10
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProductStatus"
+              }
+            ]
+          },
+          "settings": {
+            "type": "string"
+          },
+          "build_mode": {
+            "type": "string",
+            "enum": [
+              "auto_build",
+              "plan_first"
+            ]
+          },
+          "default_branch": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "cost_cap_per_task": {
+            "type": "number",
+            "minimum": 0,
+            "nullable": true
+          },
+          "cost_cap_monthly": {
+            "type": "number",
+            "minimum": 0,
+            "nullable": true
+          },
+          "batch_review_threshold": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          }
+        }
+      },
+      "SwipeActionSchema": {
+        "type": "object",
+        "properties": {
+          "idea_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "action": {
+            "$ref": "#/components/schemas/SwipeAction"
+          },
+          "notes": {
+            "type": "string",
+            "maxLength": 2000
+          }
+        },
+        "required": [
+          "idea_id",
+          "action"
+        ]
+      },
+      "CreateIdeaSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10000
+          },
+          "category": {
+            "$ref": "#/components/schemas/IdeaCategory"
+          },
+          "complexity": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IdeaComplexity"
+              }
+            ]
+          },
+          "impact_score": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 10
+          },
+          "feasibility_score": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 10
+          },
+          "estimated_effort_hours": {
+            "type": "number",
+            "minimum": 0
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "technical_approach": {
+            "type": "string",
+            "maxLength": 5000
+          },
+          "risks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "title",
+          "description",
+          "category"
+        ]
+      },
+      "CreateCostCapSchema": {
+        "type": "object",
+        "properties": {
+          "workspace_id": {
+            "type": "string"
+          },
+          "product_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "cap_type": {
+            "$ref": "#/components/schemas/CostCapType"
+          },
+          "limit_usd": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "period_start": {
+            "type": "string"
+          },
+          "period_end": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cap_type",
+          "limit_usd"
+        ]
+      },
+      "UpdateCostCapSchema": {
+        "type": "object",
+        "properties": {
+          "limit_usd": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "paused"
+            ]
+          },
+          "period_start": {
+            "type": "string"
+          },
+          "period_end": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateCostEventSchema": {
+        "type": "object",
+        "properties": {
+          "product_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "workspace_id": {
+            "type": "string"
+          },
+          "task_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "cycle_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "agent_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "event_type": {
+            "$ref": "#/components/schemas/CostEventType"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "tokens_input": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "tokens_output": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "cost_usd": {
+            "type": "number",
+            "minimum": 0
+          },
+          "metadata": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_type",
+          "cost_usd"
+        ]
+      },
+      "BatchSwipeSchema": {
+        "type": "object",
+        "properties": {
+          "actions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "idea_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "action": {
+                  "type": "string",
+                  "enum": [
+                    "approve",
+                    "reject",
+                    "maybe",
+                    "fire"
+                  ]
+                },
+                "notes": {
+                  "type": "string",
+                  "maxLength": 2000
+                }
+              },
+              "required": [
+                "idea_id",
+                "action"
+              ]
+            },
+            "minItems": 1,
+            "maxItems": 200
+          }
+        },
+        "required": [
+          "actions"
+        ]
+      },
+      "ScanUrlSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      },
+      "z": {
+        "type": "object"
+      },
+      "CreateScheduleSchema": {
+        "type": "object",
+        "properties": {
+          "schedule_type": {
+            "type": "string",
+            "enum": [
+              "research",
+              "ideation",
+              "maybe_reevaluation",
+              "seo_audit",
+              "content_refresh",
+              "analytics_report",
+              "social_batch",
+              "growth_experiment"
+            ]
+          },
+          "cron_expression": {
+            "type": "string",
+            "minLength": 1
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "config": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "schedule_type",
+          "cron_expression"
+        ]
+      },
+      "UpdateScheduleSchema": {
+        "type": "object",
+        "properties": {
+          "cron_expression": {
+            "type": "string",
+            "minLength": 1
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "config": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "responses": {
+      "400": {
+        "description": "Bad Request",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "error": {
+                  "type": "string",
+                  "example": "Invalid request parameters"
+                },
+                "code": {
+                  "type": "string",
+                  "example": "400"
+                }
+              }
+            }
+          }
+        }
+      },
+      "401": {
+        "description": "Unauthorized",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "error": {
+                  "type": "string",
+                  "example": "Authentication required"
+                },
+                "code": {
+                  "type": "string",
+                  "example": "401"
+                }
+              }
+            }
+          }
+        }
+      },
+      "403": {
+        "description": "Forbidden",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "error": {
+                  "type": "string",
+                  "example": "Access denied"
+                },
+                "code": {
+                  "type": "string",
+                  "example": "403"
+                }
+              }
+            }
+          }
+        }
+      },
+      "404": {
+        "description": "Not Found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "error": {
+                  "type": "string",
+                  "example": "Resource not found"
+                },
+                "code": {
+                  "type": "string",
+                  "example": "404"
+                }
+              }
+            }
+          }
+        }
+      },
+      "409": {
+        "description": "Conflict",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "error": {
+                  "type": "string",
+                  "example": "Resource already exists"
+                },
+                "code": {
+                  "type": "string",
+                  "example": "409"
+                }
+              }
+            }
+          }
+        }
+      },
+      "500": {
+        "description": "Internal Server Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "error": {
+                  "type": "string",
+                  "example": "An unexpected error occurred"
+                },
+                "code": {
+                  "type": "string",
+                  "example": "500"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/tasks/{id}": {
+      "patch": {
+        "operationId": "patch-tasks-{id}",
+        "summary": "Update task fields or transition stage.",
+        "description": "",
+        "tags": [
+          "Agent Callbacks"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Task UUID"
+            },
+            "required": true,
+            "description": "Task UUID",
+            "example": "123"
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTaskSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/tasks/{id}/activities": {
+      "post": {
+        "operationId": "post-tasks-{id}-activities",
+        "summary": "Log an activity for a task.",
+        "description": "",
+        "tags": [
+          "Agent Callbacks"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Task UUID"
+            },
+            "required": true,
+            "description": "Task UUID",
+            "example": "123"
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateActivitySchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/tasks/{id}/checkpoint": {
+      "post": {
+        "operationId": "post-tasks-{id}-checkpoint",
+        "summary": "Save a work-state checkpoint for a long-running task.",
+        "description": "",
+        "tags": [
+          "Agent Callbacks"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Task UUID"
+            },
+            "required": true,
+            "description": "Task UUID",
+            "example": "123"
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CheckpointSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/tasks/{id}/deliverables": {
+      "post": {
+        "operationId": "post-tasks-{id}-deliverables",
+        "summary": "Register a deliverable (file, URL, or artifact) produced by a task.",
+        "description": "",
+        "tags": [
+          "Agent Callbacks"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Task UUID"
+            },
+            "required": true,
+            "description": "Task UUID",
+            "example": "123"
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDeliverableSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/tasks/{id}/fail": {
+      "post": {
+        "operationId": "post-tasks-{id}-fail",
+        "summary": "Report a stage failure and trigger the fail-loopback.",
+        "description": "",
+        "tags": [
+          "Agent Callbacks"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Task UUID"
+            },
+            "required": true,
+            "description": "Task UUID",
+            "example": "123"
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FailTaskSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { ApiReferenceReact } from "@scalar/api-reference-react";
+
+import "@scalar/api-reference-react/style.css";
+
+export default function ApiDocsPage() {
+  return (
+    <ApiReferenceReact
+      configuration={{
+        _integration: "nextjs",
+        url: "/openapi.json",
+      }}
+    />
+  );
+}

--- a/src/app/api/tasks/[id]/activities/route.ts
+++ b/src/app/api/tasks/[id]/activities/route.ts
@@ -70,8 +70,16 @@ export async function GET(request: NextRequest, props: { params: Promise<{ id: s
 }
 
 /**
- * POST /api/tasks/[id]/activities
- * Log a new activity for a task
+ * Log an activity for a task.
+ *
+ * Agents call this to report progress, completed steps, and file creations so
+ * the activity feed and stall detector see forward motion.
+ *
+ * @openapi
+ * @tag Agent Callbacks
+ * @auth bearer
+ * @pathParams TaskIdParam
+ * @body CreateActivitySchema
  */
 export async function POST(request: NextRequest, props: { params: Promise<{ id: string }> }) {
   const params = await props.params;

--- a/src/app/api/tasks/[id]/checkpoint/route.ts
+++ b/src/app/api/tasks/[id]/checkpoint/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { saveCheckpoint, getLatestCheckpoint } from '@/lib/checkpoint';
 import { deliverPendingNotesAtCheckpoint } from '@/lib/task-notes';
-import type { CheckpointType } from '@/lib/types';
+import { CheckpointSchema } from '@/lib/validation';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,22 +9,31 @@ interface RouteParams {
   params: Promise<{ id: string }>;
 }
 
-// POST /api/tasks/[id]/checkpoint — Save a work checkpoint
+/**
+ * Save a work-state checkpoint for a long-running task.
+ *
+ * Agents call this periodically (or before risky operations) so the task can
+ * be audited, resumed after a crash, or used as a reference for operator
+ * notes delivered at checkpoint boundaries.
+ *
+ * @openapi
+ * @tag Agent Callbacks
+ * @auth bearer
+ * @pathParams TaskIdParam
+ * @body CheckpointSchema
+ */
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const body = await request.json();
-    const { agent_id, checkpoint_type, state_summary, files_snapshot, context_data } = body as {
-      agent_id: string;
-      checkpoint_type?: CheckpointType;
-      state_summary: string;
-      files_snapshot?: Array<{ path: string; hash: string; size: number }>;
-      context_data?: Record<string, unknown>;
-    };
-
-    if (!agent_id || !state_summary) {
-      return NextResponse.json({ error: 'agent_id and state_summary are required' }, { status: 400 });
+    const validation = CheckpointSchema.safeParse(body);
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: validation.error.issues },
+        { status: 400 }
+      );
     }
+    const { agent_id, checkpoint_type, state_summary, files_snapshot, context_data } = validation.data;
 
     const checkpoint = saveCheckpoint({
       taskId: id,

--- a/src/app/api/tasks/[id]/deliverables/route.ts
+++ b/src/app/api/tasks/[id]/deliverables/route.ts
@@ -46,8 +46,16 @@ export async function GET(request: NextRequest, props: { params: Promise<{ id: s
 }
 
 /**
- * POST /api/tasks/[id]/deliverables
- * Add a new deliverable to a task
+ * Register a deliverable (file, URL, or artifact) produced by a task.
+ *
+ * Agents call this after writing outputs so the UI can show download links
+ * and the evidence gate recognizes the stage as having produced work.
+ *
+ * @openapi
+ * @tag Agent Callbacks
+ * @auth bearer
+ * @pathParams TaskIdParam
+ * @body CreateDeliverableSchema
  */
 export async function POST(request: NextRequest, props: { params: Promise<{ id: string }> }) {
   const params = await props.params;

--- a/src/app/api/tasks/[id]/fail/route.ts
+++ b/src/app/api/tasks/[id]/fail/route.ts
@@ -3,17 +3,23 @@ import { queryOne } from '@/lib/db';
 import { handleStageFailure, drainQueue } from '@/lib/workflow-engine';
 import { notifyLearner } from '@/lib/learner';
 import { logDebugEvent } from '@/lib/debug-log';
+import { FailTaskSchema } from '@/lib/validation';
 import type { Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * POST /api/tasks/[id]/fail
+ * Report a stage failure and trigger the fail-loopback.
  *
- * Report a stage failure. Triggers the workflow engine's fail-loopback
- * to send the task back to the appropriate stage (usually in_progress/builder).
+ * Agents in testing/review/verification call this when the prior stage's work
+ * didn't pass. The workflow engine routes the task back to the appropriate
+ * earlier stage (usually in_progress/builder) with the reason attached.
  *
- * Body: { reason: "What failed and why" }
+ * @openapi
+ * @tag Agent Callbacks
+ * @auth bearer
+ * @pathParams TaskIdParam
+ * @body FailTaskSchema
  */
 export async function POST(
   request: NextRequest,
@@ -23,11 +29,14 @@ export async function POST(
 
   try {
     const body = await request.json();
-    const { reason } = body;
-
-    if (!reason) {
-      return NextResponse.json({ error: 'reason is required' }, { status: 400 });
+    const validation = FailTaskSchema.safeParse(body);
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: validation.error.issues },
+        { status: 400 }
+      );
     }
+    const { reason } = validation.data;
 
     const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
     if (!task) {

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -42,7 +42,21 @@ export async function GET(
   }
 }
 
-// PATCH /api/tasks/[id] - Update a task
+/**
+ * Update task fields or transition stage.
+ *
+ * Agents call this to move a task between stages (e.g. in_progress → testing)
+ * after their work is done. Operators use the same endpoint from the board.
+ * The evidence gate rejects forward transitions into testing/review/
+ * verification/done unless the task has at least one deliverable and one
+ * activity note.
+ *
+ * @openapi
+ * @tag Agent Callbacks
+ * @auth bearer
+ * @pathParams TaskIdParam
+ * @body UpdateTaskSchema
+ */
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -84,6 +84,15 @@ export const ReleaseCycleSchema = z.object({
   released_by: z.string().max(200).optional(),
 });
 
+// Shared path-param schemas for OpenAPI doc generation
+export const TaskIdParam = z.object({
+  id: z.string().describe('Task UUID'),
+});
+
+export const AgentIdParam = z.object({
+  id: z.string().describe('Agent UUID or 32-char hex gateway ID'),
+});
+
 // Activity validation schema
 export const CreateActivitySchema = z.object({
   activity_type: ActivityType,
@@ -98,6 +107,28 @@ export const CreateDeliverableSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   path: z.string().optional(),
   description: z.string().optional(),
+});
+
+// Fail-task validation schema — agents hit this to trigger a fail-loopback
+// from testing/review/verification back to in_progress.
+export const FailTaskSchema = z.object({
+  reason: z.string().min(1, 'reason is required').max(5000),
+});
+
+// Checkpoint validation schema — agents save work-state snapshots so
+// mission-control can resume or audit long-running tasks.
+const CheckpointFileSnapshot = z.object({
+  path: z.string().min(1),
+  hash: z.string().min(1),
+  size: z.number().int().min(0),
+});
+
+export const CheckpointSchema = z.object({
+  agent_id: agentId,
+  checkpoint_type: z.enum(['auto', 'manual', 'crash_recovery']).optional(),
+  state_summary: z.string().min(1, 'state_summary is required').max(10000),
+  files_snapshot: z.array(CheckpointFileSnapshot).optional(),
+  context_data: z.record(z.string(), z.unknown()).optional(),
 });
 
 // Product Autopilot validation schemas
@@ -231,3 +262,5 @@ export type UpdateCostCapInput = z.infer<typeof UpdateCostCapSchema>;
 export type CreateCostEventInput = z.infer<typeof CreateCostEventSchema>;
 export type CreateScheduleInput = z.infer<typeof CreateScheduleSchema>;
 export type UpdateScheduleInput = z.infer<typeof UpdateScheduleSchema>;
+export type FailTaskInput = z.infer<typeof FailTaskSchema>;
+export type CheckpointInput = z.infer<typeof CheckpointSchema>;


### PR DESCRIPTION
## Summary

- Install [next-openapi-gen](https://github.com/tazo90/next-openapi-gen) + [@scalar/api-reference-react](https://github.com/scalar/scalar); generate spec from route-handler JSDoc + existing Zod schemas
- Serve the spec at `/openapi.json` and a Scalar-rendered browser explorer at `/api-docs`
- Scoped to the five agent-callback endpoints where wrong-endpoint / wrong-auth failures cost us the most; other routes opt in as they're annotated

## What agents see now

Bearer-auth, typed request bodies, grouped under a single **Agent Callbacks** tag:

| Method | Path | Body schema |
|---|---|---|
| `PATCH` | `/api/tasks/{id}` | `UpdateTaskSchema` |
| `POST` | `/api/tasks/{id}/activities` | `CreateActivitySchema` |
| `POST` | `/api/tasks/{id}/deliverables` | `CreateDeliverableSchema` |
| `POST` | `/api/tasks/{id}/fail` | `FailTaskSchema` *(newly Zod-validated)* |
| `POST` | `/api/tasks/{id}/checkpoint` | `CheckpointSchema` *(newly Zod-validated)* |

## How it works

- `next.openapi.json` is the config (security scheme, tag defaults, `/api` relative server URL, `includeOpenApiRoutes: true` so only `@openapi`-annotated routes appear)
- Each route has a JSDoc block like:
  ```ts
  /**
   * @openapi
   * @tag Agent Callbacks
   * @auth bearer
   * @pathParams TaskIdParam
   * @body CreateActivitySchema
   */
  ```
- Shared Zod schemas live in `src/lib/validation.ts` and are auto-discovered by the generator via `schemaDir`
- `npm run openapi:generate` writes `public/openapi.json` (checked in so `/api-docs` works without a generate step on every dev start)

## Why not all 130 routes at once

Most existing handlers don't use Zod yet. Annotating only these five keeps the first pass small and lets the rest opt in route-by-route as Zod schemas are added for other reasons. Two of the five also gain runtime validation as a bonus (`fail`, `checkpoint` were using manual null-checks).

## Test plan

- [x] `npm run openapi:generate` — produces `public/openapi.json` with 5 paths, 34 schemas
- [x] `GET /openapi.json` returns 200 against the running dev server
- [x] `GET /api-docs` returns 200 with Scalar assets linked
- [ ] Open `/api-docs` in browser — confirm Scalar renders the 5 endpoints under "Agent Callbacks" and the "Try it" button respects bearer auth (preview tool couldn't verify in-harness because Next.js locks to one dev server per directory)
- [ ] Spot-check one endpoint via Scalar's try-it panel with a real `MC_API_TOKEN`
- [ ] Hit `POST /api/tasks/<id>/fail` with `{}` — should now return 400 `Validation failed` from Zod instead of the previous ad-hoc check

## Follow-ups (not in this PR)

- Zod-ify the remaining ~125 routes incrementally
- Add per-endpoint response schemas (currently only error-set responses are documented)
- Decide whether to regenerate `public/openapi.json` via a `prebuild` hook or keep it manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)