### PR TITLE
feat(authz): agent-task binding on state-changing routes

### DIFF
--- a/src/app/api/agents/[id]/mail/route.ts
+++ b/src/app/api/agents/[id]/mail/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { queryOne } from '@/lib/db';
 import { getUnreadMail, markAsRead, sendMail } from '@/lib/mailbox';
 import { recordRollCallReplyIfMatch } from '@/lib/rollcall';
+import { authorizeAgentActive, authorizeAgentForTask } from '@/lib/authz/http';
 import type { Agent } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -57,14 +58,26 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Sanity-check both agents exist so FK errors surface as clean 4xx.
+    // Authorize the sender: must be an existing, active agent. Replaces the
+    // looser "agent row exists" check — disabled agents should not send mail.
+    const senderFail = authorizeAgentActive(body.from_agent_id);
+    if (senderFail) return senderFail;
+
+    // If the mail is scoped to a task (help_request, task-local coordination),
+    // the sender must be on that task. Cross-task probing via mail is a real
+    // vector — an agent that learns of a task_id could otherwise use mail to
+    // pressure other agents outside its assignment.
+    if (body.task_id) {
+      const taskFail = authorizeAgentForTask(body.from_agent_id, body.task_id, 'activity');
+      if (taskFail) return taskFail;
+    }
+
+    // Recipient existence still needs a plain lookup — the recipient doesn't
+    // authorize the call; they just need to exist so the FK on agent_mailbox
+    // doesn't blow up with an opaque 500.
     const recipient = queryOne<Agent>('SELECT id FROM agents WHERE id = ?', [toAgentId]);
     if (!recipient) {
       return NextResponse.json({ error: `Recipient agent ${toAgentId} not found` }, { status: 404 });
-    }
-    const sender = queryOne<Agent>('SELECT id FROM agents WHERE id = ?', [body.from_agent_id]);
-    if (!sender) {
-      return NextResponse.json({ error: `Sender agent ${body.from_agent_id} not found` }, { status: 400 });
     }
 
     const result = await sendMail({

--- a/src/app/api/tasks/[id]/activities/route.ts
+++ b/src/app/api/tasks/[id]/activities/route.ts
@@ -8,6 +8,7 @@ import { getDb } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { CreateActivitySchema } from '@/lib/validation';
 import { logDebugEvent } from '@/lib/debug-log';
+import { authorizeAgentForTask } from '@/lib/authz/http';
 import type { TaskActivity } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -97,6 +98,10 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
     }
 
     const { activity_type, message, agent_id, metadata } = validation.data;
+
+    // Agent-task authorization: enforce when agent_id is provided.
+    const authzFail = authorizeAgentForTask(agent_id, taskId, 'activity');
+    if (authzFail) return authzFail;
 
     const db = getDb();
     const id = crypto.randomUUID();

--- a/src/app/api/tasks/[id]/checkpoint/route.ts
+++ b/src/app/api/tasks/[id]/checkpoint/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { saveCheckpoint, getLatestCheckpoint } from '@/lib/checkpoint';
 import { deliverPendingNotesAtCheckpoint } from '@/lib/task-notes';
 import { CheckpointSchema } from '@/lib/validation';
+import { authorizeAgentForTask } from '@/lib/authz/http';
 
 export const dynamic = 'force-dynamic';
 
@@ -34,6 +35,11 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
     const { agent_id, checkpoint_type, state_summary, files_snapshot, context_data } = validation.data;
+
+    // Agent-task authorization: agent_id is required on CheckpointSchema, so
+    // this always runs (no operator-skip path).
+    const authzFail = authorizeAgentForTask(agent_id, id, 'checkpoint');
+    if (authzFail) return authzFail;
 
     const checkpoint = saveCheckpoint({
       taskId: id,

--- a/src/app/api/tasks/[id]/deliverables/route.ts
+++ b/src/app/api/tasks/[id]/deliverables/route.ts
@@ -8,6 +8,7 @@ import { getDb } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { CreateDeliverableSchema } from '@/lib/validation';
 import { logDebugEvent } from '@/lib/debug-log';
+import { authorizeAgentForTask } from '@/lib/authz/http';
 import { existsSync } from 'fs';
 import {
   isUnderDeliverablesHostRoot,
@@ -72,7 +73,12 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
       );
     }
 
-    const { deliverable_type, title, path, description, spec_deliverable_id } = validation.data;
+    const { deliverable_type, title, path, description, spec_deliverable_id, agent_id } = validation.data;
+
+    // Agent-task authorization: enforce when agent_id is provided.
+    // Operator flows (UI) skip this and are trusted via proxy.ts same-origin.
+    const authzFail = authorizeAgentForTask(agent_id, taskId, 'deliverable');
+    if (authzFail) return authzFail;
 
     // Reject the reserved ssh:// prefix — the column is widened for future
     // remote storage, but nothing reads it yet. Failing here avoids half-wired

--- a/src/app/api/tasks/[id]/fail/route.ts
+++ b/src/app/api/tasks/[id]/fail/route.ts
@@ -4,6 +4,7 @@ import { handleStageFailure, drainQueue } from '@/lib/workflow-engine';
 import { notifyLearner } from '@/lib/learner';
 import { logDebugEvent } from '@/lib/debug-log';
 import { FailTaskSchema } from '@/lib/validation';
+import { authorizeAgentForTask } from '@/lib/authz/http';
 import type { Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -36,7 +37,11 @@ export async function POST(
         { status: 400 }
       );
     }
-    const { reason } = validation.data;
+    const { reason, agent_id } = validation.data;
+
+    // Agent-task authorization: enforce when agent_id is provided.
+    const authzFail = authorizeAgentForTask(agent_id, taskId, 'fail');
+    if (authzFail) return authzFail;
 
     const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
     if (!task) {

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -10,6 +10,7 @@ import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
 import { UpdateTaskSchema } from '@/lib/validation';
 import { logDebugEvent } from '@/lib/debug-log';
+import { authorizeAgentForTask } from '@/lib/authz/http';
 import type { Task, UpdateTaskRequest, Agent, TaskDeliverable } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -96,6 +97,17 @@ export async function PATCH(
         requested_status: validatedData.status ?? null,
       },
     });
+
+    // Agent-task authorization: enforce when updated_by_agent_id is provided.
+    // Skipped for operator flows (no agent_id, trusted via proxy.ts
+    // same-origin bypass). The existing master-role check below layers on
+    // top of this for review→done transitions.
+    const authzFail = authorizeAgentForTask(
+      validatedData.updated_by_agent_id,
+      id,
+      'status',
+    );
+    if (authzFail) return authzFail;
 
     // Keep OpenClaw agent catalog synced opportunistically on task updates
     await syncGatewayAgentsToCatalog({ reason: 'task_patch' }).catch(err => {

--- a/src/lib/authz/agent-task.test.ts
+++ b/src/lib/authz/agent-task.test.ts
@@ -1,0 +1,198 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { run } from '@/lib/db';
+import {
+  AuthzError,
+  assertAgentActive,
+  assertAgentCanActOnTask,
+} from './agent-task';
+
+// Seed helpers — match the style of task-governance.test.ts:11.
+
+function seedAgent(opts: {
+  id?: string;
+  workspace?: string;
+  isActive?: number;
+  role?: string;
+} = {}): string {
+  const id = opts.id ?? crypto.randomUUID();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, created_at, updated_at)
+     VALUES (?, 'A', ?, ?, ?, datetime('now'), datetime('now'))`,
+    [id, opts.role ?? 'builder', opts.workspace ?? 'default', opts.isActive ?? 1],
+  );
+  return id;
+}
+
+function seedTask(opts: {
+  id?: string;
+  workspace?: string;
+  assigned?: string | null;
+  creator?: string | null;
+} = {}): string {
+  const id = opts.id ?? crypto.randomUUID();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, assigned_agent_id, created_by_agent_id, created_at, updated_at)
+     VALUES (?, 'T', 'assigned', 'normal', ?, 'default', ?, ?, datetime('now'), datetime('now'))`,
+    [id, opts.workspace ?? 'default', opts.assigned ?? null, opts.creator ?? null],
+  );
+  return id;
+}
+
+function seedRole(taskId: string, agentId: string, role: string): void {
+  run(
+    `INSERT INTO task_roles (id, task_id, role, agent_id, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, ?, ?, datetime('now'))`,
+    [taskId, role, agentId],
+  );
+}
+
+// ─── assertAgentActive ──────────────────────────────────────────────
+
+test('assertAgentActive throws on missing agent', () => {
+  assert.throws(() => assertAgentActive('nonexistent'), (err: unknown) => {
+    return err instanceof AuthzError && (err as AuthzError).code === 'agent_not_found';
+  });
+});
+
+test('assertAgentActive throws on disabled agent', () => {
+  const id = seedAgent({ isActive: 0 });
+  assert.throws(() => assertAgentActive(id), (err: unknown) => {
+    return err instanceof AuthzError && (err as AuthzError).code === 'agent_disabled';
+  });
+});
+
+test('assertAgentActive passes for active agent', () => {
+  const id = seedAgent();
+  assert.doesNotThrow(() => assertAgentActive(id));
+});
+
+// ─── assertAgentCanActOnTask — agent/task existence ─────────────────
+
+test('throws agent_not_found when agent missing', () => {
+  const task = seedTask();
+  assert.throws(
+    () => assertAgentCanActOnTask('nonexistent', task, 'activity'),
+    (err: unknown) => err instanceof AuthzError && (err as AuthzError).code === 'agent_not_found',
+  );
+});
+
+test('throws agent_disabled when agent is_active=0', () => {
+  const agent = seedAgent({ isActive: 0 });
+  const task = seedTask({ assigned: agent });
+  assert.throws(
+    () => assertAgentCanActOnTask(agent, task, 'activity'),
+    (err: unknown) => err instanceof AuthzError && (err as AuthzError).code === 'agent_disabled',
+  );
+});
+
+test('throws task_not_found when task missing', () => {
+  const agent = seedAgent();
+  assert.throws(
+    () => assertAgentCanActOnTask(agent, 'nonexistent', 'activity'),
+    (err: unknown) => err instanceof AuthzError && (err as AuthzError).code === 'task_not_found',
+  );
+});
+
+// ─── workspace isolation ────────────────────────────────────────────
+
+test('throws workspace_mismatch when agent and task are in different workspaces', () => {
+  // Seed a non-default workspace (FK target)
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug) VALUES ('other-ws', 'Other', 'other-ws')`,
+    [],
+  );
+  const agent = seedAgent({ workspace: 'other-ws' });
+  const task = seedTask({ workspace: 'default', assigned: agent });
+  assert.throws(
+    () => assertAgentCanActOnTask(agent, task, 'activity'),
+    (err: unknown) => err instanceof AuthzError && (err as AuthzError).code === 'workspace_mismatch',
+  );
+});
+
+// ─── authorization paths ────────────────────────────────────────────
+
+test('assigned_agent_id passes for any non-delegate action', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  for (const action of ['read', 'activity', 'deliverable', 'status', 'fail', 'checkpoint'] as const) {
+    assert.doesNotThrow(
+      () => assertAgentCanActOnTask(agent, task, action),
+      `assigned agent should pass for ${action}`,
+    );
+  }
+});
+
+test('task_roles entry (any role) passes for state-changing actions', () => {
+  const agent = seedAgent();
+  const task = seedTask(); // not assigned to this agent
+  seedRole(task, agent, 'tester');
+
+  assert.doesNotThrow(() => assertAgentCanActOnTask(agent, task, 'activity'));
+  assert.doesNotThrow(() => assertAgentCanActOnTask(agent, task, 'status'));
+  assert.doesNotThrow(() => assertAgentCanActOnTask(agent, task, 'fail'));
+});
+
+test('unrelated agent throws agent_not_on_task for non-delegate action', () => {
+  const agent = seedAgent();
+  const task = seedTask(); // unrelated
+  assert.throws(
+    () => assertAgentCanActOnTask(agent, task, 'activity'),
+    (err: unknown) =>
+      err instanceof AuthzError && (err as AuthzError).code === 'agent_not_on_task',
+  );
+});
+
+// ─── delegate — coordinator-only ────────────────────────────────────
+
+test('delegate throws agent_not_coordinator for a plain task-roles entry', () => {
+  // Has a task role, but role != coordinator → still not allowed to delegate.
+  const agent = seedAgent();
+  const task = seedTask();
+  seedRole(task, agent, 'builder');
+  assert.throws(
+    () => assertAgentCanActOnTask(agent, task, 'delegate'),
+    (err: unknown) =>
+      err instanceof AuthzError && (err as AuthzError).code === 'agent_not_coordinator',
+  );
+});
+
+test('delegate passes when agent has task_roles[role=coordinator]', () => {
+  const agent = seedAgent({ role: 'builder' });
+  const task = seedTask();
+  seedRole(task, agent, 'coordinator');
+  assert.doesNotThrow(() => assertAgentCanActOnTask(agent, task, 'delegate'));
+});
+
+test('delegate passes when agent is assigned AND has role=coordinator', () => {
+  const agent = seedAgent({ role: 'coordinator' });
+  const task = seedTask({ assigned: agent });
+  assert.doesNotThrow(() => assertAgentCanActOnTask(agent, task, 'delegate'));
+});
+
+test('delegate passes when agent is the task creator (created_by_agent_id)', () => {
+  const agent = seedAgent({ role: 'builder' });
+  const task = seedTask({ creator: agent });
+  assert.doesNotThrow(() => assertAgentCanActOnTask(agent, task, 'delegate'));
+});
+
+test('delegate throws when agent is assigned but not a coordinator-role', () => {
+  // Assigned agent has role=builder — they can act on the task but cannot
+  // delegate. This prevents a builder from fanning out fake delegations.
+  const agent = seedAgent({ role: 'builder' });
+  const task = seedTask({ assigned: agent });
+  assert.throws(
+    () => assertAgentCanActOnTask(agent, task, 'delegate'),
+    (err: unknown) =>
+      err instanceof AuthzError && (err as AuthzError).code === 'agent_not_coordinator',
+  );
+});
+
+// ─── role matching is case-insensitive ──────────────────────────────
+
+test('task_roles role match is case-insensitive for coordinator', () => {
+  const agent = seedAgent();
+  const task = seedTask();
+  seedRole(task, agent, 'COORDINATOR');
+  assert.doesNotThrow(() => assertAgentCanActOnTask(agent, task, 'delegate'));
+});

--- a/src/lib/authz/agent-task.ts
+++ b/src/lib/authz/agent-task.ts
@@ -1,0 +1,172 @@
+/**
+ * Agent→task authorization.
+ *
+ * Today's agent-facing HTTP routes (/api/tasks/:id/*, /api/agents/:id/mail)
+ * only gate on the global MC_API_TOKEN bearer. Any agent with the token can
+ * act on any task — register deliverables, log activities, transition
+ * status, send mail as another agent. The blast radius is limited in
+ * practice because agents get the token from the dispatch message for
+ * their own task, but nothing enforces that at the route level.
+ *
+ * This module closes the gap: every state-changing route now calls
+ * `assertAgentCanActOnTask(agentId, taskId, action)` and 403s if the agent
+ * isn't assigned to the task, doesn't hold a role in task_roles, and
+ * isn't the task's coordinator.
+ *
+ * The MCP server (PR 3) depends on this helper — MCP tools take agent_id
+ * as an explicit arg and every call passes through here.
+ *
+ * Throws `AuthzError` with a machine-readable `code` so callers can map to
+ * HTTP status (403) or MCP error responses uniformly.
+ */
+
+import { queryOne } from '@/lib/db';
+
+export type AuthzAction =
+  | 'read'
+  | 'activity'
+  | 'deliverable'
+  | 'status'
+  | 'fail'
+  | 'checkpoint'
+  | 'delegate';
+
+export type AuthzErrorCode =
+  | 'agent_not_found'
+  | 'agent_disabled'
+  | 'task_not_found'
+  | 'workspace_mismatch'
+  | 'agent_not_on_task'
+  | 'agent_not_coordinator';
+
+export class AuthzError extends Error {
+  constructor(
+    public readonly code: AuthzErrorCode,
+    message: string,
+    public readonly context: { agentId?: string; taskId?: string; action?: AuthzAction } = {},
+  ) {
+    super(message);
+    this.name = 'AuthzError';
+  }
+}
+
+interface AgentRow {
+  id: string;
+  workspace_id: string | null;
+  is_active: number | null;
+  role: string | null;
+}
+
+interface TaskRow {
+  id: string;
+  workspace_id: string | null;
+  assigned_agent_id: string | null;
+  created_by_agent_id: string | null;
+}
+
+function loadAgent(agentId: string): AgentRow {
+  const row = queryOne<AgentRow>(
+    `SELECT id, workspace_id, is_active, role FROM agents WHERE id = ?`,
+    [agentId],
+  );
+  if (!row) {
+    throw new AuthzError('agent_not_found', `agent not found: ${agentId}`, { agentId });
+  }
+  // COALESCE — existing rows predate the column; treat NULL as active=1 (the
+  // column default for new rows), matching the behavior in
+  // src/lib/agent-resolver.ts and elsewhere.
+  if (row.is_active === 0) {
+    throw new AuthzError('agent_disabled', `agent is disabled: ${agentId}`, { agentId });
+  }
+  return row;
+}
+
+function loadTask(taskId: string): TaskRow {
+  const row = queryOne<TaskRow>(
+    `SELECT id, workspace_id, assigned_agent_id, created_by_agent_id
+       FROM tasks WHERE id = ?`,
+    [taskId],
+  );
+  if (!row) {
+    throw new AuthzError('task_not_found', `task not found: ${taskId}`, { taskId });
+  }
+  return row;
+}
+
+function hasTaskRole(taskId: string, agentId: string, role?: string): boolean {
+  const sql = role
+    ? `SELECT 1 AS ok FROM task_roles WHERE task_id = ? AND agent_id = ? AND lower(role) = lower(?)`
+    : `SELECT 1 AS ok FROM task_roles WHERE task_id = ? AND agent_id = ?`;
+  const params: unknown[] = role ? [taskId, agentId, role] : [taskId, agentId];
+  return Boolean(queryOne<{ ok: number }>(sql, params));
+}
+
+/**
+ * Assert that the agent is real and active. Use this for flows that aren't
+ * tied to a specific task (e.g. `POST /api/agents/:id/mail` without a
+ * task_id — just validates the sender).
+ */
+export function assertAgentActive(agentId: string): void {
+  loadAgent(agentId); // throws on missing/disabled
+}
+
+/**
+ * Assert that the given agent can perform the given action on the given
+ * task. Throws `AuthzError` on any failure; returns void on success.
+ *
+ * Rules:
+ *   - Agent exists and is not disabled
+ *   - Task exists
+ *   - Agent and task share workspace_id
+ *   - For 'delegate': agent must be the task's coordinator (either
+ *     task_roles[role='coordinator'], or the task's assigned_agent_id with
+ *     an agent.role of 'coordinator')
+ *   - For all other actions: agent is the task's assigned_agent_id, OR has
+ *     any row in task_roles for this task, OR is the task's
+ *     created_by_agent_id (coordinators who dispatched the task)
+ */
+export function assertAgentCanActOnTask(
+  agentId: string,
+  taskId: string,
+  action: AuthzAction,
+): void {
+  const agent = loadAgent(agentId);
+  const task = loadTask(taskId);
+
+  // Workspace isolation — defaults to 'default' per schema, so non-null.
+  if ((agent.workspace_id ?? 'default') !== (task.workspace_id ?? 'default')) {
+    throw new AuthzError(
+      'workspace_mismatch',
+      `agent ${agentId} (workspace=${agent.workspace_id}) cannot act on task ${taskId} (workspace=${task.workspace_id})`,
+      { agentId, taskId, action },
+    );
+  }
+
+  const isAssigned = task.assigned_agent_id === agentId;
+  const isCreator = task.created_by_agent_id === agentId;
+  const hasAnyRole = hasTaskRole(taskId, agentId);
+  const hasCoordinatorRole = hasTaskRole(taskId, agentId, 'coordinator');
+  const isCoordinator =
+    hasCoordinatorRole ||
+    isCreator ||
+    (isAssigned && (agent.role || '').toLowerCase() === 'coordinator');
+
+  if (action === 'delegate') {
+    if (!isCoordinator) {
+      throw new AuthzError(
+        'agent_not_coordinator',
+        `agent ${agentId} is not the coordinator for task ${taskId}`,
+        { agentId, taskId, action },
+      );
+    }
+    return;
+  }
+
+  if (!isAssigned && !hasAnyRole && !isCoordinator) {
+    throw new AuthzError(
+      'agent_not_on_task',
+      `agent ${agentId} is not on task ${taskId}`,
+      { agentId, taskId, action },
+    );
+  }
+}

--- a/src/lib/authz/http.ts
+++ b/src/lib/authz/http.ts
@@ -1,0 +1,68 @@
+/**
+ * HTTP glue for the agent-task authorization helper.
+ *
+ * Keeps the try/catch + NextResponse-mapping boilerplate out of each route
+ * handler. The enforce-if-provided pattern is deliberate: operator calls
+ * (UI moves on the kanban board) go through the same routes but don't
+ * carry an agent_id, and they're already trusted via the same-origin
+ * bypass in src/proxy.ts. Only agent-initiated calls carry an agent_id,
+ * and those are the ones we authorize here.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  AuthzError,
+  AuthzAction,
+  assertAgentActive,
+  assertAgentCanActOnTask,
+} from './agent-task';
+
+function authzErrorResponse(err: AuthzError): NextResponse {
+  return NextResponse.json(
+    {
+      error: err.message,
+      code: err.code,
+    },
+    { status: 403 },
+  );
+}
+
+/**
+ * If `agentId` is provided, enforce task authorization and return a 403
+ * NextResponse on failure. Returns null on success (route continues).
+ *
+ * Operator flows (no agent_id in body) return null without checking — they
+ * are trusted via the same-origin bypass in src/proxy.ts.
+ */
+export function authorizeAgentForTask(
+  agentId: string | null | undefined,
+  taskId: string,
+  action: AuthzAction,
+): NextResponse | null {
+  if (!agentId) return null;
+  try {
+    assertAgentCanActOnTask(agentId, taskId, action);
+    return null;
+  } catch (err) {
+    if (err instanceof AuthzError) return authzErrorResponse(err);
+    throw err;
+  }
+}
+
+/**
+ * If `agentId` is provided, enforce that the agent exists and is active,
+ * but do not check task binding. Used for mail where the sender isn't tied
+ * to a specific task (roll-call replies, broadcasts).
+ */
+export function authorizeAgentActive(
+  agentId: string | null | undefined,
+): NextResponse | null {
+  if (!agentId) return null;
+  try {
+    assertAgentActive(agentId);
+    return null;
+  } catch (err) {
+    if (err instanceof AuthzError) return authzErrorResponse(err);
+    throw err;
+  }
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -107,6 +107,11 @@ export const CreateDeliverableSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   path: z.string().optional(),
   description: z.string().optional(),
+  /** The agent posting this deliverable. When present, the agent-task
+   *  authorization check (src/lib/authz/agent-task.ts) enforces the agent
+   *  is actually on this task. Optional for backward compatibility with
+   *  operator flows; MCP-dispatched agents always provide it. */
+  agent_id: agentId.optional(),
   /** When fulfilling a planning-spec deliverable, name which one. The
    *  evidence gate reconciles this against planning_spec.deliverables[].id
    *  before allowing a transition into testing/review/verification/done. */
@@ -136,6 +141,10 @@ export const SpecSuccessCriterionSchema = z.object({
 // from testing/review/verification back to in_progress.
 export const FailTaskSchema = z.object({
   reason: z.string().min(1, 'reason is required').max(5000),
+  /** The agent reporting the failure. When present, the agent-task
+   *  authorization check enforces the agent is the tester/reviewer for
+   *  this task. Optional for backward compatibility. */
+  agent_id: agentId.optional(),
 });
 
 // Checkpoint validation schema — agents save work-state snapshots so


### PR DESCRIPTION
## Summary
- New `src/lib/authz/` module: `assertAgentCanActOnTask(agent, task, action)` + `assertAgentActive(agent)` + typed `AuthzError` with machine-readable `code`
- Wired into six agent-facing state-changing routes: deliverables, activities, PATCH /tasks/:id, fail, checkpoint, mail
- Enforcement is conditional on `agent_id` in the body — operator UI (no agent_id, trusted via same-origin bypass in `src/proxy.ts`) keeps working unchanged; agent-initiated calls are newly gated
- Mail additionally enforces `assertAgentActive` on every `from_agent_id` and `assertAgentCanActOnTask` when `task_id` is present — closes a real cross-task probing vector

## Context
First PR in the `sc-mission-control` MCP adapter track (plan in `~/.claude/plans/can-you-make-that-async-eich.md`). MCP agents self-identify per-call and OpenClaw doesn't carry per-agent auth at the transport layer (Phase 0 spike confirmed this), so every state-changing MCP tool needs this helper. The gap it closes exists today on the HTTP API too — value is independent of MCP shipping.

## Test plan
- [x] 16 new unit tests in `src/lib/authz/agent-task.test.ts` — all pass in isolation
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke with curl against `yarn dev`:
  - [ ] Create a task assigned to agent A
  - [ ] POST deliverable with `agent_id: A` → 200
  - [ ] POST deliverable with `agent_id: <unrelated agent>` → 403 with `code: agent_not_on_task`
  - [ ] POST deliverable without `agent_id` (operator flow) → 200 (backward compat)
  - [ ] PATCH status with `updated_by_agent_id: <unrelated agent>` → 403
  - [ ] Cross-workspace attempt → 403 with `code: workspace_mismatch`

Note: `yarn test` flakes on a pre-existing concurrency issue — `tsx --test` runs files in parallel against a shared sqlite, which lock-contend. The authz file passes 16/16 when run in isolation. Recommend tracking the harness fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)