### PR TITLE
fix(docker): bind-mount deliverables dir so files are downloadable from host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,23 @@ PLANNING_POLL_INTERVAL_MS=2000
 # PROJECTS_PATH=~/Documents/Shared/projects
 
 # ====================================
+# Deliverables (Docker host mapping)
+# ====================================
+
+# Absolute host path that docker-compose bind-mounts into the container at
+# /app/deliverables. Agents on the host write finished deliverables here and
+# Mission Control reads them back through the mount — this is also the path
+# you download files from on the host. Must be ABSOLUTE; defaults to
+# $HOME/mission-control/deliverables when unset.
+# MC_DELIVERABLES_HOST_DIR=/Users/me/mission-control/deliverables
+
+# Advanced: override the agent-facing / MC-facing paths directly. Normally
+# you only need MC_DELIVERABLES_HOST_DIR above — docker-compose wires both
+# of these for you.
+# MC_DELIVERABLES_HOST_PATH=/Users/me/mission-control/deliverables
+# MC_DELIVERABLES_CONTAINER_PATH=/app/deliverables
+
+# ====================================
 # Agent Configuration
 # ====================================
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ next-env.d.ts
 # claude code local files
 .claude/settings.local.json
 .claude/tsc-cache/
+.claude/launch.json
 
 # local development notes/handoffs (may contain sensitive context)
 /thoughts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/next.config.mjs ./next.config.mjs
 
-RUN mkdir -p /app/data /app/workspace/projects \
+RUN mkdir -p /app/data /app/workspace/projects /app/deliverables \
   && chown -R node:node /app
 
 USER node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,21 @@ services:
       DATABASE_PATH: /app/data/mission-control.db
       WORKSPACE_BASE_PATH: /app/workspace
       PROJECTS_PATH: /app/workspace/projects
+      # Deliverables live on a bind-mounted host directory so files can be
+      # downloaded directly from the host. Agents (running on the host) write
+      # to MC_DELIVERABLES_HOST_PATH; MC (in this container) reads the same
+      # bytes via MC_DELIVERABLES_CONTAINER_PATH.
+      MC_DELIVERABLES_HOST_PATH: ${MC_DELIVERABLES_HOST_DIR:-${HOME}/mission-control/deliverables}
+      MC_DELIVERABLES_CONTAINER_PATH: /app/deliverables
       # Set this if OpenClaw runs on the host machine:
       # OPENCLAW_GATEWAY_URL: ws://host.docker.internal:18789
     volumes:
       - mission-control-data:/app/data
       - mission-control-workspace:/app/workspace
+      # Bind-mount the host deliverables directory. Override the source with
+      # MC_DELIVERABLES_HOST_DIR (must be an absolute host path, since it is
+      # also injected into agent dispatch prompts).
+      - ${MC_DELIVERABLES_HOST_DIR:-${HOME}/mission-control/deliverables}:/app/deliverables
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary
- Bind-mount a host directory into the container at `/app/deliverables` so agent-generated deliverables are directly downloadable from the host (previously the workspace was a Docker-managed named volume, stranding files in Docker's internal storage).
- Wire `MC_DELIVERABLES_HOST_PATH` (agent-facing) and `MC_DELIVERABLES_CONTAINER_PATH` (MC-facing) env vars so the existing storage-layer host/container path split in `src/lib/deliverables/storage.ts` resolves correctly under Docker.
- Document the new `MC_DELIVERABLES_HOST_DIR` override in `.env.example` and pre-create `/app/deliverables` in the Dockerfile with `node` ownership.

## Why
Before this change, the agent (running on the host via OpenClaw) was told to write deliverables to a container-only path (`/app/workspace/projects`), so files never showed up on the host and had to be extracted with `docker cp`. The storage layer already knew how to translate between host and container perspectives — it just needed compose to supply the right env vars and mount.

## Reviewer notes
- Default host location is `${HOME}/mission-control/deliverables` — override with `MC_DELIVERABLES_HOST_DIR` in `.env`. Must be absolute because the same path is injected into agent dispatch prompts.
- No code changes — only Dockerfile, docker-compose.yml, .env.example, and a `.gitignore` tweak for `.claude/launch.json`.
- Verified with `docker compose config`: env vars resolve to absolute host paths and the bind mount is registered correctly.

## Test plan
- [ ] `docker compose up --build` succeeds and `/app/deliverables` is writable as `node`.
- [ ] Dispatch a task; confirm agent writes to the configured host directory and the file appears on the host filesystem.
- [ ] Download the deliverable via the MC UI; confirm MC reads it through `/app/deliverables` without error.
- [ ] Override `MC_DELIVERABLES_HOST_DIR` in `.env` and confirm the new location is used on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)