### PR TITLE
feat(sidebar): per-agent send/receive ping indicator that fades over 60s

### DIFF
--- a/src/app/api/agents/activity/route.ts
+++ b/src/app/api/agents/activity/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { getAllAgentPings } from '@/lib/agent-pings';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/agents/activity — Snapshot of per-agent last-sent/last-received
+// timestamps. Used by the sidebar to hydrate the ping indicators on mount;
+// live updates arrive via SSE `agent_pinged` events.
+export async function GET() {
+  try {
+    return NextResponse.json(getAllAgentPings());
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch agent activity' }, { status: 500 });
+  }
+}

--- a/src/components/AgentPingIndicator.tsx
+++ b/src/components/AgentPingIndicator.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ArrowUp, ArrowDown } from 'lucide-react';
+
+/**
+ * Two-arrow liveness indicator for an agent row. Up arrow = MC → agent
+ * (last outbound message), down arrow = agent → MC (last reply). Each
+ * arrow independently fades from green → amber → red → gray as its
+ * timestamp ages past 60s. When no timestamp exists yet the arrow is
+ * rendered dimmed gray so the slot doesn't shift when the first ping
+ * lands.
+ */
+
+const FADE_TICK_MS = 1_000;
+
+// Buckets chosen to match the operator's mental model of "recent / active /
+// cooling off / stale". Thresholds are inclusive upper bounds in seconds.
+interface Bucket { maxSeconds: number; className: string; label: string }
+const BUCKETS: Bucket[] = [
+  { maxSeconds: 5,  className: 'text-green-400',        label: 'just now' },
+  { maxSeconds: 20, className: 'text-green-500/70',     label: 'recent' },
+  { maxSeconds: 40, className: 'text-amber-400',        label: 'cooling' },
+  { maxSeconds: 60, className: 'text-red-400',          label: 'stale' },
+];
+const INACTIVE_CLASS = 'text-mc-text-secondary/30';
+
+function ageSeconds(iso: string | undefined, now: number): number | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  return Math.max(0, (now - t) / 1000);
+}
+
+function classify(age: number | null): { className: string; title: string } {
+  if (age == null) return { className: INACTIVE_CLASS, title: 'no activity yet' };
+  for (const bucket of BUCKETS) {
+    if (age <= bucket.maxSeconds) {
+      return { className: bucket.className, title: `${bucket.label} (${Math.floor(age)}s ago)` };
+    }
+  }
+  return { className: INACTIVE_CLASS, title: `idle (${Math.floor(age)}s ago)` };
+}
+
+interface AgentPingIndicatorProps {
+  sentAt?: string;
+  receivedAt?: string;
+}
+
+export function AgentPingIndicator({ sentAt, receivedAt }: AgentPingIndicatorProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  // Only keep the ticker alive while at least one arrow is still within the
+  // fade window — otherwise the component is visually static and the
+  // interval is wasted work.
+  const stillFading = (() => {
+    const a = ageSeconds(sentAt, now);
+    const b = ageSeconds(receivedAt, now);
+    if (a != null && a <= 60) return true;
+    if (b != null && b <= 60) return true;
+    return false;
+  })();
+
+  useEffect(() => {
+    if (!stillFading) return;
+    const id = setInterval(() => setNow(Date.now()), FADE_TICK_MS);
+    return () => clearInterval(id);
+  }, [stillFading]);
+
+  const sent = classify(ageSeconds(sentAt, now));
+  const received = classify(ageSeconds(receivedAt, now));
+
+  return (
+    <div className="flex flex-col items-center gap-0 leading-none" aria-label="Agent message activity">
+      <span title={`Sent: ${sent.title}`} className="flex">
+        <ArrowUp className={`w-3 h-3 transition-colors duration-500 ${sent.className}`} aria-label="last sent" />
+      </span>
+      <span title={`Received: ${received.title}`} className="flex">
+        <ArrowDown className={`w-3 h-3 transition-colors duration-500 ${received.className}`} aria-label="last received" />
+      </span>
+    </div>
+  );
+}

--- a/src/components/AgentsSidebar.tsx
+++ b/src/components/AgentsSidebar.tsx
@@ -7,6 +7,7 @@ import type { Agent, AgentStatus, AgentHealthState, OpenClawSession } from '@/li
 import { AgentModal } from './AgentModal';
 import { DiscoverAgentsModal } from './DiscoverAgentsModal';
 import { HealthIndicator } from './HealthIndicator';
+import { AgentPingIndicator } from './AgentPingIndicator';
 
 interface RollCallEntryView {
   id: string;
@@ -37,7 +38,7 @@ interface AgentsSidebarProps {
 }
 
 export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = true }: AgentsSidebarProps) {
-  const { agents, selectedAgent, setSelectedAgent, agentOpenClawSessions, setAgentOpenClawSession, updateAgent } = useMissionControl();
+  const { agents, selectedAgent, setSelectedAgent, agentOpenClawSessions, setAgentOpenClawSession, updateAgent, agentPings, setAgentPings } = useMissionControl();
   const [filter, setFilter] = useState<FilterTab>('all');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingAgent, setEditingAgent] = useState<Agent | null>(null);
@@ -129,6 +130,22 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
     const interval = setInterval(loadHealth, 30000);
     return () => clearInterval(interval);
   }, []);
+
+  // Hydrate ping indicators on mount. Live updates arrive via SSE
+  // `agent_pinged` events — this only handles the first paint so an agent
+  // that last spoke seconds before the page loaded still shows green.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/agents/activity');
+        if (!res.ok || cancelled) return;
+        const data = await res.json() as Record<string, { sentAt?: string; receivedAt?: string }>;
+        setAgentPings(data);
+      } catch {}
+    })();
+    return () => { cancelled = true; };
+  }, [setAgentPings]);
 
   // Toggle is_active for an agent. Optimistic update — on failure we roll
   // back and surface the error.
@@ -502,6 +519,10 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
                 </div>
 
                 <div className="flex items-center gap-1.5">
+                  <AgentPingIndicator
+                    sentAt={agentPings[agent.id]?.sentAt}
+                    receivedAt={agentPings[agent.id]?.receivedAt}
+                  />
                   <span
                     role="button"
                     tabIndex={0}

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -22,6 +22,7 @@ export function useSSE() {
     setIsOnline,
     selectedTask,
     setSelectedTask,
+    recordAgentPing,
   } = useMissionControl();
 
   // Update ref when selectedTask changes (outside the SSE effect)
@@ -184,6 +185,14 @@ export function useSSE() {
               });
               break;
 
+            case 'agent_pinged': {
+              const p = sseEvent.payload as { agentId?: string; direction?: 'sent' | 'received'; at?: string };
+              if (p.agentId && p.direction && p.at) {
+                recordAgentPing(p.agentId, p.direction, p.at);
+              }
+              break;
+            }
+
             default:
               debug.sse('Unknown event type', sseEvent);
           }
@@ -225,5 +234,5 @@ export function useSSE() {
     };
   // selectedTask removed from deps to prevent re-connection loop
   // We use selectedTaskIdRef to check the current selected task ID without triggering re-renders
-  }, [addTask, removeTask, updateTask, setIsOnline, setSelectedTask]);
+  }, [addTask, removeTask, updateTask, setIsOnline, setSelectedTask, recordAgentPing]);
 }

--- a/src/lib/agent-pings.ts
+++ b/src/lib/agent-pings.ts
@@ -1,0 +1,121 @@
+/**
+ * Per-agent ping tracker — lightweight, in-memory signal of when MC last
+ * sent a message to each agent and when it last heard back. Powers the
+ * sidebar "up/down arrow" indicators that fade from green to gray over 60
+ * seconds so the operator can see at a glance which agents are currently
+ * exchanging traffic.
+ *
+ * This is deliberately in-memory. The indicator is a *liveness cue*, not
+ * a durable log — if the server restarts, indicators reset to gray and
+ * re-populate as real traffic flows. For durable history use the debug
+ * console (`/debug`) which persists to SQLite.
+ */
+import { queryAll } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+
+export type PingDirection = 'sent' | 'received';
+
+interface AgentPing {
+  sentAt?: string;      // ISO timestamp of last MC → agent message
+  receivedAt?: string;  // ISO timestamp of last agent → MC message
+}
+
+const pings = new Map<string, AgentPing>();
+
+// Cached sessionKey-prefix → agentId index. We match an inbound/outbound
+// sessionKey against every active agent's session_key_prefix; refreshing
+// per-event would hammer SQLite, so the index is cached and rebuilt at
+// most every few seconds.
+interface PrefixEntry { agentId: string; prefix: string }
+let prefixIndex: PrefixEntry[] | null = null;
+let prefixIndexRefreshedAt = 0;
+const PREFIX_INDEX_TTL_MS = 5_000;
+
+function refreshPrefixIndex(): void {
+  const now = Date.now();
+  if (prefixIndex && now - prefixIndexRefreshedAt < PREFIX_INDEX_TTL_MS) return;
+  try {
+    const rows = queryAll<{ id: string; session_key_prefix: string | null; gateway_agent_id: string | null; name: string }>(
+      `SELECT id, session_key_prefix, gateway_agent_id, name FROM agents`
+    );
+    const entries: PrefixEntry[] = [];
+    for (const r of rows) {
+      // Mirror resolveAgentSessionKeyPrefix() priority: explicit override,
+      // then gateway id, then name slug. We don't import the helper here to
+      // avoid a db ← session-key ← db cycle — the fallback logic is short.
+      const explicit = r.session_key_prefix?.trim();
+      let prefix: string | null = null;
+      if (explicit) {
+        prefix = explicit.endsWith(':') ? explicit : `${explicit}:`;
+      } else if (r.gateway_agent_id) {
+        prefix = `agent:${r.gateway_agent_id}:`;
+      } else {
+        const slug = r.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        if (slug) prefix = `agent:${slug}:`;
+      }
+      if (prefix) entries.push({ agentId: r.id, prefix });
+    }
+    // Sort by prefix length desc so more-specific prefixes win when they
+    // happen to overlap (e.g. "agent:mc-builder-2:" vs "agent:mc-builder:").
+    entries.sort((a, b) => b.prefix.length - a.prefix.length);
+    prefixIndex = entries;
+    prefixIndexRefreshedAt = now;
+  } catch {
+    // DB not ready (e.g. during instrumentation boot) — leave index null and
+    // retry on the next call. Callers treat null as "no match".
+    prefixIndex = prefixIndex ?? [];
+  }
+}
+
+export function resolveAgentIdFromSessionKey(sessionKey: string | null | undefined): string | null {
+  if (!sessionKey) return null;
+  refreshPrefixIndex();
+  for (const entry of prefixIndex ?? []) {
+    if (sessionKey.startsWith(entry.prefix)) return entry.agentId;
+  }
+  return null;
+}
+
+/**
+ * Record a ping for an agent and broadcast it to SSE subscribers. Safe to
+ * call from any traffic path — a missing/unresolvable agentId is a no-op.
+ */
+export function pingAgent(agentId: string | null | undefined, direction: PingDirection): void {
+  if (!agentId) return;
+  const at = new Date().toISOString();
+  const existing = pings.get(agentId) ?? {};
+  if (direction === 'sent') existing.sentAt = at;
+  else existing.receivedAt = at;
+  pings.set(agentId, existing);
+  broadcast({ type: 'agent_pinged', payload: { agentId, direction, at } });
+}
+
+/**
+ * Convenience: resolve from sessionKey + ping in one call. Returns true if
+ * the sessionKey mapped to a known agent (useful for callers that want to
+ * know whether the ping landed).
+ */
+export function pingAgentBySessionKey(sessionKey: string | null | undefined, direction: PingDirection): boolean {
+  const agentId = resolveAgentIdFromSessionKey(sessionKey);
+  if (!agentId) return false;
+  pingAgent(agentId, direction);
+  return true;
+}
+
+export function getAllAgentPings(): Record<string, AgentPing> {
+  const out: Record<string, AgentPing> = {};
+  for (const [agentId, p] of pings.entries()) {
+    out[agentId] = { ...p };
+  }
+  return out;
+}
+
+/**
+ * Test-only: clear all pings. Not exported from any barrel; reach for it
+ * directly from the test file if you ever need to reset between cases.
+ */
+export function __resetPingsForTests(): void {
+  pings.clear();
+  prefixIndex = null;
+  prefixIndexRefreshedAt = 0;
+}

--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -6,6 +6,7 @@ import { loadOrCreateDeviceIdentity, signDevicePayload, buildDeviceAuthPayload, 
 import { createHash } from 'crypto';
 import { logDebugEvent } from '../debug-log';
 import { extractTaskIdFromSessionKey } from './session-key';
+import { pingAgentBySessionKey } from '../agent-pings';
 
 // Types for gateway model discovery (matches OpenClaw models.list response)
 export interface GatewayModelChoice {
@@ -325,6 +326,12 @@ export class OpenClawClient extends EventEmitter {
             if (data.type === 'event' && data.event === 'chat' && data.payload) {
               this.emit('chat_event', data.payload);
               const sessionKey = (data.payload as { sessionKey?: string })?.sessionKey ?? null;
+              // Only count final/assistant frames as a "received" ping — streaming
+              // token deltas would otherwise spam the SSE channel once per chunk.
+              const state = (data.payload as { state?: string })?.state;
+              if (state === 'final') {
+                pingAgentBySessionKey(sessionKey, 'received');
+              }
               logDebugEvent({
                 type: 'chat.response',
                 direction: 'inbound',
@@ -524,6 +531,15 @@ export class OpenClawClient extends EventEmitter {
     const id = crypto.randomUUID();
     const message = { type: 'req', id, method, params };
     const started = Date.now();
+
+    // Sidebar ping: any direct-to-agent chat send is a "sent" signal. We
+    // fire on enqueue (not on ack) so the indicator flashes the moment MC
+    // commits to the message — the operator cares about outbound intent,
+    // not gateway round-trip.
+    if (method === 'chat.send') {
+      const sessionKey = (params as { sessionKey?: string } | undefined)?.sessionKey ?? null;
+      pingAgentBySessionKey(sessionKey, 'sent');
+    }
 
     // Keep the request body summary out of the hot path's closure so the
     // GC can release the full payload once the debug row is serialised.

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -35,6 +35,11 @@ interface MissionControlState {
   agentOpenClawSessions: Record<string, OpenClawSession | null>; // agentId -> session
   openclawMessages: Message[]; // Messages from OpenClaw (displayed alongside regular messages)
 
+  // Per-agent last-sent / last-received ISO timestamps, powering the
+  // sidebar ping indicators. Populated from /api/agents/activity on mount
+  // and updated live by SSE `agent_pinged` events.
+  agentPings: Record<string, { sentAt?: string; receivedAt?: string }>;
+
   // UI State
   selectedAgent: Agent | null;
   selectedTask: Task | null;
@@ -71,6 +76,10 @@ interface MissionControlState {
   setAgentOpenClawSession: (agentId: string, session: OpenClawSession | null) => void;
   setOpenclawMessages: (messages: Message[]) => void;
   addOpenclawMessage: (message: Message) => void;
+
+  // Ping actions
+  setAgentPings: (pings: Record<string, { sentAt?: string; receivedAt?: string }>) => void;
+  recordAgentPing: (agentId: string, direction: 'sent' | 'received', at: string) => void;
 }
 
 export const useMissionControl = create<MissionControlState>((set) => ({
@@ -83,6 +92,7 @@ export const useMissionControl = create<MissionControlState>((set) => ({
   messages: [],
   agentOpenClawSessions: {},
   openclawMessages: [],
+  agentPings: {},
   selectedAgent: null,
   selectedTask: null,
   isOnline: false,
@@ -197,4 +207,14 @@ export const useMissionControl = create<MissionControlState>((set) => ({
   setOpenclawMessages: (messages) => set({ openclawMessages: messages }),
   addOpenclawMessage: (message) =>
     set((state) => ({ openclawMessages: [...state.openclawMessages, message] })),
+
+  setAgentPings: (pings) => set({ agentPings: pings }),
+  recordAgentPing: (agentId, direction, at) =>
+    set((state) => {
+      const existing = state.agentPings[agentId] ?? {};
+      const next = direction === 'sent'
+        ? { ...existing, sentAt: at }
+        : { ...existing, receivedAt: at };
+      return { agentPings: { ...state.agentPings, [agentId]: next } };
+    }),
 }));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -901,7 +901,8 @@ export type SSEEventType =
   | 'tasks_cleared'
   | 'rollcall_started'
   | 'rollcall_delivered'
-  | 'rollcall_entry_updated';
+  | 'rollcall_entry_updated'
+  | 'agent_pinged';
 
 export interface SSEEvent {
   type: SSEEventType;


### PR DESCRIPTION
## Summary
Two small arrows next to each agent row: up for MC → agent, down for agent → MC. Each starts green when a message lands and fades through amber → red → dim gray over 60 seconds, so the operator can see at a glance which agents are currently exchanging traffic.

![screenshot placeholder — arrows green on the 6 agents that received a roll-call chat.send; coordinator (skipped self) and paused main stay dim]

## Flow
- **[src/lib/agent-pings.ts](src/lib/agent-pings.ts)** — in-memory `{agentId → {sentAt, receivedAt}}` map + sessionKey-prefix index (cached, 5s TTL) for mapping inbound/outbound traffic back to an agent.
- **[src/lib/openclaw/client.ts](src/lib/openclaw/client.ts)** — ping `sent` on outbound `chat.send` at enqueue time; ping `received` on inbound `chat_event` frames with `state:'final'` (streaming deltas excluded so a long reply doesn't spam SSE once per token).
- **[src/lib/types.ts](src/lib/types.ts)** — new SSE event type `agent_pinged`.
- **[src/app/api/agents/activity/route.ts](src/app/api/agents/activity/route.ts)** — hydrates the snapshot on mount so pings that landed before the page loaded still show green.
- **[src/lib/store.ts](src/lib/store.ts)** — zustand `agentPings` slice + `recordAgentPing` action.
- **[src/hooks/useSSE.ts](src/hooks/useSSE.ts)** — consumes `agent_pinged` events.
- **[src/components/AgentPingIndicator.tsx](src/components/AgentPingIndicator.tsx)** — two-arrow indicator. Four color buckets (≤5s, ≤20s, ≤40s, ≤60s) then dim gray. The per-second re-render interval suspends once both arrows are past the 60s window — no background work for idle rows.
- **[src/components/AgentsSidebar.tsx](src/components/AgentsSidebar.tsx)** — renders the indicator inside each agent row's control cluster.

## Design notes
- **Deliberately in-memory.** The indicator is a liveness cue, not a durable log. Server restart → indicators reset to gray and re-populate from real traffic. For historical activity the `/debug` console already persists every frame to SQLite.
- **`state:'final'` gate on receives.** OpenClaw streams token deltas as multiple `chat_event` frames. Pinging per delta would broadcast an SSE event every few tokens during a long reply — we only want to ping when the reply lands.
- **Ping on enqueue, not on ack.** For outbound the indicator flashes the moment MC commits to the message; operators care about intent, not gateway round-trip.
- **Prefix-index sort.** The sessionKey-prefix cache sorts longest-first so more-specific prefixes win when they overlap (e.g. `agent:mc-builder-2:` before `agent:mc-builder:`).

## Verification
Dev server against live OpenClaw gateway, roll-call POST:
- `/api/agents/activity` returned 6 `sentAt` entries (one per `chat.send`).
- The 6 corresponding sidebar arrows flipped to `text-green-500/70` within the SSE round-trip; the two excluded agents (master skipping itself, paused `main`) stayed at `text-mc-text-secondary/30`.
- After ~60s of no new traffic, all arrows transitioned through the amber/red buckets back to dim gray, and the re-render interval correctly suspended.
- `yarn build` passes.

## Test plan
- [ ] Open a workspace; confirm each agent row shows two dim arrows (\"no activity yet\" tooltip) on first load.
- [ ] Trigger any chat/dispatch action to an agent (roll-call is the quickest way); confirm that agent's up arrow flashes bright green.
- [ ] Wait; confirm arrows fade green → amber → red → gray across ~60s.
- [ ] When the agent replies, confirm the down arrow flashes green.
- [ ] Restart the server; confirm all arrows reset to gray and repopulate on next traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)