### PR TITLE
fix: convoy subtask dependencies stall after first completes

### DIFF
--- a/src/app/api/tasks/[id]/convoy/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/convoy/dispatch/route.ts
@@ -1,10 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getConvoy, getDispatchableSubtasks, updateConvoyProgress } from '@/lib/convoy';
-import { getMissionControlUrl } from '@/lib/config';
-import { queryOne, queryAll, run } from '@/lib/db';
-import { pickDynamicAgent } from '@/lib/task-governance';
-import { formatMailForDispatch } from '@/lib/mailbox';
-import type { Task } from '@/lib/types';
+import { getConvoy, dispatchReadyConvoySubtasks } from '@/lib/convoy';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,7 +8,7 @@ interface RouteParams {
 }
 
 // POST /api/tasks/[id]/convoy/dispatch — Dispatch all ready sub-tasks
-export async function POST(request: NextRequest, { params }: RouteParams) {
+export async function POST(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
     const convoy = getConvoy(id);
@@ -26,90 +21,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: `Convoy is ${convoy.status}, cannot dispatch` }, { status: 400 });
     }
 
-    const allDispatchable = getDispatchableSubtasks(convoy.id);
-
-    if (allDispatchable.length === 0) {
-      return NextResponse.json({ dispatched: 0, message: 'No sub-tasks ready for dispatch' });
+    const result = await dispatchReadyConvoySubtasks(convoy.id);
+    if (result.dispatched === 0 && result.skipped) {
+      return NextResponse.json({ dispatched: 0, message: result.skipped });
     }
 
-    // Respect max parallel agents limit (default 5)
-    const MAX_PARALLEL = 5;
-    const currentlyActive = queryAll<{ id: string }>(
-      `SELECT t.id FROM convoy_subtasks cs JOIN tasks t ON cs.task_id = t.id
-       WHERE cs.convoy_id = ? AND t.status IN ('assigned', 'in_progress', 'testing', 'verification')`,
-      [convoy.id]
-    ).length;
-    const slots = Math.max(0, MAX_PARALLEL - currentlyActive);
-    const dispatchable = allDispatchable.slice(0, slots);
-
-    if (dispatchable.length === 0) {
-      return NextResponse.json({ dispatched: 0, message: `Max parallel limit reached (${MAX_PARALLEL} active)` });
-    }
-
-    const missionControlUrl = getMissionControlUrl();
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (process.env.MC_API_TOKEN) {
-      headers['Authorization'] = `Bearer ${process.env.MC_API_TOKEN}`;
-    }
-
-    const results: Array<{ taskId: string; success: boolean; error?: string }> = [];
-
-    for (const subtask of dispatchable) {
-      const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [subtask.task_id]);
-      if (!task) continue;
-
-      // Auto-assign agent if not assigned. Use the decomposition's role hint
-      // so researcher/writer/reviewer sub-tasks reach their own agent;
-      // `pickDynamicAgent` falls back to any non-offline agent if no match
-      // for the role exists (see src/lib/task-governance.ts). Prior to this,
-      // every sub-task passed 'builder' here — which is why every sub-task
-      // in a convoy landed on the single builder agent.
-      let agentId = task.assigned_agent_id;
-      if (!agentId) {
-        const roleHint = subtask.suggested_role || 'builder';
-        const picked = pickDynamicAgent(subtask.task_id, roleHint);
-        if (picked) {
-          agentId = picked.id;
-          run('UPDATE tasks SET assigned_agent_id = ?, updated_at = datetime(\'now\') WHERE id = ?', [agentId, subtask.task_id]);
-        }
-      }
-
-      if (!agentId) {
-        results.push({ taskId: subtask.task_id, success: false, error: 'No agent available' });
-        continue;
-      }
-
-      // Move to assigned status to trigger dispatch
-      run('UPDATE tasks SET status = \'assigned\', updated_at = datetime(\'now\') WHERE id = ?', [subtask.task_id]);
-
-      try {
-        const res = await fetch(`${missionControlUrl}/api/tasks/${subtask.task_id}/dispatch`, {
-          method: 'POST',
-          headers,
-          signal: AbortSignal.timeout(30_000),
-        });
-
-        if (res.ok) {
-          results.push({ taskId: subtask.task_id, success: true });
-        } else {
-          const errorText = await res.text();
-          results.push({ taskId: subtask.task_id, success: false, error: errorText });
-        }
-      } catch (err) {
-        results.push({ taskId: subtask.task_id, success: false, error: (err as Error).message });
-      }
-    }
-
-    // Update convoy progress
-    updateConvoyProgress(convoy.id);
-
-    const dispatched = results.filter(r => r.success).length;
-    return NextResponse.json({
-      dispatched,
-      total: dispatchable.length,
-      results,
-    });
+    return NextResponse.json(result);
   } catch (error) {
+    console.error('[Convoy Dispatch] failed:', error);
     return NextResponse.json({ error: 'Failed to dispatch convoy' }, { status: 500 });
   }
 }

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -5,7 +5,7 @@ import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { handleStageTransition, handleStageFailure, getTaskWorkflow, drainQueue, populateTaskRolesFromAgents } from '@/lib/workflow-engine';
 import { hasStageEvidence, canUseBoardOverride, auditBoardOverride, taskCanBeDone, recordLearnerOnTransition, isTerminalStatus } from '@/lib/task-governance';
-import { updateConvoyProgress, checkConvoyCompletion } from '@/lib/convoy';
+import { updateConvoyProgress, checkConvoyCompletion, dispatchReadyConvoySubtasks } from '@/lib/convoy';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
 import { UpdateTaskSchema } from '@/lib/validation';
@@ -478,7 +478,15 @@ export async function PATCH(
       try {
         updateConvoyProgress(existing.convoy_id);
         if (nextStatus === 'done') {
-          checkConvoyCompletion(existing.convoy_id);
+          const wasFinal = checkConvoyCompletion(existing.convoy_id);
+          // If the convoy still has work left, promote any sub-tasks whose
+          // dependencies just cleared. Without this the convoy stalls with
+          // dependent sub-tasks permanently stuck in inbox.
+          if (!wasFinal) {
+            dispatchReadyConvoySubtasks(existing.convoy_id).catch(err =>
+              console.error('[Convoy] auto-dispatch on subtask done failed:', err)
+            );
+          }
         }
       } catch (err) {
         console.error('[Convoy] progress update failed:', err);

--- a/src/lib/convoy.ts
+++ b/src/lib/convoy.ts
@@ -2,7 +2,39 @@ import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run, transaction } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { notifyLearner } from '@/lib/learner';
+import { getMissionControlUrl } from '@/lib/config';
+import { pickDynamicAgent } from '@/lib/task-governance';
 import type { Convoy, ConvoySubtask, Task, ConvoyStatus, DecompositionStrategy } from '@/lib/types';
+
+/**
+ * The decomposition LLM writes `depends_on` as zero-based symbolic refs
+ * like "subtask-0", "subtask-1" (see src/app/api/tasks/[id]/convoy/route.ts
+ * prompt). Translate those into the actual task UUIDs so downstream
+ * dependency checks work without a symbol table. Unknown refs are dropped
+ * with a warning — they'd only produce a permanently-blocked subtask.
+ */
+function resolveSymbolicDeps(
+  deps: string[] | undefined,
+  indexToTaskId: string[]
+): string[] | undefined {
+  if (!deps || deps.length === 0) return deps;
+  const resolved: string[] = [];
+  for (const dep of deps) {
+    const match = /^subtask-(\d+)$/.exec(dep);
+    if (match) {
+      const idx = parseInt(match[1], 10);
+      if (idx >= 0 && idx < indexToTaskId.length) {
+        resolved.push(indexToTaskId[idx]);
+      } else {
+        console.warn(`[Convoy] depends_on "${dep}" out of range — dropping`);
+      }
+    } else {
+      // Already a UUID (or some other concrete ref) — pass through.
+      resolved.push(dep);
+    }
+  }
+  return resolved;
+}
 
 interface CreateSubtaskInput {
   title: string;
@@ -54,11 +86,15 @@ export function createConvoy(input: CreateConvoyInput): Convoy {
       [now, parentTaskId]
     );
 
-    // Create sub-tasks
+    // Pre-allocate UUIDs so we can translate symbolic `depends_on` refs
+    // ("subtask-N") into real task IDs before inserting any rows.
+    const indexToTaskId = subtasks.map(() => uuidv4());
+
     for (let i = 0; i < subtasks.length; i++) {
       const sub = subtasks[i];
-      const subtaskId = uuidv4();
+      const subtaskId = indexToTaskId[i];
       const convoySubtaskId = uuidv4();
+      const resolvedDeps = resolveSymbolicDeps(sub.depends_on, indexToTaskId);
 
       // Create the task entry
       run(
@@ -71,7 +107,7 @@ export function createConvoy(input: CreateConvoyInput): Convoy {
       run(
         `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, depends_on, suggested_role, created_at)
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
-        [convoySubtaskId, convoyId, subtaskId, i, sub.depends_on ? JSON.stringify(sub.depends_on) : null, sub.suggested_role || null, now]
+        [convoySubtaskId, convoyId, subtaskId, i, resolvedDeps && resolvedDeps.length > 0 ? JSON.stringify(resolvedDeps) : null, sub.suggested_role || null, now]
       );
     }
 
@@ -227,6 +263,103 @@ export function checkConvoyCompletion(convoyId: string): boolean {
   return false;
 }
 
+const MAX_PARALLEL_CONVOY_SUBTASKS = 5;
+
+export interface ConvoyDispatchResult {
+  dispatched: number;
+  total: number;
+  skipped?: string;
+  results: Array<{ taskId: string; success: boolean; error?: string }>;
+}
+
+/**
+ * Advance every ready subtask in a convoy: auto-assign agents, move to
+ * `assigned`, and POST to the per-task dispatch endpoint. Used both by the
+ * explicit `/convoy/dispatch` endpoint (operator nudge) and by the PATCH
+ * done-handler (auto-advance when a dependency completes).
+ *
+ * No-ops gracefully when the convoy is missing, inactive, or already at the
+ * parallel-subtask cap. Never throws — callers should treat the result as
+ * advisory.
+ */
+export async function dispatchReadyConvoySubtasks(convoyId: string): Promise<ConvoyDispatchResult> {
+  const convoy = queryOne<Convoy>('SELECT * FROM convoys WHERE id = ?', [convoyId]);
+  if (!convoy) return { dispatched: 0, total: 0, skipped: 'convoy not found', results: [] };
+  if (convoy.status !== 'active') return { dispatched: 0, total: 0, skipped: `convoy is ${convoy.status}`, results: [] };
+
+  const allDispatchable = getDispatchableSubtasks(convoyId);
+  if (allDispatchable.length === 0) {
+    return { dispatched: 0, total: 0, skipped: 'no subtasks ready', results: [] };
+  }
+
+  const currentlyActive = queryAll<{ id: string }>(
+    `SELECT t.id FROM convoy_subtasks cs JOIN tasks t ON cs.task_id = t.id
+     WHERE cs.convoy_id = ? AND t.status IN ('assigned', 'in_progress', 'testing', 'verification')`,
+    [convoyId]
+  ).length;
+  const slots = Math.max(0, MAX_PARALLEL_CONVOY_SUBTASKS - currentlyActive);
+  const dispatchable = allDispatchable.slice(0, slots);
+
+  if (dispatchable.length === 0) {
+    return { dispatched: 0, total: allDispatchable.length, skipped: `max parallel reached (${MAX_PARALLEL_CONVOY_SUBTASKS})`, results: [] };
+  }
+
+  const missionControlUrl = getMissionControlUrl();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (process.env.MC_API_TOKEN) {
+    headers['Authorization'] = `Bearer ${process.env.MC_API_TOKEN}`;
+  }
+
+  const results: ConvoyDispatchResult['results'] = [];
+
+  for (const subtask of dispatchable) {
+    const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [subtask.task_id]);
+    if (!task) continue;
+
+    let agentId = task.assigned_agent_id;
+    if (!agentId) {
+      const roleHint = subtask.suggested_role || 'builder';
+      const picked = pickDynamicAgent(subtask.task_id, roleHint);
+      if (picked) {
+        agentId = picked.id;
+        run('UPDATE tasks SET assigned_agent_id = ?, updated_at = datetime(\'now\') WHERE id = ?', [agentId, subtask.task_id]);
+      }
+    }
+
+    if (!agentId) {
+      results.push({ taskId: subtask.task_id, success: false, error: 'No agent available' });
+      continue;
+    }
+
+    run('UPDATE tasks SET status = \'assigned\', updated_at = datetime(\'now\') WHERE id = ?', [subtask.task_id]);
+
+    try {
+      const res = await fetch(`${missionControlUrl}/api/tasks/${subtask.task_id}/dispatch`, {
+        method: 'POST',
+        headers,
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      if (res.ok) {
+        results.push({ taskId: subtask.task_id, success: true });
+      } else {
+        const errorText = await res.text();
+        results.push({ taskId: subtask.task_id, success: false, error: errorText });
+      }
+    } catch (err) {
+      results.push({ taskId: subtask.task_id, success: false, error: (err as Error).message });
+    }
+  }
+
+  updateConvoyProgress(convoyId);
+
+  return {
+    dispatched: results.filter(r => r.success).length,
+    total: dispatchable.length,
+    results,
+  };
+}
+
 /**
  * Find sub-tasks that are ready to dispatch (in inbox, all dependencies done).
  */
@@ -274,10 +407,23 @@ export function addSubtasks(convoyId: string, subtasks: CreateSubtaskInput[]): C
   const now = new Date().toISOString();
 
   return transaction(() => {
+    // Pre-allocate UUIDs for the new subtasks so symbolic deps referring to
+    // other new subtasks ("subtask-N", counting from the convoy start) resolve
+    // correctly. Existing subtasks are also addressable by the same scheme.
+    const existingByOrder = queryAll<{ task_id: string; sort_order: number }>(
+      'SELECT task_id, sort_order FROM convoy_subtasks WHERE convoy_id = ? ORDER BY sort_order',
+      [convoyId]
+    );
+    const indexToTaskId: string[] = existingByOrder.map(r => r.task_id);
+    for (let i = 0; i < subtasks.length; i++) {
+      indexToTaskId.push(uuidv4());
+    }
+
     for (let i = 0; i < subtasks.length; i++) {
       const sub = subtasks[i];
-      const subtaskId = uuidv4();
+      const subtaskId = indexToTaskId[existingByOrder.length + i];
       const convoySubtaskId = uuidv4();
+      const resolvedDeps = resolveSymbolicDeps(sub.depends_on, indexToTaskId);
 
       run(
         `INSERT INTO tasks (id, title, description, status, priority, assigned_agent_id, workspace_id, business_id, workflow_template_id, convoy_id, is_subtask, created_at, updated_at)
@@ -288,10 +434,10 @@ export function addSubtasks(convoyId: string, subtasks: CreateSubtaskInput[]): C
       run(
         `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, depends_on, suggested_role, created_at)
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
-        [convoySubtaskId, convoyId, subtaskId, maxOrder + i + 1, sub.depends_on ? JSON.stringify(sub.depends_on) : null, sub.suggested_role || null, now]
+        [convoySubtaskId, convoyId, subtaskId, maxOrder + i + 1, resolvedDeps && resolvedDeps.length > 0 ? JSON.stringify(resolvedDeps) : null, sub.suggested_role || null, now]
       );
 
-      created.push({ id: convoySubtaskId, convoy_id: convoyId, task_id: subtaskId, sort_order: maxOrder + i + 1, depends_on: sub.depends_on, suggested_role: sub.suggested_role || null, created_at: now });
+      created.push({ id: convoySubtaskId, convoy_id: convoyId, task_id: subtaskId, sort_order: maxOrder + i + 1, depends_on: resolvedDeps, suggested_role: sub.suggested_role || null, created_at: now });
     }
 
     // Update total count

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1844,6 +1844,73 @@ const migrations: Migration[] = [
 
       console.log('[Migration 033] Complete: tasks.is_archived/archived_at and task_deliverables.storage_scheme/size_bytes added.');
     }
+  },
+  {
+    id: '034',
+    name: 'convoy_resolve_symbolic_depends_on',
+    up: (db) => {
+      // The decomposition LLM emits `depends_on: ["subtask-0", "subtask-1"]`
+      // style refs and prior code wrote them to convoy_subtasks verbatim. The
+      // dispatcher compares against task UUIDs, so those refs never matched —
+      // any convoy with dependencies stalled after the first subtask. Translate
+      // every remaining symbolic ref to the referenced task's UUID (looked up
+      // by sort_order within the same convoy). Rows whose depends_on is NULL,
+      // empty, or already UUIDs are left alone. Done for all existing convoys
+      // regardless of status; harmless on ones that already completed.
+      console.log('[Migration 034] Resolving symbolic depends_on refs in convoy_subtasks...');
+
+      const rows = db.prepare(
+        `SELECT id, convoy_id, depends_on FROM convoy_subtasks WHERE depends_on IS NOT NULL AND depends_on != '' AND depends_on != '[]'`
+      ).all() as { id: string; convoy_id: string; depends_on: string }[];
+
+      let updated = 0;
+      const orderCache = new Map<string, Map<number, string>>();
+      const update = db.prepare('UPDATE convoy_subtasks SET depends_on = ? WHERE id = ?');
+
+      for (const row of rows) {
+        let parsed: string[];
+        try {
+          parsed = JSON.parse(row.depends_on);
+        } catch {
+          continue;
+        }
+        if (!Array.isArray(parsed) || parsed.length === 0) continue;
+
+        let order = orderCache.get(row.convoy_id);
+        if (!order) {
+          const siblings = db.prepare(
+            'SELECT task_id, sort_order FROM convoy_subtasks WHERE convoy_id = ?'
+          ).all(row.convoy_id) as { task_id: string; sort_order: number }[];
+          order = new Map(siblings.map(s => [s.sort_order, s.task_id]));
+          orderCache.set(row.convoy_id, order);
+        }
+
+        let changed = false;
+        const resolved: string[] = [];
+        for (const dep of parsed) {
+          const match = typeof dep === 'string' ? /^subtask-(\d+)$/.exec(dep) : null;
+          if (match) {
+            const taskId = order.get(parseInt(match[1], 10));
+            if (taskId) {
+              resolved.push(taskId);
+              changed = true;
+            } else {
+              console.warn(`[Migration 034] convoy_subtask ${row.id}: dep ${dep} out of range, dropping`);
+              changed = true;
+            }
+          } else {
+            resolved.push(dep);
+          }
+        }
+
+        if (changed) {
+          update.run(resolved.length > 0 ? JSON.stringify(resolved) : null, row.id);
+          updated += 1;
+        }
+      }
+
+      console.log(`[Migration 034] Complete: rewrote depends_on on ${updated} convoy_subtasks row(s).`);
+    }
   }
 ];
 


### PR DESCRIPTION
## Summary

Convoys with cross-subtask dependencies stalled forever once the first subtask finished — the rest sat in `inbox` permanently. Fixes two stacked bugs.

## The bugs

### 1. Symbolic `depends_on` refs never resolved to UUIDs
The decomposition LLM is told to emit dependencies as `"subtask-0"`, `"subtask-1"` (see the prompt in [convoy/route.ts:66](src/app/api/tasks/%5Bid%5D/convoy/route.ts:66)). That string was written to `convoy_subtasks.depends_on` verbatim. But [`getDispatchableSubtasks`](src/lib/convoy.ts) compared those strings against **task UUIDs** — `deps.every(id => doneTaskIds.has(id))` was always false for any subtask with a dep.

### 2. Nothing auto-advanced ready subtasks
The PATCH done-handler in [tasks/[id]/route.ts](src/app/api/tasks/%5Bid%5D/route.ts) only called `updateConvoyProgress` (counter tick) and `checkConvoyCompletion` (all-done check). `getDispatchableSubtasks` was only reachable by **manually** POSTing to `/api/tasks/<parent>/convoy/dispatch`.

### Impact
Any convoy whose LLM decomposition produced dependencies was DOA after the first subtask. Found on test task `ba1139da`: Research done, Write + Build stuck in inbox for 15+ minutes.

## Fix

- **Write-time normalization** in `createConvoy` and `addSubtasks` ([convoy.ts](src/lib/convoy.ts)): pre-allocate task UUIDs, translate `"subtask-N"` → UUID via the index map before inserting the row. `addSubtasks` also consults existing `sort_order` so deps referring to already-created subtasks resolve correctly.
- **New shared helper** `dispatchReadyConvoySubtasks(convoyId)`: extracted from the `/convoy/dispatch` endpoint so the endpoint (operator nudge) and the new PATCH auto-trigger share one code path. No behavior change for the endpoint.
- **Auto-dispatch on subtask done** in PATCH handler: if the convoy is still active after a subtask moves to `done`, fire `dispatchReadyConvoySubtasks` to promote any newly-unblocked siblings from `inbox` → `assigned`.
- **Migration 034** rewrites existing broken `depends_on` rows in place — `"subtask-N"` → real UUID via `sort_order` lookup. Harmless on already-completed convoys; unsticks mid-flight ones.

## Test plan

- [x] Migration 034 ran on dev DB: `_migrations` shows entry, `convoy_subtasks.depends_on` on the stuck test task now contains real UUIDs.
- [x] `POST /api/tasks/ba1139da-.../convoy/dispatch` returns `{ dispatched: 1 }` (was "No sub-tasks ready" before). Write subtask moved `inbox → in_progress`, assigned to Writer.
- [ ] When Write reaches `done`, Build should auto-promote to `assigned` via the new PATCH trigger — will confirm as the test task progresses.
- [ ] Regression: a convoy whose subtasks have no dependencies should behave as before (first subtask dispatches immediately, completion advances counters).

## Limitations / follow-ups

- The evidence gate still applies — subtasks without at least one deliverable + one activity note can't cross into testing/review/verification/done. Orthogonal to this fix but worth noting if a subtask stalls at the gate.
- Parallel limit is 5 (as before). Large convoys with many ready-at-once subtasks queue naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)