### PR TITLE
feat: structured deliverables + spec-reconciling evidence gate + hardened prompts

### DIFF
--- a/src/app/api/tasks/[id]/convoy/route.ts
+++ b/src/app/api/tasks/[id]/convoy/route.ts
@@ -13,6 +13,7 @@ import {
   MIN_NEW_AGENT_RATIONALE_LENGTH,
   type RosterAgent,
 } from '@/lib/agent-resolver';
+import { parsePlanningSpec } from '@/lib/planning-spec';
 import type { Task, Agent, ConvoyStatus, DecompositionStrategy } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -40,11 +41,38 @@ interface ParsedSubtask {
  * existing agents by id instead of silently producing ghosts.
  */
 function buildDecompositionPrompt(task: Task, roster: RosterAgent[]): string {
-  const specSection = task.description || 'No description provided.';
   const rosterBlock = formatRosterForPrompt(roster);
   const createPolicy = roster.length === 0
     ? 'No existing agents. Set agent_id to null for every sub-task.'
     : 'Prefer assigning sub-tasks to agents in the roster above. Only set agent_id to null when no listed agent is a reasonable fit; in that case you MUST provide a specific rationale naming the capability or capacity gap.';
+
+  // Inject the structured spec (if planning produced one) so the decomposition
+  // can make per-deliverable subtasks instead of one monolithic "Build" task.
+  // Falls back to task.description for non-planned tasks. This is the biggest
+  // single lever against the "one builder subtask swallows five deliverables
+  // and ships a skeleton" failure mode.
+  const parsedSpec = parsePlanningSpec(
+    (task as Task & { planning_spec?: string }).planning_spec
+  );
+
+  let specSection: string;
+  let perDeliverableHint: string;
+  if (parsedSpec && parsedSpec.deliverables.length > 0) {
+    const deliverableLines = parsedSpec.deliverables
+      .map(d => {
+        const pathPart = d.path_pattern ? ` → \`${d.path_pattern}\`` : '';
+        return `- **${d.id}** (${d.kind})${pathPart}: ${d.acceptance}`;
+      })
+      .join('\n');
+    const summary = parsedSpec.summary ? `\n\n**Summary:** ${parsedSpec.summary}` : '';
+    specSection = `${parsedSpec.title ? `**Planned Title:** ${parsedSpec.title}\n` : ''}${summary}\n\n**Deliverables from planning spec (each must be produced):**\n${deliverableLines}`;
+    perDeliverableHint = `
+- **Map each planning-spec deliverable to at least one builder sub-task.** Do not collapse five deliverables into one "Build" sub-task — that's how we end up with a skeleton HTML file referencing missing CSS/JS. Each builder sub-task's \`description\` MUST name the specific \`deliverables[].id\` it fulfills (e.g. "Fulfills spec deliverables: shot-logger, pwa-manifest"). File-kind deliverables especially should each be their own builder sub-task unless they're trivially small (< 20 lines).
+- **Always include a dedicated Tester sub-task** with \`suggested_role: "tester"\` that depends on all builder sub-tasks. Its description must name every success criterion id it's responsible for verifying. The Reviewer runs AFTER the Tester, not instead of one.`;
+  } else {
+    specSection = task.description || 'No description provided.';
+    perDeliverableHint = '';
+  }
 
   return `TASK DECOMPOSITION REQUEST
 
@@ -68,7 +96,7 @@ Rules:
 - Do not assign more than ${MAX_TASKS_PER_AGENT} sub-tasks to the same agent_id; if more work exists for a role, prefer creating a new agent over overloading.
 - Prefer agents with status "standby" over "working".
 - For each sub-task include "agent_id" (from the roster above) OR null, plus "suggested_role" (human-readable), and a "rationale" explaining the choice.
-- If agent_id is null, "rationale" must name the specific capability gap — "no suitable agent" is not acceptable.
+- If agent_id is null, "rationale" must name the specific capability gap — "no suitable agent" is not acceptable.${perDeliverableHint}
 
 Respond with ONLY valid JSON — no markdown fences, no commentary — in this exact shape:
 {
@@ -77,7 +105,7 @@ Respond with ONLY valid JSON — no markdown fences, no commentary — in this e
   "subtasks": [
     {
       "title": "Sub-task title",
-      "description": "Detailed description of what this sub-task should accomplish",
+      "description": "Detailed description. For builder sub-tasks, name the spec deliverables[].id values this fulfills.",
       "suggested_role": "researcher",
       "agent_id": "<existing agent id from roster, or null>",
       "agent_name": "<name for new agent, only when agent_id is null>",

--- a/src/app/api/tasks/[id]/deliverables/route.ts
+++ b/src/app/api/tasks/[id]/deliverables/route.ts
@@ -72,7 +72,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
       );
     }
 
-    const { deliverable_type, title, path, description } = validation.data;
+    const { deliverable_type, title, path, description, spec_deliverable_id } = validation.data;
 
     // Reject the reserved ssh:// prefix — the column is widened for future
     // remote storage, but nothing reads it yet. Failing here avoids half-wired
@@ -113,8 +113,8 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
 
     // Insert deliverable
     db.prepare(`
-      INSERT INTO task_deliverables (id, task_id, deliverable_type, title, path, description, storage_scheme, size_bytes)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO task_deliverables (id, task_id, deliverable_type, title, path, description, storage_scheme, size_bytes, spec_deliverable_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       taskId,
@@ -123,7 +123,8 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
       path || null,
       description || null,
       storageScheme,
-      sizeBytes ?? null
+      sizeBytes ?? null,
+      spec_deliverable_id || null
     );
 
     // Get the created deliverable

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -15,6 +15,7 @@ import { logDebugEvent } from '@/lib/debug-log';
 import { formatMailForDispatch } from '@/lib/mailbox';
 import { getPendingNotesForDispatch } from '@/lib/task-notes';
 import { createTaskWorkspace, determineIsolationStrategy } from '@/lib/workspace-isolation';
+import { parsePlanningSpec } from '@/lib/planning-spec';
 import type { Task, Agent, Product, OpenClawSession, WorkflowStage, TaskImage } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -238,7 +239,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // Parse planning_spec and planning_agents if present (stored as JSON text on the task row)
     const rawTask = task as Task & { assigned_agent_name?: string; workspace_id: string; planning_spec?: string; planning_agents?: string };
     let planningSpecSection = '';
+    let deliverablesChecklistSection = '';
+    let successCriteriaChecklistSection = '';
     let agentInstructionsSection = '';
+
+    // Normalize the planner's output so dispatch can build structured
+    // checklists for the builder (deliverables) and tester (criteria),
+    // regardless of whether the planner emitted the old string[] shape or
+    // the new structured one.
+    const normalizedSpec = parsePlanningSpec(rawTask.planning_spec);
 
     if (rawTask.planning_spec) {
       try {
@@ -250,6 +259,21 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         // If not valid JSON, treat as plain text
         planningSpecSection = `\n---\n**📋 PLANNING SPECIFICATION:**\n${rawTask.planning_spec}\n`;
       }
+    }
+
+    if (normalizedSpec && normalizedSpec.deliverables.length > 0) {
+      const lines = normalizedSpec.deliverables.map(d => {
+        const pathPart = d.path_pattern ? ` → \`${d.path_pattern}\`` : '';
+        return `- [ ] **\`${d.id}\`** (${d.kind})${pathPart}\n      - Title: ${d.title}\n      - Acceptance: ${d.acceptance}`;
+      }).join('\n');
+      deliverablesChecklistSection = `\n---\n**✅ DELIVERABLES CHECKLIST — every entry must be produced and registered by id:**\n${lines}\n`;
+    }
+
+    if (normalizedSpec && normalizedSpec.success_criteria.length > 0) {
+      const lines = normalizedSpec.success_criteria.map(c =>
+        `- [ ] **\`${c.id}\`**: ${c.assertion}\n      - How to test: ${c.how_to_test}`
+      ).join('\n');
+      successCriteriaChecklistSection = `\n---\n**🎯 SUCCESS CRITERIA — each must be verified as pass/fail:**\n${lines}\n`;
     }
 
     if (rawTask.planning_agents) {
@@ -416,7 +440,64 @@ ${authHeaderLine}  -d '{"status":"${nextStatus}"}'
 When complete, reply with:
 \`TASK_COMPLETE: [summary of what was delegated, to whom, and the aggregate outcome]\``;
     } else if (isBuilder) {
-      completionInstructions = `**IMPORTANT:** After completing work, you MUST make these three calls in order — all require the Authorization header:
+      // Build the builder's completion block. When a structured spec exists,
+      // require one deliverable POST per spec id (the evidence gate enforces
+      // this server-side) and instruct an explicit self-check before the
+      // status transition. When no spec exists, fall back to the legacy
+      // single-deliverable flow so ad-hoc tasks still work.
+      const hasStructuredSpec = Boolean(normalizedSpec && normalizedSpec.deliverables.length > 0);
+
+      if (hasStructuredSpec && normalizedSpec) {
+        const exampleId = normalizedSpec.deliverables[0].id;
+        const examplePath = normalizedSpec.deliverables[0].path_pattern || `${deliverablesDir}/<filename>`;
+        const fileIds = normalizedSpec.deliverables.filter(d => d.kind === 'file').map(d => d.id);
+        const allIds = normalizedSpec.deliverables.map(d => d.id);
+        const fileCheckHint = fileIds.length > 0
+          ? `For each \`kind: "file"\` deliverable above (${fileIds.map(id => `\`${id}\``).join(', ')}), \`ls -la\` the \`path_pattern\` under ${deliverablesDir}. If any file is missing, FIX IT before transitioning — the evidence gate will reject the status PATCH otherwise.`
+          : 'No file-kind deliverables — verify behavior deliverables by manually reproducing each acceptance statement.';
+
+        completionInstructions = `**✅ DEFINITION OF DONE** — you cannot transition this task until EVERY entry in the checklist above is registered.
+
+**Step 1 — produce every deliverable in the checklist.** Do not ship a skeleton referencing files that don't exist. If the checklist lists \`styles.css\` and \`app.js\` as separate entries, they must each exist as separate files under the deliverables dir with real content.
+
+**Step 2 — self-check before transitioning:**
+${fileCheckHint}
+
+If your output includes an HTML entry point, grep it for every \`href=\`/\`src=\` reference and confirm each target file actually exists. A page that references a missing \`app.js\` is not shippable.
+
+**Step 3 — register one deliverable per spec id** (the Authorization header is required on every call):
+
+\`\`\`bash
+# Repeat this POST for each deliverables[] entry in the checklist, using the matching spec_deliverable_id.
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/deliverables" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"deliverable_type":"file","title":"<human name>","path":"${examplePath}","spec_deliverable_id":"${exampleId}"}'
+\`\`\`
+
+Expected spec_deliverable_id values: ${allIds.map(id => `\`${id}\``).join(', ')}
+
+**Step 4 — log a completion activity:**
+
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"activity_type":"completed","message":"<what you built — one line>"}'
+\`\`\`
+
+**Step 5 — transition status.** If this returns HTTP 400 with "missing: <ids>", you're missing deliverables. Produce them and retry — do NOT try to force the transition.
+
+\`\`\`bash
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\`
+
+When complete, reply with:
+\`TASK_COMPLETE: [brief summary — which deliverables you registered]\``;
+      } else {
+        // Legacy / unplanned task path — evidence gate only enforces the
+        // baseline bar (1 deliverable + 1 activity).
+        completionInstructions = `**IMPORTANT:** After completing work, you MUST make these three calls in order — all require the Authorization header:
 
 \`\`\`bash
 # 1. Register deliverable
@@ -438,13 +519,39 @@ ${authHeaderLine}  -d '{"status":"${nextStatus}"}'
 
 When complete, reply with:
 \`TASK_COMPLETE: [brief summary of what you did]\``;
+      }
     } else if (isTester) {
-      completionInstructions = `**YOUR ROLE: TESTER** — Test the deliverables for this task.
+      // Testers get the success_criteria list as a pass/fail checklist — this
+      // is the difference between "I glanced at the deliverable" and "I
+      // actually verified each assertion".
+      const hasCriteria = Boolean(normalizedSpec && normalizedSpec.success_criteria.length > 0);
+      const criteriaGuidance = hasCriteria && normalizedSpec
+        ? `\n**Your job: verify each success criterion in the checklist above.** For each one:
+1. Run the \`how_to_test\` step.
+2. Record the result (pass or fail) with the criterion's id.
 
-Review the output directory for deliverables and run any applicable tests.
+Do NOT pass the stage unless every criterion passes. "Looks good to me" is not verification.
 
-**If tests PASS** — all calls require the Authorization header:
+**When you pass all criteria:**
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"activity_type":"completed","message":"All ${normalizedSpec.success_criteria.length} success criteria passed: [<sc-1> ok; <sc-2> ok; ...]"}'
 
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\`
+
+**When any criterion fails** — name the failing ids explicitly so the builder knows what to fix:
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/fail" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"reason":"Failed criteria: <sc-id1>: <what you observed>; <sc-id2>: <what you observed>. Builder must address each named criterion."}'
+\`\`\``
+        : `\n**No structured success criteria on this task.** Review the deliverables against the spec/description and use your judgment.
+
+**If tests pass:**
 \`\`\`bash
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
   -H "Content-Type: application/json" \\
@@ -455,17 +562,24 @@ curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
 ${authHeaderLine}  -d '{"status":"${nextStatus}"}'
 \`\`\`
 
-**If tests FAIL:**
-
+**If tests fail:**
 \`\`\`bash
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/fail" \\
   -H "Content-Type: application/json" \\
 ${authHeaderLine}  -d '{"reason":"<detailed description of what failed and what needs fixing>"}'
-\`\`\`
+\`\`\``;
 
-Reply with: \`TEST_PASS: [summary]\` or \`TEST_FAIL: [what failed]\``;
+      completionInstructions = `**YOUR ROLE: TESTER** — Verify deliverables against the success criteria above.
+${criteriaGuidance}
+
+Reply with: \`TEST_PASS: [summary]\` or \`TEST_FAIL: [what failed, by criterion id]\``;
     } else if (isVerifier) {
-      completionInstructions = `**YOUR ROLE: VERIFIER** — Verify that all work meets quality standards.
+      const hasCriteria = Boolean(normalizedSpec && normalizedSpec.success_criteria.length > 0);
+      const criteriaReminder = hasCriteria
+        ? `\n\nEvery success criterion in the checklist above must pass. "Looks good" is not verification — confirm each assertion using its \`how_to_test\` step, then list the ids you confirmed in your activity message.`
+        : '';
+
+      completionInstructions = `**YOUR ROLE: VERIFIER** — Verify that all work meets quality standards.${criteriaReminder}
 
 Review deliverables, test results, and task requirements.
 
@@ -474,22 +588,22 @@ Review deliverables, test results, and task requirements.
 \`\`\`bash
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
   -H "Content-Type: application/json" \\
-${authHeaderLine}  -d '{"activity_type":"completed","message":"Verification passed: <summary>"}'
+${authHeaderLine}  -d '{"activity_type":"completed","message":"Verification passed: <summary; criteria verified: [<ids>]>"}'
 
 curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
   -H "Content-Type: application/json" \\
 ${authHeaderLine}  -d '{"status":"${nextStatus}"}'
 \`\`\`
 
-**If verification FAILS:**
+**If verification FAILS** — name the specific criterion ids that failed:
 
 \`\`\`bash
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/fail" \\
   -H "Content-Type: application/json" \\
-${authHeaderLine}  -d '{"reason":"<detailed description of what failed and what needs fixing>"}'
+${authHeaderLine}  -d '{"reason":"Failed criteria: <sc-id1>: <what you observed>; <sc-id2>: ...</what you observed>"}'
 \`\`\`
 
-Reply with: \`VERIFY_PASS: [summary]\` or \`VERIFY_FAIL: [what failed]\``;
+Reply with: \`VERIFY_PASS: [summary]\` or \`VERIFY_FAIL: [what failed, by criterion id]\``;
     } else {
       // Fallback for unknown roles
       completionInstructions = `**IMPORTANT:** After completing work, update status — the call requires the Authorization header:
@@ -565,6 +679,13 @@ ${authHeaderLine}  -d '{"status":"${nextStatus}"}'
         ? 'NEW TASK ASSIGNED'
         : `${roleLabel.toUpperCase()} STAGE — ${task.title}`;
 
+    // Put the structured checklists up front when they exist — the builder
+    // needs the deliverables list before wading through the spec prose, and
+    // the tester needs the criteria list up front. Old-shape tasks (no
+    // structured spec) render only the existing planningSpecSection below.
+    const deliverablesLead = isBuilder ? deliverablesChecklistSection : '';
+    const criteriaLead = (isTester || isVerifier) ? successCriteriaChecklistSection : '';
+
     const taskMessage = `${priorityEmoji} **${headline}**
 
 **Title:** ${task.title}
@@ -572,7 +693,7 @@ ${task.description ? `**Description:** ${task.description}\n` : ''}
 **Priority:** ${task.priority.toUpperCase()}
 ${task.due_date ? `**Due:** ${task.due_date}\n` : ''}
 **Task ID:** ${task.id}
-${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}${delegationRosterSection}
+${deliverablesLead}${criteriaLead}${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}${delegationRosterSection}
 ${isBuilder ? (workspaceIsolated
   ? `**\u{1F512} ISOLATED WORKSPACE:** ${taskProjectDir}\n- **Port:** ${workspacePort || 'default'} (use this for dev server, NOT the default)\n${workspaceBranchName ? `- **Branch:** ${workspaceBranchName}\n` : ''}- **IMPORTANT:** Do NOT modify files outside this workspace directory. Other agents may be working on the same project in parallel. All your work must stay within: ${taskProjectDir}\n**DELIVERABLES DIR (separate):** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`
   : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n**DELIVERABLES DIR:** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`)

--- a/src/app/api/tasks/[id]/planning/answer/route.ts
+++ b/src/app/api/tasks/[id]/planning/answer/route.ts
@@ -57,14 +57,29 @@ For another question, respond with JSON:
   ]
 }
 
-If planning is complete, respond with JSON:
+If planning is complete, respond with JSON using the STRUCTURED spec shape (every deliverable must have id/kind/acceptance — no bare strings):
+
 {
   "status": "complete",
   "spec": {
     "title": "Task title",
     "summary": "Summary of what needs to be done",
-    "deliverables": ["List of deliverables"],
-    "success_criteria": ["How we know it's done"],
+    "deliverables": [
+      {
+        "id": "short-machine-id",
+        "title": "Human-readable name",
+        "kind": "file",
+        "path_pattern": "relative/path.ext",
+        "acceptance": "Binary testable assertion — what the file must contain or do"
+      }
+    ],
+    "success_criteria": [
+      {
+        "id": "sc-1",
+        "assertion": "Binary pass/fail assertion",
+        "how_to_test": "Specific command, step, or check the tester runs"
+      }
+    ],
     "constraints": {}
   },
   "agents": [
@@ -80,7 +95,13 @@ If planning is complete, respond with JSON:
     "approach": "How to execute",
     "steps": ["Step 1", "Step 2"]
   }
-}`;
+}
+
+RULES:
+- Every major artifact gets its own deliverables entry. An HTML app with a service worker is AT LEAST four entries (index.html, styles.css, app.js, sw.js), not one "PWA module".
+- kind=file REQUIRES path_pattern. Name the file — do not say "some CSS file".
+- kind=behavior REQUIRES a testable acceptance ("page loads from cache with network disabled", not "works offline").
+- success_criteria entries must each be independently pass/fail-able.`;
 
     // Parse existing messages
     const messages = task.planning_messages ? JSON.parse(task.planning_messages) : [];

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -174,7 +174,13 @@ export async function POST(
     const roster = getAgentRoster(task.workspace_id);
     const rosterBlock = formatRosterForPrompt(roster);
 
-    // Build the initial planning prompt
+    // Build the initial planning prompt. Two things matter here: the
+    // question-asking loop (which fires now) and the final completion
+    // shape the planner MUST emit once it's done asking. We spell the
+    // completion schema out up front because agents anchor on structure
+    // when shown it once — asking for a binary-testable spec only at the
+    // "answer" stage was producing narrative summaries that downstream
+    // builders then interpreted in the cheapest way possible.
     const planningPrompt = `PLANNING REQUEST
 
 Task Title: ${task.title}
@@ -187,7 +193,48 @@ When you later emit the final plan (status: "complete") with an "agents" array, 
 
 You are starting a planning session for this task. Read PLANNING.md for your protocol.
 
-Generate your FIRST question to understand what the user needs. Remember:
+**Your job has two phases:**
+
+PHASE 1 — ask multiple-choice questions until you understand what the user needs.
+PHASE 2 — emit a final spec with STRUCTURED, TESTABLE deliverables and success criteria (see schema below) so downstream builders and testers can objectively tell whether work is done.
+
+**Completion schema** (for when you're ready to emit status: "complete"):
+\`\`\`json
+{
+  "status": "complete",
+  "spec": {
+    "title": "...",
+    "summary": "...",
+    "deliverables": [
+      {
+        "id": "short-machine-id",              // stable id builders use when registering fulfillment
+        "title": "Human-readable name",
+        "kind": "file" | "behavior" | "artifact",
+        "path_pattern": "src/foo.js",          // required when kind=file; relative to the deliverables dir
+        "acceptance": "Binary, testable assertion — e.g. 'exports logShot(data) which persists to IndexedDB db=espresso-shots'"
+      }
+    ],
+    "success_criteria": [
+      {
+        "id": "sc-1",
+        "assertion": "Binary: passes or fails, no ambiguity",
+        "how_to_test": "Specific command, manual step, or assertion the tester runs"
+      }
+    ],
+    "constraints": {}
+  },
+  "agents": [ /* as described above */ ],
+  "execution_plan": {}
+}
+\`\`\`
+
+**Rules for the spec (these are the difference between a working deliverable and a broken mockup):**
+- EVERY major artifact needed to ship the task must be its own entry in \`deliverables\` — not bundled under a vague "module" entry. If the task needs an HTML page + CSS + JS + service worker, that is four deliverables, not one.
+- For \`kind: "file"\`, \`path_pattern\` MUST name the file. No "some JS file" — name it.
+- For \`kind: "behavior"\`, \`acceptance\` MUST be verifiable (e.g. "page loads from cache with network disabled", not "works offline").
+- \`success_criteria\` are for the Tester: each one should be something pass/fail-able. If you can't describe how to test it, it doesn't belong here.
+
+PHASE 1 starts now. Generate your FIRST question to understand what the user needs. Remember:
 - Questions must be multiple choice
 - Include an "Other" option
 - Be specific to THIS task, not generic

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -4,7 +4,7 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { handleStageTransition, handleStageFailure, getTaskWorkflow, drainQueue, populateTaskRolesFromAgents } from '@/lib/workflow-engine';
-import { hasStageEvidence, canUseBoardOverride, auditBoardOverride, taskCanBeDone, recordLearnerOnTransition, isTerminalStatus } from '@/lib/task-governance';
+import { hasStageEvidence, checkStageEvidence, canUseBoardOverride, auditBoardOverride, taskCanBeDone, recordLearnerOnTransition, isTerminalStatus } from '@/lib/task-governance';
 import { updateConvoyProgress, checkConvoyCompletion, dispatchReadyConvoySubtasks } from '@/lib/convoy';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
@@ -215,13 +215,22 @@ export async function PATCH(
         );
       }
 
-      // Hard evidence gate for forward-stage transitions and completion
+      // Hard evidence gate for forward-stage transitions and completion.
+      // Rejection includes the specific reason (missing spec deliverables by
+      // id) so agents can take the correct corrective action instead of
+      // guessing what "evidence requirements" means.
       const enteringQualityStage = ['testing', 'review', 'verification', 'done'].includes(nextStatus);
-      if (enteringQualityStage && !boardOverrideAllowed && !hasStageEvidence(id)) {
-        return NextResponse.json(
-          { error: 'Evidence gate failed: stage transition requires at least one deliverable and one activity note' },
-          { status: 400 }
-        );
+      if (enteringQualityStage && !boardOverrideAllowed) {
+        const evidence = checkStageEvidence(id);
+        if (!evidence.ok) {
+          return NextResponse.json(
+            {
+              error: evidence.reason || 'Evidence gate failed',
+              missingDeliverableIds: evidence.missingDeliverableIds,
+            },
+            { status: 400 }
+          );
+        }
       }
 
       // Failure transitions must include status_reason

--- a/src/components/PlanningTab.tsx
+++ b/src/components/PlanningTab.tsx
@@ -31,8 +31,20 @@ interface PlanningState {
   spec?: {
     title: string;
     summary: string;
-    deliverables: string[];
-    success_criteria: string[];
+    // Old planner output is string[]; new structured output is objects. The
+    // renderer below accepts both — old in-flight tasks still display.
+    deliverables: Array<string | {
+      id?: string;
+      title: string;
+      kind?: 'file' | 'behavior' | 'artifact';
+      path_pattern?: string;
+      acceptance?: string;
+    }>;
+    success_criteria: Array<string | {
+      id?: string;
+      assertion: string;
+      how_to_test?: string;
+    }>;
     constraints: Record<string, unknown>;
   };
   agents?: Array<{
@@ -539,21 +551,39 @@ export function PlanningTab({ taskId, onSpecLocked }: PlanningTabProps) {
           {state.spec.deliverables?.length > 0 && (
             <div className="mb-3">
               <h4 className="text-sm font-medium mb-1">Deliverables:</h4>
-              <ul className="list-disc list-inside text-sm text-mc-text-secondary">
-                {state.spec.deliverables.map((d, i) => (
-                  <li key={i}>{d}</li>
-                ))}
+              <ul className="list-disc list-inside text-sm text-mc-text-secondary space-y-1">
+                {state.spec.deliverables.map((d, i) => {
+                  if (typeof d === 'string') {
+                    return <li key={i}>{d}</li>;
+                  }
+                  return (
+                    <li key={d.id || i}>
+                      <span className="font-medium text-mc-text">{d.title}</span>
+                      {d.kind ? <span className="text-xs text-mc-text-tertiary"> ({d.kind})</span> : null}
+                      {d.path_pattern ? <code className="ml-1 text-xs text-mc-accent">{d.path_pattern}</code> : null}
+                      {d.acceptance ? <div className="text-xs ml-5 text-mc-text-tertiary">{d.acceptance}</div> : null}
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           )}
-          
+
           {state.spec.success_criteria?.length > 0 && (
             <div>
               <h4 className="text-sm font-medium mb-1">Success Criteria:</h4>
-              <ul className="list-disc list-inside text-sm text-mc-text-secondary">
-                {state.spec.success_criteria.map((c, i) => (
-                  <li key={i}>{c}</li>
-                ))}
+              <ul className="list-disc list-inside text-sm text-mc-text-secondary space-y-1">
+                {state.spec.success_criteria.map((c, i) => {
+                  if (typeof c === 'string') {
+                    return <li key={i}>{c}</li>;
+                  }
+                  return (
+                    <li key={c.id || i}>
+                      <span>{c.assertion}</span>
+                      {c.how_to_test ? <div className="text-xs ml-5 text-mc-text-tertiary">Test: {c.how_to_test}</div> : null}
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           )}

--- a/src/lib/agent-resolver.ts
+++ b/src/lib/agent-resolver.ts
@@ -23,7 +23,9 @@ export interface RosterAgent {
 }
 
 /** Policy caps shared by planning + convoy flows. Keep small and explicit. */
-export const MAX_CONVOY_SUBTASKS = parseInt(process.env.MAX_CONVOY_SUBTASKS || '6', 10);
+// Default bumped from 6 → 8 so a typical planned app (one sub-task per
+// deliverable + a dedicated Tester sub-task) fits without hitting the cap.
+export const MAX_CONVOY_SUBTASKS = parseInt(process.env.MAX_CONVOY_SUBTASKS || '8', 10);
 export const MAX_TASKS_PER_AGENT = parseInt(process.env.MAX_TASKS_PER_AGENT || '2', 10);
 export const MIN_NEW_AGENT_RATIONALE_LENGTH = 20;
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1911,6 +1911,27 @@ const migrations: Migration[] = [
 
       console.log(`[Migration 034] Complete: rewrote depends_on on ${updated} convoy_subtasks row(s).`);
     }
+  },
+  {
+    id: '035',
+    name: 'deliverable_spec_id_for_reconciliation',
+    up: (db) => {
+      // Evidence gate upgrade: every deliverable listed in planning_spec must
+      // be registered with a matching spec_deliverable_id before a task can
+      // transition into testing/review/verification/done. Agents POST their
+      // deliverables with a spec_deliverable_id naming the spec entry they
+      // fulfill. Column is nullable so legacy rows + ad-hoc deliverables (no
+      // spec) still work — the gate only reconciles when a spec exists.
+      console.log('[Migration 035] Adding task_deliverables.spec_deliverable_id...');
+
+      const info = db.prepare('PRAGMA table_info(task_deliverables)').all() as { name: string }[];
+      if (!info.some(c => c.name === 'spec_deliverable_id')) {
+        db.exec('ALTER TABLE task_deliverables ADD COLUMN spec_deliverable_id TEXT');
+        db.exec('CREATE INDEX IF NOT EXISTS idx_task_deliverables_spec_id ON task_deliverables(task_id, spec_deliverable_id)');
+      }
+
+      console.log('[Migration 035] Complete.');
+    }
   }
 ];
 

--- a/src/lib/planning-spec.ts
+++ b/src/lib/planning-spec.ts
@@ -1,0 +1,123 @@
+import type { SpecDeliverable, SpecSuccessCriterion } from '@/lib/types';
+
+/**
+ * Normalized planning spec used by the dispatcher, evidence gate, and UI.
+ * The planner's raw JSON blob (stored in tasks.planning_spec) may be in one
+ * of two shapes, both of which this helper resolves to a single structure.
+ */
+export interface NormalizedPlanningSpec {
+  title?: string;
+  summary?: string;
+  deliverables: SpecDeliverable[];
+  success_criteria: SpecSuccessCriterion[];
+  constraints?: Record<string, unknown>;
+  /** True when at least one of the structured fields (deliverables with `id`
+   *  and `acceptance`, or success_criteria with `assertion`) was present in
+   *  the raw spec. False for legacy string[] specs — the evidence gate only
+   *  reconciles when this is true. */
+  isStructured: boolean;
+}
+
+function slugify(s: string, index: number): string {
+  const base = s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+  return base ? base : `item-${index}`;
+}
+
+/**
+ * Parse tasks.planning_spec (which may be a string or an already-parsed
+ * object) and coerce both old and new shapes to NormalizedPlanningSpec.
+ *
+ * Old shape (pre-structured):
+ *   { title, summary, deliverables: string[], success_criteria: string[], constraints }
+ *
+ * New shape:
+ *   { title, summary,
+ *     deliverables: [{id, title, kind, path_pattern?, acceptance}],
+ *     success_criteria: [{id, assertion, how_to_test}],
+ *     constraints }
+ *
+ * Mixed shapes (objects missing optional fields) are tolerated — missing
+ * ids are derived from the title.
+ */
+export function parsePlanningSpec(raw: unknown): NormalizedPlanningSpec | null {
+  if (!raw) return null;
+
+  let obj: Record<string, unknown>;
+  if (typeof raw === 'string') {
+    try {
+      obj = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  } else if (typeof raw === 'object') {
+    obj = raw as Record<string, unknown>;
+  } else {
+    return null;
+  }
+
+  const deliverablesRaw = Array.isArray(obj.deliverables) ? obj.deliverables : [];
+  const criteriaRaw = Array.isArray(obj.success_criteria) ? obj.success_criteria : [];
+
+  let structuredSeen = false;
+
+  const deliverables: SpecDeliverable[] = deliverablesRaw.map((entry, idx): SpecDeliverable => {
+    if (typeof entry === 'string') {
+      return {
+        id: slugify(entry, idx),
+        title: entry,
+        kind: 'artifact',
+        acceptance: entry,
+      };
+    }
+    const rec = entry as Record<string, unknown>;
+    const id = typeof rec.id === 'string' && rec.id.length > 0
+      ? rec.id
+      : slugify(typeof rec.title === 'string' ? rec.title : '', idx);
+    const title = typeof rec.title === 'string' ? rec.title : id;
+    const rawKind = typeof rec.kind === 'string' ? rec.kind : 'artifact';
+    const kind = (rawKind === 'file' || rawKind === 'behavior' || rawKind === 'artifact')
+      ? rawKind
+      : 'artifact';
+    const path_pattern = typeof rec.path_pattern === 'string' ? rec.path_pattern : undefined;
+    const acceptance = typeof rec.acceptance === 'string' && rec.acceptance.length > 0
+      ? rec.acceptance
+      : title;
+    if (typeof rec.id === 'string' && typeof rec.acceptance === 'string') {
+      structuredSeen = true;
+    }
+    return { id, title, kind, path_pattern, acceptance };
+  });
+
+  const success_criteria: SpecSuccessCriterion[] = criteriaRaw.map((entry, idx): SpecSuccessCriterion => {
+    if (typeof entry === 'string') {
+      return {
+        id: `sc-${idx + 1}`,
+        assertion: entry,
+        how_to_test: '(not specified)',
+      };
+    }
+    const rec = entry as Record<string, unknown>;
+    const id = typeof rec.id === 'string' && rec.id.length > 0 ? rec.id : `sc-${idx + 1}`;
+    const assertion = typeof rec.assertion === 'string' ? rec.assertion : String(entry);
+    const how_to_test = typeof rec.how_to_test === 'string' ? rec.how_to_test : '(not specified)';
+    if (typeof rec.id === 'string' && typeof rec.assertion === 'string') {
+      structuredSeen = true;
+    }
+    return { id, assertion, how_to_test };
+  });
+
+  return {
+    title: typeof obj.title === 'string' ? obj.title : undefined,
+    summary: typeof obj.summary === 'string' ? obj.summary : undefined,
+    deliverables,
+    success_criteria,
+    constraints: typeof obj.constraints === 'object' && obj.constraints !== null
+      ? (obj.constraints as Record<string, unknown>)
+      : undefined,
+    isStructured: structuredSeen,
+  };
+}

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -1,5 +1,6 @@
 import { queryAll, queryOne, run, transaction } from '@/lib/db';
 import { notifyLearner } from '@/lib/learner';
+import { parsePlanningSpec } from '@/lib/planning-spec';
 import type { Task } from '@/lib/types';
 
 const ACTIVE_STATUSES = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification'];
@@ -9,13 +10,89 @@ export function isTerminalStatus(status: string): boolean {
   return TERMINAL_STATUSES.includes(status);
 }
 
-export function hasStageEvidence(taskId: string): boolean {
-  const deliverable = queryOne<{ count: number }>('SELECT COUNT(*) as count FROM task_deliverables WHERE task_id = ?', [taskId]);
-  const activity = queryOne<{ count: number }>(
-    `SELECT COUNT(*) as count FROM task_activities WHERE task_id = ? AND activity_type IN ('completed','file_created','updated')`,
+export interface StageEvidenceResult {
+  ok: boolean;
+  /** Single-line reason suitable for surfacing to agents + operators. */
+  reason?: string;
+  /** Ids from planning_spec.deliverables that have no registered fulfillment.
+   *  Empty when the task had no structured spec or all deliverables are done. */
+  missingDeliverableIds?: string[];
+}
+
+/**
+ * Check if a task has enough evidence to transition forward into a quality
+ * stage. Baseline bar (always enforced): at least one deliverable + one
+ * progress activity. Upgraded bar (enforced when the task has a structured
+ * planning spec): every spec deliverable must be registered via a
+ * task_deliverables row carrying the matching spec_deliverable_id, otherwise
+ * the gate rejects and lists the missing ones.
+ */
+export function checkStageEvidence(taskId: string): StageEvidenceResult {
+  const deliverableCount = Number(
+    queryOne<{ count: number }>('SELECT COUNT(*) as count FROM task_deliverables WHERE task_id = ?', [taskId])?.count || 0
+  );
+  const activityCount = Number(
+    queryOne<{ count: number }>(
+      `SELECT COUNT(*) as count FROM task_activities WHERE task_id = ? AND activity_type IN ('completed','file_created','updated')`,
+      [taskId]
+    )?.count || 0
+  );
+
+  if (deliverableCount === 0) {
+    return { ok: false, reason: 'Evidence gate: no deliverables registered for this task' };
+  }
+  if (activityCount === 0) {
+    return { ok: false, reason: 'Evidence gate: no progress activity logged for this task' };
+  }
+
+  // Spec reconciliation: when planning produced a structured spec, every
+  // deliverables[] entry must have a matching registration. Tasks without a
+  // spec (or with a legacy string[] spec) skip this check — the baseline bar
+  // above still applies.
+  const task = queryOne<{ planning_spec?: string; convoy_id?: string | null }>(
+    'SELECT planning_spec, convoy_id FROM tasks WHERE id = ?',
     [taskId]
   );
-  return Number(deliverable?.count || 0) > 0 && Number(activity?.count || 0) > 0;
+
+  // Convoy subtasks don't each carry the parent's spec — they carry their
+  // own descriptions. Reconciliation happens at the parent level when the
+  // convoy transitions. So for subtasks we fall back to the baseline bar.
+  if (task?.convoy_id) {
+    return { ok: true };
+  }
+
+  const spec = parsePlanningSpec(task?.planning_spec);
+  if (!spec || !spec.isStructured || spec.deliverables.length === 0) {
+    return { ok: true };
+  }
+
+  const fulfilled = new Set(
+    queryAll<{ spec_deliverable_id: string }>(
+      `SELECT spec_deliverable_id FROM task_deliverables
+       WHERE task_id = ? AND spec_deliverable_id IS NOT NULL AND spec_deliverable_id != ''`,
+      [taskId]
+    ).map(r => r.spec_deliverable_id)
+  );
+
+  const missing = spec.deliverables.filter(d => !fulfilled.has(d.id)).map(d => d.id);
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      reason: `Evidence gate: ${missing.length} spec deliverable(s) not fulfilled — missing: ${missing.join(', ')}. Register each with {"spec_deliverable_id": "<id>"} when POSTing to /deliverables.`,
+      missingDeliverableIds: missing,
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Legacy boolean wrapper. Prefer checkStageEvidence() in new code so callers
+ * can surface the rejection reason. Kept because several call sites upstream
+ * still expect a plain bool.
+ */
+export function hasStageEvidence(taskId: string): boolean {
+  return checkStageEvidence(taskId).ok;
 }
 
 export function canUseBoardOverride(request: Request): boolean {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -268,7 +268,37 @@ export interface TaskDeliverable {
   description?: string;
   storage_scheme?: DeliverableStorageScheme;
   size_bytes?: number;
+  /** When the builder is fulfilling a planning-spec deliverable, this names
+   *  which one (matches SpecDeliverable.id). Null for ad-hoc deliverables
+   *  from tasks that never went through planning. */
+  spec_deliverable_id?: string | null;
   created_at: string;
+}
+
+/** Structured spec deliverable emitted by the planner's final output. The
+ *  old shape (array of strings) is still accepted by readers for backward
+ *  compatibility, but new tasks always get this shape. */
+export interface SpecDeliverable {
+  /** Stable machine id the builder uses when registering fulfillment. */
+  id: string;
+  title: string;
+  /** `file` = expects one or more output files matching path_pattern;
+   *  `behavior` = runtime assertion the tester verifies;
+   *  `artifact` = non-file deliverable (URL, config change, doc entry). */
+  kind: 'file' | 'behavior' | 'artifact';
+  /** For kind=file: glob-like pattern under the deliverables dir
+   *  (e.g. "src/shot-logger.js", "manifest.json"). */
+  path_pattern?: string;
+  /** Binary, testable description — the tester uses this as the assertion. */
+  acceptance: string;
+}
+
+export interface SpecSuccessCriterion {
+  id: string;
+  /** Binary assertion (passes or fails, no ambiguity). */
+  assertion: string;
+  /** How the tester can verify it (command, manual step, spec reference). */
+  how_to_test: string;
 }
 
 // Planning types

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -107,6 +107,29 @@ export const CreateDeliverableSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   path: z.string().optional(),
   description: z.string().optional(),
+  /** When fulfilling a planning-spec deliverable, name which one. The
+   *  evidence gate reconciles this against planning_spec.deliverables[].id
+   *  before allowing a transition into testing/review/verification/done. */
+  spec_deliverable_id: z.string().max(200).optional(),
+});
+
+// Planning spec deliverables + success criteria (structured shape). Readers
+// still accept the legacy array-of-strings shape for in-flight tasks — see
+// parsePlanningSpec in src/lib/planning-spec.ts.
+const SpecDeliverableKind = z.enum(['file', 'behavior', 'artifact']);
+
+export const SpecDeliverableSchema = z.object({
+  id: z.string().min(1).max(100),
+  title: z.string().min(1).max(500),
+  kind: SpecDeliverableKind,
+  path_pattern: z.string().max(500).optional(),
+  acceptance: z.string().min(1).max(2000),
+});
+
+export const SpecSuccessCriterionSchema = z.object({
+  id: z.string().min(1).max(100),
+  assertion: z.string().min(1).max(1000),
+  how_to_test: z.string().min(1).max(1000),
 });
 
 // Fail-task validation schema — agents hit this to trigger a fail-loopback


### PR DESCRIPTION
## Summary

The test task decomposed cleanly and all three subtasks reached `done`, but the Builder shipped an [HTML skeleton referencing missing `styles.css` / `app.js`](https://github.com/smb209/mission-control/issues/14-deliverable-file) and the evidence gate rubber-stamped it — one file + one activity = pass. This PR closes that gap end-to-end.

## What changes

### 1. Planner output is now structured (with backward compat)
Both planning prompts ([init](src/app/api/tasks/%5Bid%5D/planning/route.ts) + [answer](src/app/api/tasks/%5Bid%5D/planning/answer/route.ts)) now request:

```json
"deliverables": [
  {"id": "shot-logger", "title": "...", "kind": "file", "path_pattern": "src/shot-logger.js", "acceptance": "logShot(data) persists to IndexedDB 'espresso-shots'"}
],
"success_criteria": [
  {"id": "sc-1", "assertion": "Binary pass/fail", "how_to_test": "specific command or step"}
]
```

Old `string[]` shapes are still accepted — the new [`parsePlanningSpec`](src/lib/planning-spec.ts) normalizer coerces both and reports `isStructured` so the evidence gate only reconciles when there's real structure to reconcile against.

### 2. Evidence gate reconciles against the spec
[`checkStageEvidence`](src/lib/task-governance.ts) returns `{ok, reason, missingDeliverableIds}`. When a task has a structured spec, every `deliverables[].id` must have a `task_deliverables` row whose new `spec_deliverable_id` column matches. Legacy tasks still pass on the baseline bar (1 deliverable + 1 activity) — no regression.

The PATCH `/api/tasks/[id]` evidence-gate error now tells the agent exactly which ids are missing instead of a generic message. Example from smoke test:

```
{
  "error": "Evidence gate: 1 spec deliverable(s) not fulfilled — missing: b. Register each with {\"spec_deliverable_id\": \"<id>\"} when POSTing to /deliverables.",
  "missingDeliverableIds": ["b"]
}
```

### 3. Builder dispatch leads with the checklist + a self-check step
The structured checklist renders above the spec prose. For each `kind: "file"` deliverable, the prompt tells the builder to `ls -la` its `path_pattern`, and for HTML entrypoints to grep every `href`/`src` and confirm the referenced files exist. Status PATCH happens only after the self-check; if the gate rejects with missing ids, the agent knows the exact next action.

### 4. Tester / Verifier dispatch leads with success criteria
Each criterion is a `- [ ]` checkbox with `how_to_test`. Agents must name the ids they verified in their activity message (and the specific ids that failed in the fail reason). "Looks good" no longer qualifies.

### 5. Convoy decomposition pulls from the structured spec
[convoy/route.ts](src/app/api/tasks/%5Bid%5D/convoy/route.ts): when `planning_spec` is structured, the decomposition prompt lists every deliverable so the decomposer can make per-deliverable builder subtasks (not one monolithic "Build"). It also mandates a dedicated Tester subtask that depends on all builders.

`MAX_CONVOY_SUBTASKS` bumped 6 → 8 so a typical app (N file deliverables + a Tester) fits without "deferred".

### 6. Migration 035
Adds `task_deliverables.spec_deliverable_id TEXT` (nullable) + an index `(task_id, spec_deliverable_id)`. Existing rows keep working.

## Test plan

- [x] Migration 035 applies cleanly on the dev DB; `spec_deliverable_id` column queryable.
- [x] `POST /api/tasks/[id]/deliverables` accepts `spec_deliverable_id` and persists it (verified via DB).
- [x] Evidence gate: fresh task with structured spec + zero deliverables → rejects "no deliverables registered".
- [x] Evidence gate: after registering 1 of 2 deliverables → rejects with `"missing: b"` and `missingDeliverableIds: ["b"]`.
- [x] Legacy in-flight task with old string[] spec still passes baseline bar (test task `ba1139da-...` reached `done` on 1 deliverable + 29 activities).
- [x] No TypeScript errors in Turbopack dev logs.
- [ ] End-to-end: run a fresh planning session and confirm the planner emits structured shape + builder produces per-deliverable files + tester verifies criterion ids. Next time you start a new task.
- [ ] Convoy decomposition: confirm a structured-spec parent now produces per-deliverable subtasks plus a dedicated Tester subtask.

## Not in this PR (follow-ups)

- UI visualisation of spec-vs-delivered on the board.
- Server-side automated smoke test (e.g. `python -m http.server` + curl each registered path) — the builder is currently told to do this manually.
- Structured per-criterion pass/fail body for Tester (right now the agent stuffs it into a string).

## Interaction with PR #15

This PR uses migration id `035`. [#15](https://github.com/smb209/mission-control/pull/15) uses `034`. They don't touch the same tables — either merge order is fine. If #15 goes first, no rebase needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)