### PR TITLE
Render markdown deliverables in-browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "playwright": "^1.59.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "source-map-js": "^1.2.1",
     "uuid": "^14.0.0",
     "zod": "^4.3.6",

--- a/src/app/api/deliverables/[id]/raw/route.ts
+++ b/src/app/api/deliverables/[id]/raw/route.ts
@@ -1,0 +1,65 @@
+/**
+ * Raw bytes for a single file deliverable.
+ *
+ * Powers the in-browser viewer (currently markdown). Returns the file body
+ * inline (no Content-Disposition: attachment) so it can be fetched and
+ * rendered client-side. Path resolution + traversal safety go through
+ * resolveDeliverableReadPath() so MC-managed and legacy host-only rows
+ * behave identically to the download route.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createReadStream } from 'fs';
+import { Readable } from 'stream';
+import { getDb } from '@/lib/db';
+import {
+  resolveDeliverableReadPath,
+  mimeTypeForPath,
+  fileSizeBytes,
+  DeliverableReadError,
+} from '@/lib/deliverables/storage';
+import type { TaskDeliverable } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(_request: NextRequest, props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
+  const db = getDb();
+  const deliverable = db.prepare(`SELECT * FROM task_deliverables WHERE id = ?`).get(params.id) as
+    | TaskDeliverable
+    | undefined;
+
+  if (!deliverable) {
+    return NextResponse.json({ error: 'Deliverable not found' }, { status: 404 });
+  }
+  if (deliverable.deliverable_type !== 'file') {
+    return NextResponse.json(
+      { error: 'Only file deliverables can be viewed' },
+      { status: 400 }
+    );
+  }
+
+  let absPath: string;
+  try {
+    absPath = resolveDeliverableReadPath(deliverable);
+  } catch (e) {
+    if (e instanceof DeliverableReadError) {
+      return NextResponse.json({ error: e.message }, { status: e.status });
+    }
+    throw e;
+  }
+
+  const size = fileSizeBytes(absPath);
+  const contentType = mimeTypeForPath(absPath);
+
+  const nodeStream = createReadStream(absPath);
+  const webStream = Readable.toWeb(nodeStream) as unknown as ReadableStream;
+
+  const headers: Record<string, string> = {
+    'Content-Type': contentType,
+    'Cache-Control': 'private, max-age=0, must-revalidate',
+  };
+  if (size !== undefined) headers['Content-Length'] = String(size);
+
+  return new NextResponse(webStream, { status: 200, headers });
+}

--- a/src/app/api/deliverables/[id]/route.ts
+++ b/src/app/api/deliverables/[id]/route.ts
@@ -1,0 +1,20 @@
+/**
+ * Single-deliverable metadata fetch. Powers the standalone viewer page so it
+ * can show title/path/type without scraping the per-task list endpoint.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/db';
+import type { TaskDeliverable } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(_request: NextRequest, props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
+  const db = getDb();
+  const row = db
+    .prepare(`SELECT * FROM task_deliverables WHERE id = ?`)
+    .get(params.id) as TaskDeliverable | undefined;
+  if (!row) return NextResponse.json({ error: 'Deliverable not found' }, { status: 404 });
+  return NextResponse.json(row);
+}

--- a/src/app/deliverables/[id]/view/page.tsx
+++ b/src/app/deliverables/[id]/view/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { use, useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { ArrowLeft, Download, ExternalLink, FileText } from 'lucide-react';
+import type { TaskDeliverable } from '@/lib/types';
+
+const MAX_INLINE_BYTES = 5 * 1024 * 1024; // 5 MB cap on the viewer — anything bigger should download
+
+interface ViewState {
+  meta?: TaskDeliverable;
+  content?: string;
+  error?: string;
+}
+
+export default function DeliverableViewPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [state, setState] = useState<ViewState>({});
+
+  useEffect(() => {
+    document.title = 'Deliverable viewer';
+    let cancelled = false;
+    (async () => {
+      try {
+        const metaRes = await fetch(`/api/deliverables/${id}`);
+        if (!metaRes.ok) {
+          const err = await metaRes.json().catch(() => ({}));
+          if (!cancelled) setState({ error: err.error || `Failed to load deliverable (${metaRes.status})` });
+          return;
+        }
+        const meta = (await metaRes.json()) as TaskDeliverable;
+
+        const rawRes = await fetch(`/api/deliverables/${id}/raw`);
+        if (!rawRes.ok) {
+          const err = await rawRes.json().catch(() => ({}));
+          if (!cancelled) setState({ meta, error: err.error || `Failed to fetch file (${rawRes.status})` });
+          return;
+        }
+        const lenHeader = rawRes.headers.get('Content-Length');
+        if (lenHeader && Number(lenHeader) > MAX_INLINE_BYTES) {
+          if (!cancelled)
+            setState({
+              meta,
+              error: `File is ${(Number(lenHeader) / 1024 / 1024).toFixed(1)} MB — too large to render inline. Use the download link below.`,
+            });
+          return;
+        }
+        const text = await rawRes.text();
+        if (!cancelled) {
+          setState({ meta, content: text });
+          if (meta.title) document.title = `${meta.title} — Deliverable viewer`;
+        }
+      } catch (err) {
+        if (!cancelled) setState({ error: err instanceof Error ? err.message : 'Unexpected error' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const meta = state.meta;
+  const path = meta?.path;
+  const looksMarkdown = !!path && /\.(md|markdown|mdx)$/i.test(path);
+  const downloadHref = meta && meta.deliverable_type === 'file' ? `/api/deliverables/${id}/download` : null;
+
+  return (
+    <div className="min-h-screen bg-mc-bg text-mc-text">
+      <header className="sticky top-0 z-10 border-b border-mc-border bg-mc-bg-secondary/95 backdrop-blur">
+        <div className="max-w-4xl mx-auto px-4 py-3 flex items-center gap-3">
+          <button
+            onClick={() => {
+              if (window.history.length > 1) window.history.back();
+              else window.close();
+            }}
+            className="inline-flex items-center gap-1.5 px-2 py-1 text-sm text-mc-text-secondary hover:text-mc-text rounded-sm hover:bg-mc-bg-tertiary"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back
+          </button>
+          <div className="flex-1 min-w-0">
+            <h1 className="text-sm font-medium text-mc-text truncate flex items-center gap-2">
+              <FileText className="w-4 h-4 text-mc-accent shrink-0" />
+              {meta?.title ?? 'Loading…'}
+            </h1>
+            {path && (
+              <p className="text-xs text-mc-text-secondary font-mono truncate">{path}</p>
+            )}
+          </div>
+          {downloadHref && (
+            <a
+              href={downloadHref}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-sm border border-mc-border hover:border-mc-accent hover:bg-mc-bg-tertiary"
+            >
+              <Download className="w-3.5 h-3.5" />
+              Download
+            </a>
+          )}
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-4 py-6">
+        {state.error && (
+          <div className="p-4 rounded-md border border-red-500/30 bg-red-500/10 text-sm text-red-300">
+            {state.error}
+            {downloadHref && (
+              <p className="mt-2">
+                <a className="text-mc-accent hover:underline inline-flex items-center gap-1" href={downloadHref}>
+                  <Download className="w-3.5 h-3.5" /> Download original
+                </a>
+              </p>
+            )}
+          </div>
+        )}
+
+        {!state.error && state.content !== undefined && looksMarkdown && (
+          <article className="mc-md">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{state.content}</ReactMarkdown>
+          </article>
+        )}
+
+        {!state.error && state.content !== undefined && !looksMarkdown && (
+          <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-mc-bg-secondary border border-mc-border rounded-md p-4">
+            {state.content}
+          </pre>
+        )}
+
+        {!state.error && state.content === undefined && (
+          <div className="text-sm text-mc-text-secondary">Loading…</div>
+        )}
+
+        {!state.error && state.content !== undefined && !looksMarkdown && path && (
+          <p className="mt-4 text-xs text-mc-text-secondary inline-flex items-center gap-1.5">
+            <ExternalLink className="w-3.5 h-3.5" />
+            Showing raw text. Markdown rendering activates for .md / .markdown / .mdx files.
+          </p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -195,3 +195,87 @@ body {
 .online-glow {
   box-shadow: 0 0 10px var(--mc-accent-green), 0 0 20px var(--mc-accent-green);
 }
+
+/* Markdown viewer typography (deliverables/[id]/view). Scoped so it doesn't
+   bleed into other markdown surfaces; styled with mc-* tokens. */
+.mc-md {
+  color: var(--mc-text);
+  font-size: 15px;
+  line-height: 1.65;
+}
+.mc-md > :first-child { margin-top: 0; }
+.mc-md > :last-child { margin-bottom: 0; }
+.mc-md h1, .mc-md h2, .mc-md h3, .mc-md h4, .mc-md h5, .mc-md h6 {
+  color: var(--mc-text);
+  font-weight: 600;
+  margin: 1.6em 0 0.6em;
+  line-height: 1.3;
+}
+.mc-md h1 { font-size: 1.85em; border-bottom: 1px solid var(--mc-border); padding-bottom: 0.3em; }
+.mc-md h2 { font-size: 1.45em; border-bottom: 1px solid var(--mc-border); padding-bottom: 0.25em; }
+.mc-md h3 { font-size: 1.2em; }
+.mc-md h4 { font-size: 1.05em; }
+.mc-md h5, .mc-md h6 { font-size: 0.95em; color: var(--mc-text-secondary); }
+.mc-md p { margin: 0.8em 0; }
+.mc-md a { color: var(--mc-accent); text-decoration: underline; text-underline-offset: 2px; }
+.mc-md a:hover { opacity: 0.85; }
+.mc-md ul, .mc-md ol { margin: 0.8em 0; padding-left: 1.6em; }
+.mc-md ul { list-style: disc; }
+.mc-md ol { list-style: decimal; }
+.mc-md li { margin: 0.25em 0; }
+.mc-md li > p { margin: 0.25em 0; }
+.mc-md blockquote {
+  margin: 1em 0; padding: 0.4em 1em;
+  border-left: 3px solid var(--mc-accent);
+  color: var(--mc-text-secondary);
+  background: var(--mc-bg-secondary);
+  border-radius: 0 4px 4px 0;
+}
+.mc-md hr { border: 0; border-top: 1px solid var(--mc-border); margin: 2em 0; }
+.mc-md code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  background: var(--mc-bg-tertiary);
+  padding: 0.12em 0.4em;
+  border-radius: 3px;
+  color: var(--mc-accent-pink);
+}
+.mc-md pre {
+  background: var(--mc-bg-secondary);
+  border: 1px solid var(--mc-border);
+  border-radius: 6px;
+  padding: 1em;
+  overflow-x: auto;
+  margin: 1em 0;
+}
+.mc-md pre code {
+  background: transparent;
+  padding: 0;
+  color: var(--mc-text);
+  font-size: 0.85em;
+}
+.mc-md table {
+  border-collapse: collapse;
+  margin: 1em 0;
+  width: 100%;
+  font-size: 0.95em;
+}
+.mc-md th, .mc-md td {
+  border: 1px solid var(--mc-border);
+  padding: 0.5em 0.75em;
+  text-align: left;
+}
+.mc-md th {
+  background: var(--mc-bg-tertiary);
+  font-weight: 600;
+}
+.mc-md img { max-width: 100%; height: auto; border-radius: 4px; }
+.mc-md input[type="checkbox"] { margin-right: 0.4em; vertical-align: middle; }
+.mc-md kbd {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--mc-bg-tertiary);
+  border: 1px solid var(--mc-border);
+  border-radius: 3px;
+  padding: 0.1em 0.4em;
+}

--- a/src/components/DeliverablesList.tsx
+++ b/src/components/DeliverablesList.tsx
@@ -6,7 +6,7 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import { FileText, Link as LinkIcon, Package, ExternalLink, Eye, Download, Archive } from 'lucide-react';
+import { FileText, Link as LinkIcon, Package, ExternalLink, Eye, Download, Archive, BookOpen } from 'lucide-react';
 import { debug } from '@/lib/debug';
 import type { TaskDeliverable } from '@/lib/types';
 
@@ -202,6 +202,19 @@ export function DeliverablesList({ taskId, refreshKey = 0 }: DeliverablesListPro
                   >
                     <Eye className="w-4 h-4" />
                   </button>
+                )}
+                {/* Rendered viewer for markdown / plain-text files. Opens in
+                    a new tab so the user can keep the task modal in view. */}
+                {deliverable.deliverable_type === 'file' && deliverable.path && /\.(md|markdown|mdx|txt)$/i.test(deliverable.path) && (
+                  <a
+                    href={`/deliverables/${deliverable.id}/view`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0 p-1.5 hover:bg-mc-bg-tertiary rounded-sm text-mc-accent-cyan"
+                    title="View rendered"
+                  >
+                    <BookOpen className="w-4 h-4" />
+                  </a>
                 )}
                 {/* Open/Reveal button */}
                 {deliverable.path && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2588,7 +2588,14 @@
   dependencies:
     "@types/ms" "*"
 
-"@types/estree@^1.0.6":
+"@types/estree-jsx@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/estree-jsx/-/estree-jsx-1.0.5.tgz#858a88ea20f34fe65111f005a689fa1ebf70dc18"
+  integrity sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==
+  dependencies:
+    "@types/estree" "*"
+
+"@types/estree@*", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
@@ -2669,6 +2676,11 @@
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
   integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
+
+"@types/unist@^2.0.0":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
+  integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
 
 "@types/use-sync-external-store@^0.0.6":
   version "0.0.6"
@@ -3581,6 +3593,11 @@ character-entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
   integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
 
+character-reference-invalid@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz#85c66b041e43b47210faf401278abf808ac45cb9"
+  integrity sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==
+
 chokidar@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-5.0.0.tgz#949c126a9238a80792be9a0265934f098af369a5"
@@ -4376,6 +4393,11 @@ estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-util-is-identifier-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz#0b5ef4c4ff13508b34dcd01ecfa945f61fce5dbd"
+  integrity sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==
+
 estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
@@ -4994,6 +5016,27 @@ hast-util-to-html@^9.0.0:
     stringify-entities "^4.0.0"
     zwitch "^2.0.4"
 
+hast-util-to-jsx-runtime@^2.0.0:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz#ff31897aae59f62232e21594eac7ef6b63333e98"
+  integrity sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    devlop "^1.0.0"
+    estree-util-is-identifier-name "^3.0.0"
+    hast-util-whitespace "^3.0.0"
+    mdast-util-mdx-expression "^2.0.0"
+    mdast-util-mdx-jsx "^3.0.0"
+    mdast-util-mdxjs-esm "^2.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    style-to-js "^1.0.0"
+    unist-util-position "^5.0.0"
+    vfile-message "^4.0.0"
+
 hast-util-to-parse5@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz#95aa391cc0514b4951418d01c883d1038af42f5d"
@@ -5066,6 +5109,11 @@ hookable@^6.0.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/hookable/-/hookable-6.1.1.tgz#825f966b4b426db2e622d94d7a31a70f196f9d2f"
   integrity sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==
+
+html-url-attributes@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-url-attributes/-/html-url-attributes-3.0.1.tgz#83b052cd5e437071b756cd74ae70f708870c2d87"
+  integrity sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==
 
 html-void-elements@^3.0.0:
   version "3.0.0"
@@ -5140,6 +5188,11 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+inline-style-parser@0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.2.7.tgz#b1fc68bfc0313b8685745e4464e37f9376b9c909"
+  integrity sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==
+
 internal-slot@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.1.0.tgz#1eac91762947d2f7056bc838d93e13b2e9604961"
@@ -5163,6 +5216,19 @@ is-absolute-url@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-4.0.1.tgz#16e4d487d4fded05cfe0685e53ec86804a5e94dc"
   integrity sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==
+
+is-alphabetical@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-2.0.1.tgz#01072053ea7c1036df3c7d19a6daaec7f19e789b"
+  integrity sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==
+
+is-alphanumerical@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz#7c03fbe96e3e931113e57f964b0a368cc2dfd875"
+  integrity sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==
+  dependencies:
+    is-alphabetical "^2.0.0"
+    is-decimal "^2.0.0"
 
 is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"
@@ -5235,6 +5301,11 @@ is-date-object@^1.0.5, is-date-object@^1.1.0:
     call-bound "^1.0.2"
     has-tostringtag "^1.0.2"
 
+is-decimal@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
+  integrity sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -5269,6 +5340,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz#86b5bf668fca307498d319dfc03289d781a90027"
+  integrity sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==
 
 is-identifier@^1.0.1:
   version "1.0.1"
@@ -5850,6 +5926,48 @@ mdast-util-gfm@^3.0.0:
     mdast-util-gfm-strikethrough "^2.0.0"
     mdast-util-gfm-table "^2.0.0"
     mdast-util-gfm-task-list-item "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-mdx-expression@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz#43f0abac9adc756e2086f63822a38c8d3c3a5096"
+  integrity sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-mdx-jsx@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz#fd04c67a2a7499efb905a8a5c578dddc9fdada0d"
+  integrity sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
+    ccount "^2.0.0"
+    devlop "^1.1.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+    parse-entities "^4.0.0"
+    stringify-entities "^4.0.0"
+    unist-util-stringify-position "^4.0.0"
+    vfile-message "^4.0.0"
+
+mdast-util-mdxjs-esm@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz#019cfbe757ad62dd557db35a695e7314bcc9fa97"
+  integrity sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    mdast-util-from-markdown "^2.0.0"
     mdast-util-to-markdown "^2.0.0"
 
 mdast-util-phrasing@^4.0.0:
@@ -6597,6 +6715,19 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-entities@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-4.0.2.tgz#61d46f5ed28e4ee62e9ddc43d6b010188443f159"
+  integrity sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    character-entities-legacy "^3.0.0"
+    character-reference-invalid "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    is-alphanumerical "^2.0.0"
+    is-decimal "^2.0.0"
+    is-hexadecimal "^2.0.0"
+
 parse-ms@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-4.0.0.tgz#c0c058edd47c2a590151a718990533fd62803df4"
@@ -6893,6 +7024,23 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-markdown@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-10.1.0.tgz#e22bc20faddbc07605c15284255653c0f3bad5ca"
+  integrity sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    hast-util-to-jsx-runtime "^2.0.0"
+    html-url-attributes "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    remark-parse "^11.0.0"
+    remark-rehype "^11.0.0"
+    unified "^11.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+
 react-redux@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-9.2.0.tgz#96c3ab23fb9a3af2cb4654be4b51c989e32366f5"
@@ -7059,7 +7207,7 @@ remark-parse@^11.0.0:
     micromark-util-types "^2.0.0"
     unified "^11.0.0"
 
-remark-rehype@^11.1.2:
+remark-rehype@^11.0.0, remark-rehype@^11.1.2:
   version "11.1.2"
   resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-11.1.2.tgz#2addaadda80ca9bd9aa0da763e74d16327683b37"
   integrity sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==
@@ -7616,6 +7764,20 @@ style-mod@^4.0.0, style-mod@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.3.tgz#6e9012255bb799bdac37e288f7671b5d71bf9f73"
   integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
+
+style-to-js@^1.0.0:
+  version "1.1.21"
+  resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.21.tgz#2908941187f857e79e28e9cd78008b9a0b3e0e8d"
+  integrity sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==
+  dependencies:
+    style-to-object "1.0.14"
+
+style-to-object@1.0.14:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-1.0.14.tgz#1d22f0e7266bb8c6d8cae5caf4ec4f005e08f611"
+  integrity sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==
+  dependencies:
+    inline-style-parser "0.2.7"
 
 styled-jsx@5.1.6:
   version "5.1.6"


### PR DESCRIPTION
## Summary
- New `/deliverables/[id]/view` page renders `.md`/`.markdown`/`.mdx` deliverables with `react-markdown` + `remark-gfm`; `.txt` falls through to a styled `<pre>` block.
- New API endpoints: `GET /api/deliverables/[id]` (metadata) and `/raw` (bytes), both gated by `resolveDeliverableReadPath()` for the same path-traversal safety as download.
- Scoped `.mc-md` typography in `globals.css` using existing `--mc-*` tokens — headings, code, GFM tables, blockquote, links, task-list checkboxes.
- DeliverablesList gains a BookOpen "View rendered" button (opens in a new tab) for matching files alongside the existing download/reveal/preview controls.

## Test plan
- [ ] Open a task with a `.md` deliverable → click View → page renders with formatted headings, lists, code blocks, GFM tables, blockquote, and task-list checkboxes
- [ ] Same for a `.txt` deliverable → renders as monospace text in a `<pre>` block
- [ ] Try a >5 MB file → friendly error with a download fallback link
- [ ] Try a non-file deliverable id → 400 error
- [ ] Try a missing deliverable id → 404 on metadata endpoint
- [ ] Path-traversal probe (e.g. `../etc/passwd` style stored path) is rejected by `resolveDeliverableReadPath()` — same protection as `/download`

🤖 Generated with [Claude Code](https://claude.com/claude-code)