### PR TITLE
fix: verify coordinator delegations actually fired; harden prompt + audit

### DIFF
--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -424,7 +424,8 @@ their persona, memory, and channel bindings.
 For each peer agent you want to delegate work to:
 
 1. **Invoke \`sessions_send\` FIRST.** Do NOT announce the delegation before the tool call returns. Capture the tool-call result id the gateway returns.
-   - \`sessionKey\`: discover via \`sessions_list\`, or target the agent's main session. Gateway ids are listed above.
+   - \`sessionKey\`: construct a FRESH per-task session key as \`agent:<peer_gateway_id>:task-${task.id}\` — substitute the peer's gateway id from the list above (e.g. \`agent:mc-researcher:task-${task.id}\`). The gateway creates the session implicitly on first send.
+   - **Do NOT target the peer's \`:main\` session.** Shared \`:main\` sessions carry context from prior tasks, collide when multiple tasks run in parallel, and appear to get aborted more aggressively by the gateway's run lifecycle (see the task cc3d40e1 post-mortem: every peer delegation landed on \`:main\` and was aborted before responding). Per-task session keys give each delegation an isolated lane.
    - \`message\`: include the task id (\`${task.id}\`), the specific slice of work, any context, and prefix it with "You are the <role> for this task".
    - \`timeoutSeconds\`: \`0\` for fire-and-forget parallel work.
 

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -402,43 +402,68 @@ their persona, memory, and channel bindings.
 
     let completionInstructions: string;
     if (isCoordinator) {
-      completionInstructions = `**YOUR ROLE: COORDINATOR** — Break this task down and delegate to the persistent agents above. Track their progress and roll the results up to Mission Control.
+      // This prompt is the response to a specific failure mode observed on
+      // task cc3d40e1 (2026-04-20): the Coordinator posted one umbrella
+      // "Delegated parallel research+write+review to 3 agents" activity
+      // *without* ever invoking the sessions_send tool. Gateway logs showed
+      // zero outbound peer messages. The Coordinator then went idle waiting
+      // for callbacks that could never happen.
+      //
+      // Defense in depth below:
+      //   (a) Ordering: sessions_send BEFORE the activity, not after.
+      //   (b) One activity per sessions_send call, each tagged with a parseable
+      //       marker that includes the tool_call_id the gateway returned.
+      //   (c) Explicit ban on umbrella "I delegated to N agents" claims.
+      //   (d) Server-side audit (see auditCoordinatorDelegations in
+      //       src/lib/coordinator-audit.ts) flags tasks where claimed
+      //       delegations > 0 but zero peer callbacks arrived.
+      completionInstructions = `**YOUR ROLE: COORDINATOR** — Delegate to the persistent agents above via the gateway. Mission Control cannot see tool invocations on the gateway side, so YOU are responsible for emitting structured proof of each delegation after it fires.
 
-**CRITICAL — HOW TO DELEGATE:**
-- Use the \`sessions_send\` tool (a.k.a. \`agent.send\`) to dispatch work to each persistent agent.
-  - \`sessionKey\`: call \`sessions_list\` first to discover the target agent's active session, or target its main session. The gateway ids above identify each agent.
-  - \`message\`: include the task id (\`${task.id}\`), the specific slice of work you want them to do, and any context they need. Prefix each message with \"You are the <role> for this task\" so they receive the role framing they would get from Mission Control directly.
-  - \`timeoutSeconds\`: use \`0\` (fire-and-forget) for parallel work; use a positive value only when you need a synchronous reply.
-- **DO NOT use \`sessions_spawn\`** for this workflow. Spawned subagents inherit a stripped context (no SOUL.md/IDENTITY.md) and won't know the role they're meant to play. We want the pinned persona of the persistent agents.
-- If \`sessions_send\` is rejected with a permissions/allow-list error (e.g. *"Session send visibility is restricted"*), the OpenClaw allow-list on this coordinator needs \`tools.sessions.visibility: "all"\` — or an explicit list of peer agent ids. Surface the blocker via:
-  \`\`\`bash
-  curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/fail" \\
-    -H "Content-Type: application/json" \\
-${authHeaderLine}    -d '{"reason":"sessions_send blocked by allow-list: <error text>"}'
-  \`\`\`
+**DELEGATION PROTOCOL — strict ordering:**
 
-**TRACKING & REPORTING** (all calls require the Authorization header):
+For each peer agent you want to delegate work to:
+
+1. **Invoke \`sessions_send\` FIRST.** Do NOT announce the delegation before the tool call returns. Capture the tool-call result id the gateway returns.
+   - \`sessionKey\`: discover via \`sessions_list\`, or target the agent's main session. Gateway ids are listed above.
+   - \`message\`: include the task id (\`${task.id}\`), the specific slice of work, any context, and prefix it with "You are the <role> for this task".
+   - \`timeoutSeconds\`: \`0\` for fire-and-forget parallel work.
+
+2. **IMMEDIATELY AFTER the tool call returns successfully, POST ONE activity** logging that specific delegation. Each activity message MUST start with the \`[DELEGATION]\` marker in the exact format below. Mission Control audits these — messages that don't match the format are treated as unverified:
 
 \`\`\`bash
-# Log each delegation / receipt
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
   -H "Content-Type: application/json" \\
-${authHeaderLine}  -d '{"activity_type":"updated","message":"Delegated <slice> to <agent name>"}'
+${authHeaderLine}  -d '{"activity_type":"updated","message":"[DELEGATION] target=\\"<agent name>\\" gateway_id=\\"<gateway_agent_id>\\" tool_call_id=\\"<id returned by sessions_send>\\" slice=\\"<one-line summary of what you asked them to do>\\""}'
+\`\`\`
 
-# Register aggregated deliverable (after all peers report in)
-# Save the file to the **DELIVERABLES DIR** below so it becomes web-downloadable.
+**ONE activity per sessions_send call.** Do NOT bundle multiple delegations into a single activity. Do NOT post an umbrella "Delegated work to 3 agents" activity — it will be rejected by the audit and the stall detector will flag the task as suspected hallucinated delegation.
+
+**DO NOT use \`sessions_spawn\`.** Spawned subagents inherit a stripped context and won't know their role.
+
+**If \`sessions_send\` is rejected** with an allow-list error (*"Session send visibility is restricted"*), the OpenClaw allow-list on this coordinator needs \`tools.sessions.visibility: "all"\`. Surface the blocker immediately — do not post a \`[DELEGATION]\` activity since no delegation actually happened:
+
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/fail" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"reason":"sessions_send blocked by allow-list: <error text>"}'
+\`\`\`
+
+**AGGREGATION & COMPLETION** (after every peer has reported back):
+
+\`\`\`bash
+# Register the aggregated deliverable. Save it to the DELIVERABLES DIR below.
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/deliverables" \\
   -H "Content-Type: application/json" \\
 ${authHeaderLine}  -d '{"deliverable_type":"file","title":"<title>","path":"${deliverablesDir}/<filename>"}'
 
-# Close the task
+# Transition the task.
 curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
   -H "Content-Type: application/json" \\
 ${authHeaderLine}  -d '{"status":"${nextStatus}"}'
 \`\`\`
 
 When complete, reply with:
-\`TASK_COMPLETE: [summary of what was delegated, to whom, and the aggregate outcome]\``;
+\`TASK_COMPLETE: [one line per delegated agent with tool_call_id + outcome]\``;
     } else if (isBuilder) {
       // Build the builder's completion block. When a structured spec exists,
       // require one deliverable POST per spec id (the evidence gate enforces

--- a/src/lib/coordinator-audit.ts
+++ b/src/lib/coordinator-audit.ts
@@ -1,0 +1,146 @@
+import { queryAll, queryOne } from '@/lib/db';
+
+/**
+ * Parseable marker the Coordinator dispatch prompt requires on every
+ * per-delegation activity message. Anchored at the start of the message so
+ * prose surrounding the marker is ignored. The inner fields are matched
+ * loosely — field presence matters more than exact formatting for the audit.
+ */
+const DELEGATION_MARKER_RE = /^\[DELEGATION\]/i;
+
+export interface DelegationClaim {
+  activity_id: string;
+  created_at: string;
+  agent_id: string | null;
+  message: string;
+  target: string | null;
+  gateway_id: string | null;
+  tool_call_id: string | null;
+}
+
+export interface CoordinatorAuditResult {
+  /** Activities posted by the task's assigned (coordinator) agent that carry
+   *  the [DELEGATION] marker. These are the coordinator's *claims* that a
+   *  delegation happened. */
+  claims: DelegationClaim[];
+  /** Count of activities from agents OTHER than the assigned coordinator.
+   *  These are the real signal that a peer received work and responded. */
+  peerCallbacks: number;
+  /** True when the coordinator has claimed at least one delegation but no
+   *  peer has reported back after the freshness threshold. Callers use this
+   *  to enrich stall reasons without blocking on exact-match proof. */
+  suspicious: boolean;
+  /** Minutes since the earliest delegation claim. Null when no claims. */
+  minutesSinceFirstClaim: number | null;
+  /** Activities that *look* like delegation announcements ("delegated", "sent
+   *  to", etc.) but don't carry the marker. These are the umbrella-claim
+   *  pattern we want to catch — they inflate the count of apparent work while
+   *  carrying no proof of tool invocation. */
+  unmarkedClaimActivities: number;
+}
+
+function parseDelegationFields(message: string): { target: string | null; gateway_id: string | null; tool_call_id: string | null } {
+  // The marker format is:
+  //   [DELEGATION] target="..." gateway_id="..." tool_call_id="..." slice="..."
+  // but the LLM may drop quotes or use single quotes. Extract best-effort.
+  const grab = (key: string): string | null => {
+    const re = new RegExp(`${key}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'][^\\s]*))`, 'i');
+    const m = re.exec(message);
+    return m ? (m[1] ?? m[2] ?? m[3] ?? null) : null;
+  };
+  return {
+    target: grab('target'),
+    gateway_id: grab('gateway_id'),
+    tool_call_id: grab('tool_call_id'),
+  };
+}
+
+/**
+ * Audit a task's coordinator-claimed delegations against evidence that peer
+ * agents actually received work. Used by stall detection to distinguish
+ * "coordinator waiting on real peers" from "coordinator narrated a delegation
+ * it never actually invoked".
+ *
+ * Freshness threshold: a claim older than `stalenessMinutes` with zero peer
+ * callbacks is suspicious. Below that window we assume peers may still be
+ * responding and don't flag. Defaults to 5 minutes.
+ */
+export function auditCoordinatorDelegations(
+  taskId: string,
+  opts: { stalenessMinutes?: number } = {}
+): CoordinatorAuditResult {
+  const stalenessMinutes = opts.stalenessMinutes ?? 5;
+
+  const task = queryOne<{ assigned_agent_id: string | null }>(
+    'SELECT assigned_agent_id FROM tasks WHERE id = ?',
+    [taskId]
+  );
+  const coordId = task?.assigned_agent_id ?? null;
+
+  // Every activity on the task with the parseable marker.
+  const markedRows = queryAll<{ id: string; created_at: string; agent_id: string | null; message: string }>(
+    `SELECT id, created_at, agent_id, message
+     FROM task_activities
+     WHERE task_id = ? AND message LIKE '[DELEGATION]%'
+     ORDER BY created_at ASC`,
+    [taskId]
+  );
+  const claims: DelegationClaim[] = markedRows
+    .filter(r => DELEGATION_MARKER_RE.test(r.message))
+    .map(r => ({
+      activity_id: r.id,
+      created_at: r.created_at,
+      agent_id: r.agent_id,
+      message: r.message,
+      ...parseDelegationFields(r.message),
+    }));
+
+  // Umbrella-claim pattern: activities from the coordinator that talk about
+  // delegating but don't carry the marker. Useful signal but not counted as
+  // real delegations.
+  let unmarkedClaimActivities = 0;
+  if (coordId) {
+    const umbrella = queryAll<{ id: string }>(
+      `SELECT id FROM task_activities
+       WHERE task_id = ?
+         AND agent_id = ?
+         AND (message LIKE '%delegat%' OR message LIKE '%dispatched to%' OR message LIKE '%sent to%')
+         AND message NOT LIKE '[DELEGATION]%'`,
+      [taskId, coordId]
+    );
+    unmarkedClaimActivities = umbrella.length;
+  }
+
+  // Peer callbacks: activities by agents OTHER than the coordinator. Exclude
+  // system-generated status_changed rows (health/stall noise) and the
+  // coordinator's own self-report rows.
+  const peerCallbacks = Number(
+    queryOne<{ n: number }>(
+      `SELECT COUNT(*) as n FROM task_activities
+       WHERE task_id = ?
+         AND activity_type != 'status_changed'
+         AND agent_id IS NOT NULL
+         AND agent_id != COALESCE(?, '')`,
+      [taskId, coordId]
+    )?.n ?? 0
+  );
+
+  let minutesSinceFirstClaim: number | null = null;
+  if (claims.length > 0) {
+    minutesSinceFirstClaim = (Date.now() - new Date(claims[0].created_at).getTime()) / 60000;
+  }
+
+  const suspicious =
+    claims.length > 0 &&
+    peerCallbacks === 0 &&
+    minutesSinceFirstClaim !== null &&
+    minutesSinceFirstClaim >= stalenessMinutes;
+
+  return {
+    claims,
+    peerCallbacks,
+    suspicious,
+    minutesSinceFirstClaim,
+    unmarkedClaimActivities,
+  };
+}

--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -5,6 +5,7 @@ import type { OpenClawMessage, OpenClawSessionInfo } from '../types';
 import { loadOrCreateDeviceIdentity, signDevicePayload, buildDeviceAuthPayload, publicKeyRawBase64Url } from './device-identity';
 import { createHash } from 'crypto';
 import { logDebugEvent } from '../debug-log';
+import { extractTaskIdFromSessionKey } from './session-key';
 
 // Types for gateway model discovery (matches OpenClaw models.list response)
 export interface GatewayModelChoice {
@@ -303,23 +304,32 @@ export class OpenClawClient extends EventEmitter {
 
             console.log('[OpenClaw] Received:', data.type === 'res' ? `res:${String(data.id).slice(0, 8)}` : this.generateEventId(data).slice(0, 16));
 
-            // Forward gateway streaming events so subscribers can tap in
+            // Forward gateway streaming events so subscribers can tap in.
+            // We also extract the task UUID from the sessionKey suffix so
+            // per-task debug queries surface these rows. Shared :main
+            // sessions (peer agents without a per-task dispatch) have no
+            // task UUID and the field stays null — that's expected and
+            // correct, not a bug.
             if (data.type === 'event' && data.event === 'agent' && data.payload) {
               this.emit('agent_event', data.payload);
+              const sessionKey = (data.payload as { sessionKey?: string })?.sessionKey ?? null;
               logDebugEvent({
                 type: 'agent.event',
                 direction: 'inbound',
-                sessionKey: (data.payload as { sessionKey?: string })?.sessionKey ?? null,
+                taskId: extractTaskIdFromSessionKey(sessionKey),
+                sessionKey,
                 responseBody: data.payload,
                 metadata: { seq: data.seq, event: data.event },
               });
             }
             if (data.type === 'event' && data.event === 'chat' && data.payload) {
               this.emit('chat_event', data.payload);
+              const sessionKey = (data.payload as { sessionKey?: string })?.sessionKey ?? null;
               logDebugEvent({
                 type: 'chat.response',
                 direction: 'inbound',
-                sessionKey: (data.payload as { sessionKey?: string })?.sessionKey ?? null,
+                taskId: extractTaskIdFromSessionKey(sessionKey),
+                sessionKey,
                 responseBody: data.payload,
                 metadata: { seq: data.seq, event: data.event },
               });

--- a/src/lib/openclaw/session-key.ts
+++ b/src/lib/openclaw/session-key.ts
@@ -31,3 +31,25 @@ export function resolveAgentSessionKeyPrefix(
   const slug = agent.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
   return `agent:${slug || 'unknown'}:`;
 }
+
+// UUID pattern. Exported so other session-key helpers can reuse it.
+const UUID_RE = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i;
+
+/**
+ * Extract the task UUID from a sessionKey, if present.
+ *
+ * Per-task session keys (coordinator dispatches, planning sessions) embed
+ * the task's UUID as a suffix — e.g.
+ *   agent:mc-coordinator:mission-control-coordinator-<UUID>
+ *   agent:mc-coordinator:planning:<UUID>
+ *
+ * Shared per-agent sessions (e.g. agent:mc-researcher:main) have no task
+ * identity and return null. The caller must fall back to the runId hint or
+ * leave task_id NULL on the debug row rather than guessing.
+ */
+export function extractTaskIdFromSessionKey(sessionKey: string | null | undefined): string | null {
+  if (!sessionKey) return null;
+  const m = UUID_RE.exec(sessionKey);
+  return m ? m[1] : null;
+}
+

--- a/src/lib/stall-detection.ts
+++ b/src/lib/stall-detection.ts
@@ -97,23 +97,29 @@ export async function scanStalledTasks(): Promise<StallReport> {
     //    (recovery-guard) when the coordinator does anything real.
     //
     // Before writing the reason string, run a coordinator-delegation audit.
-    // If the coordinator has claimed delegations via [DELEGATION] markers
-    // (or, worse, emitted umbrella "I delegated to N agents" prose) but no
-    // peer agent has posted anything back, this is the hallucinated-delegation
-    // pattern observed on task cc3d40e1 — narrating a tool call without
-    // actually invoking it. Surface it explicitly so operators know this is
-    // a recoverable "nudge the coordinator to actually fire sessions_send"
-    // stall, not a generic peer-is-slow stall.
+    // If the coordinator has claimed delegations (via [DELEGATION] markers
+    // or the older umbrella "I delegated to N agents" prose) but no peer
+    // agent has posted anything back, the claim is unverified. There are
+    // two plausible causes and the audit alone can't distinguish them:
+    //   (a) the coordinator never actually invoked sessions_send — the
+    //       hallucinated-tool-call failure mode;
+    //   (b) the coordinator DID invoke sessions_send but the peer session
+    //       was aborted on the gateway side before responding (observed on
+    //       task cc3d40e1 where the gateway logged 4 `completed`
+    //       sessions_send calls but zero peer chat.response events).
+    // Either way the task is stuck, and "unverified delegation" captures
+    // both cases without over-claiming. Operators then inspect the gateway
+    // log to disambiguate.
     const coordinatorAudit = auditCoordinatorDelegations(task.id);
-    const suspectedHallucination =
+    const unverifiedDelegation =
       coordinatorAudit.suspicious ||
       (coordinatorAudit.claims.length === 0 &&
         coordinatorAudit.unmarkedClaimActivities > 0 &&
         coordinatorAudit.peerCallbacks === 0);
 
     if (!alreadyFlagged) {
-      const reasonTail = suspectedHallucination
-        ? ` (suspected hallucinated delegation: ${coordinatorAudit.claims.length} marked + ${coordinatorAudit.unmarkedClaimActivities} unmarked claims, 0 peer callbacks)`
+      const reasonTail = unverifiedDelegation
+        ? ` (unverified delegation: ${coordinatorAudit.claims.length} marked + ${coordinatorAudit.unmarkedClaimActivities} unmarked claims, 0 peer callbacks — check gateway log to distinguish hallucinated tool call vs aborted peer session)`
         : '';
       run(
         `UPDATE tasks SET status_reason = ?, updated_at = ? WHERE id = ?`,
@@ -126,13 +132,13 @@ export async function scanStalledTasks(): Promise<StallReport> {
       logTaskActivity({
         taskId: task.id,
         type: 'stall_detected',
-        message: suspectedHallucination
-          ? `Task idle ${Math.round(minutesIdle)}m with 0 peer callbacks despite ${coordinatorAudit.claims.length + coordinatorAudit.unmarkedClaimActivities} coordinator delegation claim(s) — suspected hallucinated delegation`
+        message: unverifiedDelegation
+          ? `Task idle ${Math.round(minutesIdle)}m with 0 peer callbacks despite ${coordinatorAudit.claims.length + coordinatorAudit.unmarkedClaimActivities} coordinator delegation claim(s) — unverified delegation (hallucinated call OR aborted peer session)`
           : `Task idle for ${Math.round(minutesIdle)}m with no deliverables`,
         metadata: {
           minutes_idle: Math.round(minutesIdle),
           threshold: thresholdMinutes,
-          suspected_hallucinated_delegation: suspectedHallucination,
+          unverified_delegation: unverifiedDelegation,
           marked_claims: coordinatorAudit.claims.length,
           unmarked_claims: coordinatorAudit.unmarkedClaimActivities,
           peer_callbacks: coordinatorAudit.peerCallbacks,

--- a/src/lib/stall-detection.ts
+++ b/src/lib/stall-detection.ts
@@ -4,6 +4,7 @@ import { sendMail } from '@/lib/mailbox';
 import { logTaskActivity } from '@/lib/activity-log';
 import { saveCheckpointThrottled } from '@/lib/checkpoint';
 import { logDebugEvent } from '@/lib/debug-log';
+import { auditCoordinatorDelegations } from '@/lib/coordinator-audit';
 import type { Task } from '@/lib/types';
 
 // Active statuses that can go stale. Kept in sync with
@@ -94,11 +95,30 @@ export async function scanStalledTasks(): Promise<StallReport> {
 
     // 1. Mark the task. status_reason is cleared by Phase 3.5
     //    (recovery-guard) when the coordinator does anything real.
+    //
+    // Before writing the reason string, run a coordinator-delegation audit.
+    // If the coordinator has claimed delegations via [DELEGATION] markers
+    // (or, worse, emitted umbrella "I delegated to N agents" prose) but no
+    // peer agent has posted anything back, this is the hallucinated-delegation
+    // pattern observed on task cc3d40e1 — narrating a tool call without
+    // actually invoking it. Surface it explicitly so operators know this is
+    // a recoverable "nudge the coordinator to actually fire sessions_send"
+    // stall, not a generic peer-is-slow stall.
+    const coordinatorAudit = auditCoordinatorDelegations(task.id);
+    const suspectedHallucination =
+      coordinatorAudit.suspicious ||
+      (coordinatorAudit.claims.length === 0 &&
+        coordinatorAudit.unmarkedClaimActivities > 0 &&
+        coordinatorAudit.peerCallbacks === 0);
+
     if (!alreadyFlagged) {
+      const reasonTail = suspectedHallucination
+        ? ` (suspected hallucinated delegation: ${coordinatorAudit.claims.length} marked + ${coordinatorAudit.unmarkedClaimActivities} unmarked claims, 0 peer callbacks)`
+        : '';
       run(
         `UPDATE tasks SET status_reason = ?, updated_at = ? WHERE id = ?`,
         [
-          `stalled_no_activity (idle ${Math.round(minutesIdle)}m, detected ${new Date().toISOString()})`,
+          `stalled_no_activity (idle ${Math.round(minutesIdle)}m, detected ${new Date().toISOString()})${reasonTail}`,
           new Date().toISOString(),
           task.id,
         ]
@@ -106,8 +126,17 @@ export async function scanStalledTasks(): Promise<StallReport> {
       logTaskActivity({
         taskId: task.id,
         type: 'stall_detected',
-        message: `Task idle for ${Math.round(minutesIdle)}m with no deliverables`,
-        metadata: { minutes_idle: Math.round(minutesIdle), threshold: thresholdMinutes },
+        message: suspectedHallucination
+          ? `Task idle ${Math.round(minutesIdle)}m with 0 peer callbacks despite ${coordinatorAudit.claims.length + coordinatorAudit.unmarkedClaimActivities} coordinator delegation claim(s) — suspected hallucinated delegation`
+          : `Task idle for ${Math.round(minutesIdle)}m with no deliverables`,
+        metadata: {
+          minutes_idle: Math.round(minutesIdle),
+          threshold: thresholdMinutes,
+          suspected_hallucinated_delegation: suspectedHallucination,
+          marked_claims: coordinatorAudit.claims.length,
+          unmarked_claims: coordinatorAudit.unmarkedClaimActivities,
+          peer_callbacks: coordinatorAudit.peerCallbacks,
+        },
       });
 
       logDebugEvent({


### PR DESCRIPTION
## Concrete failure mode this addresses

Task `cc3d40e1` (Healthcare App Research, 2026-04-20) got stuck. The stall detector flagged it but the reason just said "idle, no deliverables", giving operators no way to see what was actually wrong.

**Initial diagnosis (was wrong):** I thought the Coordinator posted a single umbrella activity reading "Delegated parallel research+write+review to 3 agents" *without* invoking `sessions_send` — a hallucinated tool call.

**Corrected diagnosis after looking at `chat.response` events keyed by `session_key`:** the Coordinator actually DID invoke `sessions_send` 4 times (all logged `completed` by the gateway). The peer sessions (`mc-researcher:main`, `mc-writer:main`, `mc-reviewer:main`) received zero `chat.response` events during the delegation window — they were aborted on the gateway side before responding. The Coordinator's own chat stream later said: *"agent sessions get aborted by heartbeat cycles"*.

The reason I missed this initially: `agent.event` debug rows carried `session_key` but not `task_id`, so my per-task debug query returned zero tool invocations.

## Fix — five layers

### 1. Hardened Coordinator dispatch prompt ([dispatch/route.ts](src/app/api/tasks/%5Bid%5D/dispatch/route.ts))
- Strict ordering: **invoke `sessions_send` first**, then post the activity.
- **One activity per `sessions_send` call.** Umbrella claims forbidden.
- Each activity message MUST begin with `[DELEGATION]` and carry the `tool_call_id` the gateway returned.

### 2. Per-task session keys for Coordinator delegations
Same prompt now tells the Coordinator to construct `sessionKey` as:
```
agent:<peer_gateway_id>:task-<taskId>
```
instead of targeting the peer's shared `:main` session. The gateway creates a fresh per-task session on first send. Rationale:
- `:main` carries context from prior tasks → pollutes the new work
- Concurrent tasks collide on the same session
- Observed on cc3d40e1: every peer delegation landed on `:main` and was aborted before responding
- Mirrors what MC already does for its own initial dispatch to the Coordinator (`agent:mc-coordinator:mission-control-coordinator-<UUID>`)

**Deliberately NOT changed**: the Learner still uses its persistent session. Cross-task context is a feature there — it's how the Learner recognized the heartbeat-abort pattern on cc3d40e1 in the first place.

### 3. New audit helper ([src/lib/coordinator-audit.ts](src/lib/coordinator-audit.ts))
`auditCoordinatorDelegations(taskId)` returns:
- `claims` — parsed `[DELEGATION]` activities (target / gateway_id / tool_call_id extracted)
- `unmarkedClaimActivities` — the legacy umbrella pattern
- `peerCallbacks` — activities from agents other than the coordinator
- `suspicious` — ≥1 marked claim + 0 peer callbacks after a 5-min grace

### 4. Stall detection integration ([src/lib/stall-detection.ts](src/lib/stall-detection.ts))
- Enriches `tasks.status_reason` and the `stall_detected` activity with the audit result.
- **Label is `unverified_delegation`, not `hallucinated_delegation`** — the audit can't distinguish "coordinator narrated without invoking" from "coordinator invoked but peer aborted" without gateway-side telemetry. The reason text points operators at the gateway log to disambiguate.

### 5. Task-id tagging on gateway event rows ([openclaw/client.ts](src/lib/openclaw/client.ts) + [openclaw/session-key.ts](src/lib/openclaw/session-key.ts))
New helper `extractTaskIdFromSessionKey` pulls the UUID out of per-task session keys:
```
agent:mc-coordinator:mission-control-coordinator-<UUID>  →  <UUID>
agent:mc-coordinator:planning:<UUID>                     →  <UUID>
agent:mc-researcher:main                                 →  null
```
Used when logging `agent.event` and `chat.response` rows. Per-task debug queries now surface tool invocations — this is the gap that caused my initial misdiagnosis.

## Verification

- **Audit helper** against `cc3d40e1`: `{claims: 0, unmarkedClaimActivities: 2, peerCallbacks: 0, suspicious: false}`. Stall detection's composite trigger fires via the legacy-pattern branch and would tag it `unverified_delegation = true`.
- **`extractTaskIdFromSessionKey`**: unit-tested against 7 real session key shapes from the DB; all pass.
- Server compiles; Turbopack has no errors; `/api/tasks/scan-stalls` returns 200.
- **Next coordinator dispatch** will use the new per-task sessionKey pattern — requires a fresh task to verify end-to-end.

## Not in this PR (follow-ups)

- **Gateway-side tool-invocation verification** — would let MC distinguish "hallucinated" from "aborted peer" automatically.
- **Auto-recovery on unverified delegation** — currently operator-driven.
- **Gateway heartbeat lifecycle investigation** — root cause of `:main` session aborts is gateway-side; per-task keys are a workaround, not a fix for the underlying abort behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)