### PR TITLE
fix(db): prevent half-initialized singleton from blocking migrations

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,21 @@
+/**
+ * Next.js instrumentation hook — runs once per server process, at boot,
+ * before any request is handled.
+ *
+ * We use it to force DB initialization (and therefore migrations) eagerly,
+ * so a fresh container that hasn't received traffic yet still ends up on
+ * the latest schema. Without this, migrations only fire on the first API
+ * call that touches the DB — which means "docker compose up" can appear
+ * healthy while the schema is still out-of-date.
+ */
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+
+  const { getDb } = await import('@/lib/db');
+  try {
+    getDb();
+  } catch (err) {
+    console.error('[Instrumentation] Eager DB init failed:', err);
+    throw err;
+  }
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -12,17 +12,29 @@ let db: Database.Database | null = null;
 export function getDb(): Database.Database {
   if (!db) {
     const isNewDb = !fs.existsSync(DB_PATH);
-    
-    db = new Database(DB_PATH);
-    db.pragma('journal_mode = WAL');
-    db.pragma('foreign_keys = ON');
 
-    // Initialize base schema (creates tables if they don't exist)
-    db.exec(schema);
+    const instance = new Database(DB_PATH);
+    instance.pragma('journal_mode = WAL');
+    instance.pragma('foreign_keys = ON');
 
-    // Run migrations for schema updates
-    // This handles both new and existing databases
-    runMigrations(db);
+    // Seed the full schema only for brand-new databases. Running schema.exec
+    // against an existing DB is redundant (everything is CREATE ... IF NOT
+    // EXISTS) and can actively *block* migrations: if schema.ts adds an index
+    // or constraint referencing a column that a pending migration will add,
+    // SQLite throws mid-exec — and because `db` would already be assigned,
+    // the half-initialized handle gets cached and migrations never run. For
+    // existing DBs, migrations are the sole source of schema truth.
+    if (isNewDb) {
+      instance.exec(schema);
+    }
+
+    // Run migrations for schema updates (handles both new and existing DBs).
+    runMigrations(instance);
+
+    // Only publish the singleton after init fully succeeds. If anything above
+    // throws, `db` stays null and the next call retries cleanly instead of
+    // returning a poisoned handle.
+    db = instance;
 
     // Recover orphaned autopilot cycles from prior crash/restart
     import('@/lib/autopilot/recovery').then(({ recoverOrphanedCycles }) =>
@@ -31,7 +43,7 @@ export function getDb(): Database.Database {
 
     // Keep Mission Control's agent catalog synced with OpenClaw-installed agents
     ensureCatalogSyncScheduled();
-    
+
     if (isNewDb) {
       console.log('[DB] New database created at:', DB_PATH);
     }


### PR DESCRIPTION
## Summary
Migrations silently stop running when `schema.ts` gains a statement that references a column a pending migration will add. The module-level `db` singleton gets assigned *before* `db.exec(schema)`, so when exec throws the cached handle is already populated — subsequent `getDb()` calls return a half-initialized DB and `runMigrations()` never runs.

This actually fired in prod after migration 032 (\"generalizes agent_mailbox\"): `schema.ts` has `CREATE INDEX ... ON agent_mailbox(task_id)`, but `task_id` doesn't exist until 032 applies. A container starting on any pre-032 DB could never cross that line on its own. Symptom was UI errors like `no such column: is_active` plus zero `[DB] Running migration N` lines in the container logs.

## Changes
- **[src/lib/db/index.ts](src/lib/db/index.ts)** — seed the full schema only for brand-new databases, and assign the `db` singleton only *after* init fully succeeds. A throw during init now leaves `db` null so the next call retries cleanly rather than returning a poisoned handle. For existing DBs, migrations are the sole source of schema truth (which `schema.ts` already documents in its header comment).
- **[src/instrumentation.ts](src/instrumentation.ts)** — new Next.js instrumentation hook that calls `getDb()` once at server boot. Without this, migrations only ran on the first API call that touched the DB, so a fresh container could appear healthy while still on an old schema. Instrumentation is default-enabled in Next 15+; no config change needed.

## Why both fixes
The init-order fix alone prevents future poisoning. The instrumentation hook makes \"migrate on launch\" actually true — the user's mental model and what the Dockerfile healthcheck implies. Together, \"docker compose up\" now reliably puts you on the latest schema before any request is served.

## Reviewer notes
- No change to migration content — the 032→035 migrations that were stuck are the existing ones; they just couldn't run.
- Removing `schema.exec(schema)` from the existing-DB path is safe because every `schema.ts` statement is `CREATE ... IF NOT EXISTS` and migrations handle ALL post-baseline schema evolution (each migration guards with `PRAGMA table_info` checks before altering). Fresh databases still get the full seed.
- Instrumentation fails loud: any throw from eager `getDb()` propagates out of `register()`, which prevents the server from starting in a broken state.

## Verification
Against the affected live container, I loaded the compiled `runMigrations` via the turbopack runtime and called it on the poisoned DB — migrations 032–035 applied cleanly with the expected pre-migration backup and log lines, and `agents.is_active` now exists. After this fix lands, the init path reaches `runMigrations` on every boot, so this recovery is self-service.

## Test plan
- [ ] Rebuild and restart the container on an existing pre-032 DB; logs show `[DB] Running migration 032/033/034/035` and each `[DB] Migration N completed`.
- [ ] Hit an endpoint that uses `agents.is_active` (e.g. `/api/agents/rollcall`) and confirm 200.
- [ ] Delete the DB file, start fresh; confirm schema is seeded and migrations run to the latest id without errors.
- [ ] Force a throw early in `getDb()` (e.g. temporary code) and confirm the second `getDb()` call retries instead of returning a poisoned handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)