### PR TITLE
test(mcp): Next.js e2e harness — spawn `next dev` + exercise /api/mcp

### DIFF
--- a/docs/MCP-QUICKSTART.md
+++ b/docs/MCP-QUICKSTART.md
@@ -26,16 +26,21 @@ One launcher subprocess proxies every agent's stdio JSON-RPC to MC's HTTP endpoi
 
 ## 0. Pre-flight — before touching anything live
 
-Run both test harnesses locally. No openclaw, no Docker. Both should pass in under 15 seconds:
+Three harnesses, cheapest first:
 
 ```bash
 # From the mission-control repo root:
 yarn install
 cd mcp-launcher && npm install && cd ..
 
-yarn mcp:smoke         # launcher ⇄ mock MC (validates stdio↔HTTP proxy)
-yarn mcp:integration   # real launcher ⇄ real MCP server ⇄ real sqlite
+yarn mcp:smoke         # ~5s — launcher ⇄ mock MC  (stdio↔HTTP proxy only)
+yarn mcp:integration   # ~10s — real MCP server mounted on node:http ⇄ real launcher ⇄ sqlite
+yarn mcp:e2e:next      # ~10s — real Next.js dev server ⇄ real /api/mcp route ⇄ sqlite
 ```
+
+The three layers catch disjoint bug classes — `mcp:e2e:next` is the one that would have caught the `WebStandardStreamableHTTPServerTransport` regression and the `Accept: application/json, text/event-stream` requirement before hitting production. Run all three before any rollout.
+
+> `mcp:e2e:next` spawns `next dev` and writes to `.next/`. Don't run it while `yarn dev` is running on the default port — they'll clobber each other's compilation cache.
 
 Expected output of `mcp:integration`:
 
@@ -309,8 +314,10 @@ openclaw gateway restart
 | `src/lib/authz/agent-task.ts` | `assertAgentCanActOnTask` — every state change passes through |
 | `src/lib/services/*.ts` | Business logic shared by HTTP routes and MCP tools |
 | `mcp-launcher/launcher.mjs` | stdio↔HTTP proxy spawned by openclaw |
-| `mcp-launcher/smoke.mjs` | Proxy smoke (no MC) |
-| `scripts/mcp-integration-test.mjs` | End-to-end (real server + real launcher + real sqlite) |
+| `mcp-launcher/smoke.mjs` | Proxy-only smoke (no MC, no DB) |
+| `scripts/mcp-integration-test.mjs` | Service-layer E2E (node:http + real launcher + real sqlite) |
+| `scripts/mcp-next-e2e.mjs` | Next.js E2E (real `next dev` + real `/api/mcp` + real sqlite) |
+| `scripts/mcp-next-e2e.seed.ts` | Sibling seeder for the Next.js E2E |
 | `src/lib/openclaw/worker-context.ts` | Writes MC-CONTEXT.json (just `my_agent_id` now) |
 
 ## 9. Reference: all 11 tools

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "mkdir -p .tmp && rm -f .tmp/mission-control-test.db* && NODE_ENV=test DATABASE_PATH=.tmp/mission-control-test.db tsx --test src/**/*.test.ts",
     "mcp:smoke": "cd mcp-launcher && npm run smoke",
     "mcp:integration": "tsx scripts/mcp-integration-test.mjs",
+    "mcp:e2e:next": "node scripts/mcp-next-e2e.mjs",
     "db:seed": "tsx src/lib/db/seed.ts",
     "db:backup": "sqlite3 mission-control.db 'PRAGMA wal_checkpoint(TRUNCATE);' && cp mission-control.db mission-control.db.backup && echo 'Backed up to mission-control.db.backup'",
     "db:restore": "cp mission-control.db.backup mission-control.db && echo 'Restored from backup'",

--- a/scripts/mcp-next-e2e.mjs
+++ b/scripts/mcp-next-e2e.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+/**
+ * Next.js end-to-end test for /api/mcp.
+ *
+ * Spawns a real `next dev` subprocess on a random port against a throwaway
+ * sqlite DB, then exercises the MCP endpoint over HTTP like a production
+ * caller would. Complements scripts/mcp-integration-test.mjs, which mounts
+ * the MCP server on a plain node:http listener — that version misses
+ * Next.js-specific wrapper bugs in src/app/api/mcp/route.ts.
+ *
+ * The two bugs that shipped to production on PR 7 and would have been
+ * caught by this harness:
+ *
+ *   1. `StreamableHTTPServerTransport` (Node-flavoured) wrapped with a
+ *      fake IncomingMessage/ServerResponse shim → 500 on every request.
+ *      This harness calls the REAL Next.js route handler, so the shim
+ *      path (or lack thereof) is exercised.
+ *
+ *   2. The MCP Streamable-HTTP spec requires `Accept: application/json,
+ *      text/event-stream` on every POST. Our node:http integration test
+ *      used the MCP SDK client which sets this automatically. Direct
+ *      `fetch` calls in this harness include and omit the header
+ *      deliberately to pin down the 406 behaviour.
+ *
+ * WARNING: do NOT run this while `yarn dev` is running on the default
+ * port — both processes would try to write to `.next/`. We use a
+ * random port but share the `.next` build cache, so concurrent dev
+ * servers clobber each other's incremental compilation state.
+ *
+ * Run:  yarn mcp:e2e:next
+ * Exit: 0 on success, non-zero on first failure.
+ */
+
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+async function pickFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForServer(url, { timeoutMs = 60_000, label = 'server' } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr;
+  while (Date.now() < deadline) {
+    try {
+      // Any 2xx/3xx/4xx proves the HTTP listener is up — 404 on the root
+      // is fine, we just need a live socket that speaks HTTP.
+      const res = await fetch(url, { method: 'GET' });
+      if (res.status < 500) return;
+    } catch (err) {
+      lastErr = err;
+    }
+    await delay(400);
+  }
+  throw new Error(`${label} did not come up within ${timeoutMs}ms; last error: ${lastErr?.message ?? 'n/a'}`);
+}
+
+// ─── fixtures ────────────────────────────────────────────────────────
+
+const fixtures = {
+  agentId: '00000000-0000-0000-0000-000000000a01',
+  outsiderId: '00000000-0000-0000-0000-000000000a02',
+  taskId: '00000000-0000-0000-0000-000000000b10',
+};
+
+const MC_API_TOKEN = 'next-e2e-token';
+
+// ─── main ────────────────────────────────────────────────────────────
+
+const tmpDb = path.join(os.tmpdir(), `mcp-next-e2e-${process.pid}.db`);
+for (const s of ['', '-shm', '-wal']) {
+  const p = tmpDb + s;
+  if (fs.existsSync(p)) fs.unlinkSync(p);
+}
+
+const failures = [];
+function expect(cond, msg) {
+  if (!cond) failures.push(msg);
+}
+
+let nextProc;
+let port;
+
+try {
+  port = await pickFreePort();
+  const BASE = `http://127.0.0.1:${port}`;
+  console.log(`[next-e2e] DB=${tmpDb} PORT=${port}`);
+
+  // Seed fixtures via a sibling tsx script. Doing it from this plain-node
+  // file directly would require bringing in tsx as a runtime; spawning a
+  // small seeder keeps that layer thin.
+  const { spawnSync } = await import('node:child_process');
+  const seederPath = new URL('./mcp-next-e2e.seed.ts', import.meta.url).pathname;
+  const seed = spawnSync('npx', ['tsx', seederPath], {
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      DATABASE_PATH: tmpDb,
+      SEED_AGENT_ID: fixtures.agentId,
+      SEED_OUTSIDER_ID: fixtures.outsiderId,
+      SEED_TASK_ID: fixtures.taskId,
+    },
+    stdio: 'inherit',
+  });
+  if (seed.status !== 0) throw new Error('seeder failed');
+
+  // Spawn next dev. Inherit stdio so compile errors surface. Use NODE_ENV
+  // undefined so next picks 'development' itself — setting NODE_ENV=test
+  // makes next refuse to start.
+  console.log('[next-e2e] spawning next dev …');
+  nextProc = spawn('npx', ['next', 'dev', '-p', String(port), '-H', '127.0.0.1'], {
+    env: {
+      ...process.env,
+      NODE_ENV: undefined,
+      DATABASE_PATH: tmpDb,
+      MC_API_TOKEN,
+      MC_MCP_ENABLED: '1',
+      // Keep next dev quiet-ish so our test output stays legible.
+      NEXT_TELEMETRY_DISABLED: '1',
+    },
+    stdio: 'inherit',
+  });
+
+  // Wait for next dev to accept HTTP connections. First request after
+  // cold-start also triggers on-demand compilation of the MCP route, so
+  // give it generous time.
+  await waitForServer(BASE, { timeoutMs: 90_000, label: 'next dev' });
+
+  // Prime the /api/mcp route so subsequent timing measurements aren't
+  // skewed by cold-compile. Any disabled / 4xx response is fine; we just
+  // need the route handler compiled.
+  await fetch(`${BASE}/api/mcp`, { method: 'GET' }).catch(() => {});
+
+  const post = async (body, extraHeaders = {}) => {
+    const res = await fetch(`${BASE}/api/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${MC_API_TOKEN}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        ...extraHeaders,
+      },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    let json;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      json = null;
+    }
+    return { status: res.status, json, text };
+  };
+
+  // ── 1. 406 when Accept header is missing the SSE mime ──
+  {
+    const res = await fetch(`${BASE}/api/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${MC_API_TOKEN}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+    });
+    const body = await res.json();
+    expect(res.status === 406, `expected 406 when Accept omits text/event-stream, got ${res.status}`);
+    expect(
+      typeof body?.error?.message === 'string' &&
+        body.error.message.toLowerCase().includes('must accept'),
+      'expected 406 body to explain the Accept-header requirement',
+    );
+  }
+
+  // ── 2. 401 when bearer is wrong ──
+  {
+    const res = await fetch(`${BASE}/api/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer totally-wrong',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+    });
+    expect(res.status === 401, `expected 401 for bad bearer, got ${res.status}`);
+  }
+
+  // ── 3. tools/list returns 11 tools as JSON (not SSE) ──
+  {
+    const { status, json } = await post({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {},
+    });
+    expect(status === 200, `tools/list should 200, got ${status}`);
+    expect(
+      Array.isArray(json?.result?.tools) && json.result.tools.length === 11,
+      `tools/list should return 11 tools, got ${json?.result?.tools?.length}`,
+    );
+    const names = new Set(json?.result?.tools?.map((t) => t.name) ?? []);
+    for (const t of [
+      'whoami',
+      'list_peers',
+      'get_task',
+      'fetch_mail',
+      'register_deliverable',
+      'log_activity',
+      'update_task_status',
+      'fail_task',
+      'save_checkpoint',
+      'send_mail',
+      'delegate',
+    ]) {
+      expect(names.has(t), `tools/list missing ${t}`);
+    }
+  }
+
+  // ── 4. whoami hits the real DB via the real route ──
+  {
+    const { status, json } = await post({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'whoami', arguments: { agent_id: fixtures.agentId } },
+    });
+    expect(status === 200, `whoami should 200, got ${status}`);
+    const sc = json?.result?.structuredContent ?? {};
+    expect(sc.id === fixtures.agentId, `whoami should echo agent id; got ${sc.id}`);
+    expect(sc.gateway_agent_id === 'mc-e2e-builder', 'whoami should return seeded gateway_agent_id');
+  }
+
+  // ── 5. register_deliverable happy path ──
+  {
+    const { json } = await post({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'register_deliverable',
+        arguments: {
+          agent_id: fixtures.agentId,
+          task_id: fixtures.taskId,
+          deliverable_type: 'artifact',
+          title: 'next-e2e',
+        },
+      },
+    });
+    const sc = json?.result?.structuredContent ?? {};
+    expect(sc.deliverable?.task_id === fixtures.taskId, 'deliverable row should reference the task');
+  }
+
+  // ── 6. cross-agent authz ──
+  {
+    const { json } = await post({
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: {
+        name: 'register_deliverable',
+        arguments: {
+          agent_id: fixtures.outsiderId,
+          task_id: fixtures.taskId,
+          deliverable_type: 'artifact',
+          title: 'should-be-blocked',
+        },
+      },
+    });
+    expect(json?.result?.isError === true, 'outsider agent should be blocked');
+    expect(
+      json?.result?.structuredContent?.error === 'authz_denied',
+      `outsider should get authz_denied; got ${JSON.stringify(json?.result?.structuredContent)}`,
+    );
+  }
+
+  // ── 7. MC_MCP_ENABLED kill-switch returns 503 (separate next dev restart
+  //     would be needed to actually test the 503 path without fiddling
+  //     with env mid-run; we assert the happy path and trust unit tests
+  //     for the 503 branch). ──
+} finally {
+  if (nextProc) {
+    nextProc.kill('SIGTERM');
+    // Give next dev a chance to tidy up its file handles; then force-kill.
+    const closed = await Promise.race([
+      new Promise((r) => nextProc.once('close', r)),
+      delay(5000).then(() => 'timeout'),
+    ]);
+    if (closed === 'timeout') nextProc.kill('SIGKILL');
+  }
+  for (const s of ['', '-shm', '-wal']) {
+    const p = tmpDb + s;
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+}
+
+if (failures.length) {
+  console.error('\n[next-e2e] FAILED:');
+  for (const f of failures) console.error('  -', f);
+  process.exit(1);
+}
+console.log('[next-e2e] OK — real /api/mcp route validated via next dev');

--- a/scripts/mcp-next-e2e.seed.ts
+++ b/scripts/mcp-next-e2e.seed.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Seeder for scripts/mcp-next-e2e.mjs.
+ *
+ * Opens the tmpfile DB (path in $DATABASE_PATH), runs the app's migrations
+ * via getDb(), inserts a piloted agent + an outsider + a task, then
+ * closes the handle. Called by the main harness via `tsx` so TypeScript
+ * path aliases resolve.
+ */
+
+import { getDb, run, closeDb } from '../src/lib/db/index';
+
+// Touch getDb() so migrations run before we INSERT.
+getDb();
+
+const agentId = process.env.SEED_AGENT_ID;
+const outsiderId = process.env.SEED_OUTSIDER_ID;
+const taskId = process.env.SEED_TASK_ID;
+
+if (!agentId || !outsiderId || !taskId) {
+  console.error('SEED_AGENT_ID, SEED_OUTSIDER_ID, SEED_TASK_ID are required');
+  process.exit(2);
+}
+
+run(
+  `INSERT INTO agents (id, name, role, workspace_id, is_active, gateway_agent_id, created_at, updated_at)
+   VALUES (?, 'Builder (E2E)', 'builder', 'default', 1, 'mc-e2e-builder', datetime('now'), datetime('now'))`,
+  [agentId],
+);
+
+run(
+  `INSERT INTO agents (id, name, role, workspace_id, is_active, gateway_agent_id, created_at, updated_at)
+   VALUES (?, 'Outsider (E2E)', 'tester', 'default', 1, 'mc-e2e-outsider', datetime('now'), datetime('now'))`,
+  [outsiderId],
+);
+
+run(
+  `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, assigned_agent_id, created_at, updated_at)
+   VALUES (?, 'E2E task', 'in_progress', 'normal', 'default', 'default', ?, datetime('now'), datetime('now'))`,
+  [taskId, agentId],
+);
+
+closeDb();
+console.log(`[next-e2e.seed] seeded agent=${agentId}, outsider=${outsiderId}, task=${taskId}`);


### PR DESCRIPTION
Stacked on #29. Adds the third test layer that would have caught PR 7's production defects before they shipped.

## The gap

PR 7 shipped two defects to a live container:

1. **`/api/mcp` returned 500** because the Node-flavoured \`StreamableHTTPServerTransport\` can't be shimmed with fake \`IncomingMessage\`/\`ServerResponse\` — the SDK delegates to Hono's \`getRequestListener\` which needs real event emitters. Fix (on PR 7): swap to \`WebStandardStreamableHTTPServerTransport\`.
2. **Accept header requirement** — MCP Streamable-HTTP spec mandates \`application/json, text/event-stream\`. Curl with only \`application/json\` got a cryptic 406.

Neither was caught by existing tests:

| Existing harness | Why it missed |
|---|---|
| \`src/lib/mcp/mcp.test.ts\` | Uses \`InMemoryTransport\` — no HTTP at all |
| \`scripts/mcp-integration-test.mjs\` | Mounts on \`node:http\` with real Node \`req\`/\`res\` — so the Node-flavoured transport worked fine there |

Only a real \`next dev\` exercises the Next.js Request↔SDK transport boundary where these defects lived.

## What this adds

\`yarn mcp:e2e:next\` (~10s cold-start, ~2s subsequent):

- Picks a free port, seeds a throwaway sqlite via \`tsx\` (running full migrations), spawns \`next dev -p \$PORT\` with env wired up, waits for the listener, primes \`/api/mcp\`, then runs 6 assertion groups:

  1. **406 when Accept omits \`text/event-stream\`** — pins the spec requirement
  2. **401 when bearer is wrong** — pins the proxy middleware
  3. **tools/list returns 11 tools as JSON** (confirms \`enableJsonResponse: true\` is wired and all tools register)
  4. **whoami** against a seeded agent returns the seeded \`gateway_agent_id\` (confirms DB path from Next → getDb → queryOne works end-to-end)
  5. **register_deliverable happy path** writes a row
  6. **register_deliverable from an outsider → authz_denied** (confirms authz flows through the Next route too)

## Layering

| Script | Speed | What it catches |
|---|---|---|
| \`yarn mcp:smoke\` | ~5s | launcher's stdio↔HTTP proxy (no MC) |
| \`yarn mcp:integration\` | ~10s | service-layer on \`node:http\` + launcher + sqlite (no Next) |
| \`yarn mcp:e2e:next\` | ~10s | real \`next dev\` + \`/api/mcp\` + sqlite |

Cheapest-first keeps TDD fast. \`mcp:e2e:next\` is the one to run before any rollout.

## Known limitation

\`next dev\` writes to \`.next/\` — don't run this alongside a live \`yarn dev\` on the default port. Documented in the script doc-comment and the quickstart's pre-flight.

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] All three harnesses pass on this branch (5s / 9s / 8s)
- [ ] Intentional regression test: revert PR 7's transport fix locally, run \`yarn mcp:e2e:next\`, confirm it fails with a 500. (I did this by hand while developing; happy to script it if you want the regression pinned.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)