### PR TITLE
feat(planning): validation-first phased planner flow + explicit Lock & Dispatch

### DIFF
--- a/src/app/api/tasks/[id]/planning/advance/route.ts
+++ b/src/app/api/tasks/[id]/planning/advance/route.ts
@@ -1,0 +1,123 @@
+/**
+ * POST /api/tasks/[id]/planning/advance
+ *
+ * User-gated phase transition. The planner never advances its own phase —
+ * it emits "I'm confident" or "I'm done researching" and waits. This
+ * endpoint is what the UI calls when the user clicks "Start research" or
+ * "Continue to plan", and it sends the appropriate kickoff prompt to the
+ * planner session so the next round of work begins.
+ *
+ * Request body: { to: 'research' | 'plan' }
+ *
+ * Legal transitions:
+ *   clarify → research     (only if last clarify envelope said needs_research:true
+ *                           or the user override-forces it via force:true)
+ *   clarify → plan         (default when clarify is done and research isn't needed)
+ *   research → plan        (after research_done envelope)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { queryOne, run } from '@/lib/db';
+import { getOpenClawClient } from '@/lib/openclaw/client';
+import { broadcast } from '@/lib/events';
+import {
+  buildResearchKickoffPrompt,
+  buildPlanKickoffPrompt,
+} from '@/lib/planner-prompt';
+import type { Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: taskId } = await params;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const to = body.to as 'research' | 'plan' | undefined;
+    if (to !== 'research' && to !== 'plan') {
+      return NextResponse.json(
+        { error: 'Invalid advance target — must be "research" or "plan"' },
+        { status: 400 }
+      );
+    }
+
+    const task = queryOne<{
+      id: string;
+      planning_session_key?: string;
+      planning_phase?: string;
+      planning_understanding?: string;
+      planning_unknowns?: string;
+      planning_research?: string;
+    }>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+
+    if (!task) {
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    }
+    if (!task.planning_session_key) {
+      return NextResponse.json({ error: 'Planning has not started' }, { status: 400 });
+    }
+
+    const currentPhase = task.planning_phase || 'clarify';
+
+    // Validate transition is legal.
+    if (to === 'research' && currentPhase !== 'clarify') {
+      return NextResponse.json(
+        { error: `Cannot advance to research from phase "${currentPhase}"` },
+        { status: 400 }
+      );
+    }
+    if (to === 'plan' && currentPhase !== 'clarify' && currentPhase !== 'research') {
+      return NextResponse.json(
+        { error: `Cannot advance to plan from phase "${currentPhase}"` },
+        { status: 400 }
+      );
+    }
+
+    const understanding = task.planning_understanding || '(understanding not recorded)';
+    const unknowns: string[] = task.planning_unknowns ? JSON.parse(task.planning_unknowns) : [];
+    const research = task.planning_research ? JSON.parse(task.planning_research) : null;
+
+    // Build the prompt for the new phase.
+    let prompt: string;
+    if (to === 'research') {
+      prompt = buildResearchKickoffPrompt({ understanding, unknowns });
+    } else {
+      prompt = buildPlanKickoffPrompt({
+        understanding,
+        researchSummary: research?.summary,
+      });
+    }
+
+    // Send the kickoff message. The poll endpoint will pick up whatever the
+    // planner emits next.
+    const client = getOpenClawClient();
+    if (!client.isConnected()) await client.connect();
+    await client.call('chat.send', {
+      sessionKey: task.planning_session_key,
+      message: prompt,
+      idempotencyKey: `planning-advance-${to}-${taskId}-${Date.now()}`,
+    });
+
+    // Record the transition. We store the "target" phase optimistically so the
+    // UI renders the right loader while the planner responds. The poll loop
+    // will replace it with 'research' or 'confirm' based on what comes back.
+    run(
+      `UPDATE tasks SET planning_phase = ?, updated_at = datetime('now') WHERE id = ?`,
+      [to, taskId]
+    );
+
+    const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (updatedTask) broadcast({ type: 'task_updated', payload: updatedTask });
+
+    return NextResponse.json({ success: true, phase: to });
+  } catch (err) {
+    console.error('[Planning Advance] Error:', err);
+    return NextResponse.json(
+      { error: 'Failed to advance planning phase: ' + (err as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tasks/[id]/planning/answer/route.ts
+++ b/src/app/api/tasks/[id]/planning/answer/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
-import { extractJSON } from '@/lib/planning-utils';
+import { buildClarifyAnswerPrompt } from '@/lib/planner-prompt';
 
 export const dynamic = 'force-dynamic';
 // POST /api/tasks/[id]/planning/answer - Submit an answer and get next question
@@ -37,71 +37,14 @@ export async function POST(
     }
 
     // Build the answer message
-    const answerText = answer?.toLowerCase() === 'other' && otherText 
+    const answerText = answer?.toLowerCase() === 'other' && otherText
       ? `Other: ${otherText}`
       : answer;
 
-    const answerPrompt = `User's answer: ${answerText}
-
-Based on this answer and the conversation so far, either:
-1. Ask your next question (if you need more information)
-2. Complete the planning (if you have enough information)
-
-For another question, respond with JSON:
-{
-  "question": "Your next question?",
-  "options": [
-    {"id": "A", "label": "Option A"},
-    {"id": "B", "label": "Option B"},
-    {"id": "other", "label": "Other"}
-  ]
-}
-
-If planning is complete, respond with JSON using the STRUCTURED spec shape (every deliverable must have id/kind/acceptance — no bare strings):
-
-{
-  "status": "complete",
-  "spec": {
-    "title": "Task title",
-    "summary": "Summary of what needs to be done",
-    "deliverables": [
-      {
-        "id": "short-machine-id",
-        "title": "Human-readable name",
-        "kind": "file",
-        "path_pattern": "relative/path.ext",
-        "acceptance": "Binary testable assertion — what the file must contain or do"
-      }
-    ],
-    "success_criteria": [
-      {
-        "id": "sc-1",
-        "assertion": "Binary pass/fail assertion",
-        "how_to_test": "Specific command, step, or check the tester runs"
-      }
-    ],
-    "constraints": {}
-  },
-  "agents": [
-    {
-      "name": "Agent Name",
-      "role": "Agent role",
-      "avatar_emoji": "🎯",
-      "soul_md": "Agent personality...",
-      "instructions": "Specific instructions..."
-    }
-  ],
-  "execution_plan": {
-    "approach": "How to execute",
-    "steps": ["Step 1", "Step 2"]
-  }
-}
-
-RULES:
-- Every major artifact gets its own deliverables entry. An HTML app with a service worker is AT LEAST four entries (index.html, styles.css, app.js, sw.js), not one "PWA module".
-- kind=file REQUIRES path_pattern. Name the file — do not say "some CSS file".
-- kind=behavior REQUIRES a testable acceptance ("page loads from cache with network disabled", not "works offline").
-- success_criteria entries must each be independently pass/fail-able.`;
+    // In the enhanced flow, /answer is ONLY called during the clarify phase.
+    // Other transitions (start research, move to plan, submit a tweak, lock &
+    // dispatch) have dedicated endpoints so the state machine stays explicit.
+    const answerPrompt = buildClarifyAnswerPrompt(answerText);
 
     // Parse existing messages
     const messages = task.planning_messages ? JSON.parse(task.planning_messages) : [];

--- a/src/app/api/tasks/[id]/planning/force-complete/route.ts
+++ b/src/app/api/tasks/[id]/planning/force-complete/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { queryOne, run } from '@/lib/db';
-import { extractJSON } from '@/lib/planning-utils';
+import { parsePlanningEnvelope, type PlanEnvelope } from '@/lib/planning-envelope';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { v4 as uuidv4 } from 'uuid';
@@ -42,13 +42,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     const messages = task.planning_messages ? JSON.parse(task.planning_messages) : [];
     
-    // Scan messages from the end looking for the completion JSON
-    let completionParsed: any = null;
+    // Scan messages from the end looking for a plan envelope (new shape) or
+    // a legacy `status: complete` completion (old shape). parsePlanningEnvelope
+    // classifies both.
+    let completionParsed: PlanEnvelope | null = null;
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].role === 'assistant') {
-        const parsed = extractJSON(messages[i].content);
-        if (parsed && (parsed as any).status === 'complete') {
-          completionParsed = parsed;
+        const { envelope } = parsePlanningEnvelope(messages[i].content);
+        if (envelope?.kind === 'plan') {
+          completionParsed = envelope;
           break;
         }
       }
@@ -104,10 +106,11 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // Update task
+    // Update task — set planning_phase to 'complete' to match new flow.
     run(
-      `UPDATE tasks SET 
+      `UPDATE tasks SET
          planning_complete = 1,
+         planning_phase = 'complete',
          planning_spec = ?,
          planning_agents = ?,
          assigned_agent_id = ?,

--- a/src/app/api/tasks/[id]/planning/lock/route.ts
+++ b/src/app/api/tasks/[id]/planning/lock/route.ts
@@ -1,0 +1,61 @@
+/**
+ * POST /api/tasks/[id]/planning/lock
+ *
+ * Final confirmation step of the enhanced planning flow. Moves a task whose
+ * planner has produced a spec (phase = 'confirm') into 'complete' status and
+ * fires the dispatch endpoint. This is the one and only place where planning
+ * commits — no other route auto-dispatches.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { queryOne } from '@/lib/db';
+import { lockAndDispatch } from '@/lib/planning-persist';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: taskId } = await params;
+
+  try {
+    const task = queryOne<{
+      id: string;
+      planning_phase?: string;
+      planning_complete?: number;
+      planning_spec?: string;
+    }>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+
+    if (!task) return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    if (task.planning_complete) {
+      return NextResponse.json({ error: 'Planning already locked' }, { status: 400 });
+    }
+    if (task.planning_phase !== 'confirm') {
+      return NextResponse.json(
+        { error: `Can only lock from confirm phase (current: ${task.planning_phase})` },
+        { status: 400 }
+      );
+    }
+    if (!task.planning_spec) {
+      return NextResponse.json(
+        { error: 'No spec to lock — planner has not produced a plan yet' },
+        { status: 400 }
+      );
+    }
+
+    const { firstAgentId, dispatchError } = await lockAndDispatch(taskId);
+
+    return NextResponse.json({
+      success: !dispatchError,
+      firstAgentId,
+      dispatchError,
+    });
+  } catch (err) {
+    console.error('[Planning Lock] Error:', err);
+    return NextResponse.json(
+      { error: 'Failed to lock planning: ' + (err as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tasks/[id]/planning/poll/route.ts
+++ b/src/app/api/tasks/[id]/planning/poll/route.ts
@@ -1,228 +1,81 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { queryOne, run, getDb, queryAll } from '@/lib/db';
+import { queryOne, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
-import { getMissionControlUrl } from '@/lib/config';
-import { extractJSON, getMessagesFromOpenClaw } from '@/lib/planning-utils';
-import { findAgentForRole, verifyAgentInWorkspace } from '@/lib/agent-resolver';
+import { getMessagesFromOpenClaw } from '@/lib/planning-utils';
+import { parsePlanningEnvelope, type PlanningEnvelope } from '@/lib/planning-envelope';
+import { persistPlannerPlan } from '@/lib/planning-persist';
+import { buildReformatPrompt } from '@/lib/planner-prompt';
 import { Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
-// Planning timeout and poll interval configuration with validation
-const PLANNING_TIMEOUT_MS = parseInt(process.env.PLANNING_TIMEOUT_MS || '30000', 10);
-const PLANNING_POLL_INTERVAL_MS = parseInt(process.env.PLANNING_POLL_INTERVAL_MS || '2000', 10);
 
-// Validate environment variables
-if (isNaN(PLANNING_TIMEOUT_MS) || PLANNING_TIMEOUT_MS < 1000) {
-  throw new Error('PLANNING_TIMEOUT_MS must be a valid number >= 1000ms');
-}
-if (isNaN(PLANNING_POLL_INTERVAL_MS) || PLANNING_POLL_INTERVAL_MS < 100) {
-  throw new Error('PLANNING_POLL_INTERVAL_MS must be a valid number >= 100ms');
-}
-
-// Helper to handle planning completion with proper error handling
-async function handlePlanningCompletion(taskId: string, parsed: any, messages: any[]) {
-  const db = getDb();
-  let dispatchError: string | null = null;
-  let firstAgentId: string | null = null;
-
-  // Transaction 1: Save planning data, create agents, AND assign agent to task
-  // (Assigning before dispatch fixes the chicken-and-egg bug where dispatch
-  // checks assigned_agent_id and fails because it wasn't set yet)
-  const transaction = db.transaction(() => {
-    const allowDynamicAgents = process.env.ALLOW_DYNAMIC_AGENTS !== 'false';
-
-    if (allowDynamicAgents && parsed.agents && parsed.agents.length > 0) {
-      // Get the master agent's session_key_prefix to use for new agents
-      const task = db.prepare('SELECT workspace_id FROM tasks WHERE id = ?').get(taskId) as { workspace_id: string } | undefined;
-      const masterAgent = task ? db.prepare(
-        `SELECT session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`
-      ).get(task.workspace_id) as { session_key_prefix?: string } | undefined : undefined;
-
-      // Only inherit an explicit prefix if the master has one set. When it's
-      // null we leave the new agent's prefix null too — the runtime
-      // resolver (resolveAgentSessionKeyPrefix) will default to the new
-      // agent's own namespace at send time instead of baking in the
-      // `agent:main:` catchall that misrouted everything to the gateway's
-      // main agent.
-      const sessionKeyPrefix = masterAgent?.session_key_prefix || null;
-
-      const insertAgent = db.prepare(`
-        INSERT INTO agents (id, workspace_id, name, role, description, avatar_emoji, status, soul_md, session_key_prefix, created_at, updated_at)
-        VALUES (?, (SELECT workspace_id FROM tasks WHERE id = ?), ?, ?, ?, ?, 'standby', ?, ?, datetime('now'), datetime('now'))
-      `);
-
-      const workspaceId = task?.workspace_id;
-
-      // For each agent the planner wants to spin up, first check whether the
-      // workspace already has a gateway-linked (or session-routed) agent that
-      // fills this role. If so, reuse it — this is the core fix for the ghost
-      // agent duplication bug. Only when no existing agent matches (or the
-      // planner gave an explicit agent_id that we've verified) do we create a
-      // new row.
-      for (const agent of parsed.agents) {
-        let resolvedId: string | null = null;
-
-        if (workspaceId && agent.agent_id) {
-          const verified = verifyAgentInWorkspace(workspaceId, agent.agent_id);
-          if (verified) {
-            resolvedId = verified.id;
-          } else {
-            console.warn(`[Planning Poll] Planner returned unknown agent_id ${agent.agent_id} for role "${agent.role}" — falling back to role match`);
-          }
-        }
-
-        if (!resolvedId && workspaceId && agent.role) {
-          const existing = findAgentForRole(workspaceId, agent.role);
-          if (existing) {
-            resolvedId = existing.id;
-            console.log(`[Planning Poll] Reusing existing agent ${existing.name} (${existing.id}) for role "${agent.role}" — skipping insert`);
-          }
-        }
-
-        if (!resolvedId) {
-          resolvedId = crypto.randomUUID();
-          insertAgent.run(
-            resolvedId,
-            taskId,
-            agent.name,
-            agent.role,
-            agent.instructions || '',
-            agent.avatar_emoji || '🤖',
-            agent.soul_md || '',
-            sessionKeyPrefix
-          );
-        }
-
-        if (!firstAgentId) firstAgentId = resolvedId;
-      }
-    } else if (!allowDynamicAgents && parsed.agents && parsed.agents.length > 0) {
-      console.log(`[Planning Poll] Dynamic agent generation disabled (ALLOW_DYNAMIC_AGENTS=false), skipping creation of ${parsed.agents.length} agent(s)`);
-    }
-
-    // Save planning data + assign the first agent + mark complete in one atomic step
-    db.prepare(`
-      UPDATE tasks
-      SET planning_messages = ?,
-          planning_spec = ?,
-          planning_agents = ?,
-          planning_complete = 1,
-          assigned_agent_id = ?,
-          status = 'assigned',
-          planning_dispatch_error = NULL,
-          updated_at = datetime('now')
-      WHERE id = ?
-    `).run(
-      JSON.stringify(messages),
-      JSON.stringify(parsed.spec),
-      JSON.stringify(parsed.agents),
-      firstAgentId,
-      taskId
-    );
-
-    return firstAgentId;
-  });
-
-  firstAgentId = transaction();
-
-  // Re-check for other orchestrators before dispatching
-  if (firstAgentId) {
-    const task = queryOne<{ workspace_id: string }>('SELECT workspace_id FROM tasks WHERE id = ?', [taskId]);
-    if (task) {
-      const defaultMaster = queryOne<{ id: string }>(
-        `SELECT id FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
-        [task.workspace_id]
+/**
+ * Apply a single planner envelope to the task row. This is the state-machine
+ * dispatcher — it keeps the business rules for "what does this phase do with
+ * this envelope" in one place and lets the HTTP handler stay thin.
+ */
+function applyEnvelope(taskId: string, envelope: PlanningEnvelope): void {
+  switch (envelope.kind) {
+    case 'clarify_question': {
+      run(
+        `UPDATE tasks
+         SET planning_phase = 'clarify',
+             planning_understanding = ?,
+             planning_unknowns = ?,
+             updated_at = datetime('now')
+         WHERE id = ?`,
+        [
+          envelope.understanding || null,
+          envelope.unknowns.length ? JSON.stringify(envelope.unknowns) : null,
+          taskId,
+        ]
       );
-      const otherOrchestrators = queryAll<{ id: string; name: string }>(
-        `SELECT id, name FROM agents WHERE is_master = 1 AND id != ? AND workspace_id = ? AND status != 'offline'`,
-        [defaultMaster?.id ?? '', task.workspace_id]
+      return;
+    }
+    case 'clarify_done': {
+      run(
+        `UPDATE tasks
+         SET planning_phase = 'clarify',
+             planning_understanding = ?,
+             planning_unknowns = ?,
+             updated_at = datetime('now')
+         WHERE id = ?`,
+        [
+          envelope.understanding || null,
+          envelope.unknowns.length ? JSON.stringify(envelope.unknowns) : null,
+          taskId,
+        ]
       );
-
-      if (otherOrchestrators.length > 0) {
-        dispatchError = `Cannot auto-dispatch: ${otherOrchestrators.length} other orchestrator(s) available in workspace`;
-        console.warn(`[Planning Poll] ${dispatchError}:`, otherOrchestrators.map(o => o.name).join(', '));
-        firstAgentId = null;
-      }
+      return;
     }
-  }
-
-  // Idempotency check — only skip dispatch if the agent has actually started working.
-  // A task stuck in 'in_progress' with no recent activity means a prior dispatch was
-  // silently lost (e.g. broken WebSocket) and MUST be retried.
-  let skipDispatch = false;
-  if (firstAgentId) {
-    const currentTask = queryOne<{ status: string; updated_at: string }>('SELECT status, updated_at FROM tasks WHERE id = ?', [taskId]);
-    if (currentTask?.status === 'in_progress') {
-      // Check for any agent activity since dispatch — if none, allow re-dispatch
-      const recentActivity = queryOne<{ cnt: number }>(
-        `SELECT COUNT(*) as cnt FROM task_activities WHERE task_id = ? AND created_at > datetime('now', '-2 minutes')`,
-        [taskId]
+    case 'research_done': {
+      const payload = {
+        summary: envelope.summary,
+        updated_unknowns: envelope.updated_unknowns,
+        done_at: new Date().toISOString(),
+      };
+      run(
+        `UPDATE tasks
+         SET planning_research = ?,
+             planning_unknowns = ?,
+             updated_at = datetime('now')
+         WHERE id = ?`,
+        [
+          JSON.stringify(payload),
+          envelope.updated_unknowns.length ? JSON.stringify(envelope.updated_unknowns) : null,
+          taskId,
+        ]
       );
-      if (recentActivity && recentActivity.cnt > 0) {
-        console.log('[Planning Poll] Task in progress with recent agent activity, skipping dispatch');
-        skipDispatch = true;
-      } else {
-        console.log('[Planning Poll] Task in_progress but no recent agent activity — retrying dispatch (likely lost message)');
-        // Reset to assigned so dispatch can proceed cleanly
-        run('UPDATE tasks SET status = ?, updated_at = datetime(\'now\') WHERE id = ?', ['assigned', taskId]);
-      }
+      return;
+    }
+    case 'plan': {
+      // Store spec+agents and move to the confirm phase. Persist WITHOUT
+      // dispatching — the user must explicitly click Lock & Dispatch.
+      persistPlannerPlan(taskId, envelope);
+      return;
     }
   }
-
-  // Trigger dispatch using proper URL resolution
-  if (firstAgentId && !skipDispatch) {
-    const missionControlUrl = getMissionControlUrl();
-    const dispatchUrl = `${missionControlUrl}/api/tasks/${taskId}/dispatch`;
-    console.log(`[Planning Poll] Triggering dispatch: ${dispatchUrl}`);
-
-    try {
-      const dispatchHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (process.env.MC_API_TOKEN) {
-        dispatchHeaders['Authorization'] = `Bearer ${process.env.MC_API_TOKEN}`;
-      }
-
-      const dispatchRes = await fetch(dispatchUrl, {
-        method: 'POST',
-        headers: dispatchHeaders,
-        signal: AbortSignal.timeout(30_000),
-      });
-
-      if (dispatchRes.ok) {
-        console.log(`[Planning Poll] Dispatch successful`);
-      } else {
-        const errorText = await dispatchRes.text();
-        dispatchError = `Dispatch failed (${dispatchRes.status}): ${errorText}`;
-        console.error(`[Planning Poll] ${dispatchError}`);
-      }
-    } catch (err) {
-      dispatchError = `Dispatch error: ${(err as Error).message}`;
-      console.error(`[Planning Poll] ${dispatchError}`);
-    }
-  }
-
-  // On dispatch failure: keep planning data intact, just record the error.
-  // Task stays in 'assigned' so user can retry dispatch without re-planning.
-  if (dispatchError) {
-    run(
-      `UPDATE tasks SET planning_dispatch_error = ?, status_reason = ?, updated_at = datetime('now') WHERE id = ?`,
-      [dispatchError, 'Dispatch failed: ' + dispatchError, taskId]
-    );
-    console.log(`[Planning Poll] Dispatch failed for task ${taskId}, planning data preserved: ${dispatchError}`);
-  } else if (!firstAgentId) {
-    // No agent created — move to inbox for manual assignment
-    run(
-      `UPDATE tasks SET status = 'inbox', planning_dispatch_error = NULL, updated_at = datetime('now') WHERE id = ?`,
-      [taskId]
-    );
-  }
-
-  // Broadcast task update
-  const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
-  if (updatedTask) {
-    broadcast({ type: 'task_updated', payload: updatedTask });
-  }
-
-  return { firstAgentId, parsed, dispatchError };
 }
 
 // GET /api/tasks/[id]/planning/poll - Check for new messages from OpenClaw
@@ -239,6 +92,10 @@ export async function GET(
       planning_messages?: string;
       planning_complete?: number;
       planning_dispatch_error?: string;
+      planning_phase?: string;
+      planning_understanding?: string;
+      planning_unknowns?: string;
+      planning_research?: string;
     }>('SELECT * FROM tasks WHERE id = ?', [taskId]);
 
     if (!task || !task.planning_session_key) {
@@ -258,177 +115,142 @@ export async function GET(
     }
 
     const messages = task.planning_messages ? JSON.parse(task.planning_messages) : [];
-    // Count only assistant messages for comparison, since OpenClaw only returns assistant messages
-    const initialAssistantCount = messages.filter((m: any) => m.role === 'assistant').length;
+    const initialAssistantCount = messages.filter((m: { role: string }) => m.role === 'assistant').length;
 
-    console.log('[Planning Poll] Task', taskId, 'has', messages.length, 'total messages,', initialAssistantCount, 'assistant messages');
-
-    // Check OpenClaw for new messages (lightweight check, not a loop)
     const openclawMessages = await getMessagesFromOpenClaw(task.planning_session_key);
 
-    console.log('[Planning Poll] Comparison: stored_assistant=', initialAssistantCount, 'openclaw_assistant=', openclawMessages.length);
-
     if (openclawMessages.length > initialAssistantCount) {
-      let currentQuestion = null;
+      let currentQuestion:
+        | { question: string; options: Array<{ id: string; label: string }>; understanding?: string; unknowns?: string[] }
+        | null = null;
+      let clarifyDone:
+        | { understanding: string; unknowns: string[]; needs_research: boolean; research_rationale?: string }
+        | null = null;
+      let researchDone: { summary: string; updated_unknowns: string[] } | null = null;
+      let planReady = false;
+      let phaseAfter: string = task.planning_phase || 'clarify';
+
       const newMessages = openclawMessages.slice(initialAssistantCount);
-      console.log('[Planning Poll] Processing', newMessages.length, 'new messages');
-
-      // Find new assistant messages
       for (const msg of newMessages) {
-        console.log('[Planning Poll] Processing new message, role:', msg.role, 'content length:', msg.content?.length || 0);
+        if (msg.role !== 'assistant') continue;
+        const stored = { role: 'assistant' as const, content: msg.content, timestamp: Date.now() };
+        messages.push(stored);
 
-        if (msg.role === 'assistant') {
-          const lastMessage = { role: 'assistant', content: msg.content, timestamp: Date.now() };
-          messages.push(lastMessage);
-
-          // Check if this message contains completion status or a question
-          const parsed = extractJSON(msg.content) as {
-            status?: string;
-            question?: string;
-            options?: Array<{ id: string; label: string }>;
-            spec?: object;
-            agents?: Array<{
-              name: string;
-              role: string;
-              avatar_emoji?: string;
-              soul_md?: string;
-              instructions?: string;
-              /** Optional: planner may reuse an existing workspace agent by id. */
-              agent_id?: string | null;
-              /** Optional: why a new agent is needed vs. reusing one from the roster. */
-              rationale?: string;
-            }>;
-            execution_plan?: object;
-          } | null;
-
-          console.log('[Planning Poll] Parsed message content:', {
-            hasStatus: !!parsed?.status,
-            hasQuestion: !!parsed?.question,
-            hasOptions: !!parsed?.options,
-            status: parsed?.status,
-            question: parsed?.question?.substring(0, 50),
-            rawPreview: msg.content?.substring(0, 200)
-          });
-
-          if (parsed && parsed.status === 'complete') {
-            // Handle completion
-            console.log('[Planning Poll] Planning complete, handling...');
-            const { firstAgentId, parsed: fullParsed, dispatchError } = await handlePlanningCompletion(taskId, parsed, messages);
-
-            return NextResponse.json({
-              hasUpdates: true,
-              complete: true,
-              spec: fullParsed.spec,
-              agents: fullParsed.agents,
-              executionPlan: fullParsed.execution_plan,
-              messages,
-              autoDispatched: !!firstAgentId,
-              dispatchError,
-            });
-          }
-
-          // Extract current question if present (be tolerant if options are missing)
-          if (parsed && parsed.question) {
-            const normalizedOptions = Array.isArray(parsed.options) && parsed.options.length > 0
-              ? parsed.options
-              : [
-                  { id: 'continue', label: 'Continue' },
-                  { id: 'other', label: 'Other' },
-                ];
-            console.log('[Planning Poll] Found question with', normalizedOptions.length, 'options');
-            currentQuestion = {
-              question: parsed.question,
-              options: normalizedOptions,
-            };
-          }
+        const { envelope, reason } = parsePlanningEnvelope(msg.content);
+        if (!envelope) {
+          // Fall through to the reformat path below — we handle it once after
+          // the loop so the auto-retry only fires on the LAST bad message.
+          continue;
         }
+
+        applyEnvelope(taskId, envelope);
+
+        switch (envelope.kind) {
+          case 'clarify_question':
+            currentQuestion = {
+              question: envelope.question,
+              options: envelope.options.length
+                ? envelope.options
+                : [{ id: 'continue', label: 'Continue' }, { id: 'other', label: 'Other' }],
+              understanding: envelope.understanding,
+              unknowns: envelope.unknowns,
+            };
+            phaseAfter = 'clarify';
+            break;
+          case 'clarify_done':
+            clarifyDone = {
+              understanding: envelope.understanding,
+              unknowns: envelope.unknowns,
+              needs_research: envelope.needs_research,
+              research_rationale: envelope.research_rationale,
+            };
+            phaseAfter = 'clarify';
+            break;
+          case 'research_done':
+            researchDone = {
+              summary: envelope.summary,
+              updated_unknowns: envelope.updated_unknowns,
+            };
+            phaseAfter = 'research';
+            break;
+          case 'plan':
+            planReady = true;
+            phaseAfter = 'confirm';
+            break;
+        }
+        // Log classification outcome for diagnostics
+        console.log(
+          `[Planning Poll] Task ${taskId} envelope kind=${envelope.kind}${reason ? ' reason=' + reason : ''}`
+        );
       }
 
-      console.log('[Planning Poll] Returning updates: currentQuestion =', currentQuestion ? 'YES' : 'NO');
-
-      // Update database
+      // Persist the updated message log.
       run('UPDATE tasks SET planning_messages = ? WHERE id = ?', [JSON.stringify(messages), taskId]);
+
+      // If we saw a new plan envelope, read back spec+agents (persistPlannerPlan
+      // wrote them during applyEnvelope).
+      let spec: unknown = null;
+      let agents: unknown = null;
+      if (planReady) {
+        const fresh = queryOne<{ planning_spec?: string; planning_agents?: string }>(
+          `SELECT planning_spec, planning_agents FROM tasks WHERE id = ?`,
+          [taskId]
+        );
+        if (fresh?.planning_spec) spec = JSON.parse(fresh.planning_spec);
+        if (fresh?.planning_agents) agents = JSON.parse(fresh.planning_agents);
+      }
+
+      // Broadcast task update so other UI surfaces reflect phase changes.
+      const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+      if (updatedTask) {
+        broadcast({ type: 'task_updated', payload: updatedTask });
+      }
 
       return NextResponse.json({
         hasUpdates: true,
         complete: false,
         messages,
+        phase: phaseAfter,
         currentQuestion,
+        clarifyDone,
+        researchDone,
+        planReady,
+        spec,
+        agents,
       });
     }
 
-    // FALLBACK: Check if the last stored message is actually a completion that was
-    // saved but never processed (race condition where message was stored but
-    // extractJSON failed or the completion handler never fired).
-    const lastAssistantMsg = [...messages].reverse().find((m: any) => m.role === 'assistant');
+    // FALLBACK: If the last stored assistant message was a plan/complete that
+    // never got applied (race condition or a crash during applyEnvelope),
+    // re-apply it now. Since plan envelopes no longer auto-dispatch, this is
+    // safe to do repeatedly — persistPlannerPlan just overwrites spec/agents.
+    const lastAssistantMsg = [...messages].reverse().find((m: { role: string }) => m.role === 'assistant');
     if (lastAssistantMsg) {
-      const parsed = extractJSON(lastAssistantMsg.content) as { status?: string; question?: string; options?: unknown; spec?: object; agents?: any[]; execution_plan?: object } | null;
-      if (parsed && parsed.status === 'complete') {
-        console.log('[Planning Poll] FALLBACK: Found unprocessed completion in stored messages — handling now');
-        const { firstAgentId, parsed: fullParsed, dispatchError } = await handlePlanningCompletion(taskId, parsed, messages);
+      const { envelope, reason } = parsePlanningEnvelope(lastAssistantMsg.content);
+      if (envelope?.kind === 'plan' && task.planning_phase !== 'confirm' && task.planning_phase !== 'complete') {
+        applyEnvelope(taskId, envelope);
+        const fresh = queryOne<{ planning_spec?: string; planning_agents?: string }>(
+          `SELECT planning_spec, planning_agents FROM tasks WHERE id = ?`,
+          [taskId]
+        );
         return NextResponse.json({
           hasUpdates: true,
-          complete: true,
-          spec: fullParsed.spec,
-          agents: fullParsed.agents,
-          executionPlan: fullParsed.execution_plan,
+          complete: false,
           messages,
-          autoDispatched: !!firstAgentId,
-          dispatchError,
+          phase: 'confirm',
+          planReady: true,
+          spec: fresh?.planning_spec ? JSON.parse(fresh.planning_spec) : null,
+          agents: fresh?.planning_agents ? JSON.parse(fresh.planning_agents) : null,
         });
       }
 
-      // Unparseable response: first try a single automated reprompt asking
-      // the planner to re-emit strict JSON. Only if that also fails do we
-      // surface parseError to the UI. Most LLM failures here are semantic
-      // (missing schema keys, unescaped quotes) — `jsonrepair` can't fix them,
-      // but the agent usually can when told explicitly what broke.
-      const hasUsableShape = !!(parsed && (parsed.question || parsed.status || parsed.spec));
-      if (!hasUsableShape) {
-        console.error(
-          `[Planning Poll] Unparseable assistant response for task ${taskId}. Full content:\n${lastAssistantMsg.content}`
-        );
-
-        const alreadyReprompted = lastAssistantMsg.reprompted === true;
+      if (!envelope) {
+        // Auto-reprompt on unparseable last message, same single-retry rule
+        // as before. We only retry if we haven't already reprompted this msg.
+        const alreadyReprompted = (lastAssistantMsg as { reprompted?: boolean }).reprompted === true;
 
         if (!alreadyReprompted) {
           const sessionKey = task.planning_session_key;
-          if (!sessionKey) {
-            // Shouldn't happen — we checked earlier — but fail closed.
-            return NextResponse.json({
-              hasUpdates: true,
-              parseError: 'The planning agent returned an unparseable response and no session is available to retry.',
-              rawContent: typeof lastAssistantMsg.content === 'string'
-                ? lastAssistantMsg.content.slice(0, 4000)
-                : String(lastAssistantMsg.content).slice(0, 4000),
-              messages,
-            });
-          }
-
-          const correction = `Your last response could not be parsed as valid JSON. Common issues seen: options missing the "label" key, trailing commas, unescaped quotes, truncation.
-
-Re-emit your last output with STRICTLY VALID JSON that conforms to one of these shapes exactly.
-
-Question shape:
-{
-  "question": "...",
-  "options": [
-    {"id": "A", "label": "..."},
-    {"id": "B", "label": "..."},
-    {"id": "other", "label": "Other"}
-  ]
-}
-
-Completion shape:
-{
-  "status": "complete",
-  "spec": {...},
-  "agents": [...],
-  "execution_plan": {...}
-}
-
-EVERY option object MUST have BOTH "id" and "label" string keys. Emit ONLY the JSON object — no prose, no code fences.`;
-
           try {
             const client = getOpenClawClient();
             if (!client.isConnected()) {
@@ -436,7 +258,7 @@ EVERY option object MUST have BOTH "id" and "label" string keys. Emit ONLY the J
             }
             await client.call('chat.send', {
               sessionKey,
-              message: correction,
+              message: buildReformatPrompt(reason || 'Not a recognized planning envelope'),
               idempotencyKey: `planning-reprompt-${taskId}-${Date.now()}`,
             });
             console.log(`[Planning Poll] Sent reformat correction to planner for task ${taskId}`);
@@ -445,16 +267,12 @@ EVERY option object MUST have BOTH "id" and "label" string keys. Emit ONLY the J
             return NextResponse.json({
               hasUpdates: true,
               parseError: `Planner returned invalid JSON and the reformat request also failed: ${(err as Error).message}`,
-              rawContent: typeof lastAssistantMsg.content === 'string'
-                ? lastAssistantMsg.content.slice(0, 4000)
-                : String(lastAssistantMsg.content).slice(0, 4000),
+              rawContent: lastAssistantMsg.content.slice(0, 4000),
               messages,
             });
           }
 
-          // Mark this message so a future malformed reply falls through to
-          // parseError (we only auto-retry once per bad message).
-          const taggedMessages = messages.map((m: any) =>
+          const taggedMessages = messages.map((m: { role: string; content: string; timestamp: number; reprompted?: boolean }) =>
             m === lastAssistantMsg ? { ...m, reprompted: true } : m
           );
           run('UPDATE tasks SET planning_messages = ? WHERE id = ?', [JSON.stringify(taggedMessages), taskId]);
@@ -466,28 +284,25 @@ EVERY option object MUST have BOTH "id" and "label" string keys. Emit ONLY the J
           });
         }
 
-        // Already reprompted once and the retry is also malformed — surface.
         return NextResponse.json({
           hasUpdates: true,
           parseError: 'The planning agent returned malformed JSON twice in a row. Cancel and restart planning, or edit the task and try again.',
-          rawContent: typeof lastAssistantMsg.content === 'string'
-            ? lastAssistantMsg.content.slice(0, 4000)
-            : String(lastAssistantMsg.content).slice(0, 4000),
+          rawContent: lastAssistantMsg.content.slice(0, 4000),
           messages,
         });
       }
     }
 
-    // Check for stale planning — if no new messages for >10 minutes, flag it
+    // Stale-planning heuristic (unchanged) — surface in UI after 10 min idle.
     const lastMsgTimestamp = messages.length > 0 ? messages[messages.length - 1].timestamp : null;
-    const stalePlanningMs = 10 * 60 * 1000; // 10 minutes
-    const isStalePlanning = lastMsgTimestamp && (Date.now() - lastMsgTimestamp) > stalePlanningMs;
+    const stalePlanningMs = 10 * 60 * 1000;
+    const isStalePlanning = lastMsgTimestamp && Date.now() - lastMsgTimestamp > stalePlanningMs;
 
-    console.log('[Planning Poll] No new messages found', isStalePlanning ? '(STALE — over 10min since last message)' : '');
-    return NextResponse.json({ 
+    return NextResponse.json({
       hasUpdates: false,
+      phase: task.planning_phase || 'clarify',
       stalePlanning: isStalePlanning || undefined,
-      staleSinceMs: isStalePlanning ? (Date.now() - lastMsgTimestamp) : undefined,
+      staleSinceMs: isStalePlanning ? Date.now() - lastMsgTimestamp : undefined,
     });
   } catch (error) {
     console.error('Failed to poll for updates:', error);

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb, queryAll, queryOne, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
-import { extractJSON } from '@/lib/planning-utils';
+import { parsePlanningEnvelope } from '@/lib/planning-envelope';
 import { getAgentRoster, formatRosterForPrompt } from '@/lib/agent-resolver';
+import { buildInitialPlannerPrompt } from '@/lib/planner-prompt';
 // File system imports removed - using OpenClaw API instead
 
 export const dynamic = 'force-dynamic';
@@ -43,23 +44,50 @@ export async function GET(
     // Parse planning messages from JSON
     const messages = task.planning_messages ? JSON.parse(task.planning_messages) : [];
 
-    // Find the latest question (last assistant message with question structure)
+    // Classify the latest assistant message into a phased envelope. Legacy
+    // single-phase flows still work — parsePlanningEnvelope handles the old
+    // { question, options } and { status: 'complete', spec } shapes.
     const lastAssistantMessage = [...messages].reverse().find((m: { role: string }) => m.role === 'assistant');
-    let currentQuestion = null;
+    let currentQuestion: { question: string; options: Array<{ id: string; label: string }>; understanding?: string; unknowns?: string[] } | null = null;
+    let clarifyDone: { understanding: string; unknowns: string[]; needs_research: boolean; research_rationale?: string } | null = null;
 
     if (lastAssistantMessage) {
-      // Use extractJSON to handle code blocks and surrounding text
-      const parsed = extractJSON(lastAssistantMessage.content);
-      if (parsed && 'question' in parsed) {
-        currentQuestion = parsed;
+      const { envelope } = parsePlanningEnvelope(lastAssistantMessage.content);
+      if (envelope?.kind === 'clarify_question') {
+        currentQuestion = {
+          question: envelope.question,
+          options: envelope.options,
+          understanding: envelope.understanding,
+          unknowns: envelope.unknowns,
+        };
+      } else if (envelope?.kind === 'clarify_done') {
+        clarifyDone = {
+          understanding: envelope.understanding,
+          unknowns: envelope.unknowns,
+          needs_research: envelope.needs_research,
+          research_rationale: envelope.research_rationale,
+        };
       }
     }
+
+    type TaskRow = typeof task & {
+      planning_phase?: string;
+      planning_understanding?: string;
+      planning_unknowns?: string;
+      planning_research?: string;
+    };
+    const taskRow = task as TaskRow;
 
     return NextResponse.json({
       taskId,
       sessionKey: task.planning_session_key,
       messages,
       currentQuestion,
+      clarifyDone,
+      phase: taskRow.planning_phase ?? 'clarify',
+      understanding: taskRow.planning_understanding ?? null,
+      unknowns: taskRow.planning_unknowns ? JSON.parse(taskRow.planning_unknowns) : [],
+      research: taskRow.planning_research ? JSON.parse(taskRow.planning_research) : null,
       isComplete: !!task.planning_complete,
       spec: task.planning_spec ? JSON.parse(task.planning_spec) : null,
       agents: task.planning_agents ? JSON.parse(task.planning_agents) : null,
@@ -168,87 +196,22 @@ export async function POST(
     // Without this context the planner invents new agents every run, which is
     // the root of the ghost-agent duplication bug: the real gateway agents
     // sit idle while newly-created rows with no session_key_prefix receive
-    // the dispatch. When the planner emits its final `agents` list at status
-    // "complete", it may now return `agent_id` per agent to reuse one of these
-    // existing rows — see the polling handler for reuse/verify logic.
+    // the dispatch. When the planner emits its final plan with an "agents"
+    // array, it can now reuse one of these existing rows by agent_id — see
+    // the polling handler for reuse/verify logic.
     const roster = getAgentRoster(task.workspace_id);
     const rosterBlock = formatRosterForPrompt(roster);
 
-    // Build the initial planning prompt. Two things matter here: the
-    // question-asking loop (which fires now) and the final completion
-    // shape the planner MUST emit once it's done asking. We spell the
-    // completion schema out up front because agents anchor on structure
-    // when shown it once — asking for a binary-testable spec only at the
-    // "answer" stage was producing narrative summaries that downstream
-    // builders then interpreted in the cheapest way possible.
-    const planningPrompt = `PLANNING REQUEST
-
-Task Title: ${task.title}
-Task Description: ${task.description || 'No description provided'}
-
-AVAILABLE AGENTS (workspace roster):
-${rosterBlock}
-
-When you later emit the final plan (status: "complete") with an "agents" array, prefer assigning roles to the agents listed above by including their "agent_id" in each entry. Only propose a new agent (agent_id: null) when no listed agent is a suitable fit — and include a "rationale" explaining the specific capability gap.
-
-You are starting a planning session for this task. Read PLANNING.md for your protocol.
-
-**Your job has two phases:**
-
-PHASE 1 — ask multiple-choice questions until you understand what the user needs.
-PHASE 2 — emit a final spec with STRUCTURED, TESTABLE deliverables and success criteria (see schema below) so downstream builders and testers can objectively tell whether work is done.
-
-**Completion schema** (for when you're ready to emit status: "complete"):
-\`\`\`json
-{
-  "status": "complete",
-  "spec": {
-    "title": "...",
-    "summary": "...",
-    "deliverables": [
-      {
-        "id": "short-machine-id",              // stable id builders use when registering fulfillment
-        "title": "Human-readable name",
-        "kind": "file" | "behavior" | "artifact",
-        "path_pattern": "src/foo.js",          // required when kind=file; relative to the deliverables dir
-        "acceptance": "Binary, testable assertion — e.g. 'exports logShot(data) which persists to IndexedDB db=espresso-shots'"
-      }
-    ],
-    "success_criteria": [
-      {
-        "id": "sc-1",
-        "assertion": "Binary: passes or fails, no ambiguity",
-        "how_to_test": "Specific command, manual step, or assertion the tester runs"
-      }
-    ],
-    "constraints": {}
-  },
-  "agents": [ /* as described above */ ],
-  "execution_plan": {}
-}
-\`\`\`
-
-**Rules for the spec (these are the difference between a working deliverable and a broken mockup):**
-- EVERY major artifact needed to ship the task must be its own entry in \`deliverables\` — not bundled under a vague "module" entry. If the task needs an HTML page + CSS + JS + service worker, that is four deliverables, not one.
-- For \`kind: "file"\`, \`path_pattern\` MUST name the file. No "some JS file" — name it.
-- For \`kind: "behavior"\`, \`acceptance\` MUST be verifiable (e.g. "page loads from cache with network disabled", not "works offline").
-- \`success_criteria\` are for the Tester: each one should be something pass/fail-able. If you can't describe how to test it, it doesn't belong here.
-
-PHASE 1 starts now. Generate your FIRST question to understand what the user needs. Remember:
-- Questions must be multiple choice
-- Include an "Other" option
-- Be specific to THIS task, not generic
-
-Respond with ONLY valid JSON in this format:
-{
-  "question": "Your question here?",
-  "options": [
-    {"id": "A", "label": "First option"},
-    {"id": "B", "label": "Second option"},
-    {"id": "C", "label": "Third option"},
-    {"id": "other", "label": "Other"}
-  ]
-}`;
+    // Validation-first phased prompt. The planner now walks clarify →
+    // (optional) research → plan → confirm → complete rather than a single
+    // Q&A loop ending in auto-dispatch. See src/lib/planner-prompt.ts for
+    // the full protocol and src/lib/planning-envelope.ts for the envelope
+    // schemas both sides agree on.
+    const planningPrompt = buildInitialPlannerPrompt({
+      taskTitle: task.title,
+      taskDescription: task.description || '',
+      rosterBlock,
+    });
 
     // Connect to OpenClaw and send the planning request
     const client = getOpenClawClient();
@@ -268,7 +231,13 @@ Respond with ONLY valid JSON in this format:
 
     getDb().prepare(`
       UPDATE tasks
-      SET planning_session_key = ?, planning_messages = ?, status = 'planning'
+      SET planning_session_key = ?,
+          planning_messages = ?,
+          status = 'planning',
+          planning_phase = 'clarify',
+          planning_understanding = NULL,
+          planning_unknowns = NULL,
+          planning_research = NULL
       WHERE id = ?
     `).run(sessionKey, JSON.stringify(messages), taskId);
 
@@ -308,7 +277,9 @@ export async function DELETE(
       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
     }
 
-    // Clear planning-related fields
+    // Clear planning-related fields (including the enhanced phase columns
+    // from migration 036). Status returns to 'inbox' so the task can be
+    // re-planned cleanly.
     run(`
       UPDATE tasks
       SET planning_session_key = NULL,
@@ -316,6 +287,11 @@ export async function DELETE(
           planning_complete = 0,
           planning_spec = NULL,
           planning_agents = NULL,
+          planning_phase = 'clarify',
+          planning_understanding = NULL,
+          planning_unknowns = NULL,
+          planning_research = NULL,
+          planner_agent_id = NULL,
           status = 'inbox',
           updated_at = datetime('now')
       WHERE id = ?

--- a/src/app/api/tasks/[id]/planning/tweak/route.ts
+++ b/src/app/api/tasks/[id]/planning/tweak/route.ts
@@ -1,0 +1,86 @@
+/**
+ * POST /api/tasks/[id]/planning/tweak
+ *
+ * Free-form spec revision. Once the planner has emitted a plan envelope and
+ * the task is sitting in the confirm phase, the user can submit a tweak
+ * message (e.g. "add a dark mode toggle to deliverables" or "drop the
+ * service worker — PWA is out of scope"). This endpoint forwards the tweak
+ * to the planner; the planner responds with a revised plan in a
+ * `phase: "confirm"` envelope which the poll endpoint persists as the new
+ * spec.
+ *
+ * Request body: { message: string }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { queryOne, run } from '@/lib/db';
+import { getOpenClawClient } from '@/lib/openclaw/client';
+import { buildTweakPrompt } from '@/lib/planner-prompt';
+import { broadcast } from '@/lib/events';
+import type { Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: taskId } = await params;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const message = typeof body.message === 'string' ? body.message.trim() : '';
+    if (!message) {
+      return NextResponse.json({ error: 'message is required' }, { status: 400 });
+    }
+
+    const task = queryOne<{
+      id: string;
+      planning_session_key?: string;
+      planning_phase?: string;
+      planning_complete?: number;
+      planning_messages?: string;
+    }>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+
+    if (!task) return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    if (!task.planning_session_key) {
+      return NextResponse.json({ error: 'Planning has not started' }, { status: 400 });
+    }
+    if (task.planning_complete) {
+      return NextResponse.json(
+        { error: 'Planning is already locked — cannot tweak' },
+        { status: 400 }
+      );
+    }
+    if (task.planning_phase !== 'confirm' && task.planning_phase !== 'plan') {
+      return NextResponse.json(
+        { error: `Tweaks only allowed in confirm phase (current: ${task.planning_phase})` },
+        { status: 400 }
+      );
+    }
+
+    const client = getOpenClawClient();
+    if (!client.isConnected()) await client.connect();
+    await client.call('chat.send', {
+      sessionKey: task.planning_session_key,
+      message: buildTweakPrompt(message),
+      idempotencyKey: `planning-tweak-${taskId}-${Date.now()}`,
+    });
+
+    // Append the tweak to the message log so the UI shows the conversation.
+    const messages = task.planning_messages ? JSON.parse(task.planning_messages) : [];
+    messages.push({ role: 'user', content: `Tweak: ${message}`, timestamp: Date.now() });
+    run(`UPDATE tasks SET planning_messages = ? WHERE id = ?`, [JSON.stringify(messages), taskId]);
+
+    const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (updatedTask) broadcast({ type: 'task_updated', payload: updatedTask });
+
+    return NextResponse.json({ success: true, messages });
+  } catch (err) {
+    console.error('[Planning Tweak] Error:', err);
+    return NextResponse.json(
+      { error: 'Failed to send tweak: ' + (err as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -45,6 +45,7 @@ export async function GET(request: NextRequest) {
           verification: 0,
           done: 0,
           cancelled: 0,
+          needs_user_input: 0,
           total: 0
         };
         

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1932,6 +1932,143 @@ const migrations: Migration[] = [
 
       console.log('[Migration 035] Complete.');
     }
+  },
+  {
+    id: '036',
+    name: 'planning_phases_and_needs_user_input',
+    up: (db) => {
+      // Two related changes rolled into one migration:
+      //
+      // (a) Phased planning: the planner now validates (clarify → optional
+      //     research → plan → user-gated confirm/tweak → complete) instead
+      //     of a single Q&A→dispatch loop. New columns on `tasks` store the
+      //     current phase, planner's restatement of understanding, any
+      //     unknowns it's still tracking, research summary, and which agent
+      //     is planning.
+      //
+      // (b) `needs_user_input` task status: any agent — planner mid-flow or
+      //     worker post-dispatch — can park a task when it hits a decision
+      //     or contradiction outside the plan. Requires expanding the tasks
+      //     status CHECK constraint AND capturing the prior status so we
+      //     can restore it when the user responds.
+      console.log('[Migration 036] Adding planning phase columns, input-request fields, and needs_user_input status...');
+
+      // ---- tasks: new planning-phase + input-request columns ----
+      const tasksInfo = db.prepare('PRAGMA table_info(tasks)').all() as { name: string }[];
+      const taskColExists = (n: string) => tasksInfo.some(c => c.name === n);
+
+      if (!taskColExists('planning_phase')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN planning_phase TEXT DEFAULT 'clarify'`);
+      }
+      if (!taskColExists('planning_understanding')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN planning_understanding TEXT`);
+      }
+      if (!taskColExists('planning_unknowns')) {
+        // JSON array of strings
+        db.exec(`ALTER TABLE tasks ADD COLUMN planning_unknowns TEXT`);
+      }
+      if (!taskColExists('planning_research')) {
+        // JSON: { summary, updated_unknowns, done_at }
+        db.exec(`ALTER TABLE tasks ADD COLUMN planning_research TEXT`);
+      }
+      if (!taskColExists('planner_agent_id')) {
+        // Nullable FK to agents(id); intentionally not DECLARED as a FK here
+        // because ALTER TABLE ADD COLUMN can't declare a FK on an existing
+        // table in SQLite. App-level integrity is enough — the column is
+        // cleared via cancel/completion.
+        db.exec(`ALTER TABLE tasks ADD COLUMN planner_agent_id TEXT`);
+      }
+      if (!taskColExists('status_before_input_request')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN status_before_input_request TEXT`);
+      }
+      if (!taskColExists('input_request')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN input_request TEXT`);
+      }
+      if (!taskColExists('input_request_context')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN input_request_context TEXT`);
+      }
+      if (!taskColExists('input_request_created_at')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN input_request_created_at TEXT`);
+      }
+
+      // ---- agents: ephemeral flag ----
+      const agentsInfo = db.prepare('PRAGMA table_info(agents)').all() as { name: string }[];
+      if (!agentsInfo.some(c => c.name === 'ephemeral')) {
+        db.exec(`ALTER TABLE agents ADD COLUMN ephemeral INTEGER DEFAULT 0`);
+      }
+
+      // ---- tasks.status CHECK: add 'needs_user_input' ----
+      // SQLite can't ALTER a CHECK constraint directly. Two options: rebuild
+      // the table (mechanical, but tasks has 40+ columns and many inbound
+      // FKs — high risk of losing something), or patch sqlite_master via
+      // PRAGMA writable_schema. We take the writable_schema route here — it
+      // is officially documented (https://sqlite.org/pragma.html#pragma_writable_schema)
+      // and only rewrites the CREATE TABLE text for the existing object.
+      // The runMigrations wrapper already has foreign_keys OFF and runs in a
+      // transaction; we add an integrity_check after the rewrite so a
+      // malformed edit aborts the migration before commit.
+      const tasksSchema = db.prepare(
+        `SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'`
+      ).get() as { sql: string } | undefined;
+
+      if (tasksSchema && !tasksSchema.sql.includes("'needs_user_input'")) {
+        const oldCheck = `status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done', 'cancelled')`;
+        const newCheck = `status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done', 'cancelled', 'needs_user_input')`;
+
+        if (!tasksSchema.sql.includes(oldCheck)) {
+          // Defensive: log the actual schema so we can diagnose variants.
+          console.warn('[Migration 036] tasks CHECK constraint shape unexpected; current schema:\n' + tasksSchema.sql);
+          throw new Error('[Migration 036] Unable to locate status CHECK clause in tasks CREATE TABLE — refusing to patch');
+        }
+
+        const patched = tasksSchema.sql.replace(oldCheck, newCheck);
+        // better-sqlite3 blocks modifications of sqlite_master even when
+        // writable_schema is enabled — the driver has its own safety rail.
+        // unsafeMode(true) lifts the block for this migration only; we pair
+        // it with PRAGMA writable_schema and restore both afterwards.
+        // SQL-escape single quotes for the literal. better-sqlite3's prepare()
+        // rejects sqlite_master UPDATEs outright (even with unsafeMode), so
+        // we inline via db.exec() which bypasses the wrapper's safety check.
+        const escaped = patched.replace(/'/g, "''");
+        db.unsafeMode(true);
+        try {
+          db.pragma('writable_schema = ON');
+          db.exec(
+            `UPDATE sqlite_master SET sql = '${escaped}' WHERE type='table' AND name='tasks'`
+          );
+          db.pragma('writable_schema = OFF');
+
+          // integrity_check surfaces any damage caused by the rewrite.
+          // Raising here rolls the migration's transaction back.
+          const integrity = db.prepare('PRAGMA integrity_check').all() as { integrity_check: string }[];
+          const ok = integrity.length === 1 && integrity[0].integrity_check === 'ok';
+          if (!ok) {
+            throw new Error('[Migration 036] integrity_check failed after writable_schema patch: ' + JSON.stringify(integrity));
+          }
+        } finally {
+          db.unsafeMode(false);
+        }
+      }
+
+      // Backfill phase for existing in-flight planning rows. Rows without a
+      // planning_session_key haven't started planning and stay at the default
+      // 'clarify'; rows with a session_key but no spec are mid-flow and we
+      // treat them as 'clarify' too (legacy Q&A loop behaviour maps there);
+      // completed-spec rows jump straight to 'complete' so the new UI shows
+      // the completed state instead of re-opening planning.
+      db.exec(`
+        UPDATE tasks
+        SET planning_phase = 'complete'
+        WHERE planning_complete = 1 AND planning_phase IS NULL
+      `);
+      db.exec(`
+        UPDATE tasks
+        SET planning_phase = 'clarify'
+        WHERE planning_phase IS NULL
+      `);
+
+      console.log('[Migration 036] Complete.');
+    }
   }
 ];
 
@@ -1959,6 +2096,13 @@ function createPreMigrationBackup(db: Database.Database): void {
   // Skip backup for in-memory or temp-file databases (used in tests)
   if (!dbPath || dbPath === ':memory:' || dbPath === '') {
     console.log('[DB] Skipping pre-migration backup for non-file database');
+    return;
+  }
+  // Skip for test databases — backups aren't useful in test runs and the
+  // one-second-resolution timestamp below collides when multiple test files
+  // migrate back-to-back in the same second.
+  if (process.env.NODE_ENV === 'test' || dbPath.includes('/.tmp/')) {
+    console.log('[DB] Skipping pre-migration backup for test database');
     return;
   }
 

--- a/src/lib/planner-prompt.ts
+++ b/src/lib/planner-prompt.ts
@@ -1,0 +1,245 @@
+/**
+ * System prompt builders for the enhanced, validation-first planning flow.
+ *
+ * The planner runs as a phased state machine:
+ *   clarify → research (optional) → plan → confirm → complete
+ *
+ * Each phase uses a focused prompt instead of one giant one. The big win is
+ * that the planner now has explicit validation questions to answer at every
+ * step ("am I solving the right problem?", "do I have enough information?")
+ * rather than racing to produce a spec. This prompt module is the source of
+ * truth for those questions and for the exact envelope shapes the planner
+ * must emit — the envelope parser in planning-envelope.ts is the mirror
+ * image on the reading side.
+ */
+
+export interface PlannerInitialContext {
+  taskTitle: string;
+  taskDescription: string;
+  /** Pre-formatted roster block from agent-resolver.formatRosterForPrompt. */
+  rosterBlock: string;
+}
+
+/**
+ * Prompt sent at the very start of a planning session. Establishes the
+ * validation-first framing, the phased protocol, and the envelope schemas
+ * the planner must conform to. Asks for the first clarify message.
+ */
+export function buildInitialPlannerPrompt(ctx: PlannerInitialContext): string {
+  return `PLANNING REQUEST — validation-first protocol
+
+Task Title: ${ctx.taskTitle}
+Task Description: ${ctx.taskDescription || '(none provided)'}
+
+AVAILABLE AGENTS (workspace roster):
+${ctx.rosterBlock}
+
+You are the planner for this task. You behave like a systems engineer sizing
+a piece of work: the core discipline is VALIDATION — before producing a plan
+you must be able to answer two questions honestly.
+
+  1. Am I solving the right problem?
+     Reflect the request back in your own words. Flag anything ambiguous.
+     Ask targeted questions until you're confident.
+
+  2. Do I have enough information to proceed?
+     List unknowns explicitly. If any unknown blocks a defensible plan,
+     propose research. Otherwise advance straight to the plan.
+
+Not every task deserves heavy ceremony. Simple, well-specified tasks should
+pass quickly through clarify into a plan. Ambiguous or under-specified tasks
+earn extra rounds of clarification and, when warranted, a research step.
+
+# Phased protocol
+
+Each of your responses is a SINGLE JSON object tagged with a "phase" field.
+No prose around it — just the JSON. The user's side advances the phase based
+on what you emit.
+
+Phase: clarify (you start here)
+----------------------------------------
+Either ask a multiple-choice question, or declare confidence.
+
+  (a) Ask a question:
+  {
+    "phase": "clarify",
+    "understanding": "one-sentence restatement of what you think the user wants",
+    "unknowns": ["concrete thing you're not sure about", "..."],
+    "question": "Specific multiple-choice question about one of the unknowns",
+    "options": [
+      {"id": "A", "label": "…"},
+      {"id": "B", "label": "…"},
+      {"id": "other", "label": "Other"}
+    ]
+  }
+
+  (b) Declare confidence:
+  {
+    "phase": "clarify",
+    "understanding": "final restatement — this is what I'll plan against",
+    "unknowns": [],                      // empty if none blocking
+    "confident": true,
+    "needs_research": false              // or true with a rationale
+  }
+
+  If "needs_research": true, include "research_rationale": "why web research
+  would close a specific unknown" — be concrete; do not ask for research as a
+  reflex.
+
+  Questions MUST be multiple-choice with an "Other" option. Ask about ONE
+  thing at a time. Do not re-ask something the user already answered.
+
+Phase: research (only if the user chose to run it)
+----------------------------------------
+When the user advances to research, you will have a web_fetch tool available
+(if it wasn't enabled, the user's side will tell you and skip research).
+Use the tool directly to close the unknowns from clarify — do NOT emit a
+list of queries for someone else to run. When done, emit:
+
+  {
+    "phase": "research",
+    "done": true,
+    "summary": "What you learned, in 3–8 sentences. Cite the URLs you fetched.",
+    "updated_unknowns": []               // anything still unresolved
+  }
+
+Phase: plan
+----------------------------------------
+Produce a structured, testable spec:
+
+  {
+    "phase": "plan",
+    "spec": {
+      "title": "...",
+      "summary": "...",
+      "deliverables": [
+        {
+          "id": "short-machine-id",
+          "title": "Human-readable name",
+          "kind": "file" | "behavior" | "artifact",
+          "path_pattern": "src/foo.js",   // required when kind=file
+          "acceptance": "Binary, testable assertion"
+        }
+      ],
+      "success_criteria": [
+        { "id": "sc-1", "assertion": "Binary pass/fail", "how_to_test": "..." }
+      ],
+      "constraints": {}
+    },
+    "agents": [
+      {
+        "agent_id": "existing-agent-uuid-or-null",
+        "name": "...", "role": "...", "avatar_emoji": "🎯",
+        "soul_md": "...", "instructions": "...",
+        "rationale": "why this agent (or a new one) fits"
+      }
+    ],
+    "execution_plan": { "approach": "...", "steps": ["...", "..."] }
+  }
+
+Rules for a good spec (these are the difference between shippable work and
+a broken mockup):
+- EVERY major artifact gets its own deliverables entry. An HTML app with a
+  service worker is at least four deliverables (index.html, styles.css,
+  app.js, sw.js) — not one vague "PWA module".
+- kind=file REQUIRES path_pattern. Name the file — no "some CSS file".
+- kind=behavior REQUIRES a testable acceptance ("page loads from cache with
+  network disabled", not "works offline").
+- success_criteria entries must each be pass/fail-able on their own.
+- Prefer assigning roles to agents in the roster above by including their
+  "agent_id". Only propose a new agent (agent_id: null) when no listed agent
+  fits, and include a "rationale" naming the specific capability gap.
+
+Phase: confirm (after user tweaks the plan)
+----------------------------------------
+Same shape as "plan" but with "phase": "confirm". Re-emit the revised spec
+incorporating the user's tweak message. Keep anything they didn't change.
+
+# Start now
+
+Respond with ONLY the FIRST clarify envelope. Use the task title/description
+above to draft a one-sentence understanding and your first targeted question.
+Remember: validation first. If the task is clearly specified already, say so
+in "understanding" and move toward "confident: true" on the next turn — do
+not invent busywork.`;
+}
+
+/**
+ * Prompt appended to every user-answer turn during clarify. Reminds the
+ * planner of the envelope schema so it doesn't drift back to prose.
+ */
+export function buildClarifyAnswerPrompt(answerText: string): string {
+  return `User's answer: ${answerText}
+
+Integrate this into your understanding. Then either ask your next clarify
+question or declare "confident": true. Respond with a SINGLE JSON object
+in the "clarify" phase schema from the opening message. No prose.`;
+}
+
+/**
+ * Prompt sent when the user clicks "Start research" after clarify completes.
+ * Tells the planner to use its own tools (web_fetch) and summarize.
+ */
+export function buildResearchKickoffPrompt(params: {
+  understanding: string;
+  unknowns: string[];
+  rationale?: string;
+}): string {
+  return `User has approved research. Use your web_fetch tool to close the
+unknowns you listed — one or more direct fetches, not a generic literature
+review.
+
+Understanding to verify: ${params.understanding}
+Unknowns to close: ${params.unknowns.map((u) => `\n  - ${u}`).join('') || '  (none — decline research and return to clarify)'}
+${params.rationale ? `Your rationale: ${params.rationale}\n` : ''}
+When finished, respond with a SINGLE JSON object:
+{
+  "phase": "research",
+  "done": true,
+  "summary": "3–8 sentences of what you learned; cite the URLs you fetched",
+  "updated_unknowns": []
+}
+No prose around the JSON.`;
+}
+
+/**
+ * Prompt sent when the user clicks "Continue to plan" (either directly after
+ * clarify with confident:true and needs_research:false, or after research).
+ */
+export function buildPlanKickoffPrompt(params: {
+  understanding: string;
+  researchSummary?: string;
+}): string {
+  return `User has approved moving to the plan.
+
+Understanding: ${params.understanding}
+${params.researchSummary ? `Research summary: ${params.researchSummary}\n` : ''}
+Produce the structured plan envelope (phase: "plan") from the opening
+message's schema. Every deliverable must have id/kind/acceptance (kind=file
+requires path_pattern). success_criteria must each be binary-testable.
+Respond with ONLY the JSON object.`;
+}
+
+/**
+ * Prompt sent when the user submits a free-form tweak message after the
+ * initial plan. The planner regenerates the spec incorporating the tweak.
+ */
+export function buildTweakPrompt(tweakMessage: string): string {
+  return `User tweak: ${tweakMessage}
+
+Revise the spec to incorporate this. Keep anything the user didn't change.
+Respond with a SINGLE JSON object in the "confirm" phase schema (same shape
+as "plan" but with "phase": "confirm"). No prose.`;
+}
+
+/**
+ * Short prompt used when the planner emitted malformed JSON. Asks it to
+ * re-emit the same logical message in the correct envelope shape.
+ */
+export function buildReformatPrompt(reason: string): string {
+  return `Your last response was not a valid envelope: ${reason}
+
+Re-emit the same intent as a SINGLE JSON object in one of the phase shapes
+described in the opening message (clarify / research / plan / confirm). No
+prose, no code fences.`;
+}

--- a/src/lib/planning-envelope.ts
+++ b/src/lib/planning-envelope.ts
@@ -1,0 +1,240 @@
+/**
+ * Phase-aware planning envelope parser.
+ *
+ * The enhanced planner emits JSON envelopes tagged with a `phase` field so
+ * the backend can drive a validation-first state machine:
+ *   clarify → research (optional) → plan → confirm → complete
+ *
+ * This module:
+ *   1. Parses loose LLM output via extractJSON (reusing existing helper).
+ *   2. Classifies the envelope by phase + shape.
+ *   3. Surfaces a normalized union type the route handlers branch on.
+ *
+ * Legacy envelopes (no `phase` field) are still understood — an old-style
+ * `{ question, options }` maps to `phase: 'clarify'` with no understanding,
+ * and an old-style `{ status: "complete", spec, agents }` maps to
+ * `phase: 'plan'` so the confirm-step gate still applies to in-flight tasks
+ * upgraded mid-flow.
+ */
+
+import { extractJSON } from './planning-utils';
+import type { SpecDeliverable, SpecSuccessCriterion } from './types';
+
+export type PlanningPhase = 'clarify' | 'research' | 'plan' | 'confirm' | 'complete';
+
+export interface PlanningQuestionOption {
+  id: string;
+  label: string;
+}
+
+/** Clarify: planner has restated its understanding and is asking the user. */
+export interface ClarifyQuestionEnvelope {
+  kind: 'clarify_question';
+  understanding: string;
+  unknowns: string[];
+  question: string;
+  options: PlanningQuestionOption[];
+}
+
+/** Clarify: planner is confident it understands; decides whether research is needed. */
+export interface ClarifyDoneEnvelope {
+  kind: 'clarify_done';
+  understanding: string;
+  unknowns: string[];
+  confident: true;
+  needs_research: boolean;
+  research_rationale?: string;
+}
+
+/** Research: planner has finished its own web_fetch calls and is summarizing. */
+export interface ResearchDoneEnvelope {
+  kind: 'research_done';
+  summary: string;
+  updated_unknowns: string[];
+}
+
+/**
+ * Plan / Confirm: planner has produced a structured spec. Same shape is used
+ * for initial plan emission and post-tweak regeneration — the phase column on
+ * the task tells the caller which it is.
+ */
+export interface PlanEnvelope {
+  kind: 'plan';
+  spec: {
+    title: string;
+    summary: string;
+    deliverables: Array<SpecDeliverable | string>;
+    success_criteria: Array<SpecSuccessCriterion | string>;
+    constraints?: Record<string, unknown>;
+  };
+  agents: Array<{
+    name: string;
+    role: string;
+    avatar_emoji?: string;
+    soul_md?: string;
+    instructions?: string;
+    agent_id?: string | null;
+    rationale?: string;
+  }>;
+  execution_plan?: Record<string, unknown>;
+}
+
+export type PlanningEnvelope =
+  | ClarifyQuestionEnvelope
+  | ClarifyDoneEnvelope
+  | ResearchDoneEnvelope
+  | PlanEnvelope;
+
+export interface ParseEnvelopeResult {
+  envelope: PlanningEnvelope | null;
+  /** Raw parsed JSON, returned even when classification fails, so callers can
+   *  decide whether to display it in a parse-error banner or ask the planner
+   *  to reformat. */
+  raw: Record<string, unknown> | null;
+  /** Populated when classification fails — a short reason for logging / UI. */
+  reason?: string;
+}
+
+/**
+ * Parse and classify a planner assistant message.
+ *
+ * Returns { envelope: null, raw, reason } when the text either didn't parse
+ * as JSON or parsed but doesn't match any known envelope shape. Callers:
+ *   - If raw is null → unrecoverable garbage; surface parse error.
+ *   - If raw is present but envelope is null → ask planner to reformat
+ *     using the reason as guidance.
+ */
+export function parsePlanningEnvelope(text: string): ParseEnvelopeResult {
+  const raw = extractJSON(text) as Record<string, unknown> | null;
+  if (!raw) {
+    return { envelope: null, raw: null, reason: 'No JSON object found in planner output.' };
+  }
+
+  const phase = typeof raw.phase === 'string' ? raw.phase : undefined;
+
+  // --- Legacy shapes (no phase tag) -----------------------------------------
+  // Old question shape: { question, options }
+  if (!phase && typeof raw.question === 'string' && Array.isArray(raw.options)) {
+    return {
+      envelope: {
+        kind: 'clarify_question',
+        understanding: '',
+        unknowns: [],
+        question: raw.question,
+        options: normalizeOptions(raw.options),
+      },
+      raw,
+    };
+  }
+  // Old completion shape: { status: 'complete', spec, agents }
+  if (!phase && raw.status === 'complete' && isRecord(raw.spec)) {
+    const plan = tryBuildPlan(raw);
+    if (plan) return { envelope: plan, raw };
+  }
+
+  // --- Phased shapes --------------------------------------------------------
+  if (phase === 'clarify') {
+    const understanding = typeof raw.understanding === 'string' ? raw.understanding : '';
+    const unknowns = Array.isArray(raw.unknowns)
+      ? raw.unknowns.filter((u): u is string => typeof u === 'string')
+      : [];
+
+    if (typeof raw.question === 'string' && Array.isArray(raw.options)) {
+      return {
+        envelope: {
+          kind: 'clarify_question',
+          understanding,
+          unknowns,
+          question: raw.question,
+          options: normalizeOptions(raw.options),
+        },
+        raw,
+      };
+    }
+
+    if (raw.confident === true) {
+      return {
+        envelope: {
+          kind: 'clarify_done',
+          understanding,
+          unknowns,
+          confident: true,
+          needs_research: raw.needs_research === true,
+          research_rationale: typeof raw.research_rationale === 'string' ? raw.research_rationale : undefined,
+        },
+        raw,
+      };
+    }
+
+    return { envelope: null, raw, reason: 'clarify envelope missing both a question and confident:true' };
+  }
+
+  if (phase === 'research') {
+    if (raw.done === true && typeof raw.summary === 'string') {
+      const updated_unknowns = Array.isArray(raw.updated_unknowns)
+        ? raw.updated_unknowns.filter((u): u is string => typeof u === 'string')
+        : [];
+      return {
+        envelope: { kind: 'research_done', summary: raw.summary, updated_unknowns },
+        raw,
+      };
+    }
+    return { envelope: null, raw, reason: 'research envelope must have done:true and a summary string' };
+  }
+
+  if (phase === 'plan' || phase === 'confirm') {
+    const plan = tryBuildPlan(raw);
+    if (plan) return { envelope: plan, raw };
+    return { envelope: null, raw, reason: `${phase} envelope missing spec/agents` };
+  }
+
+  return { envelope: null, raw, reason: `Unknown phase: ${String(phase)}` };
+}
+
+function normalizeOptions(input: unknown[]): PlanningQuestionOption[] {
+  const out: PlanningQuestionOption[] = [];
+  for (const item of input) {
+    if (isRecord(item) && typeof item.id === 'string' && typeof item.label === 'string') {
+      out.push({ id: item.id, label: item.label });
+    }
+  }
+  return out;
+}
+
+function tryBuildPlan(raw: Record<string, unknown>): PlanEnvelope | null {
+  if (!isRecord(raw.spec)) return null;
+  const spec = raw.spec;
+  if (typeof spec.title !== 'string' || typeof spec.summary !== 'string') return null;
+
+  const deliverables = Array.isArray(spec.deliverables) ? spec.deliverables : [];
+  const success_criteria = Array.isArray(spec.success_criteria) ? spec.success_criteria : [];
+  const agents = Array.isArray(raw.agents) ? raw.agents : [];
+
+  return {
+    kind: 'plan',
+    spec: {
+      title: spec.title,
+      summary: spec.summary,
+      deliverables: deliverables as Array<SpecDeliverable | string>,
+      success_criteria: success_criteria as Array<SpecSuccessCriterion | string>,
+      constraints: isRecord(spec.constraints) ? (spec.constraints as Record<string, unknown>) : undefined,
+    },
+    agents: agents.filter(isRecord).map((a) => {
+      const rec = a as Record<string, unknown>;
+      return {
+        name: typeof rec.name === 'string' ? rec.name : 'Unnamed',
+        role: typeof rec.role === 'string' ? rec.role : 'worker',
+        avatar_emoji: typeof rec.avatar_emoji === 'string' ? rec.avatar_emoji : undefined,
+        soul_md: typeof rec.soul_md === 'string' ? rec.soul_md : undefined,
+        instructions: typeof rec.instructions === 'string' ? rec.instructions : undefined,
+        agent_id: typeof rec.agent_id === 'string' ? rec.agent_id : rec.agent_id === null ? null : undefined,
+        rationale: typeof rec.rationale === 'string' ? rec.rationale : undefined,
+      };
+    }),
+    execution_plan: isRecord(raw.execution_plan) ? (raw.execution_plan as Record<string, unknown>) : undefined,
+  };
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}

--- a/src/lib/planning-persist.ts
+++ b/src/lib/planning-persist.ts
@@ -1,0 +1,211 @@
+/**
+ * Shared planning-persistence helpers.
+ *
+ * The poll endpoint writes a spec+agents atomically when a plan envelope
+ * arrives (without dispatching — that's the user's explicit lock action).
+ * The lock endpoint re-runs the persistence pass (to pick up any tweak
+ * edits), assigns the first agent, and fires dispatch. Both paths share the
+ * agent-resolution and transaction logic, hence this module.
+ */
+
+import { getDb, queryAll, queryOne, run } from '@/lib/db';
+import { getMissionControlUrl } from '@/lib/config';
+import { broadcast } from '@/lib/events';
+import { findAgentForRole, verifyAgentInWorkspace } from '@/lib/agent-resolver';
+import type { PlanEnvelope } from '@/lib/planning-envelope';
+import type { Task } from '@/lib/types';
+
+export function persistPlannerPlan(taskId: string, plan: PlanEnvelope): {
+  firstAgentId: string | null;
+  resolvedAgentRows: Array<{ id: string; role: string; name: string }>;
+} {
+  const db = getDb();
+  let firstAgentId: string | null = null;
+  const resolvedAgentRows: Array<{ id: string; role: string; name: string }> = [];
+
+  const transaction = db.transaction(() => {
+    const allowDynamicAgents = process.env.ALLOW_DYNAMIC_AGENTS !== 'false';
+
+    if (allowDynamicAgents && plan.agents && plan.agents.length > 0) {
+      const task = db
+        .prepare('SELECT workspace_id FROM tasks WHERE id = ?')
+        .get(taskId) as { workspace_id: string } | undefined;
+      const masterAgent = task
+        ? (db
+            .prepare(
+              `SELECT session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`
+            )
+            .get(task.workspace_id) as { session_key_prefix?: string } | undefined)
+        : undefined;
+
+      const sessionKeyPrefix = masterAgent?.session_key_prefix || null;
+
+      const insertAgent = db.prepare(`
+        INSERT INTO agents (id, workspace_id, name, role, description, avatar_emoji, status, soul_md, session_key_prefix, created_at, updated_at)
+        VALUES (?, (SELECT workspace_id FROM tasks WHERE id = ?), ?, ?, ?, ?, 'standby', ?, ?, datetime('now'), datetime('now'))
+      `);
+
+      const workspaceId = task?.workspace_id;
+
+      for (const agent of plan.agents) {
+        let resolvedId: string | null = null;
+
+        if (workspaceId && agent.agent_id) {
+          const verified = verifyAgentInWorkspace(workspaceId, agent.agent_id);
+          if (verified) {
+            resolvedId = verified.id;
+          } else {
+            console.warn(
+              `[Planning Persist] Planner returned unknown agent_id ${agent.agent_id} for role "${agent.role}" — falling back to role match`
+            );
+          }
+        }
+
+        if (!resolvedId && workspaceId && agent.role) {
+          const existing = findAgentForRole(workspaceId, agent.role);
+          if (existing) {
+            resolvedId = existing.id;
+          }
+        }
+
+        if (!resolvedId) {
+          resolvedId = crypto.randomUUID();
+          insertAgent.run(
+            resolvedId,
+            taskId,
+            agent.name,
+            agent.role,
+            agent.instructions || '',
+            agent.avatar_emoji || '🤖',
+            agent.soul_md || '',
+            sessionKeyPrefix
+          );
+        }
+
+        if (!firstAgentId) firstAgentId = resolvedId;
+        resolvedAgentRows.push({ id: resolvedId, role: agent.role, name: agent.name });
+      }
+    }
+
+    // Store spec + agents; move phase to 'confirm'. No dispatch, no status
+    // change — that's only lockAndDispatch's job.
+    db.prepare(`
+      UPDATE tasks
+      SET planning_spec = ?,
+          planning_agents = ?,
+          planning_phase = 'confirm',
+          planning_dispatch_error = NULL,
+          updated_at = datetime('now')
+      WHERE id = ?
+    `).run(JSON.stringify(plan.spec), JSON.stringify(plan.agents), taskId);
+
+    return firstAgentId;
+  });
+
+  firstAgentId = transaction();
+  return { firstAgentId, resolvedAgentRows };
+}
+
+export async function lockAndDispatch(taskId: string): Promise<{
+  firstAgentId: string | null;
+  dispatchError: string | null;
+}> {
+  const db = getDb();
+  let dispatchError: string | null = null;
+
+  const task = queryOne<{
+    workspace_id: string;
+    planning_spec: string | null;
+    planning_agents: string | null;
+  }>(
+    `SELECT workspace_id, planning_spec, planning_agents FROM tasks WHERE id = ?`,
+    [taskId]
+  );
+  if (!task || !task.planning_spec) {
+    return { firstAgentId: null, dispatchError: 'No locked plan available to dispatch.' };
+  }
+
+  const plan: PlanEnvelope = {
+    kind: 'plan',
+    spec: JSON.parse(task.planning_spec),
+    agents: task.planning_agents ? JSON.parse(task.planning_agents) : [],
+  };
+  const { firstAgentId: resolvedFirst } = persistPlannerPlan(taskId, plan);
+  let firstAgentId: string | null = resolvedFirst;
+
+  if (firstAgentId) {
+    const defaultMaster = queryOne<{ id: string }>(
+      `SELECT id FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
+      [task.workspace_id]
+    );
+    const otherOrchestrators = queryAll<{ id: string; name: string }>(
+      `SELECT id, name FROM agents WHERE is_master = 1 AND id != ? AND workspace_id = ? AND status != 'offline'`,
+      [defaultMaster?.id ?? '', task.workspace_id]
+    );
+    if (otherOrchestrators.length > 0) {
+      dispatchError = `Cannot auto-dispatch: ${otherOrchestrators.length} other orchestrator(s) available in workspace`;
+      console.warn(
+        `[Planning Lock] ${dispatchError}:`,
+        otherOrchestrators.map((o) => o.name).join(', ')
+      );
+      firstAgentId = null;
+    }
+  }
+
+  if (firstAgentId) {
+    db.prepare(`
+      UPDATE tasks
+      SET planning_complete = 1,
+          planning_phase = 'complete',
+          assigned_agent_id = ?,
+          status = 'assigned',
+          updated_at = datetime('now')
+      WHERE id = ?
+    `).run(firstAgentId, taskId);
+
+    const missionControlUrl = getMissionControlUrl();
+    const dispatchUrl = `${missionControlUrl}/api/tasks/${taskId}/dispatch`;
+    console.log(`[Planning Lock] Triggering dispatch: ${dispatchUrl}`);
+
+    try {
+      const dispatchHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (process.env.MC_API_TOKEN) {
+        dispatchHeaders['Authorization'] = `Bearer ${process.env.MC_API_TOKEN}`;
+      }
+
+      const dispatchRes = await fetch(dispatchUrl, {
+        method: 'POST',
+        headers: dispatchHeaders,
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      if (!dispatchRes.ok) {
+        const errorText = await dispatchRes.text();
+        dispatchError = `Dispatch failed (${dispatchRes.status}): ${errorText}`;
+        console.error(`[Planning Lock] ${dispatchError}`);
+      }
+    } catch (err) {
+      dispatchError = `Dispatch error: ${(err as Error).message}`;
+      console.error(`[Planning Lock] ${dispatchError}`);
+    }
+
+    if (dispatchError) {
+      run(
+        `UPDATE tasks SET planning_dispatch_error = ?, status_reason = ?, updated_at = datetime('now') WHERE id = ?`,
+        [dispatchError, 'Dispatch failed: ' + dispatchError, taskId]
+      );
+    }
+  } else {
+    run(
+      `UPDATE tasks SET planning_complete = 1, planning_phase = 'complete', status = 'inbox', updated_at = datetime('now') WHERE id = ?`,
+      [taskId]
+    );
+  }
+
+  const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+  if (updatedTask) {
+    broadcast({ type: 'task_updated', payload: updatedTask });
+  }
+
+  return { firstAgentId, dispatchError };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,15 @@
 
 export type AgentStatus = 'standby' | 'working' | 'offline';
 
-export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'done' | 'cancelled';
+export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'done' | 'cancelled' | 'needs_user_input';
+
+/**
+ * Phase of the enhanced planning flow. Drives which prompt the backend sends
+ * next and which UI the PlanningTab renders. 'clarify' is the default for new
+ * planning sessions; 'complete' is set once the user locks the spec and
+ * dispatch fires.
+ */
+export type PlanningPhase = 'clarify' | 'research' | 'plan' | 'confirm' | 'complete';
 
 export type TaskPriority = 'low' | 'normal' | 'high' | 'urgent';
 
@@ -41,6 +49,10 @@ export interface Agent {
   gateway_agent_id?: string;
   session_key_prefix?: string;
   is_active?: number;
+  /** Migration 036: set to 1 for agents spawned by the planning flow to act
+   *  as a one-shot planner for a single task. Cleanup passes drop these
+   *  rows when the task completes or planning is cancelled. */
+  ephemeral?: number;
   total_cost_usd?: number;
   total_tokens_used?: number;
   created_at: string;
@@ -76,6 +88,20 @@ export interface Task {
   planning_complete?: number;
   planning_dispatch_error?: string;
   planning_session_key?: string;
+  // Enhanced planning flow (migration 036): phased state machine driven by
+  // the planner's JSON envelopes. See src/lib/planning-envelope.ts.
+  planning_phase?: PlanningPhase;
+  planning_understanding?: string;
+  planning_unknowns?: string; // JSON string[]
+  planning_research?: string; // JSON { summary, updated_unknowns?, done_at }
+  planner_agent_id?: string;
+  // needs_user_input surface: any agent (planner or worker) can park a task
+  // pending a user decision. Restored to status_before_input_request when the
+  // user responds.
+  status_before_input_request?: string;
+  input_request?: string;
+  input_request_context?: string; // JSON
+  input_request_created_at?: string;
   images?: string; // JSON array of TaskImage objects
   convoy_id?: string;
   is_subtask?: number;
@@ -180,6 +206,7 @@ export interface WorkspaceStats {
     verification: number;
     done: number;
     cancelled: number;
+    needs_user_input: number;
     total: number;
   };
   agentCount: number;


### PR DESCRIPTION
## Summary

Replaces the single-shot Q&A → auto-dispatch planning loop with a validation-first phased state machine: **clarify → (optional) research → plan → confirm → complete**. Planner must explicitly restate understanding and list unknowns before producing a spec; dispatch is gated behind an explicit **Lock & Dispatch** action instead of firing the moment the spec arrives.

- Migration 036 adds phased-planning columns, `planner_agent_id`, `input-request` fields, `agents.ephemeral`, and expands tasks status CHECK with `needs_user_input` (via `writable_schema`).
- New `planning-envelope.ts` classifies planner JSON by phase; legacy `{question}` / `{status:complete}` shapes still parse so in-flight tasks don't break.
- New `planner-prompt.ts` — four-phase system prompt + per-transition kickoffs (clarify answer, research kickoff, plan kickoff, tweak, reformat-on-bad-JSON).
- New routes: `POST /planning/advance`, `POST /planning/tweak`, `POST /planning/lock`. Shared `persistPlannerPlan` + `lockAndDispatch` in `planning-persist.ts`.
- `/poll` no longer auto-dispatches — plan envelopes land at `phase: 'confirm'` and wait for Lock.
- Types, `WorkspaceStats`, `force-complete`, cancel-clear-fields all updated for the new shape.
- Skip pre-migration backup for test DBs (timestamp-collision broke parallel test runs).

## Deferred (follow-up PRs)

Still in the original plan but not in this commit — they're independent and each their own PR:

- PlanningTab UI rewrite (phase stepper, understanding block, tweak chat, Lock & Dispatch button) — **the backend is ready, UI still shows legacy Q&A shape**.
- Planner picker (existing-agent dropdown + ephemeral planner spawn).
- `web_fetch` tool wired onto the ephemeral planner agent.
- `task.request_user_input` MCP tool + `needs_user_input` surface on task card (backend columns + status value already land in this PR; the MCP tool and UI are deferred).

## Test plan

- [ ] `npx tsc --noEmit` — clean.
- [ ] `DATABASE_PATH=.tmp/mission-control-test.db NODE_ENV=test npx tsx --test src/lib/services/services.test.ts` (27/27).
- [ ] Same for `src/lib/mcp/mcp.test.ts` (13/13), `src/lib/task-governance.test.ts` (4/4), `src/lib/authz/agent-task.test.ts` (16/16).
- [ ] Manual: start a task, confirm planner emits `phase: 'clarify'` envelope with understanding block; answer a couple of questions; confirm `phase: 'confirm'` on plan arrival and that the task stays in `status: 'planning'` (no auto-dispatch).
- [ ] Manual: POST `/api/tasks/{id}/planning/lock` on a confirm-phase task and confirm dispatch fires + task transitions to `assigned` / `in_progress`.
- [ ] Manual: cancel planning mid-flow and confirm all new `planning_*` columns reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)