### PR TITLE
feat(planning): freetext clarify shape + per-option clarifier input

### DIFF
--- a/src/app/api/tasks/[id]/planning/poll/route.ts
+++ b/src/app/api/tasks/[id]/planning/poll/route.ts
@@ -121,7 +121,14 @@ export async function GET(
 
     if (openclawMessages.length > initialAssistantCount) {
       let currentQuestion:
-        | { question: string; options: Array<{ id: string; label: string }>; understanding?: string; unknowns?: string[] }
+        | {
+            question: string;
+            input_kind: 'options' | 'freetext';
+            options: Array<{ id: string; label: string; allow_details?: boolean }>;
+            placeholder?: string;
+            understanding?: string;
+            unknowns?: string[];
+          }
         | null = null;
       let clarifyDone:
         | { understanding: string; unknowns: string[]; needs_research: boolean; research_rationale?: string }
@@ -149,9 +156,16 @@ export async function GET(
           case 'clarify_question':
             currentQuestion = {
               question: envelope.question,
-              options: envelope.options.length
+              input_kind: envelope.input_kind,
+              // Freetext questions carry no options — pass through as-is.
+              // For options shape, backfill an Other fallback if the planner
+              // forgot (keeps the user from getting stuck with no escape).
+              options: envelope.input_kind === 'freetext'
+                ? []
+                : envelope.options.length
                 ? envelope.options
-                : [{ id: 'continue', label: 'Continue' }, { id: 'other', label: 'Other' }],
+                : [{ id: 'continue', label: 'Continue' }, { id: 'other', label: 'Other', allow_details: true }],
+              placeholder: envelope.placeholder,
               understanding: envelope.understanding,
               unknowns: envelope.unknowns,
             };

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -48,7 +48,14 @@ export async function GET(
     // single-phase flows still work — parsePlanningEnvelope handles the old
     // { question, options } and { status: 'complete', spec } shapes.
     const lastAssistantMessage = [...messages].reverse().find((m: { role: string }) => m.role === 'assistant');
-    let currentQuestion: { question: string; options: Array<{ id: string; label: string }>; understanding?: string; unknowns?: string[] } | null = null;
+    let currentQuestion: {
+      question: string;
+      input_kind: 'options' | 'freetext';
+      options: Array<{ id: string; label: string; allow_details?: boolean }>;
+      placeholder?: string;
+      understanding?: string;
+      unknowns?: string[];
+    } | null = null;
     let clarifyDone: { understanding: string; unknowns: string[]; needs_research: boolean; research_rationale?: string } | null = null;
 
     if (lastAssistantMessage) {
@@ -56,7 +63,9 @@ export async function GET(
       if (envelope?.kind === 'clarify_question') {
         currentQuestion = {
           question: envelope.question,
+          input_kind: envelope.input_kind,
           options: envelope.options,
+          placeholder: envelope.placeholder,
           understanding: envelope.understanding,
           unknowns: envelope.unknowns,
         };

--- a/src/components/PlanningTab.tsx
+++ b/src/components/PlanningTab.tsx
@@ -6,11 +6,18 @@ import { CheckCircle, Circle, Lock, AlertCircle, Loader2, X } from 'lucide-react
 interface PlanningOption {
   id: string;
   label: string;
+  /** When true, selecting this option reveals a free-text clarifier input so
+   *  the user can add nuance alongside the choice (e.g. "Other: we use
+   *  DocuSign" or "Option B, but with X"). */
+  allow_details?: boolean;
 }
 
 interface PlanningQuestion {
   question: string;
+  /** 'options' → multiple choice. 'freetext' → textarea only (no options). */
+  input_kind?: 'options' | 'freetext';
   options: PlanningOption[];
+  placeholder?: string;
 }
 
 interface PlanningMessage {
@@ -312,17 +319,36 @@ export function PlanningTab({ taskId, onSpecLocked }: PlanningTabProps) {
 
   // Submit answer
   const submitAnswer = async () => {
-    if (!selectedOption) return;
+    const q = state?.currentQuestion;
+    const isFreetext = q?.input_kind === 'freetext';
+
+    // Guard: freetext requires non-empty text; options require a selection.
+    if (isFreetext ? !otherText.trim() : !selectedOption) return;
+
+    // When the selected option declared allow_details, the clarifier text is
+    // required (same UX as the legacy "Other" field — empty is nonsensical).
+    const selectedOpt = q?.options.find((o) => o.label === selectedOption);
+    const needsClarifier = !!selectedOpt?.allow_details;
+    if (needsClarifier && !otherText.trim()) return;
 
     setSubmitting(true);
     setIsSubmittingAnswer(true); // Show submitting state in UI
     setError(null);
 
-    // Store submission for retry
-    const submission = {
-      answer: selectedOption?.toLowerCase() === 'other' ? 'other' : selectedOption,
-      otherText: selectedOption?.toLowerCase() === 'other' ? otherText : undefined,
-    };
+    // Build submission payload. The /answer route treats answer='other' as
+    // the text-only form and sends "Other: {otherText}" to the planner. For
+    // the new allow_details flow we reuse that branch — "SelectedLabel: text"
+    // reads naturally in the planner's chat history. Freetext sends just the
+    // typed text with a generic 'other' answer so the existing server logic
+    // composes the final message.
+    let submission: { answer: string; otherText?: string };
+    if (isFreetext) {
+      submission = { answer: 'other', otherText: otherText.trim() };
+    } else if (needsClarifier) {
+      submission = { answer: 'other', otherText: `${selectedOption}: ${otherText.trim()}` };
+    } else {
+      submission = { answer: selectedOption! };
+    }
     lastSubmissionRef.current = submission;
 
     try {
@@ -725,55 +751,86 @@ export function PlanningTab({ taskId, onSpecLocked }: PlanningTabProps) {
               {state.currentQuestion.question}
             </h3>
 
-            <div className="space-y-3">
-              {state.currentQuestion.options.map((option) => {
-                const isSelected = selectedOption === option.label;
-                const isOther = option.id === 'other' || option.label.toLowerCase() === 'other';
-                const isThisOptionSubmitting = isSubmittingAnswer && isSelected;
+            {state.currentQuestion.input_kind === 'freetext' ? (
+              // Freetext shape: no options, just a textarea. Planner used
+              // this when the answer space was too broad for multiple choice.
+              <div>
+                <textarea
+                  value={otherText}
+                  onChange={(e) => setOtherText(e.target.value)}
+                  placeholder={state.currentQuestion.placeholder || 'Type your answer…'}
+                  rows={5}
+                  className="w-full bg-mc-bg border border-mc-border rounded-lg px-3 py-2 text-sm focus:outline-hidden focus:border-mc-accent"
+                  disabled={submitting}
+                  autoFocus
+                />
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {state.currentQuestion.options.map((option) => {
+                  const isSelected = selectedOption === option.label;
+                  // The planner can opt any option into a clarifier input by
+                  // setting allow_details:true. We also treat a literal
+                  // "Other" as allow_details so legacy envelopes keep working.
+                  const isOtherByConvention =
+                    option.id === 'other' || option.label.toLowerCase() === 'other';
+                  const showClarifier = !!option.allow_details || isOtherByConvention;
+                  const isThisOptionSubmitting = isSubmittingAnswer && isSelected;
 
-                return (
-                  <div key={option.id}>
-                    <button
-                      onClick={() => setSelectedOption(option.label)}
-                      disabled={submitting}
-                      className={`w-full flex items-center gap-3 p-4 rounded-lg border transition-all text-left ${
-                        isThisOptionSubmitting
-                          ? 'border-mc-accent bg-mc-accent/20'
-                          : isSelected
-                          ? 'border-mc-accent bg-mc-accent/10'
-                          : 'border-mc-border hover:border-mc-accent/50'
-                      } disabled:opacity-50`}
-                    >
-                      <span className={`w-8 h-8 rounded flex items-center justify-center text-sm font-bold ${
-                        isSelected ? 'bg-mc-accent text-mc-bg' : 'bg-mc-bg-tertiary'
-                      }`}>
-                        {option.id.toUpperCase()}
-                      </span>
-                      <span className="flex-1">{option.label}</span>
-                      {isThisOptionSubmitting ? (
-                        <Loader2 className="w-5 h-5 text-mc-accent animate-spin" />
-                      ) : isSelected && !submitting ? (
-                        <CheckCircle className="w-5 h-5 text-mc-accent" />
-                      ) : null}
-                    </button>
+                  return (
+                    <div key={option.id}>
+                      <button
+                        onClick={() => {
+                          setSelectedOption(option.label);
+                          // Clear stale clarifier when switching between
+                          // allow_details options so we don't send old text.
+                          setOtherText('');
+                        }}
+                        disabled={submitting}
+                        className={`w-full flex items-center gap-3 p-4 rounded-lg border transition-all text-left ${
+                          isThisOptionSubmitting
+                            ? 'border-mc-accent bg-mc-accent/20'
+                            : isSelected
+                            ? 'border-mc-accent bg-mc-accent/10'
+                            : 'border-mc-border hover:border-mc-accent/50'
+                        } disabled:opacity-50`}
+                      >
+                        <span className={`w-8 h-8 rounded flex items-center justify-center text-sm font-bold ${
+                          isSelected ? 'bg-mc-accent text-mc-bg' : 'bg-mc-bg-tertiary'
+                        }`}>
+                          {option.id.toUpperCase()}
+                        </span>
+                        <span className="flex-1">{option.label}</span>
+                        {isThisOptionSubmitting ? (
+                          <Loader2 className="w-5 h-5 text-mc-accent animate-spin" />
+                        ) : isSelected && !submitting ? (
+                          <CheckCircle className="w-5 h-5 text-mc-accent" />
+                        ) : null}
+                      </button>
 
-                    {/* Other text input */}
-                    {isOther && isSelected && (
-                      <div className="mt-2 ml-11">
-                        <input
-                          type="text"
-                          value={otherText}
-                          onChange={(e) => setOtherText(e.target.value)}
-                          placeholder="Please specify..."
-                          className="w-full bg-mc-bg border border-mc-border rounded-sm px-3 py-2 text-sm focus:outline-hidden focus:border-mc-accent"
-                          disabled={submitting}
-                        />
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
+                      {/* Clarifier text input — shown when the selected
+                          option opted in via allow_details (or it's "Other"). */}
+                      {showClarifier && isSelected && (
+                        <div className="mt-2 ml-11">
+                          <input
+                            type="text"
+                            value={otherText}
+                            onChange={(e) => setOtherText(e.target.value)}
+                            placeholder={
+                              state.currentQuestion?.placeholder ||
+                              (isOtherByConvention ? 'Please specify…' : 'Add details…')
+                            }
+                            className="w-full bg-mc-bg border border-mc-border rounded-sm px-3 py-2 text-sm focus:outline-hidden focus:border-mc-accent"
+                            disabled={submitting}
+                            autoFocus
+                          />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
 
             {error && (
               <div
@@ -813,9 +870,20 @@ export function PlanningTab({ taskId, onSpecLocked }: PlanningTabProps) {
 
             {/* Submit button */}
             <div className="mt-6">
+              {(() => {
+                const q = state.currentQuestion;
+                const isFreetext = q?.input_kind === 'freetext';
+                const selectedOpt = q?.options.find((o) => o.label === selectedOption);
+                const isOtherByConvention =
+                  !!selectedOpt && (selectedOpt.id === 'other' || selectedOpt.label.toLowerCase() === 'other');
+                const needsClarifier = !!selectedOpt?.allow_details || isOtherByConvention;
+                const canSubmit = isFreetext
+                  ? otherText.trim().length > 0
+                  : !!selectedOption && (!needsClarifier || otherText.trim().length > 0);
+                return (
               <button
                 onClick={submitAnswer}
-                disabled={!selectedOption || submitting || (selectedOption === 'Other' && !otherText.trim())}
+                disabled={!canSubmit || submitting}
                 className="w-full px-6 py-3 bg-mc-accent text-mc-bg rounded-lg font-medium hover:bg-mc-accent/90 disabled:opacity-50 flex items-center justify-center gap-2"
               >
                 {submitting ? (
@@ -827,6 +895,8 @@ export function PlanningTab({ taskId, onSpecLocked }: PlanningTabProps) {
                   'Continue →'
                 )}
               </button>
+                );
+              })()}
 
               {/* Waiting indicator after submit */}
               {isSubmittingAnswer && !submitting && (

--- a/src/lib/planner-prompt.ts
+++ b/src/lib/planner-prompt.ts
@@ -58,20 +58,44 @@ on what you emit.
 
 Phase: clarify (you start here)
 ----------------------------------------
-Either ask a multiple-choice question, or declare confidence.
+You have three response shapes: multiple-choice, free-text, or confident.
 
-  (a) Ask a question:
+  (a) MULTIPLE-CHOICE question (preferred when you have strong guesses):
   {
     "phase": "clarify",
     "understanding": "one-sentence restatement of what you think the user wants",
     "unknowns": ["concrete thing you're not sure about", "..."],
-    "question": "Specific multiple-choice question about one of the unknowns",
+    "question": "Specific question about one of the unknowns",
+    "input_kind": "options",
     "options": [
       {"id": "A", "label": "…"},
-      {"id": "B", "label": "…"},
-      {"id": "other", "label": "Other"}
+      {"id": "B", "label": "…", "allow_details": true},
+      {"id": "other", "label": "Other", "allow_details": true}
     ]
   }
+
+  Rules for options:
+  - ALWAYS include a final "Other" option with "allow_details": true. The
+    user needs an escape hatch to type something you didn't anticipate.
+  - Set "allow_details": true on any option where the user is likely to want
+    to qualify their choice ("Option B, but with X"). Don't set it on every
+    option — only where it adds value.
+
+  (a2) FREE-TEXT question (when the answer space is too broad for a handful
+  of options — e.g. "describe the structure of the organization", "paste
+  the error message you're seeing", "list the integrations you need"):
+  {
+    "phase": "clarify",
+    "understanding": "…",
+    "unknowns": ["…"],
+    "question": "Describe …",
+    "input_kind": "freetext",
+    "placeholder": "e.g. LLC with a single member, based in Georgia"   // optional
+  }
+
+  Choose freetext ONLY when you genuinely can't guess 2–4 plausible answers.
+  If you can, use multiple-choice with an "Other" fallback — it's faster for
+  the user.
 
   (b) Declare confidence:
   {
@@ -86,8 +110,8 @@ Either ask a multiple-choice question, or declare confidence.
   would close a specific unknown" — be concrete; do not ask for research as a
   reflex.
 
-  Questions MUST be multiple-choice with an "Other" option. Ask about ONE
-  thing at a time. Do not re-ask something the user already answered.
+  Ask about ONE thing at a time. Do not re-ask something the user already
+  answered.
 
 Phase: research (only if the user chose to run it)
 ----------------------------------------

--- a/src/lib/planning-envelope.ts
+++ b/src/lib/planning-envelope.ts
@@ -25,15 +25,34 @@ export type PlanningPhase = 'clarify' | 'research' | 'plan' | 'confirm' | 'compl
 export interface PlanningQuestionOption {
   id: string;
   label: string;
+  /** When true, selecting this option reveals a free-text clarifier input so
+   *  the user can add detail alongside the choice. Used for "Other / specify"
+   *  and for "Option B + add nuance" patterns. */
+  allow_details?: boolean;
 }
 
-/** Clarify: planner has restated its understanding and is asking the user. */
+/**
+ * Clarify: planner has restated its understanding and is asking the user.
+ *
+ * Two answer shapes:
+ *   - `input_kind: 'options'` (default) — multiple choice. Individual options
+ *     may set `allow_details: true` to reveal a clarifier text input when
+ *     selected. "Other" is a conventional example.
+ *   - `input_kind: 'freetext'` — no options; the user types a free-form
+ *     answer. Used for inherently open questions like "describe the structure
+ *     of the organization".
+ */
 export interface ClarifyQuestionEnvelope {
   kind: 'clarify_question';
   understanding: string;
   unknowns: string[];
   question: string;
+  input_kind: 'options' | 'freetext';
+  /** Non-empty when input_kind='options'; ignored otherwise. */
   options: PlanningQuestionOption[];
+  /** Optional placeholder shown in the free-text input (when input_kind is
+   *  'freetext' or an option with allow_details=true is selected). */
+  placeholder?: string;
 }
 
 /** Clarify: planner is confident it understands; decides whether research is needed. */
@@ -121,6 +140,7 @@ export function parsePlanningEnvelope(text: string): ParseEnvelopeResult {
         understanding: '',
         unknowns: [],
         question: raw.question,
+        input_kind: 'options',
         options: normalizeOptions(raw.options),
       },
       raw,
@@ -138,6 +158,23 @@ export function parsePlanningEnvelope(text: string): ParseEnvelopeResult {
     const unknowns = Array.isArray(raw.unknowns)
       ? raw.unknowns.filter((u): u is string => typeof u === 'string')
       : [];
+    const placeholder = typeof raw.placeholder === 'string' ? raw.placeholder : undefined;
+
+    // New free-text clarify shape: { phase:'clarify', question, input_kind:'freetext' }
+    if (raw.input_kind === 'freetext' && typeof raw.question === 'string') {
+      return {
+        envelope: {
+          kind: 'clarify_question',
+          understanding,
+          unknowns,
+          question: raw.question,
+          input_kind: 'freetext',
+          options: [],
+          placeholder,
+        },
+        raw,
+      };
+    }
 
     if (typeof raw.question === 'string' && Array.isArray(raw.options)) {
       return {
@@ -146,7 +183,9 @@ export function parsePlanningEnvelope(text: string): ParseEnvelopeResult {
           understanding,
           unknowns,
           question: raw.question,
+          input_kind: 'options',
           options: normalizeOptions(raw.options),
+          placeholder,
         },
         raw,
       };
@@ -195,7 +234,16 @@ function normalizeOptions(input: unknown[]): PlanningQuestionOption[] {
   const out: PlanningQuestionOption[] = [];
   for (const item of input) {
     if (isRecord(item) && typeof item.id === 'string' && typeof item.label === 'string') {
-      out.push({ id: item.id, label: item.label });
+      const opt: PlanningQuestionOption = { id: item.id, label: item.label };
+      // Treat a literal "Other" label as allow_details by default so the
+      // legacy prompt shape keeps its free-text escape hatch working even
+      // without the new flag.
+      const isOtherByConvention =
+        item.id === 'other' || item.label.toLowerCase() === 'other';
+      if (item.allow_details === true || (isOtherByConvention && item.allow_details !== false)) {
+        opt.allow_details = true;
+      }
+      out.push(opt);
     }
   }
   return out;


### PR DESCRIPTION
## Summary

Fixes a UX regression introduced in #37 and adds two new input shapes the planner can pick between when asking clarify questions.

**Regression fixed:** in the new phased flow, the planner could emit a clarify question with no "Other" option (e.g. "Ready — send your details whenever you're set.") — leaving the user with no way to type free-form input. Screenshot from @smb209:

- Only option was "Sending my details now", no text field, no "Other".

**New capabilities:**
- \`input_kind: 'freetext'\` — for inherently open questions like "describe the organization structure". Renders a textarea instead of options.
- \`allow_details: true\` on any option — selecting it reveals a clarifier text input, so the user can pick "Corporation" and add "S-corp election" in the same answer. Literal "Other" labels auto-get \`allow_details\` so legacy envelopes keep their escape hatch.

Envelope parser, planner prompt, PlanningTab UI, and the GET/poll passthroughs all updated in lockstep. "Other" is no longer special-cased — it's just a conventional shortcut for \`allow_details: true\`.

## Files

- \`src/lib/planning-envelope.ts\` — parser accepts \`input_kind\` + per-option \`allow_details\`; \`normalizeOptions\` auto-sets \`allow_details\` on conventional "Other" labels.
- \`src/lib/planner-prompt.ts\` — teaches the planner three shapes (options / freetext / confident) and when to pick each.
- \`src/components/PlanningTab.tsx\` — renders textarea when \`input_kind='freetext'\`; shows clarifier input under any option with \`allow_details\`; submit composes \`"Label: clarifier"\` or plain text.
- \`src/app/api/tasks/[id]/planning/route.ts\` + \`.../poll/route.ts\` — forward \`input_kind\` and \`placeholder\` through to the client.

## Test plan

Verified end-to-end via Claude Preview against a live dev server:

- [x] Seeded a task whose last assistant message is a freetext envelope; opened the Planning tab. Textarea renders with placeholder \`"e.g. LLC with a single member, based in Georgia"\`, Continue button disabled until text typed, enables once text is present.
- [x] Seeded a task with options \`[LLC, Corporation (allow_details), Other (allow_details)]\`. All three options render. Clicking "Corporation" reveals \`"Add details…"\` input. Continue disabled while clarifier empty, enables once filled.
- [x] Parser unit cases (legacy no-phase, phased options, freetext, implicit Other) all classify correctly.
- [x] \`npx tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)