### PR TITLE
fix(mcp): delegate tool uses chat.send (sessions.send has wrong param shape)

### DIFF
--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -591,14 +591,28 @@ export function registerAllTools(server: McpServer): void {
       // post-mortem for task cc3d40e1 — :main delegations were aborted).
       const sessionKey = `agent:${args.peer_gateway_id}:task-${args.task_id}`;
 
-      // Use the low-level call so we can provide timeoutSeconds + idempotency.
-      // sessions.send is the RPC method name in the gateway.
+      // We use `chat.send` (not `sessions.send`) — same RPC the dispatch
+      // route uses — because it implicitly creates the session on first
+      // send. `sessions.send` requires the session to already exist and
+      // fails with "session not found" for a fresh per-task key. The
+      // observed live failure was:
+      //
+      //   invalid sessions.send params: must have required property 'key';
+      //   at root: unexpected property 'sessionKey'; at root: unexpected
+      //   property 'timeoutSeconds'
+      //
+      // fixed by moving to chat.send, whose param shape is
+      // `{sessionKey, message, idempotencyKey}`. The `timeout_seconds`
+      // argument on the MCP tool is now advisory-only: chat.send is
+      // fire-and-forget by default; the gateway decides session lifecycle.
+      // We keep the argument on the tool schema for forward-compat.
+      const idempotencyKey = `delegate-${args.task_id}-${args.peer_gateway_id}-${Date.now()}`;
       let sendResult: Record<string, unknown> = {};
       try {
-        sendResult = ((await client.call('sessions.send', {
+        sendResult = ((await client.call('chat.send', {
           sessionKey,
           message: args.message,
-          timeoutSeconds: args.timeout_seconds ?? 0,
+          idempotencyKey,
         })) as Record<string, unknown>) ?? {};
       } catch (err) {
         return {


### PR DESCRIPTION
Fixes the errors visible on /debug/mcp right now: every \`delegate\` tool call shows

\`\`\`
✗ invalid sessions.send params: must have required property 'key';
  at root: unexpected property 'sessionKey';
  at root: unexpected property 'timeoutSeconds'
\`\`\`

## Two problems, one change

1. **Wrong param names.** The gateway's \`sessions.send\` RPC takes \`{key, message}\`, not \`{sessionKey, message, timeoutSeconds}\`. I had copy-pasted the shape from \`chat.send\` (where \`sessionKey\` is correct).

2. **Wrong RPC method.** Even after fixing the names, \`sessions.send\` requires the session to already exist — fresh per-task keys like \`agent:mc-researcher:task-<uuid>\` fail with "session not found".

The fix: switch from \`sessions.send\` to \`chat.send\`. Dispatch already uses \`chat.send\` successfully; it creates the session implicitly on first send. Param shape matches what we were sending: \`{sessionKey, message, idempotencyKey}\`.

The MCP tool's \`timeout_seconds\` argument becomes advisory-only and is no longer forwarded to the gateway. \`chat.send\` is fire-and-forget by default; I kept the arg on the tool's inputSchema for forward-compat in case we wire a different call shape later.

## Verified live

After rebuilding the container:

\`\`\`json
{
  "isError": null,
  "audit": "4009568d-540d-4c50-9674-3a6549d6f866",
  "peer": "Researcher",
  "key": "agent:mc-researcher:task-7b7ff874-e82f-4775-9f9e-bcebf92c0fa0"
}
\`\`\`

vs the pre-fix:

\`\`\`json
{
  "error": "sessions_send_failed",
  "message": "invalid sessions.send params: must have required property 'key'; …"
}
\`\`\`

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] 10 existing MCP tests pass in isolation
- [x] Live delegate against the running container — succeeds, audit activity logged, session message dispatched
- [ ] Watch \`/debug/mcp\` post-merge — the \`tool:delegate\` rows should show \`duration_ms\` without the error snippet

🤖 Generated with [Claude Code](https://claude.com/claude-code)