### PR TITLE
feat(mcp): sc-mission-control MCP adapter (feature-flagged)

### DIFF
--- a/mcp-launcher/.gitignore
+++ b/mcp-launcher/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/mcp-launcher/README.md
+++ b/mcp-launcher/README.md
@@ -1,0 +1,66 @@
+# sc-mission-control MCP launcher
+
+Stdio ↔ HTTP proxy. OpenClaw spawns this process; it forwards every JSON-RPC message to Mission Control's `/mcp` endpoint over HTTP, carrying the MC bearer token.
+
+## Setup
+
+```bash
+cd mcp-launcher && npm install
+```
+
+## Register with openclaw
+
+One-time, via the openclaw CLI:
+
+```bash
+openclaw mcp set sc-mission-control "$(cat <<'EOF'
+{
+  "command": "node",
+  "args": ["/Users/you/snappytwo-sandbox/mission-control/mcp-launcher/launcher.mjs"],
+  "env": {
+    "MC_URL": "http://localhost:4001/mcp",
+    "MC_API_TOKEN": "<paste your MC_API_TOKEN here>"
+  }
+}
+EOF
+)"
+```
+
+Confirm:
+
+```bash
+openclaw mcp list
+openclaw mcp show sc-mission-control
+```
+
+Then scope the server to one or more agents via their `tools.alsoAllow` in `~/.openclaw/openclaw.json` (the Phase 0 spike showed openclaw's allowlist is informational but we still configure it).
+
+## Environment
+
+| Var | Required | Default | Notes |
+|---|---|---|---|
+| `MC_URL` | yes | — | MC's `/mcp` endpoint. e.g. `http://localhost:4001/mcp`. |
+| `MC_API_TOKEN` | yes | — | Same bearer as the HTTP API. |
+
+Missing either → the launcher exits non-zero at startup and openclaw logs the error.
+
+## Feature flag
+
+Mission Control's `/mcp` endpoint returns **503** when `MC_MCP_ENABLED` isn't `1`. Set that in MC's environment (docker-compose.yml → `environment:`) to turn the endpoint on. The launcher will surface the 503 as a tool-call failure.
+
+## Rollout sequence
+
+1. Flip `MC_MCP_ENABLED=1` in MC, restart the container.
+2. Run the `openclaw mcp set` above on the host. Restart openclaw gateway.
+3. Add `sc-mission-control` to **one** agent's allowlist (e.g. mc-writer). Restart openclaw.
+4. Start a chat with that agent; prompt "list your available tools" — expect `whoami`, `list_peers`, `register_deliverable`, etc.
+5. Dispatch a real task. Watch MC's debug-events export for `mcp.tool_call` rows.
+6. Expand to other agents.
+
+## Smoke test (no openclaw needed)
+
+```bash
+npm run smoke
+```
+
+Runs a hand-crafted `initialize` + `tools/list` against the launcher's stdio transport, mocking MC with a local HTTP listener. Exits non-zero on any handshake error.

--- a/mcp-launcher/launcher.mjs
+++ b/mcp-launcher/launcher.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * sc-mission-control MCP launcher.
+ *
+ * OpenClaw spawns this as a stdio MCP server (one process, shared across
+ * agents — Phase 0 spike confirmed the subprocess is re-used). This
+ * process proxies every JSON-RPC message over HTTP to MC's /mcp
+ * endpoint.
+ *
+ * Config (passed via openclaw.json `mcp.servers.sc-mission-control.env`):
+ *   MC_URL        — e.g. http://localhost:4001/mcp (required)
+ *   MC_API_TOKEN  — bearer token for the MC endpoint (required)
+ *
+ * Usage:
+ *   openclaw mcp set sc-mission-control '{
+ *     "command": "node",
+ *     "args": ["/abs/path/to/mcp-launcher/launcher.mjs"],
+ *     "env": { "MC_URL": "http://localhost:4001/mcp",
+ *              "MC_API_TOKEN": "<token>" }
+ *   }'
+ *
+ * Everything happens in one shared subprocess — agents distinguish
+ * themselves by passing `agent_id` on every state-changing tool call.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+const MC_URL = process.env.MC_URL;
+const MC_API_TOKEN = process.env.MC_API_TOKEN;
+
+if (!MC_URL) {
+  process.stderr.write('[launcher] MC_URL env var is required\n');
+  process.exit(1);
+}
+if (!MC_API_TOKEN) {
+  process.stderr.write('[launcher] MC_API_TOKEN env var is required\n');
+  process.exit(1);
+}
+
+process.stderr.write(`[launcher] sc-mission-control launcher starting, proxying to ${MC_URL}\n`);
+
+// Connect an MCP client to MC's HTTP endpoint. This is the upstream
+// we'll forward every inbound JSON-RPC call to.
+const upstream = new Client({ name: 'sc-mc-launcher', version: '0.1.0' });
+const upstreamTransport = new StreamableHTTPClientTransport(new URL(MC_URL), {
+  requestInit: {
+    headers: { Authorization: `Bearer ${MC_API_TOKEN}` },
+  },
+});
+
+try {
+  await upstream.connect(upstreamTransport);
+} catch (err) {
+  process.stderr.write(`[launcher] Failed to connect to MC at ${MC_URL}: ${err.message}\n`);
+  process.exit(2);
+}
+
+// Downstream server — openclaw connects to this over stdio.
+const downstream = new Server(
+  { name: 'sc-mission-control', version: '0.1.0' },
+  { capabilities: { tools: {} } },
+);
+
+// Proxy tools/list
+downstream.setRequestHandler(ListToolsRequestSchema, async () => {
+  return await upstream.listTools();
+});
+
+// Proxy tools/call
+downstream.setRequestHandler(CallToolRequestSchema, async (req) => {
+  return await upstream.callTool({
+    name: req.params.name,
+    arguments: req.params.arguments ?? {},
+  });
+});
+
+const downstreamTransport = new StdioServerTransport();
+await downstream.connect(downstreamTransport);
+
+process.stderr.write('[launcher] ready; awaiting stdio requests\n');
+
+// Clean shutdown on SIGTERM/SIGINT so openclaw's process supervisor
+// doesn't accumulate zombies.
+for (const sig of ['SIGTERM', 'SIGINT']) {
+  process.on(sig, async () => {
+    process.stderr.write(`[launcher] ${sig} received; closing\n`);
+    await downstream.close().catch(() => {});
+    await upstream.close().catch(() => {});
+    process.exit(0);
+  });
+}

--- a/mcp-launcher/package.json
+++ b/mcp-launcher/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sc-mission-control-mcp-launcher",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "stdio ↔ HTTP proxy so OpenClaw can reach Mission Control's MCP endpoint. Spawned by openclaw via `openclaw mcp set sc-mission-control '{command:\"node\",args:[...]}'`.",
+  "bin": {
+    "sc-mc-launcher": "./launcher.mjs"
+  },
+  "scripts": {
+    "smoke": "node smoke.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1032.0",
     "@hello-pangea/dnd": "^18.0.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@scalar/api-reference-react": "^0.9.24",
     "@types/archiver": "^7.0.0",
     "ajv": "^8.18.0",

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,178 @@
+/**
+ * sc-mission-control MCP endpoint.
+ *
+ * Streamable-HTTP transport served at POST /mcp (for JSON-RPC messages)
+ * and GET /mcp (for the server→client SSE notification channel).
+ *
+ * Gated behind `MC_MCP_ENABLED=1`. When disabled, returns 503 so operators
+ * can roll it out gradually without a code change.
+ *
+ * Authentication is handled by the existing src/proxy.ts middleware —
+ * every request must carry `Authorization: Bearer $MC_API_TOKEN` (same as
+ * the HTTP API). OpenClaw passes no agent identity, so each tool takes
+ * `agent_id` as an explicit argument and the server authorizes using
+ * assertAgentCanActOnTask inside each service.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { buildServer } from '@/lib/mcp/server';
+
+export const dynamic = 'force-dynamic';
+
+function isEnabled(): boolean {
+  return process.env.MC_MCP_ENABLED === '1' || process.env.MC_MCP_ENABLED === 'true';
+}
+
+function disabledResponse(): NextResponse {
+  return NextResponse.json(
+    {
+      error: 'MCP endpoint is disabled',
+      hint: 'Set MC_MCP_ENABLED=1 in the MC environment to enable the sc-mission-control MCP adapter.',
+    },
+    { status: 503 },
+  );
+}
+
+/**
+ * Handle an MCP JSON-RPC request. Per the SDK pattern for stateless
+ * streamable-HTTP servers, we build a fresh server + transport per call.
+ * This matches the spike and avoids sharing state across concurrent
+ * requests (each agent's call gets its own handler).
+ *
+ * Next.js route handlers receive a `Request` object, but the MCP SDK's
+ * `handleRequest` expects a Node `IncomingMessage`/`ServerResponse` pair.
+ * We bridge via a minimal adapter.
+ */
+async function handle(request: NextRequest): Promise<Response> {
+  if (!isEnabled()) return disabledResponse();
+
+  // Read the full body once — the SDK expects an already-parsed JSON body
+  // for POST (it doesn't re-read the stream).
+  let body: unknown = undefined;
+  if (request.method === 'POST') {
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+  }
+
+  const server = buildServer();
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  await server.connect(transport);
+
+  // Collect response into a Web Response — the SDK writes into a Node
+  // ServerResponse-like object. We accumulate chunks and the final
+  // status/headers, then hand back a standard Response.
+  const responseChunks: Uint8Array[] = [];
+  let responseStatus = 200;
+  const responseHeaders = new Headers();
+  let finished = false;
+
+  // Minimal ServerResponse adapter. The SDK uses writeHead/setHeader/write/end.
+  const fakeRes = {
+    statusCode: 200,
+    headersSent: false,
+    writeHead(status: number, headers?: Record<string, string>) {
+      responseStatus = status;
+      if (headers) {
+        for (const [k, v] of Object.entries(headers)) responseHeaders.set(k, v);
+      }
+      return fakeRes;
+    },
+    setHeader(name: string, value: string | string[]) {
+      const v = Array.isArray(value) ? value.join(', ') : value;
+      responseHeaders.set(name, v);
+      return fakeRes;
+    },
+    getHeader(name: string) {
+      return responseHeaders.get(name);
+    },
+    write(chunk: unknown) {
+      const buf =
+        typeof chunk === 'string'
+          ? new TextEncoder().encode(chunk)
+          : (chunk as Uint8Array);
+      responseChunks.push(buf);
+      return true;
+    },
+    end(chunk?: unknown) {
+      if (chunk !== undefined) {
+        const buf =
+          typeof chunk === 'string'
+            ? new TextEncoder().encode(chunk)
+            : (chunk as Uint8Array);
+        responseChunks.push(buf);
+      }
+      finished = true;
+      return fakeRes;
+    },
+    on() {
+      return fakeRes;
+    },
+    once() {
+      return fakeRes;
+    },
+    emit() {
+      return false;
+    },
+  };
+
+  // The SDK's `handleRequest` reads req.headers/method for routing. Build
+  // a minimal IncomingMessage-like object.
+  const fakeReq = {
+    method: request.method,
+    url: request.url,
+    headers: Object.fromEntries(request.headers.entries()),
+  };
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await transport.handleRequest(fakeReq as any, fakeRes as any, body);
+  } catch (err) {
+    // Close the transport on error so connect() doesn't leak; rethrow.
+    await transport.close().catch(() => {});
+    return NextResponse.json(
+      { error: 'MCP transport error', message: (err as Error).message },
+      { status: 500 },
+    );
+  }
+
+  await transport.close().catch(() => {});
+
+  // Concatenate collected chunks
+  const bodyBytes =
+    responseChunks.length === 0
+      ? new Uint8Array()
+      : responseChunks.length === 1
+        ? responseChunks[0]
+        : (() => {
+            const total = responseChunks.reduce((n, c) => n + c.length, 0);
+            const merged = new Uint8Array(total);
+            let offset = 0;
+            for (const c of responseChunks) {
+              merged.set(c, offset);
+              offset += c.length;
+            }
+            return merged;
+          })();
+
+  // `bodyBytes` is a Uint8Array. Node's `new Response(body)` accepts
+  // BodyInit including strings — decoding first sidesteps TS's confusion
+  // between Uint8Array<ArrayBuffer> and Uint8Array<ArrayBufferLike>
+  // variants. MCP responses are always UTF-8 JSON.
+  const bodyText = new TextDecoder().decode(bodyBytes);
+  return new Response(bodyText, {
+    status: finished ? responseStatus : 200,
+    headers: responseHeaders,
+  });
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  return handle(request);
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  return handle(request);
+}

--- a/src/lib/debug-log.ts
+++ b/src/lib/debug-log.ts
@@ -49,7 +49,13 @@ export type DebugEventType =
   | 'autopilot.research_llm'
   | 'autopilot.ideation_llm'
   | 'autopilot.cycle_stalled'
-  | 'autopilot.cycle_aborted';
+  | 'autopilot.cycle_aborted'
+  // MCP tool invocations from the sc-mission-control MCP adapter.
+  // Captures: agent_id claimed by caller, tool name, task id (when
+  // relevant), success/error, duration. Pairs with the dispatch
+  // debug-events export so operators can see tool calls inline with
+  // chat traffic.
+  | 'mcp.tool_call';
 
 export type DebugEventDirection = 'outbound' | 'inbound' | 'internal';
 

--- a/src/lib/mcp/debug.ts
+++ b/src/lib/mcp/debug.ts
@@ -1,0 +1,37 @@
+/**
+ * Debug-log helper for MCP tool invocations.
+ *
+ * Emits one `mcp.tool_call` row per invocation so the debug-events export
+ * shows tool calls inline with the rest of the agent's traffic. Mirrors
+ * the shape used by dispatch's `chat.send` rows so filters / the export
+ * UI don't need special-casing.
+ */
+
+import { logDebugEvent } from '@/lib/debug-log';
+
+export interface McpToolCallLog {
+  toolName: string;
+  agentId: string | null;
+  taskId?: string | null;
+  ok: boolean;
+  durationMs: number;
+  error?: string;
+  /** Safe arg summary — never includes secrets. */
+  argsSummary?: Record<string, unknown>;
+}
+
+export function logMcpToolCall(entry: McpToolCallLog): void {
+  logDebugEvent({
+    type: 'mcp.tool_call',
+    direction: 'inbound',
+    taskId: entry.taskId ?? null,
+    agentId: entry.agentId,
+    durationMs: entry.durationMs,
+    error: entry.error ?? null,
+    metadata: {
+      tool_name: entry.toolName,
+      ok: entry.ok,
+      ...(entry.argsSummary ? { args: entry.argsSummary } : {}),
+    },
+  });
+}

--- a/src/lib/mcp/errors.ts
+++ b/src/lib/mcp/errors.ts
@@ -1,0 +1,45 @@
+/**
+ * MCP error mapping.
+ *
+ * Service-layer functions throw `AuthzError` with a typed `code`. MCP tool
+ * handlers catch and return a standard tool-error content block so the
+ * calling agent sees a clean "forbidden" message instead of a JSON-RPC
+ * protocol error (which would be interpreted as server malfunction).
+ */
+
+import { AuthzError } from '@/lib/authz/agent-task';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+export function authzErrorToToolResult(err: AuthzError): CallToolResult {
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text',
+        text: `Authorization denied (${err.code}): ${err.message}`,
+      },
+    ],
+    structuredContent: {
+      error: 'authz_denied',
+      code: err.code,
+      message: err.message,
+    },
+  };
+}
+
+export function internalErrorToToolResult(err: unknown): CallToolResult {
+  const message = err instanceof Error ? err.message : String(err);
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text',
+        text: `Internal error: ${message}`,
+      },
+    ],
+    structuredContent: {
+      error: 'internal_error',
+      message,
+    },
+  };
+}

--- a/src/lib/mcp/mcp.test.ts
+++ b/src/lib/mcp/mcp.test.ts
@@ -1,0 +1,259 @@
+/**
+ * MCP server integration tests.
+ *
+ * Uses the SDK's InMemoryTransport pair to exercise the full tool stack
+ * end-to-end against a real sqlite tmpfile. Covers: tool listing, read-only
+ * tools, state-changing tools (happy path + authz violation), evidence-gate
+ * integration with update_task_status.
+ *
+ * The `delegate` tool is skipped here — it calls openclaw's WebSocket
+ * gateway for sessions.send, which can't be mocked cleanly in this harness.
+ * A pilot-environment smoke will exercise it live.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { run } from '@/lib/db';
+import { buildServer } from './server';
+
+async function makePair() {
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const server = buildServer();
+  await server.connect(serverT);
+  const client = new Client({ name: 'test', version: '0.0.1' });
+  await client.connect(clientT);
+  return { client, server };
+}
+
+function seedAgent(opts: { id?: string; role?: string; workspace?: string; gateway?: string } = {}): string {
+  const id = opts.id ?? crypto.randomUUID();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, gateway_agent_id, created_at, updated_at)
+     VALUES (?, 'A', ?, ?, 1, ?, datetime('now'), datetime('now'))`,
+    [id, opts.role ?? 'builder', opts.workspace ?? 'default', opts.gateway ?? null],
+  );
+  return id;
+}
+
+function seedTask(opts: { id?: string; assigned?: string; status?: string; workspace?: string } = {}): string {
+  const id = opts.id ?? crypto.randomUUID();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, assigned_agent_id, created_at, updated_at)
+     VALUES (?, 'T', ?, 'normal', ?, 'default', ?, datetime('now'), datetime('now'))`,
+    [id, opts.status ?? 'in_progress', opts.workspace ?? 'default', opts.assigned ?? null],
+  );
+  return id;
+}
+
+// The SDK returns a union of CallToolResult shapes (the modern
+// `structuredContent` variant and a legacy `toolResult` variant). Both
+// branches have `structuredContent` at runtime for our server since we
+// always populate it. Cast to unknown to shed the union before indexing.
+function parseStructured<T = unknown>(result: unknown): T {
+  return (result as { structuredContent?: unknown }).structuredContent as T;
+}
+
+// ─── listing ────────────────────────────────────────────────────────
+
+test('tools/list returns the full sc-mission-control tool surface', async () => {
+  const { client } = await makePair();
+  const list = await client.listTools();
+  const names = new Set(list.tools.map((t) => t.name));
+  for (const expected of [
+    'whoami',
+    'list_peers',
+    'get_task',
+    'fetch_mail',
+    'register_deliverable',
+    'log_activity',
+    'update_task_status',
+    'fail_task',
+    'save_checkpoint',
+    'send_mail',
+    'delegate',
+  ]) {
+    assert.ok(names.has(expected), `missing tool: ${expected}`);
+  }
+});
+
+// ─── whoami ─────────────────────────────────────────────────────────
+
+test('whoami returns identity, assigned tasks, and peer roster', async () => {
+  const { client } = await makePair();
+  const me = seedAgent({ role: 'builder', gateway: 'mc-builder-test' });
+  seedAgent({ role: 'tester', gateway: 'mc-tester-test' });
+  const task = seedTask({ assigned: me, status: 'in_progress' });
+
+  const res = await client.callTool({ name: 'whoami', arguments: { agent_id: me } });
+  assert.equal(res.isError, undefined);
+  const payload = parseStructured<{ assigned_task_ids: string[]; peers: Record<string, unknown> }>(res);
+  assert.ok(payload.assigned_task_ids.includes(task), 'should list the assigned task');
+  assert.ok(
+    Object.keys(payload.peers).includes('mc-tester-test'),
+    'should list the tester peer by gateway id',
+  );
+});
+
+test('whoami returns an error for an unknown agent_id', async () => {
+  const { client } = await makePair();
+  const res = await client.callTool({
+    name: 'whoami',
+    arguments: { agent_id: crypto.randomUUID() },
+  });
+  assert.equal(res.isError, true);
+});
+
+// ─── register_deliverable ───────────────────────────────────────────
+
+test('register_deliverable happy path for assigned agent', async () => {
+  const { client } = await makePair();
+  const me = seedAgent();
+  const task = seedTask({ assigned: me });
+
+  const res = await client.callTool({
+    name: 'register_deliverable',
+    arguments: {
+      agent_id: me,
+      task_id: task,
+      deliverable_type: 'artifact',
+      title: 'thing',
+    },
+  });
+  assert.equal(res.isError, undefined);
+  const payload = parseStructured<{ deliverable: { task_id: string; title: string } }>(res);
+  assert.equal(payload.deliverable.task_id, task);
+  assert.equal(payload.deliverable.title, 'thing');
+});
+
+test('register_deliverable returns authz_denied for outside agent', async () => {
+  const { client } = await makePair();
+  const outsider = seedAgent();
+  const task = seedTask();
+
+  const res = await client.callTool({
+    name: 'register_deliverable',
+    arguments: {
+      agent_id: outsider,
+      task_id: task,
+      deliverable_type: 'artifact',
+      title: 'nope',
+    },
+  });
+  assert.equal(res.isError, true);
+  const payload = parseStructured<{ error: string; code: string }>(res);
+  assert.equal(payload.error, 'authz_denied');
+  assert.equal(payload.code, 'agent_not_on_task');
+});
+
+// ─── log_activity ───────────────────────────────────────────────────
+
+test('log_activity records a row for an on-task agent', async () => {
+  const { client } = await makePair();
+  const me = seedAgent();
+  const task = seedTask({ assigned: me });
+
+  const res = await client.callTool({
+    name: 'log_activity',
+    arguments: {
+      agent_id: me,
+      task_id: task,
+      activity_type: 'completed',
+      message: 'done',
+    },
+  });
+  assert.equal(res.isError, undefined);
+});
+
+// ─── update_task_status ─────────────────────────────────────────────
+
+test('update_task_status rejects with evidence_gate when no deliverable/activity exists', async () => {
+  const { client } = await makePair();
+  const me = seedAgent();
+  const task = seedTask({ assigned: me, status: 'in_progress' });
+
+  const res = await client.callTool({
+    name: 'update_task_status',
+    arguments: { agent_id: me, task_id: task, status: 'review' },
+  });
+  assert.equal(res.isError, true);
+  const payload = parseStructured<{ error: string }>(res);
+  assert.equal(payload.error, 'evidence_gate');
+});
+
+test('update_task_status succeeds after deliverable + activity are logged', async () => {
+  const { client } = await makePair();
+  const me = seedAgent();
+  const task = seedTask({ assigned: me, status: 'in_progress' });
+
+  await client.callTool({
+    name: 'register_deliverable',
+    arguments: {
+      agent_id: me,
+      task_id: task,
+      deliverable_type: 'artifact',
+      title: 'x',
+    },
+  });
+  await client.callTool({
+    name: 'log_activity',
+    arguments: {
+      agent_id: me,
+      task_id: task,
+      activity_type: 'completed',
+      message: 'built',
+    },
+  });
+
+  const res = await client.callTool({
+    name: 'update_task_status',
+    arguments: { agent_id: me, task_id: task, status: 'review' },
+  });
+  assert.equal(res.isError, undefined);
+  const payload = parseStructured<{ task: { status: string }; previous_status: string }>(res);
+  assert.equal(payload.task.status, 'review');
+  assert.equal(payload.previous_status, 'in_progress');
+});
+
+// ─── send_mail ──────────────────────────────────────────────────────
+
+test('send_mail happy path writes and matches sender + recipient', async () => {
+  const { client } = await makePair();
+  const sender = seedAgent();
+  const recipient = seedAgent();
+
+  const res = await client.callTool({
+    name: 'send_mail',
+    arguments: {
+      agent_id: sender,
+      to_agent_id: recipient,
+      body: 'hi',
+      subject: 'hello',
+    },
+  });
+  assert.equal(res.isError, undefined);
+  const payload = parseStructured<{ message: { from_agent_id: string; to_agent_id: string } }>(res);
+  assert.equal(payload.message.from_agent_id, sender);
+  assert.equal(payload.message.to_agent_id, recipient);
+});
+
+test('send_mail with task_id rejects an off-task sender', async () => {
+  const { client } = await makePair();
+  const outsider = seedAgent();
+  const recipient = seedAgent();
+  const task = seedTask();
+
+  const res = await client.callTool({
+    name: 'send_mail',
+    arguments: {
+      agent_id: outsider,
+      to_agent_id: recipient,
+      body: 'hi',
+      task_id: task,
+    },
+  });
+  assert.equal(res.isError, true);
+  const payload = parseStructured<{ error: string; code: string }>(res);
+  assert.equal(payload.error, 'authz_denied');
+});

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,0 +1,20 @@
+/**
+ * sc-mission-control MCP server factory.
+ *
+ * Returns a fresh McpServer per invocation. Per-request instantiation is
+ * the recommended pattern for streamable-HTTP transports when
+ * `sessionIdGenerator: undefined` (stateless) — matches the Phase 0 spike
+ * (see mcp-spike/server.mjs, now removed).
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerAllTools } from './tools';
+
+export const SERVER_NAME = 'sc-mission-control';
+export const SERVER_VERSION = '0.1.0';
+
+export function buildServer(): McpServer {
+  const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
+  registerAllTools(server);
+  return server;
+}

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -1,0 +1,643 @@
+/**
+ * sc-mission-control MCP tools.
+ *
+ * All 11 tools consolidated into one file. Each tool is a thin wrapper
+ * around a service-layer function (src/lib/services/*) that handles
+ * authorization, DB work, and broadcasts.
+ *
+ * Every state-changing tool takes `agent_id` as the required first arg —
+ * the Phase 0 spike confirmed OpenClaw passes no identity to MCP servers,
+ * so agents self-identify on every call. The `MC_API_TOKEN` bearer is the
+ * trust boundary (same as the current HTTP API).
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { queryAll, queryOne } from '@/lib/db';
+import { AuthzError } from '@/lib/authz/agent-task';
+import { authzErrorToToolResult, internalErrorToToolResult } from './errors';
+import { logMcpToolCall } from './debug';
+
+import { registerDeliverable } from '@/lib/services/task-deliverables';
+import { logActivity } from '@/lib/services/task-activities';
+import { transitionTaskStatus } from '@/lib/services/task-status';
+import { failTask } from '@/lib/services/task-failure';
+import { saveTaskCheckpoint } from '@/lib/services/task-checkpoint';
+import { sendAgentMail } from '@/lib/services/agent-mailbox';
+import { getUnreadMail } from '@/lib/mailbox';
+import { getOpenClawClient } from '@/lib/openclaw/client';
+
+// Common shape: agent_id on every state-changing tool.
+const agentIdArg = z
+  .string()
+  .min(1)
+  .describe("The calling agent's MC agent_id (see whoami)");
+
+const taskIdArg = z
+  .string()
+  .min(1)
+  .describe('Task UUID');
+
+/**
+ * Wraps a tool handler to log, time, and catch AuthzError uniformly.
+ * The handler returns a CallToolResult or its contents; AuthzError is
+ * mapped to a structured tool-error result rather than propagated as a
+ * JSON-RPC protocol error.
+ */
+function trace<TArgs extends { agent_id?: string; task_id?: string }>(
+  toolName: string,
+  handler: (args: TArgs) => Promise<CallToolResult> | CallToolResult,
+) {
+  return async (args: TArgs): Promise<CallToolResult> => {
+    const started = Date.now();
+    try {
+      const result = await handler(args);
+      logMcpToolCall({
+        toolName,
+        agentId: args.agent_id ?? null,
+        taskId: args.task_id ?? null,
+        ok: !result.isError,
+        durationMs: Date.now() - started,
+        error: result.isError
+          ? result.structuredContent &&
+            typeof result.structuredContent === 'object' &&
+            'message' in result.structuredContent
+            ? String((result.structuredContent as { message?: unknown }).message)
+            : 'tool returned isError'
+          : undefined,
+      });
+      return result;
+    } catch (err) {
+      const durationMs = Date.now() - started;
+      if (err instanceof AuthzError) {
+        logMcpToolCall({
+          toolName,
+          agentId: args.agent_id ?? null,
+          taskId: args.task_id ?? null,
+          ok: false,
+          durationMs,
+          error: `authz:${err.code}`,
+        });
+        return authzErrorToToolResult(err);
+      }
+      logMcpToolCall({
+        toolName,
+        agentId: args.agent_id ?? null,
+        taskId: args.task_id ?? null,
+        ok: false,
+        durationMs,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return internalErrorToToolResult(err);
+    }
+  };
+}
+
+function textResult(text: string, structured?: Record<string, unknown>): CallToolResult {
+  return {
+    content: [{ type: 'text', text }],
+    ...(structured ? { structuredContent: structured } : {}),
+  };
+}
+
+// ─── tool registrations ─────────────────────────────────────────────
+
+export function registerAllTools(server: McpServer): void {
+  // whoami ────────────────────────────────────────────────────────
+  server.registerTool(
+    'whoami',
+    {
+      title: 'Identify the calling agent',
+      description:
+        "Returns the calling agent's identity, assigned task ids, and the peer roster (gateway_id → MC agent_id). Call this once at session start to learn your own agent_id and peers.",
+      inputSchema: { agent_id: agentIdArg },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    trace('whoami', async ({ agent_id }) => {
+      const me = queryOne<{
+        id: string;
+        name: string;
+        role: string;
+        workspace_id: string;
+        gateway_agent_id: string | null;
+        is_active: number | null;
+      }>(
+        `SELECT id, name, role, workspace_id, gateway_agent_id, is_active
+           FROM agents WHERE id = ? LIMIT 1`,
+        [agent_id],
+      );
+      if (!me) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `agent ${agent_id} not found` }],
+          structuredContent: { error: 'agent_not_found', agent_id },
+        };
+      }
+
+      const tasks = queryAll<{ id: string; title: string; status: string }>(
+        `SELECT id, title, status FROM tasks
+          WHERE workspace_id = ?
+            AND (assigned_agent_id = ?
+              OR id IN (SELECT task_id FROM task_roles WHERE agent_id = ?))
+            AND status NOT IN ('done', 'cancelled')
+          ORDER BY updated_at DESC`,
+        [me.workspace_id, agent_id, agent_id],
+      );
+
+      const peers = queryAll<{ id: string; gateway_agent_id: string; name: string; role: string }>(
+        `SELECT id, gateway_agent_id, name, role FROM agents
+          WHERE workspace_id = ?
+            AND gateway_agent_id IS NOT NULL AND gateway_agent_id != ''
+            AND id != ?`,
+        [me.workspace_id, agent_id],
+      );
+      const peerMap: Record<string, { id: string; name: string; role: string }> = {};
+      for (const p of peers) {
+        peerMap[p.gateway_agent_id] = { id: p.id, name: p.name, role: p.role };
+      }
+
+      const payload = {
+        id: me.id,
+        name: me.name,
+        role: me.role,
+        workspace_id: me.workspace_id,
+        gateway_agent_id: me.gateway_agent_id,
+        assigned_task_ids: tasks.map((t) => t.id),
+        assigned_tasks: tasks,
+        peers: peerMap,
+      };
+      return textResult(JSON.stringify(payload, null, 2), payload);
+    }),
+  );
+
+  // list_peers ────────────────────────────────────────────────────
+  server.registerTool(
+    'list_peers',
+    {
+      title: 'List peer agents in your workspace',
+      description:
+        'Returns the workspace peer roster (gateway_id → MC agent_id, name, role). Use this before send_mail or delegate when you need a recipient id.',
+      inputSchema: { agent_id: agentIdArg },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    trace('list_peers', async ({ agent_id }) => {
+      const me = queryOne<{ workspace_id: string }>(
+        `SELECT workspace_id FROM agents WHERE id = ? LIMIT 1`,
+        [agent_id],
+      );
+      if (!me) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `agent ${agent_id} not found` }],
+          structuredContent: { error: 'agent_not_found', agent_id },
+        };
+      }
+      const peers = queryAll<{
+        id: string;
+        gateway_agent_id: string | null;
+        name: string;
+        role: string;
+      }>(
+        `SELECT id, gateway_agent_id, name, role FROM agents
+          WHERE workspace_id = ? AND id != ?
+          ORDER BY role, name`,
+        [me.workspace_id, agent_id],
+      );
+      return textResult(JSON.stringify({ peers }, null, 2), { peers });
+    }),
+  );
+
+  // get_task ──────────────────────────────────────────────────────
+  server.registerTool(
+    'get_task',
+    {
+      title: 'Fetch a task by id',
+      description:
+        'Returns the task row (title, description, status, assigned agent, workspace, etc.). Use before taking action on a task so you can verify its current state.',
+      inputSchema: { agent_id: agentIdArg, task_id: taskIdArg },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    trace('get_task', async ({ task_id }) => {
+      const task = queryOne<Record<string, unknown>>(
+        `SELECT t.*,
+           aa.name as assigned_agent_name,
+           aa.avatar_emoji as assigned_agent_emoji
+          FROM tasks t
+          LEFT JOIN agents aa ON t.assigned_agent_id = aa.id
+          WHERE t.id = ?`,
+        [task_id],
+      );
+      if (!task) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `task ${task_id} not found` }],
+          structuredContent: { error: 'task_not_found', task_id },
+        };
+      }
+      return textResult(JSON.stringify(task, null, 2), task);
+    }),
+  );
+
+  // fetch_mail ────────────────────────────────────────────────────
+  server.registerTool(
+    'fetch_mail',
+    {
+      title: "Fetch this agent's unread mail",
+      description: 'Returns unread mail messages sent to the calling agent.',
+      inputSchema: { agent_id: agentIdArg },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    trace('fetch_mail', async ({ agent_id }) => {
+      const messages = getUnreadMail(agent_id);
+      return textResult(JSON.stringify({ messages }, null, 2), { messages });
+    }),
+  );
+
+  // register_deliverable ──────────────────────────────────────────
+  server.registerTool(
+    'register_deliverable',
+    {
+      title: 'Register a task deliverable (file, url, or artifact)',
+      description:
+        'Records that the agent produced a deliverable for the task. Required before transitioning the task out of a build stage — the evidence gate rejects status transitions without at least one deliverable.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        task_id: taskIdArg,
+        title: z.string().min(1),
+        deliverable_type: z.enum(['file', 'url', 'artifact']),
+        path: z.string().optional(),
+        description: z.string().optional(),
+        spec_deliverable_id: z
+          .string()
+          .max(200)
+          .optional()
+          .describe("When fulfilling a planning-spec deliverable, the spec's id"),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    trace('register_deliverable', async (args) => {
+      const result = registerDeliverable({
+        taskId: args.task_id,
+        actingAgentId: args.agent_id,
+        deliverableType: args.deliverable_type,
+        title: args.title,
+        path: args.path,
+        description: args.description,
+        specDeliverableId: args.spec_deliverable_id,
+      });
+      const summary = {
+        deliverable: result.deliverable,
+        file_exists: result.fileExists,
+        normalized_path: result.normalizedPath,
+      };
+      return textResult(JSON.stringify(summary, null, 2), summary);
+    }),
+  );
+
+  // log_activity ──────────────────────────────────────────────────
+  server.registerTool(
+    'log_activity',
+    {
+      title: 'Log an activity against a task',
+      description:
+        "Append a progress note. Required before status transitions — the evidence gate rejects transitions without at least one activity. Use activity_type='completed' for your final message before transitioning.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        task_id: taskIdArg,
+        activity_type: z.enum([
+          'spawned',
+          'updated',
+          'completed',
+          'file_created',
+          'status_changed',
+        ]),
+        message: z.string().min(1).max(5000),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    trace('log_activity', async (args) => {
+      const activity = logActivity({
+        taskId: args.task_id,
+        actingAgentId: args.agent_id,
+        activityType: args.activity_type,
+        message: args.message,
+        metadata: args.metadata ? JSON.stringify(args.metadata) : undefined,
+      });
+      return textResult(JSON.stringify(activity, null, 2), { activity });
+    }),
+  );
+
+  // update_task_status ────────────────────────────────────────────
+  server.registerTool(
+    'update_task_status',
+    {
+      title: 'Transition a task to a new status',
+      description:
+        "Move the task to the next workflow stage (e.g. in_progress → review). The evidence gate rejects forward transitions without at least one deliverable + one activity. Use `next_status` from the dispatch message — don't guess. NOTE: MCP-driven status changes do NOT trigger automatic workflow orchestration (convoy progression, next-stage dispatch). The operator will handle those until a follow-up PR wires it up.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        task_id: taskIdArg,
+        status: z.enum([
+          'pending_dispatch',
+          'planning',
+          'inbox',
+          'assigned',
+          'in_progress',
+          'convoy_active',
+          'testing',
+          'review',
+          'verification',
+          'done',
+          'cancelled',
+        ]),
+        status_reason: z
+          .string()
+          .max(2000)
+          .optional()
+          .describe('Required when failing backwards from a quality stage.'),
+      },
+      annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false },
+    },
+    trace('update_task_status', async (args) => {
+      const result = transitionTaskStatus({
+        taskId: args.task_id,
+        actingAgentId: args.agent_id,
+        newStatus: args.status,
+        statusReason: args.status_reason,
+      });
+      if (!result.ok) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: result.error }],
+          structuredContent: {
+            error: result.code,
+            message: result.error,
+            ...(result.missingDeliverableIds
+              ? { missing_deliverable_ids: result.missingDeliverableIds }
+              : {}),
+          },
+        };
+      }
+      const payload = {
+        task: result.task,
+        previous_status: result.previousStatus,
+      };
+      return textResult(JSON.stringify(payload, null, 2), payload);
+    }),
+  );
+
+  // fail_task ─────────────────────────────────────────────────────
+  server.registerTool(
+    'fail_task',
+    {
+      title: 'Report a stage failure (tester/reviewer)',
+      description:
+        "Fail the current task stage, triggering the workflow engine's fail-loopback. Tester/reviewer uses this when the prior stage's work didn't pass. Include specific, actionable reasons — they're shown to the builder on re-dispatch.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        task_id: taskIdArg,
+        reason: z.string().min(1).max(5000),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    trace('fail_task', async (args) => {
+      const result = await failTask({
+        taskId: args.task_id,
+        actingAgentId: args.agent_id,
+        reason: args.reason,
+      });
+      if (!result.ok) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: result.error }],
+          structuredContent: {
+            error: result.code,
+            message: result.error,
+            ...(result.hint ? { hint: result.hint } : {}),
+          },
+        };
+      }
+      return textResult(JSON.stringify(result, null, 2), result);
+    }),
+  );
+
+  // save_checkpoint ───────────────────────────────────────────────
+  server.registerTool(
+    'save_checkpoint',
+    {
+      title: 'Save a work-state checkpoint',
+      description:
+        'Record a state snapshot for the task so it can be audited or resumed. Also triggers delivery of any pending operator notes at this checkpoint boundary.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        task_id: taskIdArg,
+        state_summary: z.string().min(1).max(10000),
+        checkpoint_type: z.enum(['auto', 'manual', 'crash_recovery']).optional(),
+        files_snapshot: z
+          .array(
+            z.object({
+              path: z.string().min(1),
+              hash: z.string().min(1),
+              size: z.number().int().min(0),
+            }),
+          )
+          .optional(),
+        context_data: z.record(z.string(), z.unknown()).optional(),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    trace('save_checkpoint', async (args) => {
+      const checkpoint = saveTaskCheckpoint({
+        taskId: args.task_id,
+        agentId: args.agent_id,
+        checkpointType: args.checkpoint_type,
+        stateSummary: args.state_summary,
+        filesSnapshot: args.files_snapshot,
+        contextData: args.context_data,
+      });
+      return textResult(JSON.stringify(checkpoint, null, 2), { checkpoint });
+    }),
+  );
+
+  // send_mail ─────────────────────────────────────────────────────
+  server.registerTool(
+    'send_mail',
+    {
+      title: 'Send mail to another agent',
+      description:
+        "Send a message to another agent's mailbox. Use list_peers or whoami to resolve recipient ids. When task_id is provided, the sender must be on that task (cross-task probing via mail is blocked).",
+      inputSchema: {
+        agent_id: agentIdArg.describe(
+          'The calling agent (the sender — goes in the From: field).',
+        ),
+        to_agent_id: z.string().min(1).describe('Recipient MC agent_id.'),
+        body: z.string().min(1),
+        subject: z.string().max(500).optional(),
+        task_id: z.string().optional(),
+        convoy_id: z.string().optional(),
+        push: z.boolean().optional().describe('If true, also push via chat.send.'),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    trace('send_mail', async (args) => {
+      const result = await sendAgentMail({
+        fromAgentId: args.agent_id,
+        toAgentId: args.to_agent_id,
+        body: args.body,
+        subject: args.subject,
+        taskId: args.task_id ?? null,
+        convoyId: args.convoy_id ?? null,
+        push: args.push,
+      });
+      if (!result.ok) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: result.error }],
+          structuredContent: { error: result.code, message: result.error },
+        };
+      }
+      const payload = {
+        message: result.message,
+        rollcall_matched: result.rollcallMatched,
+        rollcall_id: result.rollcallId ?? null,
+      };
+      return textResult(JSON.stringify(payload, null, 2), payload);
+    }),
+  );
+
+  // delegate ──────────────────────────────────────────────────────
+  // Coordinator-only. Atomically (a) sends the peer an openclaw session
+  // message and (b) logs a [DELEGATION] audit activity so the existing
+  // coordinator-audit sees the delegation happened. Replaces the two-step
+  // curl+sessions_send dance the coordinator does today.
+  server.registerTool(
+    'delegate',
+    {
+      title: 'Delegate a slice of work to a peer (coordinator-only)',
+      description:
+        "Coordinator sends a work slice to a named peer via OpenClaw sessions_send and auto-logs the required [DELEGATION] audit activity. Authorization enforces the caller is the task's coordinator. Use per-task session keys (agent:<peer_gateway_id>:task-<task_id>) — do NOT target :main.",
+      inputSchema: {
+        agent_id: agentIdArg.describe('The calling coordinator agent.'),
+        task_id: taskIdArg,
+        peer_gateway_id: z
+          .string()
+          .min(1)
+          .describe(
+            "Gateway id of the peer to delegate to, e.g. 'mc-researcher'. Use list_peers to discover.",
+          ),
+        slice: z
+          .string()
+          .min(1)
+          .max(10000)
+          .describe('One-line description of the work slice this peer owns.'),
+        message: z
+          .string()
+          .min(1)
+          .describe(
+            "The full message to send to the peer's session. Should include role framing ('You are the <role> for this task'), goal, context, success criteria.",
+          ),
+        timeout_seconds: z
+          .number()
+          .int()
+          .min(0)
+          .max(600)
+          .optional()
+          .describe('0 for fire-and-forget parallel fan-out (recommended).'),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    trace('delegate', async (args) => {
+      // Authorize explicitly — the service layer doesn't own the delegate
+      // action since there's no single "delegate service"; this tool
+      // composes sessions_send + log_activity.
+      const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
+      assertAgentCanActOnTask(args.agent_id, args.task_id, 'delegate');
+
+      // Resolve peer gateway id to a human name for the audit message.
+      const peer = queryOne<{ id: string; name: string }>(
+        `SELECT id, name FROM agents WHERE gateway_agent_id = ? LIMIT 1`,
+        [args.peer_gateway_id],
+      );
+      if (!peer) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `No agent with gateway_agent_id "${args.peer_gateway_id}" in the catalog. Call list_peers to see the roster.`,
+            },
+          ],
+          structuredContent: {
+            error: 'peer_not_found',
+            peer_gateway_id: args.peer_gateway_id,
+          },
+        };
+      }
+
+      const client = getOpenClawClient();
+      if (!client.isConnected()) {
+        await client.connect();
+      }
+
+      // Per-task session key avoids :main contention (see dispatch/route.ts
+      // post-mortem for task cc3d40e1 — :main delegations were aborted).
+      const sessionKey = `agent:${args.peer_gateway_id}:task-${args.task_id}`;
+
+      // Use the low-level call so we can provide timeoutSeconds + idempotency.
+      // sessions.send is the RPC method name in the gateway.
+      let sendResult: Record<string, unknown> = {};
+      try {
+        sendResult = ((await client.call('sessions.send', {
+          sessionKey,
+          message: args.message,
+          timeoutSeconds: args.timeout_seconds ?? 0,
+        })) as Record<string, unknown>) ?? {};
+      } catch (err) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `sessions.send failed: ${(err as Error).message}`,
+            },
+          ],
+          structuredContent: {
+            error: 'sessions_send_failed',
+            message: (err as Error).message,
+          },
+        };
+      }
+
+      const toolCallId =
+        (sendResult.tool_call_id as string | undefined) ||
+        (sendResult.run_id as string | undefined) ||
+        'unknown';
+      const auditMessage = `[DELEGATION] target="${peer.name}" gateway_id="${args.peer_gateway_id}" tool_call_id="${toolCallId}" slice="${args.slice.replace(/"/g, "'")}"`;
+
+      // Log the audit activity via the same service so coordinator-audit
+      // sees it. Authz re-runs inside logActivity — coordinator must also
+      // be on the task to post activities (they are, since delegate just
+      // passed).
+      const activity = logActivity({
+        taskId: args.task_id,
+        actingAgentId: args.agent_id,
+        activityType: 'updated',
+        message: auditMessage,
+      });
+
+      const payload = {
+        peer: { id: peer.id, name: peer.name, gateway_agent_id: args.peer_gateway_id },
+        session_key: sessionKey,
+        session_send: sendResult,
+        audit_activity_id: activity.id,
+      };
+      return textResult(
+        `Delegated to ${peer.name} (${args.peer_gateway_id}). Audit logged as activity ${activity.id}.`,
+        payload,
+      );
+    }),
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,6 +1149,11 @@
     react-redux "^9.2.0"
     redux "^5.0.1"
 
+"@hono/node-server@^1.19.9":
+  version "1.19.14"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
+  integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
+
 "@humanfs/core@^0.19.2":
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.2.tgz#a8272ca03b2acf492670222b2320b6c421bfde60"
@@ -1464,6 +1469,29 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz#775374306116d51c0c500b8c4face0f9a04752d8"
   integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
+
+"@modelcontextprotocol/sdk@^1.29.0":
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz#79786d8b525e269de850ac82b1f1f757f3915f44"
+  integrity sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==
+  dependencies:
+    "@hono/node-server" "^1.19.9"
+    ajv "^8.17.1"
+    ajv-formats "^3.0.1"
+    content-type "^1.0.5"
+    cors "^2.8.5"
+    cross-spawn "^7.0.5"
+    eventsource "^3.0.2"
+    eventsource-parser "^3.0.0"
+    express "^5.2.1"
+    express-rate-limit "^8.2.1"
+    hono "^4.11.4"
+    jose "^6.1.3"
+    json-schema-typed "^8.0.2"
+    pkce-challenge "^5.0.0"
+    raw-body "^3.0.0"
+    zod "^3.25 || ^4.0"
+    zod-to-json-schema "^3.25.1"
 
 "@napi-rs/wasm-runtime@^0.2.11":
   version "0.2.12"
@@ -3037,6 +3065,14 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
+accepts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
+  integrity sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==
+  dependencies:
+    mime-types "^3.0.0"
+    negotiator "^1.0.0"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -3057,6 +3093,13 @@ ai@6.0.33:
     "@ai-sdk/provider-utils" "4.0.5"
     "@opentelemetry/api" "1.9.0"
 
+ajv-formats@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.14.0:
   version "6.14.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.14.0.tgz#fd067713e228210636ebb08c60bd3765d6dbe73a"
@@ -3067,7 +3110,7 @@ ajv@^6.14.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.18.0:
+ajv@^8.0.0, ajv@^8.17.1, ajv@^8.18.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
@@ -3383,6 +3426,21 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
+body-parser@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-2.2.2.tgz#1a32cdb966beaf68de50a9dfbe5b58f83cb8890c"
+  integrity sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==
+  dependencies:
+    bytes "^3.1.2"
+    content-type "^1.0.5"
+    debug "^4.4.3"
+    http-errors "^2.0.0"
+    iconv-lite "^0.7.0"
+    on-finished "^2.4.1"
+    qs "^6.14.1"
+    raw-body "^3.0.1"
+    type-is "^2.0.1"
+
 bowser@^2.11.0:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
@@ -3448,6 +3506,11 @@ buffer@^6.0.3:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
+
+bytes@^3.1.2, bytes@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -3600,6 +3663,16 @@ confbox@^0.2.2:
   resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.2.4.tgz#592e7be71f882a4a874e3c88f0ac1ef6f7da1ce5"
   integrity sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==
 
+content-disposition@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.1.0.tgz#f3db789c752d45564cc7e9e1e0b31790d4a38e17"
+  integrity sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==
+
+content-type@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
+
 convert-hrtime@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/convert-hrtime/-/convert-hrtime-5.0.0.tgz#f2131236d4598b95de856926a67100a0a97e9fa3"
@@ -3610,15 +3683,33 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie-signature@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.2.tgz#57c7fc3cc293acab9fec54d73e15690ebe4a1793"
+  integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
+
 cookie@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
   integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
 
+cookie@^0.7.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cors@^2.8.5:
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.6.tgz#ff5dd69bd95e547503820d29aba4f8faf8dfec96"
+  integrity sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 crc-32@^1.2.0:
   version "1.2.2"
@@ -3638,7 +3729,7 @@ crelt@^1.0.5, crelt@^1.0.6:
   resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.6.tgz#7cc898ea74e190fb6ef9dae57f8f81cf7302df72"
   integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
 
-cross-spawn@^7.0.6:
+cross-spawn@^7.0.5, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -3779,6 +3870,11 @@ defu@^6.1.4:
   resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.7.tgz#72543567c8e9f97ff13ce402b6dbe09ac5ae4d23"
   integrity sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==
 
+depd@^2.0.0, depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 dequal@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
@@ -3832,6 +3928,11 @@ echarts@^6.0.0:
     tslib "2.3.0"
     zrender "6.0.0"
 
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
+
 electron-to-chromium@^1.5.328:
   version "1.5.340"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz#fe3f76e8d9b9541c123fb7edbc3381688272f79a"
@@ -3851,6 +3952,11 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+encodeurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
+  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.5"
@@ -4038,6 +4144,11 @@ escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
+
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -4275,6 +4386,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+etag@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
@@ -4292,15 +4408,63 @@ events@^3.3.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-eventsource-parser@^3.0.6:
+eventsource-parser@^3.0.0, eventsource-parser@^3.0.1, eventsource-parser@^3.0.6:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.8.tgz#1c792503e4080455d00701bb1f7a1d60734d0e58"
   integrity sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==
+
+eventsource@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
+  integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
+  dependencies:
+    eventsource-parser "^3.0.1"
 
 expand-template@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
+express-rate-limit@^8.2.1:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.3.2.tgz#81bbdbf599b7889a5b3cc272ec115aff200011be"
+  integrity sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==
+  dependencies:
+    ip-address "10.1.0"
+
+express@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
+  integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
+  dependencies:
+    accepts "^2.0.0"
+    body-parser "^2.2.1"
+    content-disposition "^1.0.0"
+    content-type "^1.0.5"
+    cookie "^0.7.1"
+    cookie-signature "^1.2.1"
+    debug "^4.4.0"
+    depd "^2.0.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    finalhandler "^2.1.0"
+    fresh "^2.0.0"
+    http-errors "^2.0.0"
+    merge-descriptors "^2.0.0"
+    mime-types "^3.0.0"
+    on-finished "^2.4.1"
+    once "^1.4.0"
+    parseurl "^1.3.3"
+    proxy-addr "^2.0.7"
+    qs "^6.14.0"
+    range-parser "^1.2.1"
+    router "^2.2.0"
+    send "^1.1.0"
+    serve-static "^2.2.0"
+    statuses "^2.0.1"
+    type-is "^2.0.1"
+    vary "^1.1.2"
 
 exsolve@^1.0.7:
   version "1.0.8"
@@ -4395,6 +4559,18 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+finalhandler@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-2.1.1.tgz#a2c517a6559852bcdb06d1f8bd7f51b68fad8099"
+  integrity sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==
+  dependencies:
+    debug "^4.4.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    on-finished "^2.4.1"
+    parseurl "^1.3.3"
+    statuses "^2.0.1"
+
 find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
@@ -4437,6 +4613,16 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
+
+forwarded@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
+fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
+  integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -4866,6 +5052,11 @@ highlight.js@^11.11.1, highlight.js@~11.11.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.11.1.tgz#fca06fa0e5aeecf6c4d437239135fabc15213585"
   integrity sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==
 
+hono@^4.11.4:
+  version "4.12.14"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.14.tgz#4777c9512b7c84138e4f09e61e3d2fa305eb1414"
+  integrity sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==
+
 hookable@^5.5.3:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/hookable/-/hookable-5.5.3.tgz#6cfc358984a1ef991e2518cb9ed4a778bbd3215d"
@@ -4885,6 +5076,24 @@ html-whitespace-sensitive-tag-names@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz#c35edd28205f3bf8c1fd03274608d60b923de5b2"
   integrity sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==
+
+http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
+  dependencies:
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
+
+iconv-lite@^0.7.0, iconv-lite@~0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
+  integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 identifier-regex@^1.0.0:
   version "1.0.1"
@@ -4921,7 +5130,7 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4939,6 +5148,16 @@ internal-slot@^1.1.0:
     es-errors "^1.3.0"
     hasown "^2.0.2"
     side-channel "^1.1.0"
+
+ip-address@10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.1.0.tgz#d8dcffb34d0e02eb241427444a6e23f5b0595aa4"
+  integrity sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-absolute-url@^4.0.0:
   version "4.0.1"
@@ -5097,6 +5316,11 @@ is-plain-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
+is-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
+  integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
+
 is-regex@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.2.1.tgz#76d70a3ed10ef9be48eb577887d74205bf0cad22"
@@ -5224,6 +5448,11 @@ jiti@^2.6.1:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.6.1.tgz#178ef2fc9a1a594248c20627cd820187a4d78d92"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
 
+jose@^6.1.3:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.2.tgz#d6b5279b89b3e88d531c202e3fbe351f39a44aac"
+  integrity sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==
+
 js-base64@^3.7.8:
   version "3.7.8"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.8.tgz#af44496bc09fa178ed9c4adf67eb2b46f5c6d2a4"
@@ -5260,6 +5489,11 @@ json-schema-traverse@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+json-schema-typed@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz#e98ee7b1899ff4a184534d1f167c288c66bbeff4"
+  integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
 
 json-schema@^0.4.0:
   version "0.4.0"
@@ -5668,6 +5902,16 @@ mdn-data@2.27.1:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.27.1.tgz#e37b9c50880b75366c4d40ac63d9bbcacdb61f0e"
   integrity sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==
 
+media-typer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
+  integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
+
+merge-descriptors@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz#ea922f660635a2249ee565e0449f951e6b603808"
+  integrity sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==
+
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -5959,6 +6203,18 @@ micromatch@^4.0.4:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
+mime-types@^3.0.0, mime-types@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.2.tgz#39002d4182575d5af036ffa118100f2524b2e2ab"
+  integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
+  dependencies:
+    mime-db "^1.54.0"
+
 mimic-function@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
@@ -6108,6 +6364,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+negotiator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
+  integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
+
 neverpanic@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/neverpanic/-/neverpanic-0.0.7.tgz#5f6f7a68217d00beed8acc4185753506c59ad256"
@@ -6175,7 +6436,7 @@ normalize-path@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -6240,6 +6501,13 @@ object.values@^1.1.6, object.values@^1.2.1:
     call-bound "^1.0.3"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
+
+on-finished@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
+  dependencies:
+    ee-first "1.1.1"
 
 once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -6341,6 +6609,11 @@ parse5@^7.0.0:
   dependencies:
     entities "^6.0.0"
 
+parseurl@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
 path-browserify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
@@ -6374,6 +6647,11 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
+path-to-regexp@^8.0.0:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz#795c420c4f7ca45c5b887366f622ee0c9852cccd"
+  integrity sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==
+
 pathe@^2.0.1, pathe@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
@@ -6398,6 +6676,11 @@ picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
+pkce-challenge@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz#3b4446865b17b1745e9ace2016a31f48ddf6230d"
+  integrity sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==
 
 pkg-types@^1.3.1:
   version "1.3.1"
@@ -6513,6 +6796,14 @@ property-information@^7.0.0:
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-7.1.0.tgz#b622e8646e02b580205415586b40804d3e8bfd5d"
   integrity sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
 
+proxy-addr@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
+  dependencies:
+    forwarded "0.2.0"
+    ipaddr.js "1.9.1"
+
 pump@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.4.tgz#1f313430527fa8b905622ebd22fe1444e757ab3c"
@@ -6525,6 +6816,13 @@ punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+qs@^6.14.0, qs@^6.14.1:
+  version "6.15.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.1.tgz#bdb55aed06bfac257a90c44a446a73fba5575c8f"
+  integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
+  dependencies:
+    side-channel "^1.1.0"
 
 quansync@^0.2.11:
   version "0.2.11"
@@ -6557,6 +6855,21 @@ raf-schd@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
   integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
+range-parser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+raw-body@^3.0.0, raw-body@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.2.tgz#3e3ada5ae5568f9095d84376fd3a49b8fb000a51"
+  integrity sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==
+  dependencies:
+    bytes "~3.1.2"
+    http-errors "~2.0.1"
+    iconv-lite "~0.7.0"
+    unpipe "~1.0.0"
 
 rc@^1.2.7:
   version "1.2.8"
@@ -6811,6 +7124,17 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
+router@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/router/-/router-2.2.0.tgz#019be620b711c87641167cc79b99090f00b146ef"
+  integrity sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==
+  dependencies:
+    debug "^4.4.0"
+    depd "^2.0.0"
+    is-promise "^4.0.0"
+    parseurl "^1.3.3"
+    path-to-regexp "^8.0.0"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -6856,6 +7180,11 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
 scheduler@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
@@ -6875,6 +7204,33 @@ semver@^7.3.5, semver@^7.7.1, semver@^7.7.3:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+send@^1.1.0, send@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/send/-/send-1.2.1.tgz#9eab743b874f3550f40a26867bf286ad60d3f3ed"
+  integrity sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==
+  dependencies:
+    debug "^4.4.3"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    fresh "^2.0.0"
+    http-errors "^2.0.1"
+    mime-types "^3.0.2"
+    ms "^2.1.3"
+    on-finished "^2.4.1"
+    range-parser "^1.2.1"
+    statuses "^2.0.2"
+
+serve-static@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-2.2.1.tgz#7f186a4a4e5f5b663ad7a4294ff1bf37cf0e98a9"
+  integrity sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==
+  dependencies:
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    parseurl "^1.3.3"
+    send "^1.2.0"
 
 set-cookie-parser@3.1.0:
   version "3.1.0"
@@ -6911,6 +7267,11 @@ set-proto@^1.0.0:
     dunder-proto "^1.0.1"
     es-errors "^1.3.0"
     es-object-atoms "^1.0.0"
+
+setprototypeof@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 sharp@^0.34.5:
   version "0.34.5"
@@ -7036,6 +7397,11 @@ stable-hash@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stable-hash/-/stable-hash-0.0.5.tgz#94e8837aaeac5b4d0f631d2972adef2924b40269"
   integrity sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==
+
+statuses@^2.0.1, statuses@^2.0.2, statuses@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
 stdin-discarder@^0.2.2:
   version "0.2.2"
@@ -7381,6 +7747,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+toidentifier@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
 trim-lines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
@@ -7460,6 +7831,15 @@ type-fest@^5.3.1:
   integrity sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==
   dependencies:
     tagged-tag "^1.0.0"
+
+type-is@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-2.0.1.tgz#64f6cf03f92fce4015c2b224793f6bdd4b068c97"
+  integrity sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==
+  dependencies:
+    content-type "^1.0.5"
+    media-typer "^1.1.0"
+    mime-types "^3.0.0"
 
 typed-array-buffer@^1.0.3:
   version "1.0.3"
@@ -7617,6 +7997,11 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
+unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
+
 unplugin-utils@^0.3.0, unplugin-utils@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/unplugin-utils/-/unplugin-utils-0.3.1.tgz#ef2873670a6a2a21bd2c9d31307257cc863a709c"
@@ -7690,6 +8075,11 @@ uuid@^14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
+
+vary@^1, vary@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
 vfile-location@^5.0.0:
   version "5.0.3"
@@ -7929,12 +8319,17 @@ zip-stream@^6.0.1:
     compress-commons "^6.0.2"
     readable-stream "^4.0.0"
 
+zod-to-json-schema@^3.25.1:
+  version "3.25.2"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz#3fa799a7badd554541472fb65843fdc460b2e5aa"
+  integrity sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==
+
 "zod-validation-error@^3.5.0 || ^4.0.0":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-4.0.2.tgz#bc605eba49ce0fcd598c127fee1c236be3f22918"
   integrity sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==
 
-"zod@^3.25.0 || ^4.0.0", zod@^4.3.5, zod@^4.3.6:
+"zod@^3.25 || ^4.0", "zod@^3.25.0 || ^4.0.0", zod@^4.3.5, zod@^4.3.6:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==


### PR DESCRIPTION
Stacked on top of #24 (PR 2 — service layer), which is stacked on #23 (PR 1 — authz).

## Summary
- **11 MCP tools** at \`POST /mcp\` + \`GET /mcp\` (streamable-HTTP): \`whoami\`, \`list_peers\`, \`get_task\`, \`fetch_mail\`, \`register_deliverable\`, \`log_activity\`, \`update_task_status\`, \`fail_task\`, \`save_checkpoint\`, \`send_mail\`, \`delegate\`
- **Stdio launcher** (\`mcp-launcher/\`) openclaw registers via \`openclaw mcp set sc-mission-control '…'\` — proxies JSON-RPC over HTTP to MC
- **Feature-flag gated** via \`MC_MCP_ENABLED=1\`; endpoint returns 503 when off so rollout is per-agent without a code change
- New \`mcp.tool_call\` debug-log type so the export shows MCP calls inline with existing chat/agent traffic
- Authorization routes through the service layer (PR 2) → \`assertAgentCanActOnTask\` (PR 1). MCP cannot bypass the gate

## Context
Closes the failure mode from the 2026-04-21 debug-events export (mc-writer flailing against sqlite trying to reconstruct curl templates) by giving agents typed MCP tools instead of hand-constructed curls. Plan: \`~/.claude/plans/can-you-make-that-async-eich.md\`.

Phase 0 spike (now removed) confirmed OpenClaw passes zero identity to MCP servers — no env vars, no \`clientInfo\`, no per-call \`_meta\`, shared subprocess across agents. So every state-changing tool takes \`agent_id\` as an explicit first arg and the \`MC_API_TOKEN\` bearer is the transport-level trust boundary (same as the HTTP API — net security unchanged).

## Explicit v1 limitations
- MCP-driven status transitions do NOT trigger the ~400 lines of post-transition orchestration in the PATCH handler (convoy progress, workflow handoff dispatch, skill extraction, agent-status reset). Documented in the \`update_task_status\` tool description. A follow-up after pilot data will either lift that orchestration into the service or accept the narrower contract.
- \`delegate\` isn't in the integration test suite (needs a live openclaw gateway). Will be exercised in the pilot smoke (PR 4).

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] 10 new integration tests using the SDK's \`InMemoryTransport\` pair (\`src/lib/mcp/mcp.test.ts\`) — pass 10/10 in isolation. Covers listing, whoami, register/log/transition happy path, authz-denied paths, evidence-gate on \`update_task_status\`
- [x] PR 1 (16 authz) + PR 2 (17 services) tests still pass in isolation
- [ ] Live smoke against dev MC:
  - [ ] Build image, \`MC_MCP_ENABLED=1\` in env, restart container
  - [ ] \`openclaw mcp set sc-mission-control\` pointing at the launcher (README has the exact command)
  - [ ] Scope to mc-writer's \`tools.alsoAllow\` in openclaw.json; gateway restart
  - [ ] From mc-writer chat: \`whoami\` returns identity + peers, \`register_deliverable\` writes a row, \`update_task_status\` respects the evidence gate
  - [ ] Check \`/api/debug\` export for \`mcp.tool_call\` events

Test-harness note: the repo's existing \`tsx --test\` setup runs files concurrently against one sqlite — they lock-contend. Same behavior as seen in PR 1 and PR 2; files pass 100% in isolation. Fixing the harness is a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)