### PR TITLE
feat(delegation): spawn_subtask replaces delegate — every fan-out is a tracked convoy subtask

### DIFF
--- a/specs/coordinator-delegation-via-convoy-spec.md
+++ b/specs/coordinator-delegation-via-convoy-spec.md
@@ -1,0 +1,602 @@
+# Coordinator Delegation via Convoy — Spec
+
+**Version:** 0.1 (draft)
+**Date:** 2026-04-22
+**Status:** Proposed
+**Supersedes portions of:** [`convoy-mode-spec.md`](./convoy-mode-spec.md) §7 (task decomposition is extended, not replaced)
+**Depends on:** none — this is the first of a three-part observability overhaul. A sibling proposal covers `log_activity` cadence + `ask_operator`; a third covers the per-delegation stall detector.
+
+---
+
+## 1. Problem
+
+Coordinator agents fan out work to peers via the `delegate` MCP tool today
+([`src/lib/mcp/tools.ts:577`](../src/lib/mcp/tools.ts)). That tool is
+fire-and-forget: it calls `chat.send` into a per-task session key and writes a
+single `[DELEGATION]` audit string to `task_activities`. Nothing records:
+
+- what the peer owes back (deliverables, acceptance criteria)
+- by when (expected duration, check-in cadence)
+- current state (dispatched → acknowledged → working → delivered → accepted)
+- linkage so the parent task's stall signal can reason about which branch is
+  late
+
+Empirical evidence (live DB, 2026-04-22):
+
+| Metric                                                 | Value |
+|--------------------------------------------------------|------:|
+| Tasks stuck `in_progress`                              |    45 |
+| Repeat stall flags on a single fan-out task (cc3d40e1) |   106 |
+| Unread mails older than 1 h                            |    49 |
+| `[DELEGATION]` audit rows with no follow-up delivery   | most  |
+| Convoys in use                                         |     1 |
+
+The failure mode on task `cc3d40e1` is canonical: the coordinator fired three
+`delegate` calls (Researcher, Writer, Reviewer), one peer dropped the ball,
+and the system has no way to tell which. The parent-task stall scanner just
+re-flagged 106 times because it has only a global "nothing has happened in 30
+min" rule to fall back on.
+
+Meanwhile the **convoy** feature already models everything the delegation
+flow needs — persistent subtask rows, dependency DAG, auto-completion,
+convoy-aware stall detection, and a UI — but it is operator-initiated only
+(HTTP + UI form or AI decomposition) and therefore unused by agents, which
+reach for the weaker `delegate` tool instead.
+
+---
+
+## 2. Decision
+
+**Consolidate. Convoy becomes the substrate for all coordinator-driven
+delegation; the `delegate` MCP tool is retired.**
+
+Convoys become the natural *next step of a workflow*: when a coordinator
+decides it needs peer help, creating (or appending to) a convoy is the
+mechanism that codifies what was asked, what's owed, and how we know when it
+is dead, blocked, or done.
+
+### 2.1 Mental model
+
+```
+Task (planning → assigned → coordinator-in-progress)
+      │
+      └── Coordinator decides to delegate
+              │
+              └── spawn_subtask(peer, slice, deliverables, duration, acceptance)
+                      │
+                      │  (first call on this task: lazily creates convoy)
+                      │  (subsequent calls: append subtask to same convoy)
+                      │
+                      ├── inserts `convoy_subtasks` row
+                      ├── inserts `tasks` row (child), pre-assigned to peer
+                      ├── runs the existing /api/tasks/:id/dispatch pipeline
+                      │   (peer gets a normal briefing, normal MCP roster,
+                      │    normal stall coverage — no new dispatch path)
+                      └── parent task enters `convoy_active`
+
+Peer's work drives the child task's normal lifecycle
+  (assigned → in_progress → review → done / cancelled).
+
+Convoy auto-completion (existing `checkConvoyCompletion` in convoy.ts)
+promotes the parent task when all children are `done`.
+```
+
+### 2.2 Convoy uniqueness
+
+- **Default behavior:** a task has **at most one convoy**; repeated
+  coordinator delegations append subtasks to that convoy. The convoy is "the
+  obligation tree for this task".
+- **Schema posture:** drop the `UNIQUE` on `convoys.parent_task_id` in the
+  same migration, so a multi-wave model ("wave 1 research, wave 2 review")
+  remains available as a future pivot without another schema change.
+- All convoy readers that currently use `queryOne<Convoy>` by `parent_task_id`
+  (five call-sites, listed in §5.3) switch to "latest active convoy" — a
+  semantic-preserving change under the default, future-proof otherwise.
+
+### 2.3 What's kept from the existing convoy machinery
+
+| Capability                           | Reused as-is                                                     |
+|--------------------------------------|------------------------------------------------------------------|
+| Persistent subtask rows              | `tasks` (with `is_subtask=1`, `convoy_id`)                       |
+| Dependency DAG                       | `convoy_subtasks.depends_on`                                     |
+| Parallel fan-out                     | `dispatchReadyConvoySubtasks` (cap raised — see §5.2)            |
+| Auto-completion                      | `checkConvoyCompletion` ([`convoy.ts:195`](../src/lib/convoy.ts)) |
+| Convoy-aware stall handling          | [`stall-detection.ts:234`](../src/lib/stall-detection.ts)        |
+| UI                                   | `ConvoyTab.tsx`, `DependencyGraph.tsx`                            |
+| Parent-state sentinel                | `tasks.status = 'convoy_active'`                                  |
+| AI decomposition path                | Unchanged — operator-initiated convoys still work                |
+
+### 2.4 What's retired (same PR as `spawn_subtask` ships)
+
+- The `delegate` MCP tool ([`tools.ts:577`](../src/lib/mcp/tools.ts)) —
+  handler and `server.registerTool` entry deleted outright. No
+  deprecation window: `spawn_subtask` is strictly more capable and there
+  is no production traffic worth preserving.
+- The `[DELEGATION]` audit-string convention and its prompt guidance in
+  the dispatch template (the coordinator example block in
+  [`dispatch/route.ts:447`](../src/app/api/tasks/[id]/dispatch/route.ts)
+  that shows a `delegate({…})` call).
+- `src/lib/coordinator-audit.ts` (the scanner that greps
+  `task_activities` for `[DELEGATION]` markers) — convoy subtask rows
+  make it obsolete. Remove the file and any caller / cron entry.
+- The "solo stall" branch of the stall scanner for convoy-parent tasks
+  remains; only the per-subtask path gets richer SLO rules (§5.4).
+
+---
+
+## 3. MCP surface
+
+Every agent ↔ MC interaction required by the convoy flow must go through the
+`sc-mission-control` MCP server. No agent writes to the DB directly, no
+agent POSTs to an HTTP route, and no convoy state change is reachable via
+any channel an agent could take other than a tool call. HTTP routes for
+operator-only actions (convoy delete/pause, AI decomposition) remain, but
+are firewalled from agents by the normal authz.
+
+### 3.1 Coverage matrix
+
+For each interaction an agent legitimately needs, one named MCP tool is
+authoritative:
+
+| Agent interaction                                         | Role         | Tool                   | Status             |
+|-----------------------------------------------------------|--------------|------------------------|--------------------|
+| Delegate a slice of work to a peer                        | Coordinator  | `spawn_subtask`        | **NEW** (§3.2)     |
+| List my outstanding delegations and their state           | Coordinator  | `list_my_subtasks`     | **NEW** (§3.3)     |
+| Read a single subtask's contract + live status            | Coordinator  | `get_task` *(extend)*  | MODIFIED (§3.7)    |
+| Accept a peer's delivered work                            | Coordinator  | `accept_subtask`       | **NEW** (§3.4)     |
+| Reject a peer's delivered work with a reason              | Coordinator  | `reject_subtask`       | **NEW** (§3.4)     |
+| Cancel a stuck peer before timeout                        | Coordinator  | `cancel_subtask`       | **NEW** (§3.5)     |
+| Read my own task (including the Delegation Contract)      | Peer         | `get_task` *(extend)*  | MODIFIED (§3.7)    |
+| Emit required heartbeat note                              | Peer         | `log_activity`         | Existing           |
+| Register a deliverable against my contract                | Peer         | `register_deliverable` *(extend)* | MODIFIED (§3.7) |
+| Move my task forward when done                            | Peer         | `update_task_status` *(extend)*   | MODIFIED (§3.7) |
+| Declare I'm blocked with a reason                         | Peer         | `fail_task` *(extend)* | MODIFIED (§3.7)    |
+| Ask a human for help when genuinely ambiguous             | Peer         | `ask_operator`         | NEW (sibling spec) |
+| Mail the coordinator (free-form)                          | Peer         | `send_mail`            | Existing           |
+
+Tools **not** added for agents — operator-only, HTTP only:
+
+- `createConvoy` AI-decomposition flow ([`/api/tasks/:id/convoy`](../src/app/api/tasks/[id]/convoy/route.ts)) — operator plans a task; agents never do.
+- `updateConvoyStatus` pause/resume, `deleteConvoy` — lifecycle control is operator-side.
+- `addSubtasks` bulk-operator endpoint — agents use `spawn_subtask` one at a time with a full contract each.
+
+**Tool that deliberately does not exist: peer sub-delegation.** A peer on a
+subtask cannot call `spawn_subtask` — the authz check rejects callers whose
+task has `is_subtask=1`. See §3.8 for the required escape hatch when a peer
+decides its slice is wrong.
+
+### 3.2 `spawn_subtask` (replaces `delegate` in the same change)
+
+**Authorization:** caller must be the parent task's `assigned_agent_id`
+(reuses `assertAgentCanActOnTask(… , 'spawn_subtask')`).
+
+**Input schema:**
+
+```ts
+{
+  agent_id:         string,    // calling coordinator
+  task_id:          string,    // parent task
+  peer_gateway_id:  string,    // 'mc-researcher' | 'mc-writer' | …
+  slice:            string,    // 1-line "what this peer owns"
+  message:          string,    // full brief sent to peer's session
+  expected_deliverables: Array<{ title: string, kind: 'file'|'note'|'report' }>,
+                              // ≥1 required
+  acceptance_criteria:   string[],
+                              // ≥1 required, each ≥10 chars
+  expected_duration_minutes: number,   // 5..240, required
+  checkin_interval_minutes:  number,   // default 15, 5..60
+  depends_on_subtask_ids:   string[]   // optional, same-convoy ids only
+}
+```
+
+**Behavior:**
+
+1. Resolve peer by `gateway_agent_id` (fail with `peer_not_found` otherwise).
+2. **Lazy convoy create or reuse:**
+   - Find the latest `status='active'` convoy for this parent task.
+   - If none, `createConvoy({ parentTaskId, name: "<task title> — delegations", strategy: 'agent' })` — new enum value added to the `decomposition_strategy` CHECK.
+3. Insert a `convoy_subtasks` row (with the SLO fields from §5.1) and a
+   companion `tasks` row (`is_subtask=1`, assigned to the peer, priority
+   inherited from parent).
+4. Call `/api/tasks/:child_id/dispatch` internally — peer gets the standard
+   briefing (call-home block, deliverables checklist, completion
+   instructions) plus a **Delegation Contract** section carrying
+   `slice`, `expected_deliverables`, `acceptance_criteria`,
+   `expected_duration_minutes`, `checkin_interval_minutes`, and an explicit
+   `parent_subtask_id` the peer echoes back if needed.
+5. Log `delegation_spawned` activity on the **parent** task for the timeline.
+6. Return:
+   ```json
+   { "subtask_id": "...", "child_task_id": "...", "convoy_id": "...",
+     "due_at": "2026-04-22T15:30:00Z" }
+   ```
+
+**No coexistence with `delegate`.** In the same PR that registers
+`spawn_subtask`, the `delegate` tool is deleted (handler + registration +
+schema), the `[DELEGATION]` audit-string convention is removed, and the
+`coordinator-audit.ts` scanner that greps for those strings is deleted. The
+tool is not marked deprecated; there is no fallback. Rationale: we're still
+in the build phase with low usage, so a clean swap avoids the ambiguity of
+having two tools that look like they do the same thing but have different
+observability.
+
+### 3.3 `list_my_subtasks` (coordinator-facing)
+
+Gives a coordinator the live picture of its delegations without needing to
+poll `get_task` per child.
+
+**Input:**
+```ts
+{ agent_id: string, task_id: string,
+  states?: Array<'active'|'overdue'|'drifting'|'delivered'|'closed'> }
+```
+
+**Returns:** array of
+```ts
+{
+  subtask_id, child_task_id, peer: { id, name, gateway_agent_id },
+  slice, state_derived,                 // dispatched|in_progress|drifting|overdue|delivered|accepted|rejected|timed_out
+  dispatched_at, due_at, last_activity_at,
+  deliverables_registered: number, deliverables_expected: number
+}
+```
+
+This is the single read the coordinator uses in its "am I waiting on
+anyone?" check.
+
+### 3.4 `accept_subtask` / `reject_subtask`
+
+When a peer's child task reaches `review` (builder-style) or `done`
+(tester/reviewer-style), the coordinator closes the loop via these tools.
+No HTTP fallback.
+
+- `accept_subtask({ agent_id, subtask_id })`
+  - Promotes child `review → done` (or re-affirms `done`).
+  - Bumps `convoys.completed_subtasks`; triggers `checkConvoyCompletion`
+    which may promote the parent to `review`.
+  - Logs `delegation_accepted` activity on the parent task timeline.
+- `reject_subtask({ agent_id, subtask_id, reason, new_acceptance_criteria? })`
+  - Sets child `status = 'in_progress'`, `status_reason = 'rejected: …'`.
+  - Sends the rejection note into the child's chat session (`chat.send`)
+    with the new/augmented criteria so the peer knows what to fix.
+  - Logs `delegation_rejected` on the parent timeline.
+
+### 3.5 `cancel_subtask`
+
+Lets a coordinator release a branch that is no longer needed (e.g., the
+slice changed, a peer is demonstrably stuck and the coordinator wants to
+re-spawn with a clearer brief). Distinct from `reject_subtask` which
+implies "work delivered but wrong".
+
+```ts
+cancel_subtask({ agent_id, subtask_id, reason })
+```
+- Child task → `cancelled`, `status_reason = 'cancelled_by_coordinator: …'`.
+- Bumps `convoys.failed_subtasks`; the subtask no longer blocks convoy
+  completion.
+- Logs `delegation_cancelled`.
+
+### 3.6 `ask_operator` (sibling proposal)
+
+Covered in the sibling observability spec; mentioned here because it closes
+the last "peer is stuck and needs a human" hole in the delegation path. No
+convoy-specific change — it just sets the peer's task to `awaiting_operator`
+and the convoy-aware stall logic already routes through the coordinator.
+
+### 3.7 Modifications to existing MCP tools
+
+These changes are small but make the existing surface convoy-aware so
+peers and coordinators don't need new tools for routine work.
+
+- **`get_task`** ([`tools.ts:214`](../src/lib/mcp/tools.ts))
+  When the task has `convoy_id IS NOT NULL` and a matching
+  `convoy_subtasks` row, include the Delegation Contract
+  (slice, expected_deliverables, acceptance_criteria, dispatched_at,
+  due_at, checkin_interval_minutes) in the structured response. The peer
+  uses this to refresh its contract mid-run; the coordinator uses it for
+  point-lookups. Eliminates any need to parse the dispatch brief for
+  structured data.
+
+- **`register_deliverable`** ([`tools.ts:265`](../src/lib/mcp/tools.ts))
+  Auto-resolve `parent_subtask_id` from the child task's `convoy_id`
+  (no new input required). On insert, also update
+  `convoy_subtasks.deliverables_registered_count` so
+  `list_my_subtasks` stays cheap.
+
+- **`update_task_status`** ([`tools.ts:340`](../src/lib/mcp/tools.ts))
+  When a subtask transitions to `review`, mail the coordinator (same
+  plumbing as stall detector's sendMail) with a "ready for review"
+  note so the coordinator knows to call `accept_subtask` /
+  `reject_subtask` — even if it's not actively polling `list_my_subtasks`.
+
+- **`fail_task`** ([`tools.ts:399`](../src/lib/mcp/tools.ts))
+  When called on a subtask, record the failure on
+  `convoy_subtasks.state_reason = 'blocked: …'` and mail the
+  coordinator. The peer's task stays in its current status (not
+  auto-cancelled) so a coordinator can choose to re-spawn or unblock.
+
+- **`send_mail`** — no schema change, but the convoy-aware stall code
+  already uses it to notify coordinators; document the subject-line
+  convention (`DELEGATION: drifting/overdue/blocked/ready_for_review`) so
+  the coordinator's inbox triage is deterministic.
+
+### 3.8 Peer escape hatch: "my slice is wrong, re-decompose"
+
+Peers cannot sub-delegate (see §3.1). Sub-delegation creates fan-out
+storms and obscures the coordinator's picture of the tree, and we don't
+have the observability to handle it safely yet. A peer that realizes its
+slice is too big, mis-scoped, or misaligned with the parent goal has
+exactly two sanctioned paths, in preference order:
+
+**Path A — deliver what you have, let the coordinator re-assess.**
+Preferred. The peer registers partial deliverables via
+`register_deliverable` (with a note on what's incomplete) and moves its
+task to `review` via `update_task_status`. The coordinator receives the
+`DELEGATION: ready_for_review` mail, inspects the partial work, and
+either `accept_subtask` (good enough) or `reject_subtask` (with updated
+acceptance criteria) or `cancel_subtask` + a fresh `spawn_subtask` round
+(re-decompose). Partial progress remains visible and reusable.
+
+**Path B — explicitly hand control back, then stop.** For the case where
+the peer cannot produce anything usable (e.g., the slice describes work
+the peer does not have skills for, or the acceptance criteria are
+contradictory). The peer:
+
+1. Calls `fail_task({ task_id, reason: 'redecompose: <specific ask>' })`.
+   The `redecompose:` prefix is a convention; see below for why we're
+   not adding a new tool.
+2. Optionally sends a single `send_mail` to the coordinator with subject
+   `DELEGATION: redecompose_requested` and a body describing what a
+   better decomposition would look like (suggested slices, any context
+   the coordinator will need).
+3. Returns a final message like `REDECOMPOSE_REQUESTED: <reason>` and
+   stops. No further tool calls, no workaround attempts, no
+   "meanwhile-I-tried" behavior — the peer's run ends there.
+
+The coordinator, on seeing the `redecompose:` mail, is expected to
+`cancel_subtask` on this branch and then issue one or more fresh
+`spawn_subtask` calls with better-scoped slices. The peer's session is
+effectively terminal at that point; OpenClaw cleans it up on session
+timeout or on the coordinator's `cancel_subtask` call (which closes the
+child task).
+
+**Why no dedicated `request_redecomposition` tool?** It would overlap
+almost entirely with `fail_task` + `send_mail` (both of which every peer
+already has) and add surface area agents would routinely confuse with
+`ask_operator`. The `fail_task` reason-prefix convention is explicit
+enough for the coordinator to branch on, and keeps the MCP surface
+focused. If in practice coordinators miss the prefix and re-dispatch
+without re-decomposing, revisit — promote it to a real tool then.
+
+**Dispatch-briefing update.** The peer Delegation Contract block (§4)
+gets a final line:
+
+> **If the slice is wrong:** do not sub-delegate, do not improvise. Call
+> `fail_task` with `reason: "redecompose: …"`, optionally mail the
+> coordinator with suggestions, and stop. The coordinator will re-plan.
+
+---
+
+## 4. Dispatch briefing: Delegation Contract block
+
+Peers receive an extra section in their dispatch message (appended by
+`/api/tasks/:id/dispatch` when the task has `convoy_id IS NOT NULL` AND the
+convoy subtask row has SLO fields):
+
+```
+---
+**🤝 DELEGATION CONTRACT**
+
+You were delegated this work by coordinator <name>. The contract is:
+
+- **Slice:** <one-line slice>
+- **Expected deliverables:** (must all be registered)
+  - <title> (<kind>)
+  - …
+- **Acceptance criteria:** (all must hold)
+  - <criterion 1>
+  - …
+- **Expected duration:** <N> minutes (hard deadline at <ISO-8601>)
+- **Check-in cadence:** call `log_activity` at least every <M> minutes
+  with a substantive note. Silence past 2× cadence = drift alert to coordinator.
+- **If blocked:** call `ask_operator` (preferred) or `fail_task` with a
+  specific reason. Do NOT keep working around ambiguity.
+
+Your `parent_subtask_id` is `<uuid>` — include it in `register_deliverable`
+and `fail_task` calls so the coordinator's tree updates.
+```
+
+This is the codification the operator has been asking for. It lives **inside
+the peer's briefing**, so the peer literally sees the contract it is on the
+hook for.
+
+---
+
+## 5. Schema & code changes
+
+### 5.1 Migrations
+
+```sql
+-- 1. SLO fields on convoy_subtasks
+ALTER TABLE convoy_subtasks ADD COLUMN expected_duration_minutes INTEGER;
+ALTER TABLE convoy_subtasks ADD COLUMN checkin_interval_minutes  INTEGER DEFAULT 15;
+ALTER TABLE convoy_subtasks ADD COLUMN acceptance_criteria TEXT;   -- JSON array
+ALTER TABLE convoy_subtasks ADD COLUMN expected_deliverables TEXT; -- JSON array
+ALTER TABLE convoy_subtasks ADD COLUMN dispatched_at TEXT;         -- set on spawn
+ALTER TABLE convoy_subtasks ADD COLUMN due_at        TEXT;         -- dispatched_at + expected_duration
+
+-- 2. Drop the UNIQUE on parent_task_id (SQLite = table rebuild).
+--    Replace with a non-unique index; all `queryOne` readers switch to
+--    "latest active" ordering.
+DROP INDEX IF EXISTS idx_convoys_parent;    -- was on parent_task_id
+-- (table rebuild handled in migration runner, see src/lib/db/migrations.ts
+-- pattern used for the 'convoy_active' status addition at line 757)
+CREATE INDEX idx_convoys_parent_active ON convoys(parent_task_id, status);
+
+-- 3. New decomposition_strategy value for agent-initiated convoys
+--    (SQLite CHECK constraint rebuild; pattern matches migrations.ts:1623)
+-- old: CHECK (decomposition_strategy IN ('manual','ai','planning'))
+-- new: CHECK (decomposition_strategy IN ('manual','ai','planning','agent'))
+```
+
+### 5.2 Parallel cap
+
+`MAX_PARALLEL_CONVOY_SUBTASKS` at [`convoy.ts:266`](../src/lib/convoy.ts)
+currently `5`. Raise to `10` and expose as
+`MC_CONVOY_MAX_PARALLEL` env var. Rationale: operator-planned convoys rarely
+exceed 5, but an agent-driven coordinator can legitimately fan out to every
+peer in the roster (7 roles today) in one batch.
+
+### 5.3 Single-convoy reader migration
+
+Replace in place with a shared helper `getActiveConvoyForTask(parentTaskId)`
+that returns the most-recently-created `status='active'` convoy:
+
+| Callsite                                                       | Change                                           |
+|----------------------------------------------------------------|--------------------------------------------------|
+| [`convoy.ts:71`](../src/lib/convoy.ts) (createConvoy guard)    | Remove `existing` check; convoys may co-exist.   |
+| [`convoy.ts:136`](../src/lib/convoy.ts) (getConvoy)            | Route through helper; preserve existing shape.   |
+| [`stall-detection.ts:201`](../src/lib/stall-detection.ts)      | Route through helper.                            |
+| [`admin/release-stall/route.ts:56`](../src/app/api/tasks/[id]/admin/release-stall/route.ts) | Route through helper. |
+| [`tasks/[id]/route.ts:578`](../src/app/api/tasks/[id]/route.ts) | Route through helper.                            |
+
+The helper makes the "latest active" semantic explicit so it survives future
+multi-convoy work.
+
+### 5.4 Stall detection per-subtask
+
+In [`src/lib/stall-detection.ts`](../src/lib/stall-detection.ts), when a
+candidate task has a `convoy_subtasks` row with SLO fields, replace the
+global `DEFAULT_STALL_MINUTES = 30` with:
+
+```ts
+const driftMinutes  = checkin_interval_minutes * 2;   // silent drift
+const overdueMinutes = expected_duration_minutes * 1.5; // hard overdue
+```
+
+Escalation ladder (replaces the current "flag and throttle forever" loop
+that caused 106 repeats on cc3d40e1):
+
+| Condition                                          | Action                                                                  |
+|----------------------------------------------------|-------------------------------------------------------------------------|
+| `last_activity_at` older than `driftMinutes`       | Mail coordinator (existing path), set `status_reason = 'drifting'`.     |
+| Wall-clock past `due_at`                           | Mail coordinator + operator, set `status_reason = 'overdue'`.           |
+| Past `due_at + driftMinutes` AND no deliverables   | `status = 'cancelled'`, `status_reason = 'timed_out'`, promote convoy counter. |
+
+The parent-task stall rule becomes: **all active subtasks `cancelled` or
+`blocked` and no new `spawn_subtask` in N minutes** → stall the parent.
+Deterministic, per-branch, and loop-free.
+
+### 5.5 Prompt changes
+
+- **Coordinator dispatch template**
+  ([`src/app/api/tasks/[id]/dispatch/route.ts:447`](../src/app/api/tasks/[id]/dispatch/route.ts)):
+  replace the `delegate({…})` example with a `spawn_subtask({…})` example.
+  Emphasize "every delegation must declare deliverables, acceptance,
+  duration, and cadence — no declarations means no spawn".
+- **Peer dispatch template**: add the Delegation Contract block from §4 when
+  `tasks.convoy_id IS NOT NULL` and the subtask row has SLO fields.
+
+### 5.6 UI
+
+- **ConvoyTab.tsx**: add per-subtask columns for `due_at` (countdown chip),
+  `last_activity_at` (age), and a state pill derived from
+  `tasks.status` + `status_reason` (`dispatched` / `in-progress` /
+  `drifting` / `overdue` / `delivered` / `timed-out`).
+- **Sidebar**: add "Delegations at risk" section listing subtasks with
+  `status_reason IN ('drifting','overdue')` or `status='cancelled'` with
+  `status_reason='timed_out'`.
+- **Accept/Reject controls** on each subtask in `review` status, wired to
+  the new `accept_subtask`/`reject_subtask` MCP tools via an internal API.
+
+---
+
+## 6. Rollout
+
+Single cutover. We are still in the build phase and `delegate` has no
+production dependency worth preserving, so the swap is one PR with no
+coexistence window.
+
+1. **One PR: schema + MCP surface swap.**
+   - Schema migrations from §5.1 (SLO columns, drop UNIQUE, add `'agent'`
+     strategy).
+   - `getActiveConvoyForTask` helper + the five-callsite refactor (§5.3).
+   - Register `spawn_subtask`, `list_my_subtasks`, `accept_subtask`,
+     `reject_subtask`, `cancel_subtask`; modify `get_task`,
+     `register_deliverable`, `update_task_status`, `fail_task`,
+     `send_mail` per §3.7.
+   - **Delete `delegate`** handler, registration, and the
+     `[DELEGATION]` audit-string convention.
+   - Delete `src/lib/coordinator-audit.ts` (and any caller / cron entry)
+     since the convoy subtask row replaces what it used to scan for.
+   - Update the coordinator dispatch briefing
+     ([`/api/tasks/[id]/dispatch/route.ts:447`](../src/app/api/tasks/[id]/dispatch/route.ts))
+     to describe `spawn_subtask`; add the peer Delegation Contract block.
+2. **Follow-up PR: per-subtask stall rules** (§5.4). Gated behind the
+   schema migration from (1) so SLO columns are guaranteed present. The
+   existing 30-min global rule remains the fallback for rows where SLO
+   columns are NULL (operator-created convoys from before this migration —
+   only the one existing row).
+3. **Follow-up PR: UI.** ConvoyTab SLO chips, at-risk sidebar, accept/
+   reject buttons wired to the new tools.
+
+Rollback for PR (1): revert the single commit; the migration is
+reversible via the standard `down` step (drop new columns, restore
+`UNIQUE`, re-register `delegate`). But since we're killing `delegate`
+deliberately, rollback is a "revert-and-redesign" move, not a "revert and
+keep running" move — that's the tradeoff of the clean swap.
+
+---
+
+## 7. Verification
+
+- **Unit:** `spawn_subtask` lazy-create branch; appending to existing
+  convoy; authz rejects non-coordinator callers; missing-field rejects.
+- **Integration:** coordinator spawns three subtasks; each peer receives a
+  dispatch with the contract block; one peer stays silent past
+  `2 × checkin_interval`; stall scanner marks it `drifting`; scanner mails
+  the coordinator with the specific subtask id.
+- **Regression:** operator-created convoys (AI decomposition path)
+  continue to work unchanged. `ConvoyTab` still renders them (with the new
+  columns showing NULL → `—`).
+- **Data:** re-run the §1 metrics query after a week in production.
+  Success signals: stall-repeat count per task falls below 3; median
+  subtask has `last_activity_at` freshness inside declared cadence; zero
+  `[DELEGATION]` audit strings being written.
+
+---
+
+## 8. Open questions
+
+1. **Depends-on across waves.** When a coordinator appends subtasks to an
+   existing convoy, the new rows can depend on earlier ones. The dependency
+   enforcer ([`convoy.ts:366`](../src/lib/convoy.ts)) already handles
+   arbitrary DAGs inside one convoy, but spec should state that "second
+   wave" subtasks may reference first-wave ids.
+2. **Workspace isolation for subtasks.** `workspace-isolation.ts:117`
+   already treats convoy subtasks as active; confirm that agent-spawned
+   subtasks route into the same workspace as their parent unless the peer
+   is itself a builder (which would require its own isolated dir).
+3. **Chargeback / cost attribution.** Convoy subtasks already inherit
+   cost events via the normal pipeline; no change needed unless the
+   operator wants per-delegation cost rollups in the UI.
+
+---
+
+## 9. Non-goals
+
+- **Peer sub-delegation.** A peer on a subtask cannot spawn further
+  subtasks. Authz explicitly rejects `spawn_subtask` when the caller's
+  task has `is_subtask=1`. The desired behavior when a peer thinks its
+  slice is wrong is codified in §3.8 (deliver partial → coordinator
+  re-assesses; or `fail_task("redecompose: …")` → peer stops →
+  coordinator re-plans). We prefer a coordinator re-plan to a deeper
+  tree because (a) we don't yet have the observability to reason about
+  multi-level fan-out, and (b) a partial deliverable plus a coordinator
+  prompt is always more recoverable than an orphaned sub-sub-tree. Revisit
+  only after the delegation observability numbers in §7 hold steady.
+- **Multi-convoy-per-task UX.** The schema allows it; the UI does not
+  show it yet. Deferred until a real use case emerges.
+- **Replacing operator-initiated convoy creation** (HTTP + AI
+  decomposition). Those paths remain; `spawn_subtask` is an additional
+  entry point, not a replacement.

--- a/src/app/api/tasks/[id]/admin/release-stall/route.ts
+++ b/src/app/api/tasks/[id]/admin/release-stall/route.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run, transaction } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { ReleaseStallSchema } from '@/lib/validation';
+import { getActiveConvoyForTask } from '@/lib/convoy';
 import type { Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -52,10 +53,9 @@ export async function POST(
 
     // If this task is a convoy parent, collect sub-task ids so we can end
     // sessions for every convoy member, not just the primary assignee.
-    const convoy = queryOne<{ id: string }>(
-      'SELECT id FROM convoys WHERE parent_task_id = ?',
-      [taskId]
-    );
+    // Release-stall targets the currently-active convoy; historical
+    // completed convoys on the same parent are not re-opened here.
+    const convoy = getActiveConvoyForTask(taskId);
     const convoySubtaskIds = convoy
       ? queryAll<{ task_id: string }>(
           'SELECT task_id FROM convoy_subtasks WHERE convoy_id = ?',

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -444,29 +444,51 @@ If a tool returns \`MCP endpoint is disabled\` (HTTP 503), the operator has the 
           : '(no structured spec — one deliverable call is enough)';
 
       if (isCoordinator) {
-        return `**YOUR ROLE: COORDINATOR** — Delegate to peers using the \`delegate\` MCP tool.
+        return `**YOUR ROLE: COORDINATOR** — Delegate to peers using the \`spawn_subtask\` MCP tool. Every delegation must declare deliverables, acceptance criteria, duration, and cadence — no declarations, no spawn.
 
 **Per peer, call once:**
 \`\`\`
-delegate({
+spawn_subtask({
   agent_id: "${agentId}",
   task_id: "${taskIdForMcp}",
   peer_gateway_id: "<mc-researcher | mc-writer | …>",
   slice: "<one-line summary of what this peer owns>",
-  message: "You are the <role> for this task.\\n\\n<context + success criteria>",
-  timeout_seconds: 0   // fire-and-forget for parallel fan-out
+  message: "You are the <role> for this task.\\n\\n<context + why this slice exists>",
+  expected_deliverables: [ { title: "<name>", kind: "file" | "note" | "report" } ],
+  acceptance_criteria: [ "<criterion 1>", "<criterion 2>" ],
+  expected_duration_minutes: 30,
+  checkin_interval_minutes: 15
 })
 \`\`\`
 
-\`delegate\` atomically invokes openclaw's \`sessions.send\` AND logs the \`[DELEGATION]\` audit activity for you — no separate sessions_send / activity calls needed. The coordinator-audit scanner reads the activity it writes.
+\`spawn_subtask\` creates a tracked convoy subtask with the SLO you declare, dispatches the peer through the normal pipeline, and returns a \`subtask_id\`. The peer sees your contract inline in its briefing.
 
-**When all peers have reported back:**
+**While peers are working, check on them:**
+\`\`\`
+list_my_subtasks({ agent_id: "${agentId}", task_id: "${taskIdForMcp}" })
+\`\`\`
+Each row has a \`state_derived\` (dispatched / in_progress / drifting / overdue / delivered / blocked / timed_out / accepted / rejected / cancelled).
+
+**When a peer delivers** (state_derived = "delivered"):
+\`\`\`
+accept_subtask({ agent_id: "${agentId}", subtask_id: "<id>" })
+# or if the work doesn't meet acceptance criteria:
+reject_subtask({ agent_id: "${agentId}", subtask_id: "<id>", reason: "<specific>", new_acceptance_criteria: [ ... ] })
+\`\`\`
+
+**If a peer is stuck and the slice was wrong,** cancel and re-spawn with a better brief:
+\`\`\`
+cancel_subtask({ agent_id: "${agentId}", subtask_id: "<id>", reason: "<why>" })
+spawn_subtask({ ... })   # fresh slice
+\`\`\`
+
+**When all subtasks are accepted:**
 \`\`\`
 register_deliverable({ agent_id: "${agentId}", task_id: "${taskIdForMcp}", deliverable_type: "file", title: "<title>", path: "${deliverablesDir}/<filename>" })
 update_task_status({ agent_id: "${agentId}", task_id: "${taskIdForMcp}", status: "${nextStatus}" })
 \`\`\`
 
-Reply with \`TASK_COMPLETE: [one line per delegated peer]\`.`;
+Reply with \`TASK_COMPLETE: [one line per delegated subtask]\`.`;
       }
 
       if (isBuilder) {
@@ -633,6 +655,56 @@ update_task_status({ agent_id: "${agentId}", task_id: "${taskIdForMcp}", status:
     const deliverablesLead = isBuilder ? deliverablesChecklistSection : '';
     const criteriaLead = (isTester || isVerifier) ? successCriteriaChecklistSection : '';
 
+    // Delegation Contract — shown to agent-spawned subtask peers so they
+    // see their obligation inline (SLO, acceptance criteria, deliverables,
+    // escape hatch). Operator-created convoy subtasks have NULL SLO
+    // fields and skip this section.
+    let delegationContractSection = '';
+    if ((task as Task & { is_subtask?: number }).is_subtask) {
+      const contract = queryOne<{
+        id: string;
+        slice: string | null;
+        expected_deliverables: string | null;
+        acceptance_criteria: string | null;
+        expected_duration_minutes: number | null;
+        checkin_interval_minutes: number | null;
+        due_at: string | null;
+        coordinator_name: string | null;
+      }>(
+        `SELECT cs.id, cs.slice, cs.expected_deliverables, cs.acceptance_criteria,
+                cs.expected_duration_minutes, cs.checkin_interval_minutes, cs.due_at,
+                ca.name as coordinator_name
+           FROM convoy_subtasks cs
+           JOIN convoys c ON c.id = cs.convoy_id
+           JOIN tasks p ON p.id = c.parent_task_id
+           LEFT JOIN agents ca ON ca.id = p.assigned_agent_id
+          WHERE cs.task_id = ?`,
+        [task.id],
+      );
+      if (contract && contract.expected_duration_minutes != null) {
+        const parseJson = <T,>(s: string | null): T[] => { if (!s) return []; try { return JSON.parse(s) as T[]; } catch { return []; } };
+        const delivs = parseJson<{ title: string; kind: string }>(contract.expected_deliverables);
+        const criteria = parseJson<string>(contract.acceptance_criteria);
+        delegationContractSection = `
+---
+**\u{1F91D} DELEGATION CONTRACT**
+
+You were delegated this work by coordinator ${contract.coordinator_name ?? '(unknown)'}. The contract is:
+
+- **Slice:** ${contract.slice ?? '(unset)'}
+- **Expected deliverables** (register every one via \`register_deliverable\`):
+${delivs.length > 0 ? delivs.map(d => `  - ${d.title} (${d.kind})`).join('\n') : '  - (none declared)'}
+- **Acceptance criteria** (all must hold for accept_subtask):
+${criteria.length > 0 ? criteria.map(c => `  - ${c}`).join('\n') : '  - (none declared)'}
+- **Expected duration:** ${contract.expected_duration_minutes} minutes (due at ${contract.due_at ?? 'unset'})
+- **Check-in cadence:** call \`log_activity\` at least every ${contract.checkin_interval_minutes ?? 15} minutes with a substantive note. Silence past 2\u00D7 cadence = drift alert to coordinator.
+- **Your \`subtask_id\`:** \`${contract.id}\` — referenced automatically by register_deliverable and fail_task.
+
+**If the slice is wrong:** do not sub-delegate, do not improvise. Call \`fail_task\` with \`reason: "redecompose: <specific ask>"\`, optionally mail the coordinator with suggestions, and stop. The coordinator will re-plan.
+`;
+      }
+    }
+
     const taskMessage = `${priorityEmoji} **${headline}**
 
 **Title:** ${task.title}
@@ -640,7 +712,7 @@ ${task.description ? `**Description:** ${task.description}\n` : ''}
 **Priority:** ${task.priority.toUpperCase()}
 ${task.due_date ? `**Due:** ${task.due_date}\n` : ''}
 **Task ID:** ${task.id}
-${callHomeSection}${deliverablesLead}${criteriaLead}${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}${delegationRosterSection}
+${callHomeSection}${delegationContractSection}${deliverablesLead}${criteriaLead}${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}${delegationRosterSection}
 ${isBuilder ? (workspaceIsolated
   ? `**\u{1F512} ISOLATED WORKSPACE:** ${taskProjectDir}\n- **Port:** ${workspacePort || 'default'} (use this for dev server, NOT the default)\n${workspaceBranchName ? `- **Branch:** ${workspaceBranchName}\n` : ''}- **IMPORTANT:** Do NOT modify files outside this workspace directory. Other agents may be working on the same project in parallel. All your work must stay within: ${taskProjectDir}\n**DELIVERABLES DIR (separate):** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`
   : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n**DELIVERABLES DIR:** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`)

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -574,10 +574,12 @@ export async function DELETE(
       }
     }
 
-    // Delete convoy and its sub-tasks if this is a convoy parent
-    const convoy = queryOne<{ id: string }>('SELECT id FROM convoys WHERE parent_task_id = ?', [id]);
-    if (convoy) {
-      // Delete sub-tasks first (CASCADE handles convoy_subtasks)
+    // Delete every convoy this parent has ever had (not just the active
+    // one) and all of each convoy's sub-tasks. Task delete is a full
+    // teardown — historical completed convoys would otherwise leave
+    // orphaned subtask rows after the parent row cascades away.
+    const convoys = queryAll<{ id: string }>('SELECT id FROM convoys WHERE parent_task_id = ?', [id]);
+    for (const convoy of convoys) {
       const subtaskIds = queryAll<{ task_id: string }>('SELECT task_id FROM convoy_subtasks WHERE convoy_id = ?', [convoy.id]);
       for (const { task_id } of subtaskIds) {
         run('DELETE FROM work_checkpoints WHERE task_id = ?', [task_id]);

--- a/src/lib/convoy.ts
+++ b/src/lib/convoy.ts
@@ -57,6 +57,26 @@ interface CreateConvoyInput {
 }
 
 /**
+ * Returns the most recently created still-active convoy for a parent task,
+ * or null. The schema (as of migration 037) no longer requires one-convoy-
+ * per-task; readers that need "the" convoy funnel through this helper so the
+ * "latest active" semantic is explicit and consistent.
+ *
+ * `status='active'` excludes completing/done/failed/paused convoys — a new
+ * round of coordinator-driven delegation after completion is free to create
+ * a new active convoy rather than reopening a closed one.
+ */
+export function getActiveConvoyForTask(parentTaskId: string): Convoy | null {
+  return queryOne<Convoy>(
+    `SELECT * FROM convoys
+     WHERE parent_task_id = ? AND status = 'active'
+     ORDER BY datetime(created_at) DESC
+     LIMIT 1`,
+    [parentTaskId]
+  ) ?? null;
+}
+
+/**
  * Create a convoy from a parent task with optional sub-tasks.
  */
 export function createConvoy(input: CreateConvoyInput): Convoy {
@@ -67,9 +87,13 @@ export function createConvoy(input: CreateConvoyInput): Convoy {
     if (!task) throw new Error(`Task ${parentTaskId} not found`);
     if (task.is_subtask) throw new Error('Cannot create a convoy from a sub-task');
 
-    // Check no convoy already exists for this task
-    const existing = queryOne<{ id: string }>('SELECT id FROM convoys WHERE parent_task_id = ?', [parentTaskId]);
-    if (existing) throw new Error(`Convoy already exists for task ${parentTaskId}`);
+    // Multiple convoys per parent are allowed since migration 037, but we
+    // still reject a second *active* convoy — callers that want to append
+    // work should use addSubtasks() on the existing active convoy instead,
+    // and the coordinator delegation path (spawn_subtask) already does so
+    // via getActiveConvoyForTask() before falling back to createConvoy().
+    const activeExisting = getActiveConvoyForTask(parentTaskId);
+    if (activeExisting) throw new Error(`An active convoy already exists for task ${parentTaskId} — append via addSubtasks instead`);
 
     const convoyId = uuidv4();
     const now = new Date().toISOString();
@@ -129,13 +153,12 @@ export function createConvoy(input: CreateConvoyInput): Convoy {
 }
 
 /**
- * Get convoy details for a parent task, with subtasks joined.
+ * Get convoy details for a parent task, with subtasks joined. Returns the
+ * latest active convoy (see getActiveConvoyForTask); prior completed convoys
+ * are not surfaced through this helper.
  */
 export function getConvoy(parentTaskId: string): (Convoy & { subtasks: (ConvoySubtask & { task: Task })[] }) | null {
-  const convoy = queryOne<Convoy>(
-    'SELECT * FROM convoys WHERE parent_task_id = ?',
-    [parentTaskId]
-  );
+  const convoy = getActiveConvoyForTask(parentTaskId);
   if (!convoy) return null;
 
   const subtaskRows = queryAll<ConvoySubtask & { task_title: string; task_status: string; task_assigned_agent_id: string | null }>(
@@ -263,7 +286,19 @@ export function checkConvoyCompletion(convoyId: string): boolean {
   return false;
 }
 
-const MAX_PARALLEL_CONVOY_SUBTASKS = 5;
+/**
+ * Parallel subtask cap. Defaults to 10 (up from 5 pre-PR) to accommodate
+ * agent-driven delegations that legitimately fan out to every peer in the
+ * roster; operator-planned convoys rarely approach this. Override with
+ * `MC_CONVOY_MAX_PARALLEL` env var.
+ */
+function getMaxParallelConvoySubtasks(): number {
+  const raw = process.env.MC_CONVOY_MAX_PARALLEL;
+  if (!raw) return 10;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 10;
+}
+const MAX_PARALLEL_CONVOY_SUBTASKS = getMaxParallelConvoySubtasks();
 
 export interface ConvoyDispatchResult {
   dispatched: number;
@@ -489,5 +524,145 @@ export function deleteConvoy(convoyId: string): void {
 
     const updatedParent = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [convoy.parent_task_id]);
     if (updatedParent) broadcast({ type: 'task_updated', payload: updatedParent });
+  });
+}
+
+// ─── Agent-initiated delegation ────────────────────────────────────
+
+export interface SpawnDelegationInput {
+  parentTaskId: string;
+  parentAgentId: string;
+  peerAgentId: string;
+  peerGatewayId: string;
+  suggestedRole: string;
+  slice: string;
+  message: string;
+  expectedDeliverables: { title: string; kind: 'file' | 'note' | 'report' }[];
+  acceptanceCriteria: string[];
+  expectedDurationMinutes: number;
+  checkinIntervalMinutes: number;
+  dependsOnSubtaskIds?: string[];
+}
+
+export interface SpawnDelegationResult {
+  subtaskId: string;
+  childTaskId: string;
+  convoyId: string;
+  dispatchedAt: string;
+  dueAt: string;
+}
+
+/**
+ * Create (or append to) a convoy for a coordinator-initiated delegation.
+ *
+ * Invoked by the `spawn_subtask` MCP tool. Unlike `createConvoy` +
+ * `addSubtasks`, this carries the SLO contract (slice, expected
+ * deliverables, acceptance criteria, duration, cadence) onto the
+ * `convoy_subtasks` row so stall detection and the coordinator's
+ * `list_my_subtasks` read can reason about the delegation deterministically.
+ *
+ * The actual peer dispatch (HTTP POST to /api/tasks/:child_id/dispatch) is
+ * the caller's job — we can't reach-around from here without a circular
+ * dependency (dispatch needs convoy, convoy can't need dispatch). The
+ * caller invokes the dispatch after this function returns.
+ */
+export function spawnDelegationSubtask(input: SpawnDelegationInput): SpawnDelegationResult {
+  return transaction(() => {
+    const parent = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [input.parentTaskId]);
+    if (!parent) throw new Error(`Parent task ${input.parentTaskId} not found`);
+    if (parent.is_subtask) throw new Error('Peer sub-delegation is not allowed (parent is itself a subtask)');
+
+    // Lazy-create or reuse the active convoy on this parent task.
+    let convoy = getActiveConvoyForTask(input.parentTaskId);
+    const now = new Date().toISOString();
+
+    if (!convoy) {
+      const convoyId = uuidv4();
+      run(
+        `INSERT INTO convoys (id, parent_task_id, name, status, decomposition_strategy, total_subtasks, created_at, updated_at)
+         VALUES (?, ?, ?, 'active', 'agent', 0, ?, ?)`,
+        [convoyId, input.parentTaskId, `${parent.title} — delegations`, now, now]
+      );
+      convoy = queryOne<Convoy>('SELECT * FROM convoys WHERE id = ?', [convoyId])!;
+      // Move parent into convoy_active so the stall scanner and UI see it.
+      run(
+        `UPDATE tasks SET status = 'convoy_active', updated_at = ? WHERE id = ?`,
+        [now, input.parentTaskId]
+      );
+      broadcast({ type: 'convoy_created', payload: convoy });
+    }
+
+    // Sort order = max+1 (append).
+    const maxOrder = queryOne<{ max_order: number | null }>(
+      'SELECT MAX(sort_order) as max_order FROM convoy_subtasks WHERE convoy_id = ?',
+      [convoy.id]
+    )?.max_order ?? 0;
+
+    // Create the child task row. Pre-assigned to the peer; workflow
+    // inheritance mirrors what addSubtasks does for operator flows.
+    const childTaskId = uuidv4();
+    run(
+      `INSERT INTO tasks (id, title, description, status, priority, assigned_agent_id, workspace_id, business_id, workflow_template_id, convoy_id, is_subtask, created_at, updated_at)
+       VALUES (?, ?, ?, 'inbox', ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
+      [
+        childTaskId,
+        input.slice.slice(0, 200),
+        input.message.slice(0, 4000),
+        parent.priority,
+        input.peerAgentId,
+        parent.workspace_id,
+        parent.business_id,
+        parent.workflow_template_id || null,
+        convoy.id,
+        now,
+        now,
+      ]
+    );
+
+    // Dispatched/due timestamps. The caller performs the HTTP dispatch
+    // right after; storing the timestamp here keeps SLO math monotonic
+    // even if the HTTP call retries.
+    const dueAt = new Date(Date.now() + input.expectedDurationMinutes * 60_000).toISOString();
+
+    const subtaskId = uuidv4();
+    run(
+      `INSERT INTO convoy_subtasks (
+         id, convoy_id, task_id, sort_order, depends_on, suggested_role,
+         slice, expected_deliverables, acceptance_criteria,
+         expected_duration_minutes, checkin_interval_minutes,
+         dispatched_at, due_at, deliverables_registered_count, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+      [
+        subtaskId,
+        convoy.id,
+        childTaskId,
+        maxOrder + 1,
+        input.dependsOnSubtaskIds && input.dependsOnSubtaskIds.length > 0
+          ? JSON.stringify(input.dependsOnSubtaskIds)
+          : null,
+        input.suggestedRole,
+        input.slice,
+        JSON.stringify(input.expectedDeliverables),
+        JSON.stringify(input.acceptanceCriteria),
+        input.expectedDurationMinutes,
+        input.checkinIntervalMinutes,
+        now,
+        dueAt,
+        now,
+      ]
+    );
+
+    run(
+      `UPDATE convoys SET total_subtasks = total_subtasks + 1, updated_at = ? WHERE id = ?`,
+      [now, convoy.id]
+    );
+
+    return {
+      subtaskId,
+      childTaskId,
+      convoyId: convoy.id,
+      dispatchedAt: now,
+      dueAt,
+    };
   });
 }

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -2069,6 +2069,102 @@ const migrations: Migration[] = [
 
       console.log('[Migration 036] Complete.');
     }
+  },
+  {
+    id: '037',
+    name: 'coordinator_delegation_convoy',
+    up: (db) => {
+      // Substrate for agent-initiated delegation (see specs/coordinator-
+      // delegation-via-convoy-spec.md). Three changes:
+      //   (a) SLO columns on convoy_subtasks — populated by spawn_subtask,
+      //       NULL on legacy operator-created convoys.
+      //   (b) Drop the UNIQUE on convoys.parent_task_id so a parent task
+      //       may hold multiple convoys over its lifetime. Readers switch
+      //       to "latest status='active'" via getActiveConvoyForTask().
+      //   (c) Add 'agent' to the decomposition_strategy CHECK so
+      //       spawn_subtask's lazy convoys can record their origin.
+      console.log('[Migration 037] Coordinator delegation substrate (convoys + subtasks)...');
+
+      // (a) SLO columns — simple ALTERs, idempotent via PRAGMA check.
+      const subInfo = db.prepare('PRAGMA table_info(convoy_subtasks)').all() as { name: string }[];
+      const has = (col: string) => subInfo.some(c => c.name === col);
+      if (!has('slice'))                         db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN slice TEXT`);
+      if (!has('expected_deliverables'))         db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN expected_deliverables TEXT`);
+      if (!has('acceptance_criteria'))           db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN acceptance_criteria TEXT`);
+      if (!has('expected_duration_minutes'))     db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN expected_duration_minutes INTEGER`);
+      if (!has('checkin_interval_minutes'))      db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN checkin_interval_minutes INTEGER DEFAULT 15`);
+      if (!has('dispatched_at'))                 db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN dispatched_at TEXT`);
+      if (!has('due_at'))                        db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN due_at TEXT`);
+      if (!has('deliverables_registered_count')) db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN deliverables_registered_count INTEGER DEFAULT 0`);
+
+      // (b) + (c) Rewrite the convoys CREATE TABLE text via writable_schema
+      //          (same pattern as migration 036 used for tasks). We:
+      //            - drop UNIQUE on parent_task_id
+      //            - add 'agent' to decomposition_strategy CHECK
+      //          One writable_schema rewrite covers both.
+      const convoysSchema = db.prepare(
+        `SELECT sql FROM sqlite_master WHERE type='table' AND name='convoys'`
+      ).get() as { sql: string } | undefined;
+
+      if (convoysSchema) {
+        const needsUniqueDrop   = convoysSchema.sql.includes('parent_task_id TEXT NOT NULL UNIQUE');
+        const needsStrategyAdd  = !convoysSchema.sql.includes("'agent'");
+
+        if (needsUniqueDrop || needsStrategyAdd) {
+          let patched = convoysSchema.sql;
+          if (needsUniqueDrop) {
+            patched = patched.replace(
+              'parent_task_id TEXT NOT NULL UNIQUE REFERENCES tasks(id)',
+              'parent_task_id TEXT NOT NULL REFERENCES tasks(id)'
+            );
+          }
+          if (needsStrategyAdd) {
+            const oldCheck = `decomposition_strategy TEXT DEFAULT 'manual' CHECK (decomposition_strategy IN ('manual', 'ai', 'planning'))`;
+            const newCheck = `decomposition_strategy TEXT DEFAULT 'manual' CHECK (decomposition_strategy IN ('manual', 'ai', 'planning', 'agent'))`;
+            if (!patched.includes(oldCheck)) {
+              console.warn('[Migration 037] convoys decomposition_strategy CHECK shape unexpected; current schema:\n' + convoysSchema.sql);
+              throw new Error('[Migration 037] Unable to locate decomposition_strategy CHECK clause — refusing to patch');
+            }
+            patched = patched.replace(oldCheck, newCheck);
+          }
+
+          const escaped = patched.replace(/'/g, "''");
+          db.unsafeMode(true);
+          try {
+            db.pragma('writable_schema = ON');
+            db.exec(
+              `UPDATE sqlite_master SET sql = '${escaped}' WHERE type='table' AND name='convoys'`
+            );
+            // The UNIQUE column constraint creates an implicit
+            // sqlite_autoindex_convoys_2. Dropping UNIQUE leaves it
+            // orphaned — delete that row too so the index no longer
+            // exists. Guard on presence; older fresh-DB installs may not
+            // have a _2 autoindex at all.
+            if (needsUniqueDrop) {
+              db.exec(
+                `DELETE FROM sqlite_master WHERE type='index' AND name='sqlite_autoindex_convoys_2'`
+              );
+            }
+            db.pragma('writable_schema = OFF');
+
+            const integrity = db.prepare('PRAGMA integrity_check').all() as { integrity_check: string }[];
+            const ok = integrity.length === 1 && integrity[0].integrity_check === 'ok';
+            if (!ok) {
+              throw new Error('[Migration 037] integrity_check failed after writable_schema patch: ' + JSON.stringify(integrity));
+            }
+          } finally {
+            db.unsafeMode(false);
+          }
+        }
+      }
+
+      // Replace the old per-parent index with a (parent_task_id, status)
+      // composite that makes "latest active convoy" lookups cheap.
+      db.exec(`DROP INDEX IF EXISTS idx_convoys_parent`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_convoys_parent_active ON convoys(parent_task_id, status)`);
+
+      console.log('[Migration 037] Complete.');
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -262,13 +262,16 @@ CREATE TABLE IF NOT EXISTS task_deliverables (
   created_at TEXT DEFAULT (datetime('now'))
 );
 
--- Convoys: parallel task groups
+-- Convoys: parallel task groups.
+-- parent_task_id is NOT unique: a task may have multiple convoys over time
+-- (e.g. an agent coordinator appends further delegation rounds). Readers
+-- use getActiveConvoyForTask() to pick the latest status='active' row.
 CREATE TABLE IF NOT EXISTS convoys (
   id TEXT PRIMARY KEY,
-  parent_task_id TEXT NOT NULL UNIQUE REFERENCES tasks(id) ON DELETE CASCADE,
+  parent_task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
   name TEXT NOT NULL,
   status TEXT DEFAULT 'active' CHECK (status IN ('active', 'paused', 'completing', 'done', 'failed')),
-  decomposition_strategy TEXT DEFAULT 'manual' CHECK (decomposition_strategy IN ('manual', 'ai', 'planning')),
+  decomposition_strategy TEXT DEFAULT 'manual' CHECK (decomposition_strategy IN ('manual', 'ai', 'planning', 'agent')),
   decomposition_spec TEXT,
   total_subtasks INTEGER DEFAULT 0,
   completed_subtasks INTEGER DEFAULT 0,
@@ -277,7 +280,10 @@ CREATE TABLE IF NOT EXISTS convoys (
   updated_at TEXT DEFAULT (datetime('now'))
 );
 
--- Convoy subtasks: individual work items within a convoy
+-- Convoy subtasks: individual work items within a convoy.
+-- SLO columns (expected_* / checkin_*) are populated for agent-spawned
+-- delegations; operator-created subtasks leave them NULL and fall back to
+-- the global stall threshold.
 CREATE TABLE IF NOT EXISTS convoy_subtasks (
   id TEXT PRIMARY KEY,
   convoy_id TEXT NOT NULL REFERENCES convoys(id) ON DELETE CASCADE,
@@ -285,6 +291,14 @@ CREATE TABLE IF NOT EXISTS convoy_subtasks (
   sort_order INTEGER DEFAULT 0,
   depends_on TEXT,
   suggested_role TEXT,
+  slice TEXT,
+  expected_deliverables TEXT,
+  acceptance_criteria TEXT,
+  expected_duration_minutes INTEGER,
+  checkin_interval_minutes INTEGER DEFAULT 15,
+  dispatched_at TEXT,
+  due_at TEXT,
+  deliverables_registered_count INTEGER DEFAULT 0,
   created_at TEXT DEFAULT (datetime('now'))
 );
 

--- a/src/lib/mcp/mcp.test.ts
+++ b/src/lib/mcp/mcp.test.ts
@@ -6,9 +6,10 @@
  * tools, state-changing tools (happy path + authz violation), evidence-gate
  * integration with update_task_status.
  *
- * The `delegate` tool is skipped here — it calls openclaw's WebSocket
- * gateway for sessions.send, which can't be mocked cleanly in this harness.
- * A pilot-environment smoke will exercise it live.
+ * The coordinator-delegation tools (`spawn_subtask`, `reject_subtask`) that
+ * call openclaw's WebSocket gateway are not exercised end-to-end here —
+ * the gateway client can't be mocked cleanly in this harness. A pilot-
+ * environment smoke exercises the live flow.
  */
 
 import test from 'node:test';
@@ -72,11 +73,18 @@ test('tools/list returns the full sc-mission-control tool surface', async () => 
     'fail_task',
     'save_checkpoint',
     'send_mail',
-    'delegate',
     'save_knowledge',
+    // Coordinator delegation surface (replaces the old `delegate` tool).
+    // See specs/coordinator-delegation-via-convoy-spec.md §3.
+    'spawn_subtask',
+    'list_my_subtasks',
+    'accept_subtask',
+    'reject_subtask',
+    'cancel_subtask',
   ]) {
     assert.ok(names.has(expected), `missing tool: ${expected}`);
   }
+  assert.ok(!names.has('delegate'), 'delegate tool should be removed');
 });
 
 // ─── whoami ─────────────────────────────────────────────────────────

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -15,7 +15,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
-import { queryAll, queryOne } from '@/lib/db';
+import { queryAll, queryOne, run } from '@/lib/db';
 import { AuthzError, assertAgentActive } from '@/lib/authz/agent-task';
 import { authzErrorToToolResult, internalErrorToToolResult } from './errors';
 import { logMcpToolCall } from './debug';
@@ -29,6 +29,9 @@ import { sendAgentMail } from '@/lib/services/agent-mailbox';
 import { saveKnowledge } from '@/lib/services/knowledge';
 import { getUnreadMail } from '@/lib/mailbox';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { spawnDelegationSubtask } from '@/lib/convoy';
+import { getMissionControlUrl } from '@/lib/config';
+import type { Task } from '@/lib/types';
 
 // Common shape: agent_id on every state-changing tool.
 const agentIdArg = z
@@ -237,6 +240,42 @@ export function registerAllTools(server: McpServer): void {
           structuredContent: { error: 'task_not_found', task_id },
         };
       }
+
+      // If this task is a delegation subtask with SLO fields, surface the
+      // Delegation Contract alongside the core task row so the peer can
+      // re-read its obligation without parsing its dispatch brief.
+      if (task.convoy_id) {
+        const sub = queryOne<{
+          id: string;
+          slice: string | null;
+          expected_deliverables: string | null;
+          acceptance_criteria: string | null;
+          expected_duration_minutes: number | null;
+          checkin_interval_minutes: number | null;
+          dispatched_at: string | null;
+          due_at: string | null;
+        }>(
+          `SELECT id, slice, expected_deliverables, acceptance_criteria,
+                  expected_duration_minutes, checkin_interval_minutes,
+                  dispatched_at, due_at
+             FROM convoy_subtasks WHERE task_id = ?`,
+          [task_id],
+        );
+        if (sub && sub.expected_duration_minutes != null) {
+          const parseJson = (s: string | null) => { if (!s) return null; try { return JSON.parse(s); } catch { return null; } };
+          (task as Record<string, unknown>).delegation_contract = {
+            subtask_id: sub.id,
+            slice: sub.slice,
+            expected_deliverables: parseJson(sub.expected_deliverables),
+            acceptance_criteria: parseJson(sub.acceptance_criteria),
+            expected_duration_minutes: sub.expected_duration_minutes,
+            checkin_interval_minutes: sub.checkin_interval_minutes,
+            dispatched_at: sub.dispatched_at,
+            due_at: sub.due_at,
+          };
+        }
+      }
+
       return textResult(JSON.stringify(task, null, 2), task);
     }),
   );
@@ -293,6 +332,15 @@ export function registerAllTools(server: McpServer): void {
         description: args.description,
         specDeliverableId: args.spec_deliverable_id,
       });
+      // Keep the coordinator's list_my_subtasks view cheap — bump the
+      // counter on the convoy_subtasks row if this task is a delegated
+      // subtask. No-op when the task isn't in any convoy.
+      run(
+        `UPDATE convoy_subtasks
+            SET deliverables_registered_count = COALESCE(deliverables_registered_count, 0) + 1
+          WHERE task_id = ?`,
+        [args.task_id],
+      );
       const summary = {
         deliverable: result.deliverable,
         file_exists: result.fileExists,
@@ -374,6 +422,40 @@ export function registerAllTools(server: McpServer): void {
         newStatus: args.status,
         statusReason: args.status_reason,
       });
+      if (result.ok) {
+        // If the task just moved to a delivery state (review/testing/
+        // verification) AND it's a delegation subtask, mail the
+        // coordinator so they can call accept_subtask / reject_subtask
+        // without polling list_my_subtasks. Silent if the task isn't in
+        // a convoy or the coordinator assignment is missing.
+        if (['review', 'testing', 'verification'].includes(args.status)) {
+          const ctx = queryOne<{ subtask_id: string; slice: string | null; parent_task_id: string; coordinator_id: string | null; parent_title: string; convoy_id: string }>(
+            `SELECT cs.id AS subtask_id, cs.slice AS slice,
+                    c.parent_task_id AS parent_task_id,
+                    c.id AS convoy_id,
+                    p.title AS parent_title,
+                    p.assigned_agent_id AS coordinator_id
+               FROM convoy_subtasks cs
+               JOIN convoys c ON c.id = cs.convoy_id
+               JOIN tasks p ON p.id = c.parent_task_id
+              WHERE cs.task_id = ?`,
+            [args.task_id],
+          );
+          if (ctx?.coordinator_id) {
+            sendAgentMail({
+              fromAgentId: args.agent_id,
+              toAgentId: ctx.coordinator_id,
+              subject: `DELEGATION: ready_for_review — ${ctx.slice ?? ctx.parent_title}`,
+              body: `Subtask ${ctx.subtask_id} is ready for review (status=${args.status}).\n\nCall accept_subtask({subtask_id: "${ctx.subtask_id}"}) if it meets the acceptance criteria, or reject_subtask with a reason to bounce it back.`,
+              taskId: ctx.parent_task_id,
+              convoyId: ctx.convoy_id,
+              push: true,
+            }).catch((err: unknown) => {
+              console.warn('[update_task_status] coordinator notify failed:', (err as Error).message);
+            });
+          }
+        }
+      }
       if (!result.ok) {
         return {
           isError: true,
@@ -425,6 +507,41 @@ export function registerAllTools(server: McpServer): void {
             ...(result.hint ? { hint: result.hint } : {}),
           },
         };
+      }
+      // When a delegation subtask fails, notify the coordinator with a
+      // deterministic subject line so their triage is mechanical. The
+      // `redecompose:` reason prefix is the peer's escape hatch (see
+      // specs/coordinator-delegation-via-convoy-spec.md §3.8) — surface
+      // it explicitly so the coordinator cancels + re-plans rather than
+      // re-dispatching the same slice.
+      const ctx = queryOne<{ subtask_id: string; slice: string | null; parent_task_id: string; coordinator_id: string | null; convoy_id: string }>(
+        `SELECT cs.id AS subtask_id, cs.slice AS slice,
+                c.parent_task_id AS parent_task_id,
+                c.id AS convoy_id,
+                p.assigned_agent_id AS coordinator_id
+           FROM convoy_subtasks cs
+           JOIN convoys c ON c.id = cs.convoy_id
+           JOIN tasks p ON p.id = c.parent_task_id
+          WHERE cs.task_id = ?`,
+        [args.task_id],
+      );
+      if (ctx?.coordinator_id) {
+        const redecompose = /^redecompose\s*:/i.test(args.reason);
+        sendAgentMail({
+          fromAgentId: args.agent_id,
+          toAgentId: ctx.coordinator_id,
+          subject: redecompose
+            ? `DELEGATION: redecompose_requested — ${ctx.slice ?? 'subtask'}`
+            : `DELEGATION: blocked — ${ctx.slice ?? 'subtask'}`,
+          body: `Subtask ${ctx.subtask_id} failed.\n\n**Reason:** ${args.reason}\n\n${redecompose
+            ? 'The peer is asking you to re-decompose this slice. Call cancel_subtask on this row and issue fresh spawn_subtask calls with a better-scoped brief.'
+            : 'Peer declared itself blocked. Inspect the reason and decide: reject_subtask (redo), cancel_subtask (drop), or answer and redispatch.'}`,
+          taskId: ctx.parent_task_id,
+          convoyId: ctx.convoy_id,
+          push: true,
+        }).catch((err: unknown) => {
+          console.warn('[fail_task] coordinator notify failed:', (err as Error).message);
+        });
       }
       return textResult(JSON.stringify(result, null, 2), result);
     }),
@@ -569,20 +686,22 @@ export function registerAllTools(server: McpServer): void {
     }),
   );
 
-  // delegate ──────────────────────────────────────────────────────
-  // Coordinator-only. Atomically (a) sends the peer an openclaw session
-  // message and (b) logs a [DELEGATION] audit activity so the existing
-  // coordinator-audit sees the delegation happened. Replaces the two-step
-  // curl+sessions_send dance the coordinator does today.
+  // spawn_subtask ─────────────────────────────────────────────────
+  // Coordinator-only. The single entry point for agent-driven
+  // delegation: creates (or appends to) a convoy on the caller's task,
+  // writes a SLO-populated convoy_subtasks row, then POSTs to the normal
+  // dispatch pipeline so the peer gets the standard briefing plus a
+  // Delegation Contract block. Replaces the old `delegate` tool entirely
+  // — see specs/coordinator-delegation-via-convoy-spec.md.
   server.registerTool(
-    'delegate',
+    'spawn_subtask',
     {
-      title: 'Delegate a slice of work to a peer (coordinator-only)',
+      title: 'Spawn a delegated subtask (coordinator-only)',
       description:
-        "Coordinator sends a work slice to a named peer via OpenClaw sessions_send and auto-logs the required [DELEGATION] audit activity. Authorization enforces the caller is the task's coordinator. Use per-task session keys (agent:<peer_gateway_id>:task-<task_id>) — do NOT target :main.",
+        "Coordinator delegates a slice of its task to a peer by creating a convoy subtask with a declared contract. Every field is mandatory: the peer receives an explicit Delegation Contract (deliverables, acceptance criteria, duration, check-in cadence) and is dispatched via the normal pipeline. Peer sub-delegation is rejected by authz.",
       inputSchema: {
         agent_id: agentIdArg.describe('The calling coordinator agent.'),
-        task_id: taskIdArg,
+        task_id: taskIdArg.describe('The coordinator\'s parent task id.'),
         peer_gateway_id: z
           .string()
           .min(1)
@@ -591,128 +710,507 @@ export function registerAllTools(server: McpServer): void {
           ),
         slice: z
           .string()
-          .min(1)
-          .max(10000)
-          .describe('One-line description of the work slice this peer owns.'),
+          .min(10)
+          .max(500)
+          .describe("One-line summary of what this peer owns (becomes the child task's title)."),
         message: z
           .string()
           .min(1)
+          .max(10000)
           .describe(
-            "The full message to send to the peer's session. Should include role framing ('You are the <role> for this task'), goal, context, success criteria.",
+            "The full brief sent to the peer as the child task's description. Should include context + why this slice exists.",
           ),
-        timeout_seconds: z
+        expected_deliverables: z
+          .array(
+            z.object({
+              title: z.string().min(1).max(200),
+              kind: z.enum(['file', 'note', 'report']),
+            }),
+          )
+          .min(1)
+          .describe('At least one deliverable the peer must register via register_deliverable.'),
+        acceptance_criteria: z
+          .array(z.string().min(10).max(500))
+          .min(1)
+          .describe('Each criterion ≥10 chars. The peer must satisfy all of them for the coordinator to accept_subtask.'),
+        expected_duration_minutes: z
           .number()
           .int()
-          .min(0)
-          .max(600)
+          .min(5)
+          .max(240)
+          .describe('Declared SLO — stall detection uses 1.5× this as the hard overdue line.'),
+        checkin_interval_minutes: z
+          .number()
+          .int()
+          .min(5)
+          .max(60)
           .optional()
-          .describe('0 for fire-and-forget parallel fan-out (recommended).'),
+          .describe('Default 15. The peer must log_activity at least this often; 2× is the silent-drift signal.'),
+        depends_on_subtask_ids: z
+          .array(z.string().min(1))
+          .optional()
+          .describe('Optional: subtask ids (from prior spawn_subtask calls in this convoy) that must complete first.'),
       },
       annotations: { destructiveHint: true, openWorldHint: false },
     },
-    trace('delegate', async (args) => {
-      // Authorize explicitly — the service layer doesn't own the delegate
-      // action since there's no single "delegate service"; this tool
-      // composes sessions_send + log_activity.
+    trace('spawn_subtask', async (args) => {
       const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
+      // Reuse the 'delegate' authz action — same policy (coordinator-only
+      // on this task). Action names are internal enum values, not
+      // user-facing, so renaming isn't worth a schema change.
       assertAgentCanActOnTask(args.agent_id, args.task_id, 'delegate');
 
-      // Resolve peer gateway id to a human name for the audit message.
-      const peer = queryOne<{ id: string; name: string }>(
-        `SELECT id, name FROM agents WHERE gateway_agent_id = ? LIMIT 1`,
+      // Explicit sub-delegation guard: if the caller's task is itself a
+      // subtask, reject. Authz above only checks coordinator-role-on-task;
+      // a peer could satisfy that on its own child task without this rail.
+      const parent = queryOne<{ is_subtask: number | null }>(
+        'SELECT is_subtask FROM tasks WHERE id = ?',
+        [args.task_id],
+      );
+      if (parent?.is_subtask === 1) {
+        return {
+          isError: true,
+          content: [{
+            type: 'text',
+            text: 'Peer sub-delegation is not allowed. Your task is itself a subtask — deliver what you have, or call fail_task with reason "redecompose: ..." and stop. The coordinator will re-plan.',
+          }],
+          structuredContent: {
+            error: 'peer_sub_delegation_blocked',
+            hint: 'deliver_partial_or_fail_task_with_redecompose_prefix',
+          },
+        };
+      }
+
+      const peer = queryOne<{ id: string; name: string; role: string | null }>(
+        `SELECT id, name, role FROM agents WHERE gateway_agent_id = ? LIMIT 1`,
         [args.peer_gateway_id],
       );
       if (!peer) {
         return {
           isError: true,
-          content: [
-            {
-              type: 'text',
-              text: `No agent with gateway_agent_id "${args.peer_gateway_id}" in the catalog. Call list_peers to see the roster.`,
-            },
-          ],
-          structuredContent: {
-            error: 'peer_not_found',
-            peer_gateway_id: args.peer_gateway_id,
-          },
+          content: [{
+            type: 'text',
+            text: `No agent with gateway_agent_id "${args.peer_gateway_id}" in the catalog. Call list_peers to see the roster.`,
+          }],
+          structuredContent: { error: 'peer_not_found', peer_gateway_id: args.peer_gateway_id },
         };
       }
 
-      const client = getOpenClawClient();
-      if (!client.isConnected()) {
-        await client.connect();
-      }
+      const checkinInterval = args.checkin_interval_minutes ?? 15;
 
-      // Per-task session key avoids :main contention (see dispatch/route.ts
-      // post-mortem for task cc3d40e1 — :main delegations were aborted).
-      const sessionKey = `agent:${args.peer_gateway_id}:task-${args.task_id}`;
+      const spawn = spawnDelegationSubtask({
+        parentTaskId: args.task_id,
+        parentAgentId: args.agent_id,
+        peerAgentId: peer.id,
+        peerGatewayId: args.peer_gateway_id,
+        suggestedRole: peer.role || 'builder',
+        slice: args.slice,
+        message: args.message,
+        expectedDeliverables: args.expected_deliverables,
+        acceptanceCriteria: args.acceptance_criteria,
+        expectedDurationMinutes: args.expected_duration_minutes,
+        checkinIntervalMinutes: checkinInterval,
+        dependsOnSubtaskIds: args.depends_on_subtask_ids,
+      });
 
-      // We use `chat.send` (not `sessions.send`) — same RPC the dispatch
-      // route uses — because it implicitly creates the session on first
-      // send. `sessions.send` requires the session to already exist and
-      // fails with "session not found" for a fresh per-task key. The
-      // observed live failure was:
-      //
-      //   invalid sessions.send params: must have required property 'key';
-      //   at root: unexpected property 'sessionKey'; at root: unexpected
-      //   property 'timeoutSeconds'
-      //
-      // fixed by moving to chat.send, whose param shape is
-      // `{sessionKey, message, idempotencyKey}`. The `timeout_seconds`
-      // argument on the MCP tool is now advisory-only: chat.send is
-      // fire-and-forget by default; the gateway decides session lifecycle.
-      // We keep the argument on the tool schema for forward-compat.
-      const idempotencyKey = `delegate-${args.task_id}-${args.peer_gateway_id}-${Date.now()}`;
-      let sendResult: Record<string, unknown> = {};
-      try {
-        sendResult = ((await client.call('chat.send', {
-          sessionKey,
-          message: args.message,
-          idempotencyKey,
-        })) as Record<string, unknown>) ?? {};
-      } catch (err) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: 'text',
-              text: `sessions.send failed: ${(err as Error).message}`,
-            },
-          ],
-          structuredContent: {
-            error: 'sessions_send_failed',
-            message: (err as Error).message,
-          },
-        };
-      }
-
-      const toolCallId =
-        (sendResult.tool_call_id as string | undefined) ||
-        (sendResult.run_id as string | undefined) ||
-        'unknown';
-      const auditMessage = `[DELEGATION] target="${peer.name}" gateway_id="${args.peer_gateway_id}" tool_call_id="${toolCallId}" slice="${args.slice.replace(/"/g, "'")}"`;
-
-      // Log the audit activity via the same service so coordinator-audit
-      // sees it. Authz re-runs inside logActivity — coordinator must also
-      // be on the task to post activities (they are, since delegate just
-      // passed).
-      const activity = logActivity({
+      // Log delegation_spawned on the PARENT task timeline so the
+      // coordinator's activity feed shows the fan-out. The child task's
+      // own activity starts once it's dispatched.
+      logActivity({
         taskId: args.task_id,
         actingAgentId: args.agent_id,
         activityType: 'updated',
-        message: auditMessage,
+        message: `[delegation_spawned] peer=${peer.name} gateway_id=${args.peer_gateway_id} child_task=${spawn.childTaskId} due_at=${spawn.dueAt} slice="${args.slice.replace(/"/g, "'")}"`,
       });
 
+      // Fire the dispatch. Same POST the convoy dispatcher uses — the
+      // peer gets the normal briefing; the Delegation Contract block is
+      // appended when the dispatch route detects a SLO-populated
+      // convoy_subtasks row (see src/app/api/tasks/[id]/dispatch/route.ts).
+      const missionControlUrl = getMissionControlUrl();
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (process.env.MC_API_TOKEN) {
+        headers['Authorization'] = `Bearer ${process.env.MC_API_TOKEN}`;
+      }
+
+      // Move child to 'assigned' before dispatch so the dispatch route
+      // sees a valid state. The convoy dispatcher does the same.
+      run(
+        `UPDATE tasks SET status = 'assigned', updated_at = datetime('now') WHERE id = ?`,
+        [spawn.childTaskId],
+      );
+
+      let dispatchError: string | null = null;
+      try {
+        const res = await fetch(`${missionControlUrl}/api/tasks/${spawn.childTaskId}/dispatch`, {
+          method: 'POST',
+          headers,
+          signal: AbortSignal.timeout(30_000),
+        });
+        if (!res.ok) {
+          dispatchError = `dispatch returned ${res.status}: ${await res.text()}`;
+        }
+      } catch (err) {
+        dispatchError = (err as Error).message;
+      }
+
+      if (dispatchError) {
+        // The subtask row exists but dispatch failed — the coordinator
+        // should see this explicitly and can call cancel_subtask +
+        // retry. We do NOT auto-rollback: the convoy row is real,
+        // half-done is visible, no silent data loss.
+        return {
+          isError: true,
+          content: [{
+            type: 'text',
+            text: `Subtask ${spawn.subtaskId} created but dispatch failed: ${dispatchError}. The subtask row exists — call cancel_subtask to release it, or retry.`,
+          }],
+          structuredContent: {
+            error: 'dispatch_failed',
+            message: dispatchError,
+            subtask_id: spawn.subtaskId,
+            child_task_id: spawn.childTaskId,
+            convoy_id: spawn.convoyId,
+          },
+        };
+      }
+
       const payload = {
+        subtask_id: spawn.subtaskId,
+        child_task_id: spawn.childTaskId,
+        convoy_id: spawn.convoyId,
         peer: { id: peer.id, name: peer.name, gateway_agent_id: args.peer_gateway_id },
-        session_key: sessionKey,
-        session_send: sendResult,
-        audit_activity_id: activity.id,
+        dispatched_at: spawn.dispatchedAt,
+        due_at: spawn.dueAt,
+        checkin_interval_minutes: checkinInterval,
       };
       return textResult(
-        `Delegated to ${peer.name} (${args.peer_gateway_id}). Audit logged as activity ${activity.id}.`,
+        `Spawned subtask ${spawn.subtaskId} to ${peer.name} (${args.peer_gateway_id}). Due at ${spawn.dueAt}; check-in cadence ${checkinInterval}m.`,
         payload,
       );
+    }),
+  );
+
+  // list_my_subtasks ──────────────────────────────────────────────
+  // Coordinator's live view of its outstanding delegations. Computes a
+  // derived state per row from tasks.status + SLO clock so callers don't
+  // have to re-run the math.
+  server.registerTool(
+    'list_my_subtasks',
+    {
+      title: 'List the coordinator\'s outstanding delegations',
+      description:
+        "Returns all convoy subtasks for the caller's task with per-row derived state (dispatched / in_progress / drifting / overdue / delivered / accepted / rejected / timed_out / cancelled). Use this in a coordinator's 'who am I waiting on?' check.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        task_id: taskIdArg,
+        states: z
+          .array(
+            z.enum(['active', 'overdue', 'drifting', 'delivered', 'closed']),
+          )
+          .optional()
+          .describe('Optional filter. `active` = not closed/timed_out. Omit to return all.'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    trace('list_my_subtasks', async (args) => {
+      const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
+      assertAgentCanActOnTask(args.agent_id, args.task_id, 'delegate');
+
+      const rows = queryAll<{
+        subtask_id: string;
+        child_task_id: string;
+        slice: string | null;
+        peer_agent_id: string | null;
+        peer_name: string | null;
+        peer_gateway_id: string | null;
+        task_status: string;
+        status_reason: string | null;
+        dispatched_at: string | null;
+        due_at: string | null;
+        checkin_interval_minutes: number | null;
+        deliverables_registered_count: number | null;
+        expected_deliverables: string | null;
+        last_activity_at: string | null;
+      }>(
+        `SELECT cs.id            AS subtask_id,
+                cs.task_id       AS child_task_id,
+                cs.slice         AS slice,
+                t.assigned_agent_id AS peer_agent_id,
+                a.name           AS peer_name,
+                a.gateway_agent_id AS peer_gateway_id,
+                t.status         AS task_status,
+                t.status_reason  AS status_reason,
+                cs.dispatched_at AS dispatched_at,
+                cs.due_at        AS due_at,
+                cs.checkin_interval_minutes AS checkin_interval_minutes,
+                cs.deliverables_registered_count AS deliverables_registered_count,
+                cs.expected_deliverables AS expected_deliverables,
+                (SELECT MAX(created_at) FROM task_activities WHERE task_id = t.id) AS last_activity_at
+           FROM convoy_subtasks cs
+           JOIN convoys c ON c.id = cs.convoy_id
+           JOIN tasks   t ON t.id = cs.task_id
+           LEFT JOIN agents a ON a.id = t.assigned_agent_id
+          WHERE c.parent_task_id = ?
+          ORDER BY cs.sort_order ASC`,
+        [args.task_id],
+      );
+
+      const now = Date.now();
+      const subtasks = rows.map((r) => {
+        const dueMs = r.due_at ? new Date(r.due_at).getTime() : null;
+        const lastMs = r.last_activity_at ? new Date(r.last_activity_at).getTime() : null;
+        const driftMs = r.checkin_interval_minutes ? r.checkin_interval_minutes * 2 * 60_000 : null;
+        const expectedCount = (() => {
+          if (!r.expected_deliverables) return 0;
+          try { return (JSON.parse(r.expected_deliverables) as unknown[]).length; } catch { return 0; }
+        })();
+
+        let derived: string;
+        if (r.task_status === 'done') derived = 'accepted';
+        else if (r.task_status === 'review' || r.task_status === 'verification' || r.task_status === 'testing') derived = 'delivered';
+        else if (r.task_status === 'cancelled' && r.status_reason?.startsWith('timed_out')) derived = 'timed_out';
+        else if (r.task_status === 'cancelled') derived = 'cancelled';
+        else if (r.status_reason?.startsWith('rejected:')) derived = 'rejected';
+        else if (r.status_reason === 'blocked' || r.status_reason?.startsWith('blocked:')) derived = 'blocked';
+        else if (dueMs && now > dueMs) derived = 'overdue';
+        else if (lastMs && driftMs && now - lastMs > driftMs) derived = 'drifting';
+        else if (r.task_status === 'in_progress') derived = 'in_progress';
+        else derived = 'dispatched';
+
+        return {
+          subtask_id: r.subtask_id,
+          child_task_id: r.child_task_id,
+          peer: r.peer_agent_id
+            ? { id: r.peer_agent_id, name: r.peer_name, gateway_agent_id: r.peer_gateway_id }
+            : null,
+          slice: r.slice,
+          state_derived: derived,
+          task_status: r.task_status,
+          dispatched_at: r.dispatched_at,
+          due_at: r.due_at,
+          last_activity_at: r.last_activity_at,
+          deliverables_registered: r.deliverables_registered_count ?? 0,
+          deliverables_expected: expectedCount,
+        };
+      });
+
+      // Apply state filter last so the derived-state computation is the
+      // same regardless of caller filter (keeps behavior obvious).
+      const filter = args.states;
+      const filtered = !filter || filter.length === 0
+        ? subtasks
+        : subtasks.filter((s) => {
+            if (filter.includes('active') && !['accepted', 'rejected', 'cancelled', 'timed_out'].includes(s.state_derived)) return true;
+            if (filter.includes('overdue')   && s.state_derived === 'overdue')   return true;
+            if (filter.includes('drifting')  && s.state_derived === 'drifting')  return true;
+            if (filter.includes('delivered') && s.state_derived === 'delivered') return true;
+            if (filter.includes('closed')    && ['accepted','rejected','cancelled','timed_out'].includes(s.state_derived)) return true;
+            return false;
+          });
+
+      return textResult(JSON.stringify({ subtasks: filtered }, null, 2), { subtasks: filtered });
+    }),
+  );
+
+  // accept_subtask ────────────────────────────────────────────────
+  server.registerTool(
+    'accept_subtask',
+    {
+      title: 'Accept a peer\'s delivered delegation (coordinator-only)',
+      description:
+        "Promote a delivered child task (status=review/verification/testing) to done. Bumps the convoy's completed_subtasks counter and may promote the parent via checkConvoyCompletion. Call this after verifying the peer's deliverables meet the acceptance criteria you declared in spawn_subtask.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        subtask_id: z.string().min(1).describe('The convoy_subtasks row id from spawn_subtask.'),
+      },
+      annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false },
+    },
+    trace('accept_subtask', async (args) => {
+      const row = queryOne<{ task_id: string; parent_task_id: string; task_status: string }>(
+        `SELECT cs.task_id AS task_id, c.parent_task_id AS parent_task_id, t.status AS task_status
+           FROM convoy_subtasks cs
+           JOIN convoys c ON c.id = cs.convoy_id
+           JOIN tasks t ON t.id = cs.task_id
+          WHERE cs.id = ?`,
+        [args.subtask_id],
+      );
+      if (!row) {
+        return { isError: true, content: [{ type: 'text', text: `subtask ${args.subtask_id} not found` }], structuredContent: { error: 'subtask_not_found' } };
+      }
+      const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
+      assertAgentCanActOnTask(args.agent_id, row.parent_task_id, 'delegate');
+
+      if (row.task_status === 'done') {
+        return textResult(`Subtask ${args.subtask_id} was already done. No-op.`, { subtask_id: args.subtask_id, already_done: true });
+      }
+
+      const result = transitionTaskStatus({
+        taskId: row.task_id,
+        actingAgentId: args.agent_id,
+        newStatus: 'done',
+      });
+      if (!result.ok) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `Cannot accept subtask: ${result.error}` }],
+          structuredContent: {
+            error: result.code,
+            message: result.error,
+            ...(result.missingDeliverableIds ? { missing_deliverable_ids: result.missingDeliverableIds } : {}),
+          },
+        };
+      }
+
+      logActivity({
+        taskId: row.parent_task_id,
+        actingAgentId: args.agent_id,
+        activityType: 'updated',
+        message: `[delegation_accepted] subtask=${args.subtask_id} child_task=${row.task_id}`,
+      });
+
+      // checkConvoyCompletion may promote the parent task.
+      const { checkConvoyCompletion } = await import('@/lib/convoy');
+      const convoyId = queryOne<{ convoy_id: string }>(
+        'SELECT convoy_id FROM convoy_subtasks WHERE id = ?', [args.subtask_id],
+      )?.convoy_id;
+      if (convoyId) checkConvoyCompletion(convoyId);
+
+      return textResult(`Accepted subtask ${args.subtask_id}.`, {
+        subtask_id: args.subtask_id,
+        child_task_id: row.task_id,
+        parent_task_id: row.parent_task_id,
+      });
+    }),
+  );
+
+  // reject_subtask ────────────────────────────────────────────────
+  server.registerTool(
+    'reject_subtask',
+    {
+      title: 'Reject a peer\'s delivered delegation with a reason (coordinator-only)',
+      description:
+        "Bounce a delivered child task back to in_progress with a reason the peer sees on re-dispatch. Use when deliverables don't meet the acceptance criteria. For slice mismatch (peer built the wrong thing entirely), prefer cancel_subtask + a fresh spawn_subtask instead.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        subtask_id: z.string().min(1),
+        reason: z.string().min(10).max(2000).describe('Specific, actionable — shown to the peer on re-dispatch.'),
+        new_acceptance_criteria: z
+          .array(z.string().min(10).max(500))
+          .optional()
+          .describe('Optional updated criteria. When provided, replaces the convoy_subtasks.acceptance_criteria for the next round.'),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    trace('reject_subtask', async (args) => {
+      const row = queryOne<{ task_id: string; parent_task_id: string; task_status: string }>(
+        `SELECT cs.task_id AS task_id, c.parent_task_id AS parent_task_id, t.status AS task_status
+           FROM convoy_subtasks cs
+           JOIN convoys c ON c.id = cs.convoy_id
+           JOIN tasks t ON t.id = cs.task_id
+          WHERE cs.id = ?`,
+        [args.subtask_id],
+      );
+      if (!row) {
+        return { isError: true, content: [{ type: 'text', text: `subtask ${args.subtask_id} not found` }], structuredContent: { error: 'subtask_not_found' } };
+      }
+      const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
+      assertAgentCanActOnTask(args.agent_id, row.parent_task_id, 'delegate');
+
+      const now = new Date().toISOString();
+      run(
+        `UPDATE tasks SET status = 'in_progress', status_reason = ?, updated_at = ? WHERE id = ?`,
+        [`rejected: ${args.reason}`, now, row.task_id],
+      );
+      if (args.new_acceptance_criteria && args.new_acceptance_criteria.length > 0) {
+        run(
+          `UPDATE convoy_subtasks SET acceptance_criteria = ? WHERE id = ?`,
+          [JSON.stringify(args.new_acceptance_criteria), args.subtask_id],
+        );
+      }
+
+      logActivity({
+        taskId: row.parent_task_id,
+        actingAgentId: args.agent_id,
+        activityType: 'updated',
+        message: `[delegation_rejected] subtask=${args.subtask_id} reason="${args.reason.replace(/"/g, "'")}"`,
+      });
+
+      // Notify the peer through their chat session so they see the
+      // rejection inline. Best-effort — if the openclaw client is down,
+      // the mailbox fallback still carries the message.
+      const peer = queryOne<{ gateway_agent_id: string | null }>(
+        'SELECT a.gateway_agent_id FROM tasks t JOIN agents a ON a.id = t.assigned_agent_id WHERE t.id = ?',
+        [row.task_id],
+      );
+      if (peer?.gateway_agent_id) {
+        try {
+          const client = getOpenClawClient();
+          if (!client.isConnected()) await client.connect();
+          await client.call('chat.send', {
+            sessionKey: `agent:${peer.gateway_agent_id}:task-${row.task_id}`,
+            message: `🔁 **Subtask rejected by coordinator.**\n\n**Reason:** ${args.reason}\n\n${args.new_acceptance_criteria?.length ? `**Updated acceptance criteria:**\n${args.new_acceptance_criteria.map(c => `- ${c}`).join('\n')}\n\n` : ''}Please address the issues and re-register deliverables, then move status back to review.`,
+            idempotencyKey: `reject-${args.subtask_id}-${Date.now()}`,
+          });
+        } catch (err) {
+          console.warn('[reject_subtask] chat.send notification failed:', (err as Error).message);
+        }
+      }
+
+      return textResult(`Rejected subtask ${args.subtask_id}. Peer task ${row.task_id} moved back to in_progress.`, {
+        subtask_id: args.subtask_id,
+        child_task_id: row.task_id,
+      });
+    }),
+  );
+
+  // cancel_subtask ────────────────────────────────────────────────
+  server.registerTool(
+    'cancel_subtask',
+    {
+      title: 'Cancel a delegated subtask (coordinator-only)',
+      description:
+        "Release a subtask that's no longer needed or is demonstrably stuck. The child task moves to cancelled; the convoy's failed_subtasks counter bumps so the subtask no longer blocks convoy completion. Use for scope changes and dead branches; for rejecting delivered work that needs a redo, use reject_subtask.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        subtask_id: z.string().min(1),
+        reason: z.string().min(5).max(2000),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    trace('cancel_subtask', async (args) => {
+      const row = queryOne<{ task_id: string; parent_task_id: string; convoy_id: string }>(
+        `SELECT cs.task_id AS task_id, c.parent_task_id AS parent_task_id, cs.convoy_id AS convoy_id
+           FROM convoy_subtasks cs JOIN convoys c ON c.id = cs.convoy_id WHERE cs.id = ?`,
+        [args.subtask_id],
+      );
+      if (!row) {
+        return { isError: true, content: [{ type: 'text', text: `subtask ${args.subtask_id} not found` }], structuredContent: { error: 'subtask_not_found' } };
+      }
+      const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
+      assertAgentCanActOnTask(args.agent_id, row.parent_task_id, 'delegate');
+
+      const now = new Date().toISOString();
+      run(
+        `UPDATE tasks SET status = 'cancelled', status_reason = ?, updated_at = ? WHERE id = ?`,
+        [`cancelled_by_coordinator: ${args.reason}`, now, row.task_id],
+      );
+      run(
+        `UPDATE convoys SET failed_subtasks = failed_subtasks + 1, updated_at = ? WHERE id = ?`,
+        [now, row.convoy_id],
+      );
+
+      logActivity({
+        taskId: row.parent_task_id,
+        actingAgentId: args.agent_id,
+        activityType: 'updated',
+        message: `[delegation_cancelled] subtask=${args.subtask_id} reason="${args.reason.replace(/"/g, "'")}"`,
+      });
+
+      return textResult(`Cancelled subtask ${args.subtask_id}.`, {
+        subtask_id: args.subtask_id,
+        child_task_id: row.task_id,
+      });
     }),
   );
 }

--- a/src/lib/stall-detection.ts
+++ b/src/lib/stall-detection.ts
@@ -4,6 +4,7 @@ import { sendMail } from '@/lib/mailbox';
 import { logTaskActivity } from '@/lib/activity-log';
 import { saveCheckpointThrottled } from '@/lib/checkpoint';
 import { logDebugEvent } from '@/lib/debug-log';
+import { getActiveConvoyForTask } from '@/lib/convoy';
 import type { Task } from '@/lib/types';
 
 // Active statuses that can go stale. Kept in sync with
@@ -95,16 +96,13 @@ export async function scanStalledTasks(): Promise<StallReport> {
     // 1. Mark the task. status_reason is cleared by Phase 3.5
     //    (recovery-guard) when the coordinator does anything real.
     //
-    // Prior to PR 6 we ran a coordinator-delegation audit here (the
-    // [DELEGATION] marker scan in src/lib/coordinator-audit.ts) to flag
-    // "unverified delegation" — the hallucinated-tool-call failure mode
-    // where a coordinator claimed to have delegated but sessions_send
-    // never fired. That failure mode can no longer occur: the
-    // sc-mission-control MCP `delegate` tool makes the call server-
-    // authoritative (the tool call IS the delegation + the audit
-    // activity it logs), so any "stuck" coordinator is now either a
-    // tool-call-never-invoked case (surfaced as no activity at all —
-    // the check below catches it) or a legitimate aborted-peer case.
+    // Coordinator-initiated delegations are now server-authoritative via
+    // the `spawn_subtask` MCP tool, which writes a convoy_subtasks row
+    // with its own lifecycle. The "unverified delegation" failure mode
+    // (coordinator claimed a delegation that never fired) can no longer
+    // happen — if spawn_subtask didn't run, there's no subtask row, and
+    // the parent is either legitimately stuck or trivially idle, which
+    // this scanner catches.
     if (!alreadyFlagged) {
       run(
         `UPDATE tasks SET status_reason = ?, updated_at = ? WHERE id = ?`,
@@ -196,11 +194,10 @@ interface ConvoyMembership {
  * so we synthesize it here — see src/lib/convoy.ts for the idiom.
  */
 function resolveConvoyMembership(task: Task): ConvoyMembership | null {
-  // Case (b): this task IS the convoy parent
-  const convoyAsParent = queryOne<{ id: string }>(
-    'SELECT id FROM convoys WHERE parent_task_id = ?',
-    [task.id]
-  );
+  // Case (b): this task IS the convoy parent. A task can now carry
+  // multiple convoys over its lifetime (post-migration 037); we reason
+  // about the currently-active one.
+  const convoyAsParent = getActiveConvoyForTask(task.id);
   if (convoyAsParent) {
     return {
       convoyId: convoyAsParent.id,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -451,7 +451,12 @@ export interface AgentWithOpenClaw extends Agent {
 
 // Convoy types
 export type ConvoyStatus = 'active' | 'paused' | 'completing' | 'done' | 'failed';
-export type DecompositionStrategy = 'manual' | 'ai' | 'planning';
+export type DecompositionStrategy = 'manual' | 'ai' | 'planning' | 'agent';
+
+export interface ExpectedDeliverable {
+  title: string;
+  kind: 'file' | 'note' | 'report';
+}
 export type AgentHealthState = 'idle' | 'working' | 'stalled' | 'stuck' | 'zombie' | 'offline';
 export type CheckpointType = 'auto' | 'manual' | 'crash_recovery';
 
@@ -837,6 +842,18 @@ export interface ConvoySubtask {
    *  Read by convoy dispatch to route each sub-task to an agent whose
    *  `agents.role` matches. NULL means "no hint — pick a builder". */
   suggested_role?: string | null;
+  /** Coordinator's one-line summary of this delegation (agent-spawned only). */
+  slice?: string | null;
+  /** JSON-encoded ExpectedDeliverable[]; populated by spawn_subtask. */
+  expected_deliverables?: string | null;
+  /** JSON-encoded string[] of acceptance criteria. */
+  acceptance_criteria?: string | null;
+  /** Declared SLO (agent-spawned only). NULL on operator-created subtasks. */
+  expected_duration_minutes?: number | null;
+  checkin_interval_minutes?: number | null;
+  dispatched_at?: string | null;
+  due_at?: string | null;
+  deliverables_registered_count?: number | null;
   created_at: string;
   // Joined
   task?: Task;


### PR DESCRIPTION
## Summary

Coordinators now delegate via a new `spawn_subtask` MCP tool that creates (or appends to) a convoy on the parent task and writes a `convoy_subtasks` row carrying the full contract — slice, expected deliverables, acceptance criteria, expected duration, check-in cadence. The peer is dispatched through the normal pipeline with a **Delegation Contract** block spliced into its briefing, so it sees exactly what it owes and when. The old `delegate` tool — which only wrote a free-form audit string and had zero observability — is deleted in the same PR.

## Why this exists

Empirical observability gap on the live system (snapshot from live DB):

| Symptom | Evidence |
|---|---|
| Fan-outs silently lose branches | On task `cc3d40e1` the coordinator fired three `delegate` calls; one peer dropped its branch; parent re-flagged "stalled" **106 times** with no per-branch signal |
| Dispatches pile up | 45 tasks stuck `in_progress`, 49 unread mails > 1 h old (incl. roll-call replies the coordinator never read) |
| No vocabulary for "I'm blocked" | Of 500 recent activities: 167 status_changed, 30 completed, **0** blocked/question |
| Completion notes are noise | Top `log_activity` messages: `"done"`, `"built"`, `"did thing"` |
| Dispatch prompt punts | Ended with `"If you need help or clarification, ask the orchestrator."` — no channel, no cadence, no state |

Convoy already had the substrate (persistent subtask rows, dependency DAG, parallel cap, auto-completion via `checkConvoyCompletion`, stall-aware coordinator notification, `ConvoyTab` UI) but it was HTTP-only / operator-only, so agents reached for the weaker tool. Exposing convoy to agents via MCP gives every delegation a deterministic lifecycle that stall detection and the UI can reason about.

## MCP surface changes

**New tools (5):**

| Tool | Role | Purpose |
|---|---|---|
| `spawn_subtask` | coordinator | Lazy-create convoy, insert subtask+child task, dispatch peer with contract block. Rejects peer sub-delegation (`is_subtask=1` callers). |
| `list_my_subtasks` | coordinator | Live view with per-row `state_derived` (`dispatched` / `in_progress` / `drifting` / `overdue` / `delivered` / `accepted` / `rejected` / `blocked` / `timed_out` / `cancelled`) |
| `accept_subtask` | coordinator | Promote child to `done`, bump counter, cascade `checkConvoyCompletion` |
| `reject_subtask` | coordinator | Bounce child to `in_progress` with reason + optional new acceptance criteria; notifies peer via `chat.send` |
| `cancel_subtask` | coordinator | Release a stuck or obsolete branch (for scope changes / dead ends) |

**Extensions to existing tools:**

- `get_task` — returns `delegation_contract` when the task has a SLO-populated subtask row (peer re-reads its obligation without parsing the brief).
- `register_deliverable` — bumps `deliverables_registered_count` on the subtask row so `list_my_subtasks` stays cheap.
- `update_task_status` — when a subtask reaches `review`/`testing`/`verification`, mails the coordinator with `DELEGATION: ready_for_review` (push=true).
- `fail_task` — mails `DELEGATION: blocked` or `DELEGATION: redecompose_requested` (the `redecompose:` reason prefix is the peer's escape hatch; see spec §3.8).

**Deleted:** `delegate` tool handler + registration + input schema, `[DELEGATION]` audit-string convention (prompt + stale comment in `stall-detection.ts`). The `coordinator-audit.ts` scanner was already removed pre-PR.

## Schema (migration 037)

```sql
ALTER TABLE convoy_subtasks ADD COLUMN slice TEXT;
ALTER TABLE convoy_subtasks ADD COLUMN expected_deliverables TEXT;   -- JSON
ALTER TABLE convoy_subtasks ADD COLUMN acceptance_criteria TEXT;     -- JSON
ALTER TABLE convoy_subtasks ADD COLUMN expected_duration_minutes INTEGER;
ALTER TABLE convoy_subtasks ADD COLUMN checkin_interval_minutes INTEGER DEFAULT 15;
ALTER TABLE convoy_subtasks ADD COLUMN dispatched_at TEXT;
ALTER TABLE convoy_subtasks ADD COLUMN due_at TEXT;
ALTER TABLE convoy_subtasks ADD COLUMN deliverables_registered_count INTEGER DEFAULT 0;

-- Drop UNIQUE on convoys.parent_task_id (writable_schema rewrite + drop
-- the implicit sqlite_autoindex_convoys_2). A parent task may now have
-- multiple convoys over its lifetime; readers use getActiveConvoyForTask.
-- Add 'agent' to decomposition_strategy CHECK in the same rewrite.
CREATE INDEX idx_convoys_parent_active ON convoys(parent_task_id, status);
```

Four `queryOne<Convoy>` readers refactored to a shared `getActiveConvoyForTask(parentTaskId)` helper ("latest `status='active'`"). The fifth caller — the task delete handler — now iterates **all** convoys on the parent because a delete is a full teardown.

## Dispatch briefing

- Coordinator template ([dispatch/route.ts:447](src/app/api/tasks/%5Bid%5D/dispatch/route.ts)): swapped from `delegate({…})` to `spawn_subtask({…})` with every contract field, plus the full `list_my_subtasks` / `accept` / `reject` / `cancel` flow shown inline.
- Peer template: when the task is a SLO-populated subtask, a **Delegation Contract** section is inserted right after the call-home block. It shows who delegated, the slice, the full deliverables + acceptance lists, the due-at, the cadence, and the escape hatch: *"do not sub-delegate, do not improvise — call `fail_task` with `reason: \"redecompose: …\"` and stop"*.

## Config

`MC_CONVOY_MAX_PARALLEL` env var, default raised to **10** (was a hardcoded 5). Operator-planned convoys rarely approach this, but an agent coordinator can legitimately fan out to every role in the roster.

## Validation

- `npx tsc --noEmit` clean
- `npm run lint` 0 errors (pre-existing warnings unchanged)
- `npm run build` succeeds (8.8s, 1 pre-existing warning)
- **60/60** tests pass across the four directly-relevant files:
  - `src/lib/authz/agent-task.test.ts` — 16/16
  - `src/lib/mcp/mcp.test.ts` — 13/13 (updated the `tools/list` expectation; added negative assertion that `delegate` is absent)
  - `src/lib/services/services.test.ts` — 27/27
  - `src/lib/task-governance.test.ts` — 4/4
- The full-suite `npm test` hits pre-existing `SqliteError: database is locked` flakiness when files run concurrently against the shared DB path — same behavior on `main` for unrelated files (e.g. `authz/agent-task.test.ts` passes alone on main, fails in the concurrent run).

## Test plan

- [ ] Apply migration on a snapshot DB; confirm `PRAGMA table_info(convoy_subtasks)` shows the eight new columns and that `SELECT sql FROM sqlite_master WHERE name='convoys'` no longer contains `UNIQUE` on `parent_task_id`.
- [ ] Coordinator session: call `spawn_subtask` three times → confirm one convoy with three `convoy_subtasks` rows (sort_order 1..3, all SLO fields populated, `dispatched_at` / `due_at` set).
- [ ] Confirm each peer's dispatch message contains the **Delegation Contract** block with the right slice / criteria / due_at / cadence / subtask_id.
- [ ] Peer registers a deliverable → `list_my_subtasks` returns the row with `deliverables_registered: 1`.
- [ ] Peer moves task to `review` → coordinator receives a `DELEGATION: ready_for_review` mail (push=true) with the `subtask_id` embedded.
- [ ] `accept_subtask` → child `review → done`, `convoys.completed_subtasks++`, `checkConvoyCompletion` fires.
- [ ] `reject_subtask` with `new_acceptance_criteria` → child back to `in_progress`, peer gets a chat.send inline rejection.
- [ ] A delegated peer calls `spawn_subtask` → rejected with `peer_sub_delegation_blocked` error.
- [ ] A delegated peer calls `fail_task({ reason: "redecompose: too broad" })` → coordinator receives `DELEGATION: redecompose_requested` mail.

## Follow-up PRs

Per [specs/coordinator-delegation-via-convoy-spec.md](specs/coordinator-delegation-via-convoy-spec.md) §6:

1. Per-subtask stall rules that read `expected_duration_minutes` / `checkin_interval_minutes` and escalate drifting → overdue → timed_out (replaces the global 30-min threshold that produced the 106× flag loop).
2. `ConvoyTab` UI polish — SLO countdown chips, at-risk sidebar, accept/reject buttons wired to the new tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)