### PR TITLE
feat(dispatch): expand MCP to all gateway agents by default

### DIFF
--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -411,11 +411,17 @@ their persona, memory, and channel bindings.
         ? `  -H "Authorization: Bearer ${mcAuthToken}" \\\n`
         : '';
 
-    // MCP pilot switch (PR 4). When enabled globally AND this agent's
-    // gateway id is in the per-host pilot allowlist, emit a short
-    // MCP-oriented completion block instead of the curl scaffolding.
-    // MC_MCP_PILOT_AGENTS is a comma-separated list of gateway ids (e.g.
-    // "mc-writer"); "*" or "all" pilots every gateway agent (used by PR 5).
+    // MCP switch. MC_MCP_ENABLED=1 routes every gateway agent through the
+    // MCP completion path. MC_MCP_PILOT_AGENTS stays as an optional
+    // narrowing override for staged rollouts: when set to a non-empty
+    // comma-separated list of gateway ids, only those agents get MCP.
+    // When unset or set to "*"/"all", all gateway agents match.
+    //
+    // Semantics changed in PR 5: previously an empty MC_MCP_PILOT_AGENTS
+    // meant "no agents piloted" (conservative PR-4 behaviour). After PR 5
+    // the default is "all agents" — the operator flips MC_MCP_ENABLED and
+    // every gateway agent is on MCP. PR 6 removes the curl path entirely.
+    //
     // Non-gateway agents always fall through to the curl path — they have
     // no MC-CONTEXT.json and their openclaw wiring doesn't include the
     // sc-mission-control launcher.
@@ -426,7 +432,9 @@ their persona, memory, and channel bindings.
       .map((s) => s.trim())
       .filter(Boolean);
     const pilotAllowsAll =
-      pilotAllowlist.includes('*') || pilotAllowlist.includes('all');
+      pilotAllowlist.length === 0 ||
+      pilotAllowlist.includes('*') ||
+      pilotAllowlist.includes('all');
     const isMcpPilot =
       mcpEnabled &&
       Boolean(gatewayIdForContext) &&


### PR DESCRIPTION
Stacked on #26 (PR 4 — pilot switch).

## Summary
Flips the default for \`MC_MCP_PILOT_AGENTS\`: unset/empty now means "every gateway agent gets MCP" instead of PR 4's conservative "no agents piloted". The allowlist stays as an optional staged-rollout override.

## Config compat

| \`MC_MCP_ENABLED\` | \`MC_MCP_PILOT_AGENTS\` | PR 4 | PR 5 |
|---|---|---|---|
| \`0\` | any | no MCP | no MCP |
| \`1\` | unset | no MCP | **all gateway agents** |
| \`1\` | \`mc-writer\` | mc-writer only | mc-writer only |
| \`1\` | \`*\` / \`all\` | all | all |

Anyone running PR 4 with a specific allowlist sees no change. Anyone who left the allowlist unset on PR 4 was getting no MCP; after PR 5 they get all agents — flag this in release notes.

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] Existing 43 tests still pass in isolation
- [ ] Live validation (post-merge, after ≥1 week of mc-writer soak on PR 4):
  - [ ] Dispatch to each gateway agent; confirm MCP completion block appears for each
  - [ ] Confirm existing tasks assigned before the flip still complete on curl (backward compat)
  - [ ] Watch debug-events for \`mcp.tool_call\` rows from every agent; zero curl hits to \`/api/tasks/*\`

The curl scaffolding remains as a fallback. PR 6 removes it once there's a clean week of traffic from all agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)