### PR TITLE
feat(mcp): add sc-mission-control__save_knowledge tool + migrate learner

### DIFF
--- a/docs/MCP-QUICKSTART.md
+++ b/docs/MCP-QUICKSTART.md
@@ -87,7 +87,8 @@ curl -sS \
 # [
 #   "whoami", "list_peers", "get_task", "fetch_mail",
 #   "register_deliverable", "log_activity", "update_task_status",
-#   "fail_task", "save_checkpoint", "send_mail", "delegate"
+#   "fail_task", "save_checkpoint", "send_mail", "delegate",
+#   "save_knowledge"
 # ]
 ```
 
@@ -179,7 +180,8 @@ Edit `~/.openclaw/openclaw.json`. Find `mc-writer` in `agents.list` and add the 
       "sc-mission-control__fail_task",
       "sc-mission-control__save_checkpoint",
       "sc-mission-control__send_mail",
-      "sc-mission-control__delegate"
+      "sc-mission-control__delegate",
+      "sc-mission-control__save_knowledge"
     ]
   }
 }
@@ -211,7 +213,7 @@ openclaw agent --agent mc-writer \
   --timeout 45
 ```
 
-Expect 11 names, all prefixed with `sc-mission-control__`:
+Expect 12 names, all prefixed with `sc-mission-control__`:
 
 ```
 sc-mission-control__whoami
@@ -225,6 +227,7 @@ sc-mission-control__fail_task
 sc-mission-control__save_checkpoint
 sc-mission-control__send_mail
 sc-mission-control__delegate
+sc-mission-control__save_knowledge
 ```
 
 If the tools are missing, the launcher almost certainly failed to connect upstream. The launcher's own `diagnose()` helper (see `mcp-launcher/launcher.mjs`) emits a targeted hint to stderr that openclaw captures in the gateway log. Tail it and look for `[launcher]` lines:
@@ -285,7 +288,7 @@ The debug export also shows the `ok=true` / `duration_ms=N` on each tool-call ro
 
 Open **[http://localhost:4001/debug/mcp](http://localhost:4001/debug/mcp)** — the purpose-built MCP dashboard added in PR 9. You'll see:
 
-- Endpoint status + tool count (should be 11)
+- Endpoint status + tool count (should be 12)
 - Calls last hour / last day / lifetime + error counts (tone-coded: red when there are errors)
 - Per-tool table with call volumes, average / max latency, last-called
 - Per-agent breakdown
@@ -299,7 +302,7 @@ If **Endpoint = Disabled**, step 1 didn't stick. If **Tools = 0**, the MC build 
 
 Once mc-writer has completed two back-to-back tasks cleanly:
 
-Copy the same 11-entry `alsoAllow` block (from step 3) into each of the other `mc-*` agents in `openclaw.json`, OR merge **PR 5** which flips `MC_MCP_PILOT_AGENTS` default from "explicit allowlist" to "all gateway agents". After PR 5, no agent-list maintenance is needed — every dispatch to a gateway agent uses the MCP path.
+Copy the same 12-entry `alsoAllow` block (from step 3) into each of the other `mc-*` agents in `openclaw.json`, OR merge **PR 5** which flips `MC_MCP_PILOT_AGENTS` default from "explicit allowlist" to "all gateway agents". After PR 5, no agent-list maintenance is needed — every dispatch to a gateway agent uses the MCP path.
 
 A one-liner to fan out the same allowlist to every `mc-*` agent (after editing one agent by hand):
 
@@ -310,7 +313,8 @@ p = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
 TOOLS = [f'sc-mission-control__{t}' for t in
     ['whoami','list_peers','get_task','fetch_mail',
      'register_deliverable','log_activity','update_task_status',
-     'fail_task','save_checkpoint','send_mail','delegate']]
+     'fail_task','save_checkpoint','send_mail','delegate',
+     'save_knowledge']]
 c = json.loads(p.read_text())
 for a in c.get('agents', {}).get('list', []):
     if not a.get('id','').startswith('mc-'): continue
@@ -395,7 +399,7 @@ openclaw gateway restart
 |---|---|
 | `src/app/api/mcp/route.ts` | HTTP entry for `/mcp` (stateless per-request `McpServer`) |
 | `src/lib/mcp/server.ts` | Builds the server, registers tools |
-| `src/lib/mcp/tools.ts` | All 11 tool definitions + handlers |
+| `src/lib/mcp/tools.ts` | All 12 tool definitions + handlers |
 | `src/lib/mcp/errors.ts` | Maps `AuthzError` → tool-error result |
 | `src/lib/mcp/debug.ts` | `mcp.tool_call` debug-log rows |
 | `src/lib/authz/agent-task.ts` | `assertAgentCanActOnTask` — every state change passes through |
@@ -407,7 +411,7 @@ openclaw gateway restart
 | `scripts/mcp-next-e2e.seed.ts` | Sibling seeder for the Next.js E2E |
 | `src/lib/openclaw/worker-context.ts` | Writes MC-CONTEXT.json (just `my_agent_id` now) |
 
-## 9. Reference: all 11 tools
+## 9. Reference: all 12 tools
 
 | Tool | Args | Use |
 |---|---|---|
@@ -422,3 +426,4 @@ openclaw gateway restart
 | `save_checkpoint` | `agent_id, task_id, state_summary[, …]` | Checkpoint snapshot |
 | `send_mail` | `agent_id, to_agent_id, body[, subject, task_id, …]` | Inter-agent mail |
 | `delegate` | `coordinator_agent_id, task_id, peer_gateway_id, slice, message[, timeout_seconds]` | Coordinator-only; atomic send+audit |
+| `save_knowledge` | `agent_id, workspace_id, category, title, content[, task_id, tags, confidence]` | Learner writes a lesson to the workspace knowledge base |

--- a/scripts/mcp-integration-test.mjs
+++ b/scripts/mcp-integration-test.mjs
@@ -230,6 +230,7 @@ try {
     'save_checkpoint',
     'send_mail',
     'delegate',
+    'save_knowledge',
   ]) {
     expect(names.has(t), `tools/list should expose ${t}`);
   }
@@ -346,6 +347,40 @@ try {
   const peerIds = new Set(structured(peers).peers.map((p) => p.id));
   expect(peerIds.has(outsiderId), 'list_peers should include outsider agent');
   expect(peerIds.has(recipientId), 'list_peers should include recipient agent');
+
+  // ── 13. save_knowledge writes a knowledge_entries row ──
+  const saved = await callTool('save_knowledge', {
+    agent_id: agentId,
+    workspace_id: 'default',
+    task_id: taskId,
+    category: 'pattern',
+    title: 'E2E pattern',
+    content: 'Learned during the e2e run.',
+    tags: ['e2e'],
+    confidence: 0.7,
+  });
+  expect(!isError(saved), `save_knowledge should succeed; got ${JSON.stringify(saved)}`);
+  const savedEntry = structured(saved).entry;
+  expect(savedEntry?.title === 'E2E pattern', 'save_knowledge should echo the title');
+  const knowledgeRow = queryOne(
+    `SELECT id, category, title FROM knowledge_entries WHERE id = ?`,
+    [savedEntry?.id],
+  );
+  expect(knowledgeRow?.title === 'E2E pattern', 'knowledge_entries row should exist with the title');
+
+  const deniedKnowledge = await callTool('save_knowledge', {
+    agent_id: outsiderId,
+    workspace_id: 'default',
+    task_id: taskId,
+    category: 'pattern',
+    title: 'should not land',
+    content: 'outsider attempt',
+  });
+  expect(isError(deniedKnowledge), 'save_knowledge should reject off-task outsider');
+  expect(
+    structured(deniedKnowledge).error === 'authz_denied',
+    `expected authz_denied; got ${JSON.stringify(structured(deniedKnowledge))}`,
+  );
 } finally {
   launcher.kill('SIGTERM');
   await new Promise((r) => launcher.once('close', r));
@@ -365,4 +400,4 @@ if (failures.length) {
   for (const f of failures) console.error('  -', f);
   process.exit(1);
 }
-console.log('[e2e] OK — full flow validated (handshake → tools/list → whoami → evidence gate → register → log → transition → authz → send_mail → list_peers)');
+console.log('[e2e] OK — full flow validated (handshake → tools/list → whoami → evidence gate → register → log → transition → authz → send_mail → list_peers → save_knowledge)');

--- a/src/app/api/workspaces/[id]/knowledge/route.ts
+++ b/src/app/api/workspaces/[id]/knowledge/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { queryAll, run } from '@/lib/db';
+import { queryAll } from '@/lib/db';
+import { saveKnowledge, type KnowledgeCategory } from '@/lib/services/knowledge';
+import { AuthzError } from '@/lib/authz/agent-task';
 
 export const dynamic = 'force-dynamic';
 
@@ -68,21 +70,22 @@ export async function POST(
       );
     }
 
-    const id = crypto.randomUUID();
+    const entry = saveKnowledge({
+      actingAgentId: created_by_agent_id || null,
+      workspaceId,
+      taskId: task_id || undefined,
+      category: category as KnowledgeCategory,
+      title,
+      content,
+      tags,
+      confidence,
+    });
 
-    run(
-      `INSERT INTO knowledge_entries (id, workspace_id, task_id, category, title, content, tags, confidence, created_by_agent_id, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
-      [
-        id, workspaceId, task_id || null, category, title, content,
-        tags ? JSON.stringify(tags) : null,
-        confidence ?? 0.5,
-        created_by_agent_id || null
-      ]
-    );
-
-    return NextResponse.json({ id, message: 'Knowledge entry created' }, { status: 201 });
+    return NextResponse.json({ id: entry.id, message: 'Knowledge entry created' }, { status: 201 });
   } catch (error) {
+    if (error instanceof AuthzError) {
+      return NextResponse.json({ error: error.code, message: error.message }, { status: 403 });
+    }
     console.error('Failed to create knowledge entry:', error);
     return NextResponse.json({ error: 'Failed to create entry' }, { status: 500 });
   }

--- a/src/lib/learner.ts
+++ b/src/lib/learner.ts
@@ -6,7 +6,6 @@
  */
 
 import { queryOne, queryAll, run } from '@/lib/db';
-import { getMissionControlUrl } from '@/lib/config';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
 import type { KnowledgeEntry, TaskRole, OpenClawSession } from '@/lib/types';
@@ -48,8 +47,6 @@ export async function notifyLearner(
     [learnerRole.agent_id, 'active']
   );
 
-  const missionControlUrl = getMissionControlUrl();
-
   const learningMessage = `📚 **STAGE TRANSITION — LEARNING CAPTURE**
 
 **Task:** ${task.title} (${taskId})
@@ -59,17 +56,18 @@ ${event.failReason ? `**Failure Reason:** ${event.failReason}` : ''}
 ${event.context ? `**Context:** ${event.context}` : ''}
 
 **Your job:** Analyze this transition and capture any lessons learned.
-When done, call this API to save your findings:
+When done, call this MCP tool to save your findings:
 
-POST ${missionControlUrl}/api/workspaces/${task.workspace_id}/knowledge
-Body: {
-  "task_id": "${taskId}",
-  "category": "failure" | "fix" | "pattern" | "checklist",
-  "title": "Brief lesson title",
-  "content": "Detailed description of what was learned",
-  "tags": ["relevant", "tags"],
-  "confidence": 0.8
-}
+sc-mission-control__save_knowledge({
+  agent_id: "<your agent_id — call sc-mission-control__whoami if unknown>",
+  workspace_id: "${task.workspace_id}",
+  task_id: "${taskId}",
+  category: "failure" | "fix" | "pattern" | "checklist",
+  title: "<brief lesson title>",
+  content: "<detailed description of what was learned>",
+  tags: ["relevant", "tags"],
+  confidence: 0.8
+})
 
 Focus on:
 - What went wrong (if failed)

--- a/src/lib/mcp/mcp.test.ts
+++ b/src/lib/mcp/mcp.test.ts
@@ -73,6 +73,7 @@ test('tools/list returns the full sc-mission-control tool surface', async () => 
     'save_checkpoint',
     'send_mail',
     'delegate',
+    'save_knowledge',
   ]) {
     assert.ok(names.has(expected), `missing tool: ${expected}`);
   }
@@ -256,4 +257,84 @@ test('send_mail with task_id rejects an off-task sender', async () => {
   assert.equal(res.isError, true);
   const payload = parseStructured<{ error: string; code: string }>(res);
   assert.equal(payload.error, 'authz_denied');
+});
+
+// ─── save_knowledge ─────────────────────────────────────────────────
+
+test('save_knowledge happy path writes an entry for a learner agent', async () => {
+  const { client } = await makePair();
+  const learner = seedAgent({ role: 'learner' });
+  const task = seedTask({ assigned: learner });
+
+  const res = await client.callTool({
+    name: 'save_knowledge',
+    arguments: {
+      agent_id: learner,
+      workspace_id: 'default',
+      task_id: task,
+      category: 'failure',
+      title: 'Build failed due to missing import',
+      content: 'The builder forgot to import foo.',
+      tags: ['build', 'imports'],
+      confidence: 0.85,
+    },
+  });
+  assert.equal(res.isError, undefined);
+  const payload = parseStructured<{
+    entry: {
+      task_id: string;
+      category: string;
+      title: string;
+      tags: string[];
+      confidence: number;
+      created_by_agent_id: string;
+    };
+  }>(res);
+  assert.equal(payload.entry.task_id, task);
+  assert.equal(payload.entry.category, 'failure');
+  assert.equal(payload.entry.created_by_agent_id, learner);
+  assert.deepEqual(payload.entry.tags, ['build', 'imports']);
+  assert.equal(payload.entry.confidence, 0.85);
+});
+
+test('save_knowledge returns authz_denied when agent is not on the task', async () => {
+  const { client } = await makePair();
+  const outsider = seedAgent({ role: 'learner' });
+  const task = seedTask();
+
+  const res = await client.callTool({
+    name: 'save_knowledge',
+    arguments: {
+      agent_id: outsider,
+      workspace_id: 'default',
+      task_id: task,
+      category: 'pattern',
+      title: 'nope',
+      content: 'should not land',
+    },
+  });
+  assert.equal(res.isError, true);
+  const payload = parseStructured<{ error: string; code: string }>(res);
+  assert.equal(payload.error, 'authz_denied');
+  assert.equal(payload.code, 'agent_not_on_task');
+});
+
+test('save_knowledge workspace-only (no task_id) requires only active agent', async () => {
+  const { client } = await makePair();
+  const learner = seedAgent({ role: 'learner' });
+
+  const res = await client.callTool({
+    name: 'save_knowledge',
+    arguments: {
+      agent_id: learner,
+      workspace_id: 'default',
+      category: 'pattern',
+      title: 'General pattern',
+      content: 'Use dependency injection for db handles.',
+    },
+  });
+  assert.equal(res.isError, undefined);
+  const payload = parseStructured<{ entry: { task_id?: string; confidence: number } }>(res);
+  assert.equal(payload.entry.task_id, undefined);
+  assert.equal(payload.entry.confidence, 0.5);
 });

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -1,7 +1,7 @@
 /**
  * sc-mission-control MCP tools.
  *
- * All 11 tools consolidated into one file. Each tool is a thin wrapper
+ * All 12 tools consolidated into one file. Each tool is a thin wrapper
  * around a service-layer function (src/lib/services/*) that handles
  * authorization, DB work, and broadcasts.
  *
@@ -26,6 +26,7 @@ import { transitionTaskStatus } from '@/lib/services/task-status';
 import { failTask } from '@/lib/services/task-failure';
 import { saveTaskCheckpoint } from '@/lib/services/task-checkpoint';
 import { sendAgentMail } from '@/lib/services/agent-mailbox';
+import { saveKnowledge } from '@/lib/services/knowledge';
 import { getUnreadMail } from '@/lib/mailbox';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 
@@ -510,6 +511,61 @@ export function registerAllTools(server: McpServer): void {
         rollcall_id: result.rollcallId ?? null,
       };
       return textResult(JSON.stringify(payload, null, 2), payload);
+    }),
+  );
+
+  // save_knowledge ────────────────────────────────────────────────
+  // Used by the Learner agent at stage transitions to capture lessons
+  // learned (failure patterns, fixes, checklists, best practices). The
+  // learner-knowledge pipeline (src/lib/learner.ts) injects these into
+  // future builder dispatches via `formatKnowledgeForDispatch`.
+  server.registerTool(
+    'save_knowledge',
+    {
+      title: 'Save a learning / lesson to workspace knowledge',
+      description:
+        "Record a lesson learned from a task transition. Used by the Learner agent at stage transitions (pass/fail) to capture failure patterns, fixes, checklists, and best practices that future dispatches can inject via the learner-knowledge pipeline.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        workspace_id: z
+          .string()
+          .min(1)
+          .describe(
+            'The workspace this lesson applies to. Use the workspace of the task being observed.',
+          ),
+        task_id: z
+          .string()
+          .optional()
+          .describe(
+            'When the lesson is derived from a specific task, the task id. Enables cross-referencing.',
+          ),
+        category: z.enum(['failure', 'fix', 'pattern', 'checklist']),
+        title: z.string().min(1).max(500),
+        content: z.string().min(1).max(20000),
+        tags: z.array(z.string().min(1).max(100)).optional(),
+        confidence: z
+          .number()
+          .min(0)
+          .max(1)
+          .optional()
+          .describe(
+            '0..1. Higher for patterns seen multiple times; lower for first-time observations.',
+          ),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    trace('save_knowledge', async (args) => {
+      const entry = saveKnowledge({
+        actingAgentId: args.agent_id,
+        workspaceId: args.workspace_id,
+        taskId: args.task_id,
+        category: args.category,
+        title: args.title,
+        content: args.content,
+        tags: args.tags,
+        confidence: args.confidence,
+      });
+      return textResult(JSON.stringify(entry, null, 2), { entry });
     }),
   );
 

--- a/src/lib/services/knowledge.ts
+++ b/src/lib/services/knowledge.ts
@@ -1,0 +1,97 @@
+/**
+ * Knowledge-entry service.
+ *
+ * Shared by the HTTP route (`/api/workspaces/:id/knowledge`) and the MCP
+ * `save_knowledge` tool. Handles authorization, DB insert + read-back, and
+ * tag-array normalization. HTTP-wrapper concerns (request parsing, response
+ * shaping) stay in the route.
+ *
+ * Throws `AuthzError` on authorization failure.
+ */
+
+import { getDb } from '@/lib/db';
+import { assertAgentActive, assertAgentCanActOnTask } from '@/lib/authz/agent-task';
+import type { KnowledgeEntry } from '@/lib/types';
+
+export type KnowledgeCategory = 'failure' | 'fix' | 'pattern' | 'checklist';
+
+export interface SaveKnowledgeInput {
+  /** `null` for operator flows — skip authorization. */
+  actingAgentId: string | null;
+  workspaceId: string;
+  /** When set, the calling agent must be on this task. */
+  taskId?: string;
+  category: KnowledgeCategory;
+  title: string;
+  content: string;
+  tags?: string[];
+  /** 0..1 — caller already validated range. */
+  confidence?: number;
+}
+
+interface KnowledgeRow {
+  id: string;
+  workspace_id: string;
+  task_id: string | null;
+  category: string;
+  title: string;
+  content: string;
+  tags: string | null;
+  confidence: number;
+  created_by_agent_id: string | null;
+  created_at: string;
+}
+
+export function saveKnowledge(input: SaveKnowledgeInput): KnowledgeEntry {
+  const { actingAgentId, workspaceId, taskId, category, title, content, tags, confidence } =
+    input;
+
+  if (actingAgentId) {
+    if (taskId) {
+      // Task-scoped lesson: same gate as log_activity — must be on the task.
+      assertAgentCanActOnTask(actingAgentId, taskId, 'activity');
+    } else {
+      // Workspace-level lesson (no task): just prove the agent is real
+      // and active. Workspace isolation isn't enforced here because the
+      // bearer-token transport is the trust boundary today; this mirrors
+      // the stance of `send_mail` without task_id.
+      assertAgentActive(actingAgentId);
+    }
+  }
+
+  const db = getDb();
+  const id = crypto.randomUUID();
+
+  db.prepare(
+    `INSERT INTO knowledge_entries
+       (id, workspace_id, task_id, category, title, content, tags, confidence, created_by_agent_id, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+  ).run(
+    id,
+    workspaceId,
+    taskId ?? null,
+    category,
+    title,
+    content,
+    tags && tags.length ? JSON.stringify(tags) : null,
+    confidence ?? 0.5,
+    actingAgentId,
+  );
+
+  const row = db
+    .prepare(`SELECT * FROM knowledge_entries WHERE id = ?`)
+    .get(id) as KnowledgeRow;
+
+  return {
+    id: row.id,
+    workspace_id: row.workspace_id,
+    task_id: row.task_id ?? undefined,
+    category: row.category,
+    title: row.title,
+    content: row.content,
+    tags: row.tags ? (JSON.parse(row.tags) as string[]) : [],
+    confidence: row.confidence,
+    created_by_agent_id: row.created_by_agent_id ?? undefined,
+    created_at: row.created_at,
+  };
+}

--- a/src/lib/services/services.test.ts
+++ b/src/lib/services/services.test.ts
@@ -17,6 +17,7 @@ import { failTask } from './task-failure';
 import { saveTaskCheckpoint } from './task-checkpoint';
 import { sendAgentMail } from './agent-mailbox';
 import { transitionTaskStatus } from './task-status';
+import { saveKnowledge } from './knowledge';
 
 function seedAgent(opts: { id?: string; workspace?: string; role?: string } = {}): string {
   const id = opts.id ?? crypto.randomUUID();
@@ -269,4 +270,166 @@ test('sendAgentMail happy path writes and returns a message', async () => {
     assert.equal(result.message.to_agent_id, recipient);
     assert.equal(result.message.body, 'hello');
   }
+});
+
+// ─── knowledge ──────────────────────────────────────────────────────
+
+test('saveKnowledge throws AuthzError when agent_id is set with task_id but agent is off-task', () => {
+  const outsider = seedAgent();
+  const task = seedTask();
+  assert.throws(
+    () =>
+      saveKnowledge({
+        actingAgentId: outsider,
+        workspaceId: 'default',
+        taskId: task,
+        category: 'pattern',
+        title: 't',
+        content: 'c',
+      }),
+    (err: unknown) => err instanceof AuthzError,
+  );
+});
+
+test('saveKnowledge happy path (workspace-only, no task_id)', () => {
+  const agent = seedAgent({ role: 'learner' });
+  const entry = saveKnowledge({
+    actingAgentId: agent,
+    workspaceId: 'default',
+    category: 'pattern',
+    title: 'Learned thing',
+    content: 'Some detail',
+    tags: ['testing'],
+    confidence: 0.75,
+  });
+  assert.equal(entry.workspace_id, 'default');
+  assert.equal(entry.category, 'pattern');
+  assert.equal(entry.title, 'Learned thing');
+  assert.equal(entry.confidence, 0.75);
+  assert.deepEqual(entry.tags, ['testing']);
+  assert.equal(entry.created_by_agent_id, agent);
+  assert.equal(entry.task_id, undefined);
+});
+
+test('saveKnowledge happy path when agent is on the task', () => {
+  const agent = seedAgent({ role: 'learner' });
+  const task = seedTask({ assigned: agent });
+  const entry = saveKnowledge({
+    actingAgentId: agent,
+    workspaceId: 'default',
+    taskId: task,
+    category: 'failure',
+    title: 'Boom',
+    content: 'It exploded',
+  });
+  assert.equal(entry.task_id, task);
+  assert.equal(entry.confidence, 0.5);
+  assert.deepEqual(entry.tags, []);
+});
+
+test('saveKnowledge skips authz when actingAgentId is null (operator flow)', () => {
+  const entry = saveKnowledge({
+    actingAgentId: null,
+    workspaceId: 'default',
+    category: 'checklist',
+    title: 'op note',
+    content: 'x',
+  });
+  assert.equal(entry.title, 'op note');
+  assert.equal(entry.created_by_agent_id, undefined);
+});
+
+test('saveKnowledge throws AuthzError for missing acting agent', () => {
+  assert.throws(
+    () =>
+      saveKnowledge({
+        actingAgentId: crypto.randomUUID(),
+        workspaceId: 'default',
+        category: 'pattern',
+        title: 't',
+        content: 'c',
+      }),
+    (err: unknown) => err instanceof AuthzError,
+  );
+});
+
+// ─── knowledge ──────────────────────────────────────────────────────
+
+test('saveKnowledge throws AuthzError when agent_id is set with task_id but agent is off-task', () => {
+  const outsider = seedAgent();
+  const task = seedTask();
+  assert.throws(
+    () =>
+      saveKnowledge({
+        actingAgentId: outsider,
+        workspaceId: 'default',
+        taskId: task,
+        category: 'pattern',
+        title: 't',
+        content: 'c',
+      }),
+    (err: unknown) => err instanceof AuthzError,
+  );
+});
+
+test('saveKnowledge happy path (workspace-only, no task_id)', () => {
+  const agent = seedAgent({ role: 'learner' });
+  const entry = saveKnowledge({
+    actingAgentId: agent,
+    workspaceId: 'default',
+    category: 'pattern',
+    title: 'Learned thing',
+    content: 'Some detail',
+    tags: ['testing'],
+    confidence: 0.75,
+  });
+  assert.equal(entry.workspace_id, 'default');
+  assert.equal(entry.category, 'pattern');
+  assert.equal(entry.title, 'Learned thing');
+  assert.equal(entry.confidence, 0.75);
+  assert.deepEqual(entry.tags, ['testing']);
+  assert.equal(entry.created_by_agent_id, agent);
+  assert.equal(entry.task_id, undefined);
+});
+
+test('saveKnowledge happy path when agent is on the task', () => {
+  const agent = seedAgent({ role: 'learner' });
+  const task = seedTask({ assigned: agent });
+  const entry = saveKnowledge({
+    actingAgentId: agent,
+    workspaceId: 'default',
+    taskId: task,
+    category: 'failure',
+    title: 'Boom',
+    content: 'It exploded',
+  });
+  assert.equal(entry.task_id, task);
+  assert.equal(entry.confidence, 0.5); // default
+  assert.deepEqual(entry.tags, []); // null → []
+});
+
+test('saveKnowledge skips authz when actingAgentId is null (operator flow)', () => {
+  const entry = saveKnowledge({
+    actingAgentId: null,
+    workspaceId: 'default',
+    category: 'checklist',
+    title: 'op note',
+    content: 'x',
+  });
+  assert.equal(entry.title, 'op note');
+  assert.equal(entry.created_by_agent_id, undefined);
+});
+
+test('saveKnowledge throws AuthzError for missing acting agent', () => {
+  assert.throws(
+    () =>
+      saveKnowledge({
+        actingAgentId: crypto.randomUUID(),
+        workspaceId: 'default',
+        category: 'pattern',
+        title: 't',
+        content: 'c',
+      }),
+    (err: unknown) => err instanceof AuthzError,
+  );
 });


### PR DESCRIPTION
PR 14 of the sc-mission-control MCP adapter stack. Finishes the agent-facing HTTP → MCP migration by covering the last remaining call site: the Learner's stage-transition notification.

Before PR 12 landed, the Learner's notification body still instructed agents to:

```
POST ${MC_URL}/api/workspaces/<ws>/knowledge
Body: { task_id, category, title, content, tags, confidence }
```

after every stage transition. No MCP tool covered knowledge saving, so PR 12 left this one for a follow-up. This PR adds the tool and rewrites the Learner's notification to use it.

## What changed

**New service helper** `src/lib/services/knowledge.ts`
`saveKnowledge()` owns the `knowledge_entries` INSERT + read-back + tag normalization, following the `actingAgentId`-null-for-operator + `assertAgentCanActOnTask` pattern of the other services. Workspace-only lessons (no `task_id`) downgrade authz to `assertAgentActive`, same stance as `send_mail` without `task_id`.

**New MCP tool** `sc-mission-control__save_knowledge` in `src/lib/mcp/tools.ts`
Same `trace()` + zod shape as the other 11 tools. Args:
- Required: `agent_id`, `workspace_id`, `category` (`failure`/`fix`/`pattern`/`checklist`), `title`, `content`
- Optional: `task_id`, `tags`, `confidence` (0..1)

**HTTP route refactor** `src/app/api/workspaces/[id]/knowledge/route.ts`
POST handler now calls `saveKnowledge()` so HTTP + MCP share one implementation. `AuthzError` → 403.

**Learner migration** `src/lib/learner.ts:51-78`

Before:

```
**Your job:** Analyze this transition and capture any lessons learned.
When done, call this API to save your findings:

POST ${missionControlUrl}/api/workspaces/${task.workspace_id}/knowledge
Body: {
  "task_id": "${taskId}",
  "category": "failure" | "fix" | "pattern" | "checklist",
  "title": "Brief lesson title",
  "content": "Detailed description of what was learned",
  "tags": ["relevant", "tags"],
  "confidence": 0.8
}
```

After:

```
**Your job:** Analyze this transition and capture any lessons learned.
When done, call this MCP tool to save your findings:

sc-mission-control__save_knowledge({
  agent_id: "<your agent_id — call sc-mission-control__whoami if unknown>",
  workspace_id: "${task.workspace_id}",
  task_id: "${taskId}",
  category: "failure" | "fix" | "pattern" | "checklist",
  title: "<brief lesson title>",
  content: "<detailed description of what was learned>",
  tags: ["relevant", "tags"],
  confidence: 0.8
})
```

Dropped the now-unused `getMissionControlUrl` import.

**Tests**
- `src/lib/services/services.test.ts`: +5 cases — authz-violation with `task_id`, workspace-only happy path, on-task happy path, operator-null flow, AuthzError for missing acting agent.
- `src/lib/mcp/mcp.test.ts`: +3 cases — happy path with tags+confidence, `authz_denied` for off-task agent, workspace-only path. Expected-tool-list in `tools/list` bumped to 12.
- `scripts/mcp-integration-test.mjs`: `tools/list` expect-set grows to 12; added a save_knowledge happy-path + authz-denied assertion block with a direct sqlite verify of the new row.

**Docs** `docs/MCP-QUICKSTART.md`
Counts bumped 11 → 12 in: step 1 curl example output, step 3 `alsoAllow` block, step 4.1 expected-tool-list, step 4.4 dashboard expectation, step 5 Python fan-out, step 8 file table, step 9 tools reference (with the new row).

`src/app/api/debug/mcp/status/route.ts` reads `_registeredTools` dynamically so no code change there — the count just auto-updates to 12.

## Why

Every agent-facing MC interaction should go through the typed MCP surface so (a) transport auth lives in the launcher, not in the agent's message body, and (b) MC enforces agent-task authz server-side rather than relying on bearer-token possession. The Learner's knowledge POST was the last exception; this closes it.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `services.test.ts` + `mcp.test.ts` + `authz/agent-task.test.ts` — 56/56 pass
- [x] Docker rebuild + restart, `/api/debug/mcp/status` reports `tool_count=12` and `save_knowledge` in the names list
- [x] Live MCP call to `save_knowledge` persists a `knowledge_entries` row (verified via MC's own `GET /api/workspaces/default/knowledge` — went from 4 entries to 5 entries with the expected title/confidence/tags/created_by_agent_id)
- [x] `/api/debug/mcp/status` per-tool stats show `save_knowledge: 1 call, 0 errors, 1ms` after the smoke
- [ ] End-to-end: dispatch a task with a learner role, observe the transition-notification mail shape includes the MCP tool invocation (not the HTTP POST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)