### PR TITLE
Phase 1: Roadmap planning layer — initiatives schema + audit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN yarn install --frozen-lockfile --production && yarn cache clean
 FROM base AS builder
 COPY --from=build-deps /app/node_modules ./node_modules
 COPY . .
+# Next 16 + Turbopack can exceed Node's default ~4GB heap on larger builds.
+# Belt-and-suspenders alongside the Docker Desktop memory allocation.
+ENV NODE_OPTIONS=--max-old-space-size=4096
 RUN yarn build
 
 FROM node:22-bookworm-slim AS runner

--- a/specs/roadmap-and-pm-spec.md
+++ b/specs/roadmap-and-pm-spec.md
@@ -1,0 +1,717 @@
+# Roadmap & PM Agent — Project Planning Layer for Mission Control
+
+**Version:** 0.2
+**Date:** 2026-04-24
+**Status:** Draft (awaiting operator sign-off)
+**Repo:** smb209/mission-control
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Solution Overview](#2-solution-overview)
+3. [Core Concepts](#3-core-concepts)
+4. [Decomposition Rules](#4-decomposition-rules)
+5. [Database Schema Changes](#5-database-schema-changes)
+6. [Traceability & Re-parenting](#6-traceability--re-parenting)
+7. [Date Semantics & Derived Schedule](#7-date-semantics--derived-schedule)
+8. [Status Checks](#8-status-checks)
+9. [PM Agent](#9-pm-agent)
+10. [API Surface](#10-api-surface)
+11. [MCP Surface](#11-mcp-surface)
+12. [UI Surface](#12-ui-surface)
+13. [Workflow Unification](#13-workflow-unification)
+14. [Phased Delivery](#14-phased-delivery)
+15. [Out of Scope](#15-out-of-scope)
+16. [Open Questions](#16-open-questions)
+17. [Acceptance Criteria](#17-acceptance-criteria)
+
+---
+
+## 1. Problem Statement
+
+Mission Control today is excellent at **executing one task at a time**: Task → Plan → Execute → Deliver. It has no representation of work that lives *above* a task — milestones, epics, multi-task initiatives, dependencies that span tasks, target windows.
+
+Three concrete gaps:
+
+1. **No planning horizon.** Work that's a month out has no place to live except as a stale `idea` row or in the operator's head.
+2. **No traceability after decomposition.** When a big initiative becomes ten tasks, the link from "this task" back to "this milestone" is lost.
+3. **No discipline.** The hardest part of project management is keeping the schedule honest — re-estimating, re-sequencing, flagging slippage. Doing this manually is what kills every roadmap tool.
+
+The execution board (current `tasks` table + Mission Queue UI) works. We need a **planning layer** above it, with an agent that maintains hygiene so the operator doesn't have to.
+
+---
+
+## 2. Solution Overview
+
+Add a **planning layer** on top of the existing execution layer:
+
+- **Initiatives**: a tree of planning units (themes, milestones, epics, stories). Initiatives carry target windows, owners, dependencies, effort estimates, and free-form status checks. Almost every field is optional — an initiative can be a one-line backlog idea.
+- **Tasks-in-draft on the planning board**: tasks created from story decomposition live on the roadmap in a new `draft` status. They appear on the execution board (Mission Queue) only after explicit operator promotion.
+- **Operator-driven promotion**: at every layer (idea → initiative, story → task draft, task draft → execution queue), promotion is an explicit operator action. Never automatic. Always atomic, one at a time.
+- **PM agent**: a designated agent (role=`pm`) that maintains the roadmap. It re-estimates from velocity, flags drift, and responds to disruption events ("contractor out a week", "dependency delayed") with a *proposed diff* the operator can refine and accept.
+- **Roadmap view**: a timeline UI showing initiatives, milestones, tasks (drafts and active), and dependency arrows.
+- **MCP surface**: new tools on `sc-mission-control` so the PM agent (and any other agent) can read and manipulate the roadmap through MCP, not direct DB writes.
+
+The execution board is unchanged. Tasks gain a single new pointer back to their owning initiative and a new `draft` status.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  PLANNING LAYER (new)                                        │
+│                                                              │
+│   Initiative tree → Tasks (draft) → Roadmap → PM agent       │
+│                                                              │
+└─────────────────┬─────────────────────────────────────────────┘
+                  │  operator-driven promotion only
+                  ▼  (sets task.status: draft → inbox)
+┌──────────────────────────────────────────────────────────────┐
+│  EXECUTION LAYER (existing)                                  │
+│                                                              │
+│   Tasks → Convoys → Agents → Deliverables                    │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Core Concepts
+
+### 3.1 Initiative
+
+A node in the planning tree. Every initiative has a `kind`:
+
+| Kind         | Meaning                                                                | Has children? |
+| ------------ | ---------------------------------------------------------------------- | ------------- |
+| `theme`      | Optional grouping above milestones (quarterly themes).                 | Yes           |
+| `milestone`  | External commitment (launch date, customer demo). Has `committed_end`. | Usually yes   |
+| `epic`       | Large body of work. Decomposes into stories.                           | Yes           |
+| `story`      | Promotable unit of work. Becomes one or more task drafts.              | Rarely        |
+
+`kind` is advisory for the UI — the data model doesn't enforce hierarchy depth. An operator can put a `story` directly under a `milestone` (skipping `epic`) or convert a `story` to an `epic` when scope grows (`kind` is mutable).
+
+**All fields except `id`, `workspace_id`, `kind`, and `title` are optional.** An initiative can be a one-line idea on a backlog with nothing else filled in. The PM and operator fill in details over time.
+
+### 3.2 Task draft (planning-board task)
+
+A task with `status='draft'`. Created when an operator decomposes a story into work units. Lives only on the roadmap until explicitly promoted to `inbox`. From `inbox` onward, the existing execution pipeline takes over unchanged.
+
+A task in `draft` has a populated `initiative_id`. After promotion, the `initiative_id` stays — provenance is preserved through the entire lifecycle.
+
+### 3.3 Promotion (operator-driven, atomic)
+
+There are three promotion edges, all manual, all one-at-a-time:
+
+| From            | To                  | Effect                                                  |
+| --------------- | ------------------- | ------------------------------------------------------- |
+| `idea`          | `initiative`        | Creates initiative with `source_idea_id`. Idea remains. |
+| `initiative` (story) | `task` (draft) | Creates one task in `status='draft'` linked to initiative. |
+| `task` (draft)  | `task` (inbox)      | Transitions status. Now visible on Mission Queue.       |
+
+Each is one click, one DB row created or one status flipped. Bulk versions deferred to v2.
+
+### 3.4 Disruption
+
+A free-text event the operator drops on the PM: "Sarah out next week", "API X delayed 9 days", "We're cutting Phase 2 from the launch". The PM turns it into an impact analysis + proposed diff. (See §9.)
+
+---
+
+## 4. Decomposition Rules
+
+This section defines how the planning tree behaves when items are decomposed, re-parented, or have their dependencies adjusted. Conventions follow standard agile / Linear / Jira semantics.
+
+### 4.1 Containers persist
+
+Decomposing an epic into stories, or a story into substories, **does not delete the parent**. The parent becomes a container. Its status rolls up from descendants (§7.3). The parent retains:
+
+- Its own description, dates, owner, status check, and dependencies.
+- All audit history.
+- All references from other initiatives that depend on it.
+
+A container with zero descendants behaves as a leaf — it can still be promoted (if `kind='story'`), still has its own dates, still gets scheduled.
+
+### 4.2 Dependencies attach at the declared level
+
+If "Story C depends on Story 2", that edge lives on `(C, 2)` in `initiative_dependencies`. If Story 2 is later decomposed into 2.1 and 2.2, **the edge stays on Story 2**. Story C unblocks when Story 2 (the container) reaches `done`, which by rollup means all of 2's descendants are `done`.
+
+If the operator wants finer granularity ("C only needs 2.1, not 2.2"), they explicitly:
+
+1. Delete the `C → 2` dependency.
+2. Add a `C → 2.1` dependency.
+
+Dependency edges are intentional declarations; we never auto-rewrite them. This is the standard Jira / Linear behavior and avoids surprising edge cascades during decomposition.
+
+### 4.3 Multiple prerequisites
+
+`initiative_dependencies` is many-to-many. If "C blocks on A and B", that's two rows: `(C, A)` and `(C, B)`. The derivation algorithm (§7.2) takes the max end date across all prerequisites when computing C's `derived_start`.
+
+### 4.4 Two distinct mutation operations
+
+| Operation   | What it does                                                | Reversible?                          |
+| ----------- | ----------------------------------------------------------- | ------------------------------------ |
+| **Decompose** | Add children under an initiative; parent stays as container. Optional `kind` change (e.g. story → epic when adding sub-stories). | Yes (delete children).               |
+| **Convert**   | Change an initiative's `kind` without adding children. Used when scope grew but you haven't broken it down yet. | Yes (change kind back). |
+
+A "split" operation (replace one item with N items) is intentionally **not** a primitive. If you want to "split" a story, you `convert` it to an epic and `decompose` it into stories. The original identity is preserved as the container, dependencies and history intact.
+
+### 4.5 Re-parenting tasks across initiatives
+
+Tasks (drafts and active) can be moved between initiatives at any time. Every move appends a row to `task_initiative_history` with operator, timestamp, and reason. Active tasks (status beyond `inbox`) can also be re-parented — provenance is maintained even mid-execution. (See §6.)
+
+### 4.6 Cancellation cascade
+
+- **Initiative cancelled:** child initiatives and tasks are *not* auto-cancelled. Operator decides per-child via UI prompt.
+- **Initiative deleted:** blocked if any descendant initiative or task references it. Operator must re-parent or cancel descendants first.
+- **Task archived/cancelled:** `initiative_id` retained for provenance.
+
+---
+
+## 5. Database Schema Changes
+
+### 5.1 New tables
+
+```sql
+-- Planning-layer nodes. Forms a tree via parent_initiative_id.
+-- Almost every column is nullable; an initiative can be a one-line backlog item.
+CREATE TABLE initiatives (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+  product_id TEXT REFERENCES products(id),
+  parent_initiative_id TEXT REFERENCES initiatives(id),
+  kind TEXT NOT NULL CHECK (kind IN ('theme','milestone','epic','story')),
+  title TEXT NOT NULL,
+  description TEXT,
+  status TEXT NOT NULL DEFAULT 'planned'
+    CHECK (status IN ('planned','in_progress','at_risk','blocked','done','cancelled')),
+  owner_agent_id TEXT REFERENCES agents(id),
+
+  -- Optional sizing / effort
+  estimated_effort_hours REAL,
+  complexity TEXT CHECK (complexity IN ('S','M','L','XL')),
+
+  -- Optional date semantics (see §7)
+  target_start TEXT,
+  target_end TEXT,
+  derived_start TEXT,
+  derived_end TEXT,
+  committed_end TEXT,
+
+  -- Optional status check (§8) — freeform v1
+  status_check_md TEXT,
+
+  sort_order INTEGER DEFAULT 0,
+  source_idea_id TEXT REFERENCES ideas(id),
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Cross-initiative dependencies (DAG). Many-to-many; an initiative can have
+-- multiple prerequisites (A and B blocking C is two rows here).
+CREATE TABLE initiative_dependencies (
+  id TEXT PRIMARY KEY,
+  initiative_id TEXT NOT NULL REFERENCES initiatives(id) ON DELETE CASCADE,
+  depends_on_initiative_id TEXT NOT NULL REFERENCES initiatives(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL DEFAULT 'finish_to_start'
+    CHECK (kind IN ('finish_to_start','start_to_start','blocking','informational')),
+  note TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  UNIQUE(initiative_id, depends_on_initiative_id)
+);
+
+-- Audit log of every initiative-tree move (parent change).
+CREATE TABLE initiative_parent_history (
+  id TEXT PRIMARY KEY,
+  initiative_id TEXT NOT NULL REFERENCES initiatives(id) ON DELETE CASCADE,
+  from_parent_id TEXT REFERENCES initiatives(id),
+  to_parent_id TEXT REFERENCES initiatives(id),
+  moved_by_agent_id TEXT REFERENCES agents(id),
+  reason TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Audit log of every task re-parent. First row for each task has
+-- from_initiative_id = NULL (creation/initial promotion).
+CREATE TABLE task_initiative_history (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  from_initiative_id TEXT REFERENCES initiatives(id),
+  to_initiative_id TEXT REFERENCES initiatives(id),
+  moved_by_agent_id TEXT REFERENCES agents(id),
+  reason TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Owner availability windows (PM impact analysis input).
+CREATE TABLE owner_availability (
+  id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  unavailable_start TEXT NOT NULL,
+  unavailable_end TEXT NOT NULL,
+  reason TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- PM proposal artifacts. Mirrors planning_specs pattern.
+CREATE TABLE pm_proposals (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+  trigger_text TEXT NOT NULL,
+  trigger_kind TEXT NOT NULL DEFAULT 'manual'
+    CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation')),
+  impact_md TEXT NOT NULL,
+  proposed_changes TEXT NOT NULL,                 -- JSON array of typed diffs
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft','accepted','rejected','superseded')),
+  applied_at TEXT,
+  applied_by_agent_id TEXT REFERENCES agents(id),
+  parent_proposal_id TEXT REFERENCES pm_proposals(id),
+  created_at TEXT DEFAULT (datetime('now'))
+);
+```
+
+### 5.2 Changes to existing tables
+
+```sql
+-- tasks: add initiative pointer + 'draft' status + status check.
+ALTER TABLE tasks ADD COLUMN initiative_id TEXT REFERENCES initiatives(id);
+ALTER TABLE tasks ADD COLUMN status_check_md TEXT;
+-- Status CHECK constraint extended to include 'draft'. SQLite can't ALTER
+-- a CHECK in place, so the migration uses the existing table-rebuild
+-- helper pattern in migrations.ts (CREATE _new, copy, drop, rename).
+
+-- ideas: optional path to promote idea → initiative.
+ALTER TABLE ideas ADD COLUMN initiative_id TEXT REFERENCES initiatives(id);
+```
+
+### 5.3 Indexes
+
+```sql
+CREATE INDEX idx_initiatives_workspace ON initiatives(workspace_id);
+CREATE INDEX idx_initiatives_parent ON initiatives(parent_initiative_id);
+CREATE INDEX idx_initiatives_product ON initiatives(product_id);
+CREATE INDEX idx_initiatives_status ON initiatives(status);
+CREATE INDEX idx_initiatives_target_window ON initiatives(target_start, target_end);
+CREATE INDEX idx_initiative_deps_from ON initiative_dependencies(initiative_id);
+CREATE INDEX idx_initiative_deps_to ON initiative_dependencies(depends_on_initiative_id);
+CREATE INDEX idx_task_initiative_history_task ON task_initiative_history(task_id, created_at);
+CREATE INDEX idx_initiative_parent_history ON initiative_parent_history(initiative_id, created_at);
+CREATE INDEX idx_owner_availability_agent ON owner_availability(agent_id, unavailable_start);
+CREATE INDEX idx_tasks_initiative ON tasks(initiative_id);
+CREATE INDEX idx_tasks_draft ON tasks(status, initiative_id) WHERE status='draft';
+CREATE INDEX idx_pm_proposals_status ON pm_proposals(status, created_at DESC);
+```
+
+---
+
+## 6. Traceability & Re-parenting
+
+### 6.1 Provenance model
+
+Two pointers, two audit logs:
+
+| What             | Current state                  | History                          |
+| ---------------- | ------------------------------ | -------------------------------- |
+| Initiative tree  | `initiatives.parent_initiative_id` | `initiative_parent_history` |
+| Task → initiative | `tasks.initiative_id`         | `task_initiative_history`        |
+
+**Invariant:** every task that was ever linked to an initiative has at least one row in `task_initiative_history`. The first row's `from_initiative_id` is `NULL`. The latest row's `to_initiative_id` matches the current `tasks.initiative_id`.
+
+This gives:
+
+- "Where did this task come from?" → first audit row.
+- "Where does it live now?" → `tasks.initiative_id`.
+- "Has it been re-scoped?" → audit row count > 1.
+- "Why did it move?" → `reason` on the audit row.
+
+### 6.2 Re-parenting operations
+
+All operator-driven, all audited:
+
+1. **Move a task to a different initiative.** Updates `tasks.initiative_id`, appends `task_initiative_history` row. Allowed at any task status, including mid-execution.
+2. **Move an initiative subtree.** Updates `initiatives.parent_initiative_id` for the moved node. Descendant initiatives and their tasks come along automatically (relationship is parent-pointer, no rewrite). Audit row on the moved node.
+3. **Detach a task.** `tasks.initiative_id = NULL`, audit row, UI flags as "orphaned".
+4. **Bulk move tasks.** v2; v1 is one at a time per the atomic-promotion rule.
+
+### 6.3 Re-scoping example
+
+> Initiative A "Build big feature" has tasks T1, T2, T3. Operator decides T3 belongs to a new initiative C "Phase 2 polish".
+
+1. Operator creates initiative C as sibling of A.
+2. Roadmap or task detail → "Move to initiative" → C, reason "Deferred to phase 2".
+3. `tasks.initiative_id` for T3 changes A → C. Audit row appended.
+4. Schedule re-derives nightly: A's `derived_end` likely earlier, C's later.
+5. PM's next drift scan posts a "schedule shifted" card if it crosses thresholds.
+
+---
+
+## 7. Date Semantics & Derived Schedule
+
+### 7.1 Three optional date pairs
+
+| Field             | Set by                  | Mutable? | Meaning                                           |
+| ----------------- | ----------------------- | -------- | ------------------------------------------------- |
+| `target_start/end`| Operator                | Yes      | Operator's intent. Movable freely.                |
+| `derived_start/end`| PM (computed)          | Read-only| Schedule from velocity + dep graph + availability. |
+| `committed_end`   | Operator (milestones)   | Rarely   | External commitment. Alarms when derived > committed. |
+
+All optional. An initiative with no dates renders on the roadmap as a "no date set" row — useful for backlog entries.
+
+### 7.2 Derivation algorithm (initial)
+
+Run nightly via `product_schedules` (new schedule_type `roadmap_drift_scan`):
+
+1. **Velocity model:** per-owner average `actual / estimated` ratio from completed tasks in last N days. Default 1.0 if no history.
+2. **Effective effort:** `estimated_effort_hours / velocity_ratio`. For containers, sum descendants. If neither effort nor complexity is set, exclude from derivation rather than guessing.
+3. **Critical path:** topological sort over `initiative_dependencies`. `derived_start = max(deps' derived_end, target_start, today)`.
+4. **Availability:** subtract overlapping `owner_availability` windows from the effort calendar.
+5. **Slippage flag:** if `derived_end > committed_end`, set status `at_risk`. If gap exceeds threshold, surface in PM's morning card.
+
+Keep simple in v1 — no resource leveling, no parallel-effort discounting. PM narrates the gap; operator decides.
+
+### 7.3 Status roll-up
+
+Initiative status is derived from descendants:
+
+- All descendants `done` → `done`
+- Any descendant `in_progress` / `convoy_active` / etc. → `in_progress`
+- Any descendant `at_risk` → `at_risk`
+- Any descendant `blocked` → `blocked`
+- Otherwise → `planned`
+
+Operator override deferred to v2 (would require `status_override` column).
+
+---
+
+## 8. Status Checks
+
+Every initiative and every task gets an optional `status_check_md` text field. Freeform in v1. Examples:
+
+> Linked PR https://github.com/foo/bar/pull/42 — needs review
+> Email thread with vendor; awaiting reply by Apr 30
+> Customer demo on calendar Apr 30 14:00 MT
+> Run `pnpm test:smoke` against staging
+
+The PM agent reads this field as part of impact analysis (e.g. when computing whether a milestone is realistically on track). v2 (out of scope here) adds:
+
+- `status_check_url` for actionable links the agent can fetch.
+- `status_check_last_checked_at` / `status_check_last_result` for periodic investigation.
+- A "status check investigation" PM action that fetches URLs / parses GitHub / etc. and posts a proposal if state has shifted.
+
+For v1, the field exists, the PM reads it as context, and the operator manually updates it.
+
+---
+
+## 9. PM Agent
+
+### 9.1 Identity
+
+A new agent role: **`pm`**. Distinct from the existing `coordinator` (which handles task-level decomposition into convoys) and `master` (which orchestrates execution). One PM agent per workspace, auto-seeded by migration.
+
+| Role          | Scope                                | Layer       |
+| ------------- | ------------------------------------ | ----------- |
+| `pm`          | Roadmap, initiatives, schedule       | Planning    |
+| `coordinator` | Task decomposition into convoys      | Planning ↔ Execution |
+| `master`      | Multi-agent orchestration            | Execution   |
+| Workers       | Individual tasks                     | Execution   |
+
+Reuses existing `agents` infrastructure: chat (`agent_chat_messages`), mailbox (`agent_mailbox`), sessions (`openclaw_sessions`).
+
+### 9.2 Two operating modes
+
+**Reactive (operator-triggered):**
+
+1. Operator opens PM chat (`/pm` route, reuses `agent_chat_messages`).
+2. Drops a disruption: "Sarah out 9 days, dep Y delayed til May 3".
+3. PM:
+   - Parses dates / owner names / initiative refs from text.
+   - Stages proposed `owner_availability` rows (not yet committed).
+   - Runs derivation with the staged changes layered on.
+   - Generates `impact_md` + `proposed_changes` JSON.
+4. Persists `pm_proposals` row (status=`draft`), posts a chat message linking to it.
+5. Operator can:
+   - **Refine** ("don't slip the launch milestone, defer analytics instead") → new proposal with `parent_proposal_id`.
+   - **Accept** → applies diff in one transaction. Marks proposal `accepted`.
+   - **Reject** → marks `rejected`.
+
+**Proactive (scheduled):**
+
+1. New `product_schedules.schedule_type='roadmap_drift_scan'` runs each morning.
+2. PM scans all initiatives, recomputes derivation, identifies drift.
+3. If drift exists, posts a "morning standup" proposal (trigger_kind=`scheduled_drift_scan`).
+
+### 9.3 Proposed-changes format
+
+`pm_proposals.proposed_changes` is a JSON array of typed diffs:
+
+```jsonc
+[
+  { "kind": "shift_initiative_target", "initiative_id": "...", "target_end": "2026-05-12", "reason": "..." },
+  { "kind": "add_availability", "agent_id": "...", "start": "...", "end": "...", "reason": "..." },
+  { "kind": "set_initiative_status", "initiative_id": "...", "status": "at_risk" },
+  { "kind": "add_dependency", "initiative_id": "...", "depends_on_initiative_id": "...", "note": "..." },
+  { "kind": "remove_dependency", "dependency_id": "..." },
+  { "kind": "reorder_initiatives", "parent_id": "...", "child_ids_in_order": ["..."] },
+  { "kind": "update_status_check", "initiative_id": "...", "status_check_md": "..." }
+]
+```
+
+Apply is a single transaction. v1 is all-or-nothing accept; partial accept (per-diff checkboxes) deferred to v2.
+
+### 9.4 What the PM never does
+
+- **Never** promotes ideas → initiatives, stories → tasks, drafts → inbox. All promotion is operator-driven.
+- **Never** dispatches tasks.
+- **Never** edits `tasks.status` for active tasks (anything beyond `draft`/`inbox`).
+- **Never** writes `derived_*` outside the nightly scan.
+
+The PM is a *suggester*, not an actor on the execution board.
+
+---
+
+## 10. API Surface
+
+New Next.js route handlers under `src/app/api/`:
+
+| Method | Path                                                  | Purpose                                          |
+| ------ | ----------------------------------------------------- | ------------------------------------------------ |
+| GET    | `/api/initiatives`                                    | List (filter: workspace, product, parent, status, kind) |
+| POST   | `/api/initiatives`                                    | Create initiative                                |
+| GET    | `/api/initiatives/[id]`                               | Get one (children + tasks on demand)             |
+| PATCH  | `/api/initiatives/[id]`                               | Update any field (kind, dates, status_check_md, etc.) |
+| POST   | `/api/initiatives/[id]/move`                          | Re-parent (audit row)                            |
+| POST   | `/api/initiatives/[id]/convert`                       | Change `kind` (story → epic, etc.)               |
+| POST   | `/api/initiatives/[id]/promote-to-task`               | Create one task in `status='draft'`              |
+| DELETE | `/api/initiatives/[id]`                               | Blocked if descendants exist                     |
+| POST   | `/api/initiatives/[id]/dependencies`                  | Add dependency edge                              |
+| DELETE | `/api/initiative-dependencies/[depId]`                | Remove edge                                      |
+| GET    | `/api/initiatives/[id]/history`                       | Parent-change history                            |
+| POST   | `/api/tasks/[id]/move-initiative`                     | Re-parent task (audit row)                       |
+| POST   | `/api/tasks/[id]/promote`                             | `draft` → `inbox` (the execution-board promotion) |
+| GET    | `/api/tasks/[id]/initiative-history`                  | Task provenance trail                            |
+| POST   | `/api/ideas/[id]/promote-to-initiative`               | Sibling of existing idea→task path               |
+| POST   | `/api/pm/proposals`                                   | Operator drops disruption → draft proposal      |
+| GET    | `/api/pm/proposals`                                   | List (filter status)                             |
+| POST   | `/api/pm/proposals/[id]/refine`                       | Re-prompt with constraint                        |
+| POST   | `/api/pm/proposals/[id]/accept`                       | Apply diff transactionally                       |
+| POST   | `/api/pm/proposals/[id]/reject`                       | Mark rejected                                    |
+| GET    | `/api/roadmap`                                        | Aggregated timeline data                         |
+| POST   | `/api/owner-availability`                             | Operator-managed availability                    |
+| GET    | `/api/owner-availability`                             | List (filter agent, window)                      |
+| DELETE | `/api/owner-availability/[id]`                        | Remove                                           |
+
+---
+
+## 11. MCP Surface
+
+The `sc-mission-control` MCP server (used by openclaw workers and the PM agent) gains new tools, mirroring the API. The PM agent acts through these tools, not direct DB writes — keeps the audit story uniform and gives every other agent the same affordances.
+
+### 11.1 Read tools
+
+- `list_initiatives({ workspace_id?, product_id?, parent_id?, status?, kind? })`
+- `get_initiative({ id, include_descendants?, include_tasks? })`
+- `get_initiative_tree({ workspace_id, root_id? })` — full tree for PM context
+- `get_roadmap_snapshot({ workspace_id })` — flattened initiatives + tasks + deps + availability for derivation
+- `get_initiative_history({ id })`
+- `get_task_initiative_history({ task_id })`
+- `list_owner_availability({ agent_id?, between_start?, between_end? })`
+- `get_velocity_data({ owner_agent_id?, since? })`
+
+### 11.2 Write tools (general — gated by persona)
+
+- `create_initiative(...)`
+- `update_initiative({ id, ... })`
+- `move_initiative({ id, to_parent_id, reason })`
+- `convert_initiative({ id, new_kind })`
+- `add_initiative_dependency({ initiative_id, depends_on_id, kind?, note? })`
+- `remove_initiative_dependency({ dependency_id })`
+- `move_task_to_initiative({ task_id, to_initiative_id, reason })`
+- `promote_initiative_to_task({ initiative_id, task_title, task_description? })` — creates draft
+- `promote_task_to_inbox({ task_id })` — draft → inbox
+- `add_owner_availability({ agent_id, start, end, reason })`
+
+### 11.3 PM-specific tools
+
+- `propose_changes({ trigger_text, trigger_kind, impact_md, changes: [...] })` — creates a `pm_proposals` row in `draft`. **This is the PM's primary write path.**
+- `refine_proposal({ proposal_id, additional_constraint })` — generates a new proposal with `parent_proposal_id` set.
+- `list_proposals({ status?, since? })`
+
+The PM's persona prompt instructs: "to make changes, call `propose_changes`. Never call write tools directly except to record availability the operator explicitly stated."
+
+---
+
+## 12. UI Surface
+
+### 12.1 New routes
+
+- `/roadmap` — timeline view per workspace (filter by product).
+- `/initiatives/[id]` — initiative detail (children, tasks, deps, dates, history, status check).
+- `/pm` — PM chat thread + active proposal cards.
+- `/backlog` — flat list of initiatives with no parent and no dates (idea-stage planning items).
+
+### 12.2 Roadmap view
+
+- Rows are initiatives, indented by parent.
+- Bars: `target_start..target_end` (solid), `derived_start..derived_end` (outline). Gap = schedule debt.
+- Milestones rendered as diamonds with `committed_end`.
+- Dependency arrows between bars.
+- Tasks as chips on their initiative row, colored by status (draft = ghost outline; inbox/active = filled).
+- Drag handles adjust `target_*`. `derived_*` is read-only.
+- Buttons: "Decompose", "Convert", "Promote to task", "Move", "Add dependency".
+
+### 12.3 PM chat
+
+Reuse the agent chat component. Card renderer for messages with `metadata.proposal_id`:
+
+```
+┌───────────────────────────────────────────────────┐
+│ ⚠ Schedule impact: Launch milestone slips 5d      │
+│                                                   │
+│ • "Build big feature" target_end → May 17         │
+│ • "Customer demo" milestone at_risk               │
+│ • Adds availability: Sarah out Apr 25 – May 2     │
+│                                                   │
+│ [Refine]  [Accept]  [Reject]                      │
+└───────────────────────────────────────────────────┘
+```
+
+---
+
+## 13. Workflow Unification
+
+This feature touches three pre-existing flows. Unification opportunities:
+
+### 13.1 Idea promotion paths
+
+| Path                    | Today                | After this spec                       |
+| ----------------------- | -------------------- | ------------------------------------- |
+| Idea → task (autopilot) | Yes (`product_autopilot`) | Unchanged                       |
+| Idea → initiative       | None                 | New: `POST /api/ideas/[id]/promote-to-initiative` |
+| Idea → initiative → task| Implicit             | Recommended for non-autopilot work    |
+
+The autopilot path is preserved for products with build automation. Manual / planning-driven flows go through initiatives. Both result in `tasks` rows; the difference is whether they cross the planning layer first.
+
+### 13.2 Tasks: planning-board ↔ execution-board (one source of truth)
+
+A task always lives in one row; surfaces filter by status:
+
+| `tasks.status` | On planning board (Roadmap)? | On execution board (Mission Queue)? |
+| -------------- | ---------------------------- | ----------------------------------- |
+| `draft`        | ✅ (under initiative)        | ❌                                  |
+| `inbox`        | ✅ (if `initiative_id` set)  | ✅                                  |
+| beyond inbox   | ✅ (if `initiative_id` set)  | ✅                                  |
+
+Roadmap shows all tasks with `initiative_id`. Mission Queue shows all tasks with `status != 'draft'`. One table, two views — no duplicated state.
+
+### 13.3 Convoys vs initiative decomposition
+
+These are **different layers** and stay separate:
+
+- **Convoy**: ephemeral, parallel execution under one task, agents work concurrently.
+- **Initiative decomposition**: persistent planning structure, manual promotion to tasks.
+
+A convoy is a mid-flight task-level concern. An initiative tree is a long-lived planning concern. Don't conflate.
+
+---
+
+## 14. Phased Delivery
+
+Each phase is a separate PR, demoable.
+
+### Phase 1: Schema + provenance bones
+
+- Migration: `initiatives`, `initiative_dependencies`, `initiative_parent_history`, `task_initiative_history`, `owner_availability`, `pm_proposals`, plus `tasks.initiative_id`, `tasks.status_check_md`, extend `tasks.status` CHECK to include `'draft'`, `ideas.initiative_id`.
+- Update `src/lib/db/schema.ts`.
+- DB helpers in `src/lib/db/initiatives.ts` and `src/lib/db/pm.ts`.
+- API: GET/POST/PATCH/DELETE `/api/initiatives`, move, convert, history, dependencies.
+- Minimal `/initiatives` page: tree list with create/edit/delete and parent picker.
+- Tests: re-parent writes audit; delete-with-descendants blocked; multi-prereq deps; container retention through decompose.
+
+**Done means:** initiative tree exists, every move audited, no UI past basic list.
+
+### Phase 2: Promotion + initiative-aware task UI
+
+- "Promote initiative to task" endpoint (creates `status='draft'` task).
+- "Promote task to inbox" endpoint (draft → inbox).
+- Idea → initiative endpoint.
+- Task detail shows owning initiative + provenance trail.
+- "Move to initiative" affordance.
+- `/initiatives/[id]` detail page with children + tasks.
+
+**Done means:** end-to-end manual flow: idea → promote → initiative → decompose → promote story to task draft → promote draft to inbox → existing pipeline runs.
+
+### Phase 3: Roadmap timeline view
+
+- `/api/roadmap` aggregated endpoint.
+- `/roadmap` page (lightweight Gantt; lib decision during impl).
+- Drag target-date adjustment, dependency arrows, status colors, draft-task chips.
+- Filters: workspace, product, owner, kind.
+
+**Done means:** visual planning surface; timelines visible; drift gap renders once Phase 4 lands.
+
+### Phase 4: Derivation engine + drift scan
+
+- Velocity computation from completed tasks.
+- Critical-path solver over deps + availability.
+- New `roadmap_drift_scan` schedule_type.
+- Background job updating `derived_*` and flagging `at_risk`.
+
+**Done means:** schedule moves on its own; slippage visible without operator action.
+
+### Phase 5: PM agent (reactive) + MCP surface
+
+- Seed `pm` agent (workspace migration).
+- MCP tools (§11) added to `sc-mission-control`.
+- PM dispatch path: disruption text + roadmap snapshot → `propose_changes` MCP call → `pm_proposals` row.
+- `/pm` chat UI with proposal-card renderer.
+- Refine loop (parent_proposal_id chain).
+
+**Done means:** type "Sarah out next week" → impact analysis → refine → accept → roadmap updates.
+
+### Phase 6: PM agent (proactive)
+
+- Wire `roadmap_drift_scan` schedule to the PM.
+- Morning-standup proposal generation.
+- Event feed integration.
+
+**Done means:** without prompting, PM posts a daily card if anything's drifting.
+
+---
+
+## 15. Out of Scope (v1)
+
+- **Bulk operations** (multi-task promotion, multi-task move). All atomic in v1.
+- **Resource leveling / capacity planning** beyond simple availability.
+- **Cross-workspace roadmaps.**
+- **Permissions / multi-operator conflict resolution.**
+- **Burndown charts, velocity dashboards** (the roadmap is the chart).
+- **External calendar / Linear / GitHub Projects sync.**
+- **Auto-promotion** at any layer — explicitly excluded.
+- **Status-check investigation by PM** (fetching URLs, parsing PRs). Field exists; investigation is v2.
+- **Partial-accept of PM proposals** (per-diff checkboxes). v1 is all-or-nothing.
+
+---
+
+## 16. Open Questions
+
+1. **Velocity unit when estimates are missing.** Lean: complexity → hours fallback table (`S=4`, `M=12`, `L=40`, `XL=120`), operator-overridable per workspace. If neither is set, exclude from derivation rather than guessing.
+
+2. **PM agent identity / model.** Auto-seed via migration, idempotent. Use Claude Opus 4.7 with planning-layer system prompt. Distinct from coordinator and master.
+
+3. **Status override on initiatives.** Defer; if rollup proves wrong in practice, add `status_override` in Phase 4.
+
+4. **Backlog UI.** A `/backlog` flat view for initiatives with no parent and no dates is included in Phase 2 — confirm scope.
+
+5. **Convert operation vs `kind` PATCH.** A dedicated `/convert` endpoint exists for clarity in audit logs, but mechanically it's a `kind` change. Lean: keep `/convert` as the operator-facing endpoint; PATCH on `kind` is allowed but discouraged.
+
+---
+
+## 17. Acceptance Criteria
+
+Each phase ships only when:
+
+- ✅ Migration runs cleanly on a current production DB snapshot.
+- ✅ Existing task pipeline is unaffected (no regressions on the execution board).
+- ✅ All new tables have indexes per §5.3.
+- ✅ A scripted demo walks the phase's "done means" scenario end-to-end.
+- ✅ Operator can recover from any botched action (every mutation reversible).
+- ✅ For phases with PM/MCP work: agent never bypasses `propose_changes` for non-availability writes.

--- a/specs/roadmap-and-pm-spec.md
+++ b/specs/roadmap-and-pm-spec.md
@@ -701,7 +701,9 @@ Each phase is a separate PR, demoable.
 
 4. **Backlog UI.** A `/backlog` flat view for initiatives with no parent and no dates is included in Phase 2 — confirm scope.
 
-5. **Convert operation vs `kind` PATCH.** A dedicated `/convert` endpoint exists for clarity in audit logs, but mechanically it's a `kind` change. Lean: keep `/convert` as the operator-facing endpoint; PATCH on `kind` is allowed but discouraged.
+5. **Convert operation vs `kind` PATCH.** A dedicated `/convert` endpoint exists for clarity in audit logs, but mechanically it's a `kind` change. **Resolved (post-Phase 1):** keep `/convert` as the operator-facing endpoint; convert emits a row in the existing `events` table with `type='initiative_kind_changed'` (no new audit table). PATCH on `kind` is allowed but discouraged and does not emit the event.
+
+6. **`parent_id` query param semantics on `GET /api/initiatives`.** **Resolved (post-Phase 1):** missing = no filter; literal string `"null"` = roots only (parent_initiative_id IS NULL); any other value = exact match.
 
 ---
 

--- a/src/app/api/initiative-dependencies/[depId]/route.ts
+++ b/src/app/api/initiative-dependencies/[depId]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { removeInitiativeDependency } from '@/lib/db/initiatives';
+
+export const dynamic = 'force-dynamic';
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ depId: string }> },
+) {
+  try {
+    const { depId } = await params;
+    removeInitiativeDependency(depId);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to delete dependency';
+    if (msg.startsWith('Dependency not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    console.error('Failed to delete dependency:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/initiatives/[id]/convert/route.ts
+++ b/src/app/api/initiatives/[id]/convert/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { convertInitiative } from '@/lib/db/initiatives';
+
+export const dynamic = 'force-dynamic';
+
+const ConvertSchema = z.object({
+  new_kind: z.enum(['theme', 'milestone', 'epic', 'story']),
+  moved_by_agent_id: z.string().nullish(),
+  reason: z.string().max(2000).nullish(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = ConvertSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const updated = convertInitiative(
+      id,
+      parsed.data.new_kind,
+      parsed.data.moved_by_agent_id ?? null,
+      parsed.data.reason ?? null,
+    );
+    return NextResponse.json(updated);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to convert initiative';
+    if (msg.startsWith('Initiative not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    console.error('Failed to convert initiative:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/initiatives/[id]/dependencies/route.ts
+++ b/src/app/api/initiatives/[id]/dependencies/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  addInitiativeDependency,
+  getInitiative,
+  getInitiativeDependencies,
+} from '@/lib/db/initiatives';
+
+export const dynamic = 'force-dynamic';
+
+const AddDependencySchema = z.object({
+  depends_on_initiative_id: z.string().min(1),
+  kind: z.enum(['finish_to_start', 'start_to_start', 'blocking', 'informational']).optional(),
+  note: z.string().max(2000).nullish(),
+});
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const initiative = getInitiative(id);
+    if (!initiative) {
+      return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
+    }
+    return NextResponse.json(getInitiativeDependencies(id));
+  } catch (error) {
+    console.error('Failed to fetch dependencies:', error);
+    return NextResponse.json({ error: 'Failed to fetch dependencies' }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = AddDependencySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const dep = addInitiativeDependency({
+      initiative_id: id,
+      depends_on_initiative_id: parsed.data.depends_on_initiative_id,
+      kind: parsed.data.kind,
+      note: parsed.data.note ?? null,
+    });
+    return NextResponse.json(dep, { status: 201 });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to add dependency';
+    if (msg.includes('not found')) {
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    if (msg.includes('itself') || msg.includes('already exists')) {
+      return NextResponse.json({ error: msg }, { status: 409 });
+    }
+    console.error('Failed to add dependency:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/initiatives/[id]/history/route.ts
+++ b/src/app/api/initiatives/[id]/history/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getInitiative, getInitiativeHistory } from '@/lib/db/initiatives';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const initiative = getInitiative(id);
+    if (!initiative) {
+      return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
+    }
+    const history = getInitiativeHistory(id);
+    return NextResponse.json(history);
+  } catch (error) {
+    console.error('Failed to fetch history:', error);
+    return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 });
+  }
+}

--- a/src/app/api/initiatives/[id]/move/route.ts
+++ b/src/app/api/initiatives/[id]/move/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { moveInitiative } from '@/lib/db/initiatives';
+
+export const dynamic = 'force-dynamic';
+
+const MoveSchema = z.object({
+  to_parent_id: z.string().nullable(),
+  moved_by_agent_id: z.string().nullish(),
+  reason: z.string().max(2000).nullish(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = MoveSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const updated = moveInitiative(
+      id,
+      parsed.data.to_parent_id,
+      parsed.data.moved_by_agent_id ?? null,
+      parsed.data.reason ?? null,
+    );
+    return NextResponse.json(updated);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to move initiative';
+    if (msg.startsWith('Initiative not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    if (msg.startsWith('Target parent not found')) {
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    if (msg.includes('cycle') || msg.includes('under itself')) {
+      return NextResponse.json({ error: msg }, { status: 409 });
+    }
+    console.error('Failed to move initiative:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/initiatives/[id]/route.ts
+++ b/src/app/api/initiatives/[id]/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  getInitiative,
+  updateInitiative,
+  deleteInitiative,
+} from '@/lib/db/initiatives';
+
+export const dynamic = 'force-dynamic';
+
+const StatusEnum = z.enum(['planned', 'in_progress', 'at_risk', 'blocked', 'done', 'cancelled']);
+const ComplexityEnum = z.enum(['S', 'M', 'L', 'XL']);
+
+const PatchInitiativeSchema = z.object({
+  title: z.string().min(1).max(500).optional(),
+  description: z.string().max(10000).nullish(),
+  status: StatusEnum.optional(),
+  owner_agent_id: z.string().nullish(),
+  estimated_effort_hours: z.number().nullish(),
+  complexity: ComplexityEnum.nullish(),
+  target_start: z.string().nullish(),
+  target_end: z.string().nullish(),
+  committed_end: z.string().nullish(),
+  status_check_md: z.string().nullish(),
+  sort_order: z.number().int().optional(),
+  product_id: z.string().nullish(),
+  source_idea_id: z.string().nullish(),
+});
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const { searchParams } = new URL(request.url);
+    const include = (searchParams.get('include') || '').split(',').map(s => s.trim());
+    const initiative = getInitiative(id, {
+      includeChildren: include.includes('children'),
+      includeTasks: include.includes('tasks'),
+    });
+    if (!initiative) {
+      return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
+    }
+    return NextResponse.json(initiative);
+  } catch (error) {
+    console.error('Failed to fetch initiative:', error);
+    return NextResponse.json({ error: 'Failed to fetch initiative' }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = PatchInitiativeSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const updated = updateInitiative(id, parsed.data);
+    return NextResponse.json(updated);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to update initiative';
+    if (msg.startsWith('Initiative not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    console.error('Failed to update initiative:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    deleteInitiative(id);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to delete initiative';
+    if (msg.startsWith('Initiative not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    if (msg.startsWith('Cannot delete')) {
+      return NextResponse.json({ error: msg }, { status: 409 });
+    }
+    console.error('Failed to delete initiative:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/initiatives/route.ts
+++ b/src/app/api/initiatives/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  createInitiative,
+  listInitiatives,
+  type InitiativeKind,
+  type InitiativeStatus,
+} from '@/lib/db/initiatives';
+
+export const dynamic = 'force-dynamic';
+
+const KindEnum = z.enum(['theme', 'milestone', 'epic', 'story']);
+const StatusEnum = z.enum(['planned', 'in_progress', 'at_risk', 'blocked', 'done', 'cancelled']);
+const ComplexityEnum = z.enum(['S', 'M', 'L', 'XL']);
+
+const CreateInitiativeSchema = z.object({
+  workspace_id: z.string().min(1),
+  kind: KindEnum,
+  title: z.string().min(1).max(500),
+  product_id: z.string().nullish(),
+  parent_initiative_id: z.string().nullish(),
+  description: z.string().max(10000).nullish(),
+  status: StatusEnum.optional(),
+  owner_agent_id: z.string().nullish(),
+  estimated_effort_hours: z.number().nullish(),
+  complexity: ComplexityEnum.nullish(),
+  target_start: z.string().nullish(),
+  target_end: z.string().nullish(),
+  committed_end: z.string().nullish(),
+  status_check_md: z.string().nullish(),
+  sort_order: z.number().int().optional(),
+  source_idea_id: z.string().nullish(),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const parent = searchParams.get('parent_id');
+    const filters = {
+      workspace_id: searchParams.get('workspace_id') || undefined,
+      product_id: searchParams.get('product_id') || undefined,
+      // Special-case: "null" string means filter to roots; missing = no filter.
+      parent_id: parent === null ? undefined : parent === 'null' ? null : parent,
+      status: (searchParams.get('status') as InitiativeStatus) || undefined,
+      kind: (searchParams.get('kind') as InitiativeKind) || undefined,
+    };
+    const rows = listInitiatives(filters);
+    return NextResponse.json(rows);
+  } catch (error) {
+    console.error('Failed to list initiatives:', error);
+    return NextResponse.json({ error: 'Failed to list initiatives' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = CreateInitiativeSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const initiative = createInitiative(parsed.data);
+    return NextResponse.json(initiative, { status: 201 });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to create initiative';
+    if (msg.startsWith('Parent initiative not found')) {
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    console.error('Failed to create initiative:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/initiatives/page.tsx
+++ b/src/app/initiatives/page.tsx
@@ -1,0 +1,959 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { Plus, ChevronRight, ChevronDown, Pencil, Trash2, MoveRight, Shuffle, Link2, History } from 'lucide-react';
+
+// Local types (kept separate from src/lib/types.ts so Phase 1 doesn't touch
+// the central type module — Phase 2 can promote these once the broader API
+// surface stabilises).
+type Kind = 'theme' | 'milestone' | 'epic' | 'story';
+type Status = 'planned' | 'in_progress' | 'at_risk' | 'blocked' | 'done' | 'cancelled';
+
+interface Initiative {
+  id: string;
+  workspace_id: string;
+  parent_initiative_id: string | null;
+  kind: Kind;
+  title: string;
+  description: string | null;
+  status: Status;
+  target_start: string | null;
+  target_end: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TreeNode extends Initiative {
+  children: TreeNode[];
+}
+
+const KIND_BADGE: Record<Kind, string> = {
+  theme: 'bg-purple-500/20 text-purple-300',
+  milestone: 'bg-amber-500/20 text-amber-300',
+  epic: 'bg-blue-500/20 text-blue-300',
+  story: 'bg-emerald-500/20 text-emerald-300',
+};
+
+const WORKSPACE_ID = 'default';
+
+export default function InitiativesPage() {
+  const [tree, setTree] = useState<TreeNode[]>([]);
+  const [flat, setFlat] = useState<Initiative[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<Initiative | null>(null);
+  const [creating, setCreating] = useState<{ parent_id: string | null } | null>(null);
+  const [moving, setMoving] = useState<Initiative | null>(null);
+  const [converting, setConverting] = useState<Initiative | null>(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/initiatives?workspace_id=${WORKSPACE_ID}`);
+      if (!res.ok) throw new Error(`Failed to load (${res.status})`);
+      const rows: Initiative[] = await res.json();
+      setFlat(rows);
+      setTree(buildTree(rows));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return (
+    <div className="min-h-screen bg-mc-bg p-6">
+      <header className="max-w-5xl mx-auto mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-mc-text">Initiatives</h1>
+          <p className="text-sm text-mc-text-secondary">Planning tree (Phase 1 — list view).</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Link href="/" className="px-3 py-2 rounded-lg border border-mc-border text-mc-text-secondary hover:text-mc-text text-sm">
+            Workspaces
+          </Link>
+          <button
+            onClick={() => setCreating({ parent_id: null })}
+            className="px-3 py-2 rounded-lg bg-mc-accent text-white hover:bg-mc-accent/90 text-sm flex items-center gap-2"
+          >
+            <Plus className="w-4 h-4" /> New initiative
+          </button>
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto">
+        {error && (
+          <div className="mb-4 p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300 text-sm">
+            {error}
+          </div>
+        )}
+        {loading ? (
+          <p className="text-mc-text-secondary">Loading…</p>
+        ) : tree.length === 0 ? (
+          <p className="text-mc-text-secondary">No initiatives yet. Click <em>New initiative</em> to start a planning tree.</p>
+        ) : (
+          <ul className="space-y-1">
+            {tree.map(node => (
+              <InitiativeRow
+                key={node.id}
+                node={node}
+                depth={0}
+                allInitiatives={flat}
+                onEdit={setEditing}
+                onAddChild={parent => setCreating({ parent_id: parent.id })}
+                onMove={setMoving}
+                onConvert={setConverting}
+                onDelete={async (init) => {
+                  if (!confirm(`Delete "${init.title}"?`)) return;
+                  const res = await fetch(`/api/initiatives/${init.id}`, { method: 'DELETE' });
+                  if (!res.ok) {
+                    const body = await res.json().catch(() => ({}));
+                    alert(body.error || 'Delete failed');
+                    return;
+                  }
+                  refresh();
+                }}
+              />
+            ))}
+          </ul>
+        )}
+      </main>
+
+      {creating && (
+        <CreateModal
+          parentId={creating.parent_id}
+          allInitiatives={flat}
+          onClose={() => setCreating(null)}
+          onSaved={() => {
+            setCreating(null);
+            refresh();
+          }}
+        />
+      )}
+      {editing && (
+        <EditModal
+          initiative={editing}
+          onClose={() => setEditing(null)}
+          onSaved={() => {
+            setEditing(null);
+            refresh();
+          }}
+        />
+      )}
+      {moving && (
+        <MoveModal
+          initiative={moving}
+          allInitiatives={flat}
+          onClose={() => setMoving(null)}
+          onSaved={() => {
+            setMoving(null);
+            refresh();
+          }}
+        />
+      )}
+      {converting && (
+        <ConvertModal
+          initiative={converting}
+          onClose={() => setConverting(null)}
+          onSaved={() => {
+            setConverting(null);
+            refresh();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function buildTree(rows: Initiative[]): TreeNode[] {
+  const byParent = new Map<string | null, Initiative[]>();
+  for (const r of rows) {
+    const k = r.parent_initiative_id ?? null;
+    const list = byParent.get(k) ?? [];
+    list.push(r);
+    byParent.set(k, list);
+  }
+  function build(parentId: string | null): TreeNode[] {
+    const kids = byParent.get(parentId) ?? [];
+    return kids.map(k => ({ ...k, children: build(k.id) }));
+  }
+  return build(null);
+}
+
+function InitiativeRow({
+  node,
+  depth,
+  allInitiatives,
+  onEdit,
+  onAddChild,
+  onMove,
+  onConvert,
+  onDelete,
+}: {
+  node: TreeNode;
+  depth: number;
+  allInitiatives: Initiative[];
+  onEdit: (init: Initiative) => void;
+  onAddChild: (parent: Initiative) => void;
+  onMove: (init: Initiative) => void;
+  onConvert: (init: Initiative) => void;
+  onDelete: (init: Initiative) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <>
+      <li
+        className="flex items-center gap-2 p-2 rounded-lg bg-mc-bg-secondary border border-mc-border hover:border-mc-accent/40"
+        style={{ marginLeft: depth * 24 }}
+      >
+        {depth > 0 && <ChevronRight className="w-4 h-4 text-mc-text-secondary" />}
+        <span className={`px-2 py-0.5 rounded text-xs uppercase tracking-wide ${KIND_BADGE[node.kind]}`}>
+          {node.kind}
+        </span>
+        <span className="font-medium text-mc-text">{node.title}</span>
+        <span className="text-xs text-mc-text-secondary">{node.status}</span>
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            title={expanded ? 'Hide details' : 'Show details (history + dependencies)'}
+            onClick={() => setExpanded(v => !v)}
+            className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text"
+          >
+            {expanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+          </button>
+          <button
+            title="Add child"
+            onClick={() => onAddChild(node)}
+            className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text"
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+          <button
+            title="Edit"
+            onClick={() => onEdit(node)}
+            className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text"
+          >
+            <Pencil className="w-4 h-4" />
+          </button>
+          <button
+            title="Move"
+            onClick={() => onMove(node)}
+            className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text"
+          >
+            <MoveRight className="w-4 h-4" />
+          </button>
+          <button
+            title="Convert kind"
+            onClick={() => onConvert(node)}
+            className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text"
+          >
+            <Shuffle className="w-4 h-4" />
+          </button>
+          <button
+            title="Delete"
+            onClick={() => onDelete(node)}
+            className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-red-400"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      </li>
+      {expanded && (
+        <li
+          className="rounded-lg bg-mc-bg border border-mc-border/60 px-3 py-2 -mt-1 text-sm"
+          style={{ marginLeft: depth * 24 + 12 }}
+        >
+          <DetailsPanel initiative={node} allInitiatives={allInitiatives} />
+        </li>
+      )}
+      {node.children.map(c => (
+        <InitiativeRow
+          key={c.id}
+          node={c}
+          depth={depth + 1}
+          allInitiatives={allInitiatives}
+          onEdit={onEdit}
+          onAddChild={onAddChild}
+          onMove={onMove}
+          onConvert={onConvert}
+          onDelete={onDelete}
+        />
+      ))}
+    </>
+  );
+}
+
+interface HistoryRow {
+  id: string;
+  from_parent_id: string | null;
+  to_parent_id: string | null;
+  reason: string | null;
+  created_at: string;
+}
+
+interface DepRow {
+  id: string;
+  initiative_id: string;
+  depends_on_initiative_id: string;
+  kind: string;
+  note: string | null;
+  created_at: string;
+}
+
+interface DepEdges {
+  outgoing: DepRow[];
+  incoming: DepRow[];
+}
+
+function DetailsPanel({
+  initiative,
+  allInitiatives,
+}: {
+  initiative: Initiative;
+  allInitiatives: Initiative[];
+}) {
+  const [history, setHistory] = useState<HistoryRow[]>([]);
+  const [deps, setDeps] = useState<DepEdges | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [chosenDep, setChosenDep] = useState<string>('');
+  const [err, setErr] = useState<string | null>(null);
+
+  const titleFor = useCallback(
+    (id: string | null) => (id ? allInitiatives.find(i => i.id === id)?.title ?? id : '(root)'),
+    [allInitiatives],
+  );
+
+  const refresh = useCallback(async () => {
+    try {
+      const [h, d] = await Promise.all([
+        fetch(`/api/initiatives/${initiative.id}/history`).then(r => r.json()),
+        fetch(`/api/initiatives/${initiative.id}/dependencies`).then(r => r.json()),
+      ]);
+      setHistory(Array.isArray(h) ? h : []);
+      setDeps(d && d.outgoing ? d : { outgoing: [], incoming: [] });
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to load details');
+    }
+  }, [initiative.id]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const addDep = async () => {
+    if (!chosenDep) return;
+    setErr(null);
+    try {
+      const res = await fetch(`/api/initiatives/${initiative.id}/dependencies`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ depends_on_initiative_id: chosenDep }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Add failed (${res.status})`);
+      }
+      setAdding(false);
+      setChosenDep('');
+      refresh();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Add failed');
+    }
+  };
+
+  const removeDep = async (depId: string) => {
+    setErr(null);
+    try {
+      const res = await fetch(`/api/initiative-dependencies/${depId}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Remove failed (${res.status})`);
+      }
+      refresh();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Remove failed');
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className="flex items-center gap-2 text-mc-text-secondary mb-1">
+          <Link2 className="w-3.5 h-3.5" />
+          <span className="font-medium">Dependencies</span>
+          <button
+            onClick={() => setAdding(v => !v)}
+            className="ml-auto text-xs px-2 py-0.5 rounded border border-mc-border hover:border-mc-accent/40"
+          >
+            {adding ? 'Cancel' : '+ Add dependency'}
+          </button>
+        </div>
+        {adding && (
+          <div className="flex items-center gap-2 mb-2">
+            <select
+              className="px-2 py-1 rounded bg-mc-bg border border-mc-border text-xs flex-1"
+              value={chosenDep}
+              onChange={e => setChosenDep(e.target.value)}
+            >
+              <option value="">(choose initiative this depends on)</option>
+              {allInitiatives
+                .filter(i => i.id !== initiative.id)
+                .map(i => (
+                  <option key={i.id} value={i.id}>
+                    {i.kind} — {i.title}
+                  </option>
+                ))}
+            </select>
+            <button
+              disabled={!chosenDep}
+              onClick={addDep}
+              className="text-xs px-2 py-1 rounded bg-mc-accent text-white disabled:opacity-50"
+            >
+              Add
+            </button>
+          </div>
+        )}
+        {deps === null ? (
+          <p className="text-xs text-mc-text-secondary">Loading…</p>
+        ) : deps.outgoing.length === 0 && deps.incoming.length === 0 ? (
+          <p className="text-xs text-mc-text-secondary">No dependencies.</p>
+        ) : (
+          <ul className="space-y-1 text-xs">
+            {deps.outgoing.map(d => (
+              <li key={d.id} className="flex items-center gap-2">
+                <span className="text-mc-text-secondary">depends on</span>
+                <span className="text-mc-text">{titleFor(d.depends_on_initiative_id)}</span>
+                <button
+                  onClick={() => removeDep(d.id)}
+                  className="ml-auto text-mc-text-secondary hover:text-red-400"
+                  title="Remove"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              </li>
+            ))}
+            {deps.incoming.map(d => (
+              <li key={d.id} className="flex items-center gap-2 text-mc-text-secondary">
+                <span>blocks</span>
+                <span>{titleFor(d.initiative_id)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div>
+        <div className="flex items-center gap-2 text-mc-text-secondary mb-1">
+          <History className="w-3.5 h-3.5" />
+          <span className="font-medium">Parent-change history</span>
+        </div>
+        {history.length === 0 ? (
+          <p className="text-xs text-mc-text-secondary">No moves recorded.</p>
+        ) : (
+          <ul className="space-y-1 text-xs">
+            {history.map(h => (
+              <li key={h.id} className="flex items-center gap-2">
+                <span className="text-mc-text-secondary">{h.created_at.replace('T', ' ').slice(0, 19)}</span>
+                <span className="text-mc-text">
+                  {titleFor(h.from_parent_id)} → {titleFor(h.to_parent_id)}
+                </span>
+                {h.reason && <span className="text-mc-text-secondary italic">— {h.reason}</span>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {err && <div className="text-xs text-red-400">{err}</div>}
+    </div>
+  );
+}
+
+function ModalShell({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50" onClick={onClose}>
+      <div
+        className="bg-mc-bg-secondary border border-mc-border rounded-lg p-6 w-full max-w-md text-mc-text"
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold mb-4">{title}</h2>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function CreateModal({
+  parentId,
+  allInitiatives,
+  onClose,
+  onSaved,
+}: {
+  parentId: string | null;
+  allInitiatives: Initiative[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [title, setTitle] = useState('');
+  const [kind, setKind] = useState<Kind>('story');
+  const [chosenParent, setChosenParent] = useState<string | null>(parentId);
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const submit = async () => {
+    setSubmitting(true);
+    setErr(null);
+    try {
+      const res = await fetch('/api/initiatives', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          workspace_id: WORKSPACE_ID,
+          title,
+          kind,
+          parent_initiative_id: chosenParent,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Create failed (${res.status})`);
+      }
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Create failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <ModalShell title="New initiative" onClose={onClose}>
+      <div className="space-y-3">
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Title</span>
+          <input
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            autoFocus
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Kind</span>
+          <select
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+            value={kind}
+            onChange={e => setKind(e.target.value as Kind)}
+          >
+            <option value="theme">theme</option>
+            <option value="milestone">milestone</option>
+            <option value="epic">epic</option>
+            <option value="story">story</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Parent</span>
+          <select
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+            value={chosenParent ?? ''}
+            onChange={e => setChosenParent(e.target.value || null)}
+          >
+            <option value="">(no parent)</option>
+            {allInitiatives.map(i => (
+              <option key={i.id} value={i.id}>
+                {i.kind} — {i.title}
+              </option>
+            ))}
+          </select>
+        </label>
+        {err && <div className="text-red-400 text-sm">{err}</div>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button onClick={onClose} className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm">
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={submitting || !title}
+            className="px-3 py-2 rounded bg-mc-accent text-white disabled:opacity-50 text-sm"
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+type Complexity = 'S' | 'M' | 'L' | 'XL';
+
+function EditModal({
+  initiative,
+  onClose,
+  onSaved,
+}: {
+  initiative: Initiative;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [title, setTitle] = useState(initiative.title);
+  const [description, setDescription] = useState(initiative.description ?? '');
+  const [status, setStatus] = useState<Status>(initiative.status);
+  const [targetStart, setTargetStart] = useState(initiative.target_start ?? '');
+  const [targetEnd, setTargetEnd] = useState(initiative.target_end ?? '');
+  // The list query doesn't return these fields, so default to empty strings;
+  // the patch only sends fields the operator actually edited.
+  const [complexity, setComplexity] = useState<Complexity | ''>('');
+  const [effort, setEffort] = useState('');
+  const [statusCheck, setStatusCheck] = useState('');
+  const [ownerAgentId, setOwnerAgentId] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  // Pull the full record so we have the optional fields not in the list view.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`/api/initiatives/${initiative.id}`);
+        if (!r.ok) return;
+        const full = await r.json();
+        if (cancelled) return;
+        setComplexity((full.complexity as Complexity) ?? '');
+        setEffort(full.estimated_effort_hours == null ? '' : String(full.estimated_effort_hours));
+        setStatusCheck(full.status_check_md ?? '');
+        setOwnerAgentId(full.owner_agent_id ?? '');
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [initiative.id]);
+
+  const submit = async () => {
+    setSubmitting(true);
+    setErr(null);
+    try {
+      const patch: Record<string, unknown> = {
+        title,
+        description: description || null,
+        status,
+        target_start: targetStart || null,
+        target_end: targetEnd || null,
+        complexity: complexity || null,
+        estimated_effort_hours: effort ? Number(effort) : null,
+        status_check_md: statusCheck || null,
+        owner_agent_id: ownerAgentId || null,
+      };
+      const res = await fetch(`/api/initiatives/${initiative.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Update failed (${res.status})`);
+      }
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Update failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <ModalShell title="Edit initiative" onClose={onClose}>
+      <div className="space-y-3 max-h-[70vh] overflow-y-auto pr-1">
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Title</span>
+          <input
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Description</span>
+          <textarea
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border h-24"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Status</span>
+          <select
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+            value={status}
+            onChange={e => setStatus(e.target.value as Status)}
+          >
+            <option value="planned">planned</option>
+            <option value="in_progress">in_progress</option>
+            <option value="at_risk">at_risk</option>
+            <option value="blocked">blocked</option>
+            <option value="done">done</option>
+            <option value="cancelled">cancelled</option>
+          </select>
+        </label>
+        <div className="grid grid-cols-2 gap-3">
+          <label className="block">
+            <span className="text-sm text-mc-text-secondary">Target start</span>
+            <input
+              type="date"
+              className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+              value={targetStart.slice(0, 10)}
+              onChange={e => setTargetStart(e.target.value)}
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm text-mc-text-secondary">Target end</span>
+            <input
+              type="date"
+              className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+              value={targetEnd.slice(0, 10)}
+              onChange={e => setTargetEnd(e.target.value)}
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm text-mc-text-secondary">Complexity</span>
+            <select
+              className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+              value={complexity}
+              onChange={e => setComplexity(e.target.value as Complexity | '')}
+              disabled={!loaded}
+            >
+              <option value="">(unset)</option>
+              <option value="S">S</option>
+              <option value="M">M</option>
+              <option value="L">L</option>
+              <option value="XL">XL</option>
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm text-mc-text-secondary">Effort (hours)</span>
+            <input
+              type="number"
+              step="0.5"
+              className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+              value={effort}
+              onChange={e => setEffort(e.target.value)}
+              disabled={!loaded}
+            />
+          </label>
+        </div>
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Owner agent id (optional)</span>
+          <input
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+            value={ownerAgentId}
+            onChange={e => setOwnerAgentId(e.target.value)}
+            disabled={!loaded}
+            placeholder="e.g. agent-uuid"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Status check (markdown)</span>
+          <textarea
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border h-20 font-mono text-xs"
+            value={statusCheck}
+            onChange={e => setStatusCheck(e.target.value)}
+            disabled={!loaded}
+            placeholder="Linked PR / waiting on / customer demo / etc."
+          />
+        </label>
+        {err && <div className="text-red-400 text-sm">{err}</div>}
+        <div className="flex justify-end gap-2 pt-2 sticky bottom-0 bg-mc-bg-secondary">
+          <button onClick={onClose} className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm">
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={submitting || !title}
+            className="px-3 py-2 rounded bg-mc-accent text-white disabled:opacity-50 text-sm"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+function MoveModal({
+  initiative,
+  allInitiatives,
+  onClose,
+  onSaved,
+}: {
+  initiative: Initiative;
+  allInitiatives: Initiative[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [parentId, setParentId] = useState<string | null>(initiative.parent_initiative_id);
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Filter out self — the API will also reject cycles, but trim the
+  // obvious case from the picker.
+  const candidates = allInitiatives.filter(i => i.id !== initiative.id);
+
+  const submit = async () => {
+    setSubmitting(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/initiatives/${initiative.id}/move`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to_parent_id: parentId, reason: reason || null }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Move failed (${res.status})`);
+      }
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Move failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <ModalShell title={`Move "${initiative.title}"`} onClose={onClose}>
+      <div className="space-y-3">
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">New parent</span>
+          <select
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+            value={parentId ?? ''}
+            onChange={e => setParentId(e.target.value || null)}
+          >
+            <option value="">(no parent)</option>
+            {candidates.map(i => (
+              <option key={i.id} value={i.id}>
+                {i.kind} — {i.title}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Reason (optional)</span>
+          <input
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+            value={reason}
+            onChange={e => setReason(e.target.value)}
+          />
+        </label>
+        {err && <div className="text-red-400 text-sm">{err}</div>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button onClick={onClose} className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm">
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={submitting}
+            className="px-3 py-2 rounded bg-mc-accent text-white disabled:opacity-50 text-sm"
+          >
+            Move
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+function ConvertModal({
+  initiative,
+  onClose,
+  onSaved,
+}: {
+  initiative: Initiative;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [newKind, setNewKind] = useState<Kind>(initiative.kind);
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const submit = async () => {
+    setSubmitting(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/initiatives/${initiative.id}/convert`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ new_kind: newKind, reason: reason || null }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Convert failed (${res.status})`);
+      }
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Convert failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <ModalShell title={`Convert "${initiative.title}"`} onClose={onClose}>
+      <div className="space-y-3">
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">New kind</span>
+          <select
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+            value={newKind}
+            onChange={e => setNewKind(e.target.value as Kind)}
+          >
+            <option value="theme">theme</option>
+            <option value="milestone">milestone</option>
+            <option value="epic">epic</option>
+            <option value="story">story</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Reason (optional)</span>
+          <input
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+            value={reason}
+            onChange={e => setReason(e.target.value)}
+          />
+        </label>
+        {err && <div className="text-red-400 text-sm">{err}</div>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button onClick={onClose} className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm">
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={submitting}
+            className="px-3 py-2 rounded bg-mc-accent text-white disabled:opacity-50 text-sm"
+          >
+            Convert
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}

--- a/src/lib/db/initiatives.test.ts
+++ b/src/lib/db/initiatives.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Initiative DB-helper tests (Phase 1 of the roadmap planning layer).
+ *
+ * Covers the invariants from spec §4 and §6:
+ *   - parent validation + cycle rejection on move
+ *   - container retention through decomposition (deps stay on parent)
+ *   - delete blocked when descendants exist
+ *   - multi-prereq deps allowed; self-dep + duplicate rejected
+ *   - task re-parenting always writes an audit row
+ *   - tasks.status='draft' is now accepted by the CHECK constraint
+ *   - ideas.initiative_id is settable
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+import {
+  addInitiativeDependency,
+  attachTaskToInitiative,
+  createInitiative,
+  deleteInitiative,
+  getInitiativeDependencies,
+  moveInitiative,
+  moveTaskToInitiative,
+  removeInitiativeDependency,
+} from './initiatives';
+
+function seedTask(opts: { initiativeId?: string | null; status?: string } = {}): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, initiative_id, created_at, updated_at)
+     VALUES (?, 'T', ?, 'normal', 'default', 'default', ?, datetime('now'), datetime('now'))`,
+    [id, opts.status ?? 'inbox', opts.initiativeId ?? null],
+  );
+  return id;
+}
+
+function seedProduct(): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO products (id, workspace_id, name, created_at, updated_at)
+     VALUES (?, 'default', 'P', datetime('now'), datetime('now'))`,
+    [id],
+  );
+  return id;
+}
+
+// ─── createInitiative ──────────────────────────────────────────────
+
+test('createInitiative returns a fully populated row with defaults', () => {
+  const init = createInitiative({
+    workspace_id: 'default',
+    kind: 'epic',
+    title: 'Build big feature',
+  });
+  assert.equal(init.kind, 'epic');
+  assert.equal(init.title, 'Build big feature');
+  assert.equal(init.status, 'planned');
+  assert.equal(init.parent_initiative_id, null);
+  assert.ok(init.created_at);
+});
+
+test('createInitiative rejects unknown parent', () => {
+  assert.throws(
+    () =>
+      createInitiative({
+        workspace_id: 'default',
+        kind: 'story',
+        title: 'orphan',
+        parent_initiative_id: 'does-not-exist',
+      }),
+    /Parent initiative not found/,
+  );
+});
+
+test('createInitiative attaches to existing parent', () => {
+  const parent = createInitiative({ workspace_id: 'default', kind: 'epic', title: 'parent' });
+  const child = createInitiative({
+    workspace_id: 'default',
+    kind: 'story',
+    title: 'child',
+    parent_initiative_id: parent.id,
+  });
+  assert.equal(child.parent_initiative_id, parent.id);
+});
+
+// ─── moveInitiative ─────────────────────────────────────────────────
+
+test('moveInitiative writes audit row in the same transaction', () => {
+  const a = createInitiative({ workspace_id: 'default', kind: 'epic', title: 'A' });
+  const b = createInitiative({ workspace_id: 'default', kind: 'epic', title: 'B' });
+  moveInitiative(a.id, b.id, null, 'reorganize');
+
+  const updated = queryOne<{ parent_initiative_id: string | null }>(
+    'SELECT parent_initiative_id FROM initiatives WHERE id = ?',
+    [a.id],
+  );
+  assert.equal(updated?.parent_initiative_id, b.id);
+
+  const history = queryAll<{ to_parent_id: string | null; reason: string | null }>(
+    'SELECT to_parent_id, reason FROM initiative_parent_history WHERE initiative_id = ?',
+    [a.id],
+  );
+  assert.equal(history.length, 1);
+  assert.equal(history[0].to_parent_id, b.id);
+  assert.equal(history[0].reason, 'reorganize');
+});
+
+test('moveInitiative rejects cycles (move A under one of its descendants)', () => {
+  const a = createInitiative({ workspace_id: 'default', kind: 'epic', title: 'A' });
+  const b = createInitiative({
+    workspace_id: 'default',
+    kind: 'story',
+    title: 'B',
+    parent_initiative_id: a.id,
+  });
+  // Move A under B → cycle, B is a descendant of A.
+  assert.throws(() => moveInitiative(a.id, b.id), /cycle/i);
+});
+
+test('moveInitiative rejects move under self', () => {
+  const a = createInitiative({ workspace_id: 'default', kind: 'story', title: 'self' });
+  assert.throws(() => moveInitiative(a.id, a.id), /under itself|cycle/i);
+});
+
+// ─── deleteInitiative ──────────────────────────────────────────────
+
+test('deleteInitiative blocked when descendant initiative exists', () => {
+  const parent = createInitiative({ workspace_id: 'default', kind: 'epic', title: 'parent' });
+  createInitiative({
+    workspace_id: 'default',
+    kind: 'story',
+    title: 'child',
+    parent_initiative_id: parent.id,
+  });
+  assert.throws(() => deleteInitiative(parent.id), /child initiative/);
+});
+
+test('deleteInitiative blocked when a task references it', () => {
+  const init = createInitiative({ workspace_id: 'default', kind: 'story', title: 's' });
+  const taskId = seedTask();
+  attachTaskToInitiative(taskId, init.id);
+  assert.throws(() => deleteInitiative(init.id), /task/);
+});
+
+test('deleteInitiative succeeds for a leaf with no references', () => {
+  const init = createInitiative({ workspace_id: 'default', kind: 'story', title: 'leaf' });
+  deleteInitiative(init.id);
+  assert.equal(
+    queryOne('SELECT id FROM initiatives WHERE id = ?', [init.id]),
+    undefined,
+  );
+});
+
+// ─── dependencies ──────────────────────────────────────────────────
+
+test('addInitiativeDependency allows multiple prerequisites for one initiative', () => {
+  const a = createInitiative({ workspace_id: 'default', kind: 'story', title: 'A' });
+  const b = createInitiative({ workspace_id: 'default', kind: 'story', title: 'B' });
+  const c = createInitiative({ workspace_id: 'default', kind: 'story', title: 'C' });
+  addInitiativeDependency({ initiative_id: c.id, depends_on_initiative_id: a.id });
+  addInitiativeDependency({ initiative_id: c.id, depends_on_initiative_id: b.id });
+  const deps = getInitiativeDependencies(c.id);
+  assert.equal(deps.outgoing.length, 2);
+  const targets = deps.outgoing.map(d => d.depends_on_initiative_id).sort();
+  assert.deepEqual(targets, [a.id, b.id].sort());
+});
+
+test('addInitiativeDependency rejects self-dependency', () => {
+  const a = createInitiative({ workspace_id: 'default', kind: 'story', title: 'A' });
+  assert.throws(
+    () => addInitiativeDependency({ initiative_id: a.id, depends_on_initiative_id: a.id }),
+    /itself/,
+  );
+});
+
+test('addInitiativeDependency rejects duplicate edges', () => {
+  const a = createInitiative({ workspace_id: 'default', kind: 'story', title: 'A' });
+  const b = createInitiative({ workspace_id: 'default', kind: 'story', title: 'B' });
+  addInitiativeDependency({ initiative_id: a.id, depends_on_initiative_id: b.id });
+  assert.throws(
+    () => addInitiativeDependency({ initiative_id: a.id, depends_on_initiative_id: b.id }),
+    /already exists/,
+  );
+});
+
+test('removeInitiativeDependency drops the edge', () => {
+  const a = createInitiative({ workspace_id: 'default', kind: 'story', title: 'A' });
+  const b = createInitiative({ workspace_id: 'default', kind: 'story', title: 'B' });
+  const dep = addInitiativeDependency({ initiative_id: a.id, depends_on_initiative_id: b.id });
+  removeInitiativeDependency(dep.id);
+  assert.equal(getInitiativeDependencies(a.id).outgoing.length, 0);
+});
+
+// ─── container retention through decomposition ─────────────────────
+
+test('container retention: dep on parent unaffected when children added (spec §4.2)', () => {
+  // Story A; story C depends on A.
+  const a = createInitiative({ workspace_id: 'default', kind: 'story', title: 'A' });
+  const c = createInitiative({ workspace_id: 'default', kind: 'story', title: 'C' });
+  const dep = addInitiativeDependency({
+    initiative_id: c.id,
+    depends_on_initiative_id: a.id,
+  });
+
+  // Decompose A by adding child B — A becomes a container.
+  const b = createInitiative({
+    workspace_id: 'default',
+    kind: 'story',
+    title: 'B',
+    parent_initiative_id: a.id,
+  });
+
+  // (C, A) edge stays put; no edge auto-rewritten to (C, B).
+  let depsC = getInitiativeDependencies(c.id);
+  assert.equal(depsC.outgoing.length, 1);
+  assert.equal(depsC.outgoing[0].id, dep.id);
+  assert.equal(depsC.outgoing[0].depends_on_initiative_id, a.id);
+
+  // Further decompose B; (C, A) still unaffected.
+  createInitiative({
+    workspace_id: 'default',
+    kind: 'story',
+    title: 'B.1',
+    parent_initiative_id: b.id,
+  });
+  depsC = getInitiativeDependencies(c.id);
+  assert.equal(depsC.outgoing.length, 1);
+  assert.equal(depsC.outgoing[0].depends_on_initiative_id, a.id);
+});
+
+// ─── task re-parenting & audit ─────────────────────────────────────
+
+test('moving a task between initiatives writes two task_initiative_history rows', () => {
+  const a = createInitiative({ workspace_id: 'default', kind: 'story', title: 'A' });
+  const b = createInitiative({ workspace_id: 'default', kind: 'story', title: 'B' });
+  const taskId = seedTask();
+  attachTaskToInitiative(taskId, a.id, null, 'initial');
+
+  moveTaskToInitiative(taskId, b.id, null, 'deferred to phase 2');
+
+  const history = queryAll<{
+    from_initiative_id: string | null;
+    to_initiative_id: string | null;
+    reason: string | null;
+  }>(
+    'SELECT from_initiative_id, to_initiative_id, reason FROM task_initiative_history WHERE task_id = ? ORDER BY created_at',
+    [taskId],
+  );
+  assert.equal(history.length, 2);
+  assert.equal(history[0].from_initiative_id, null);
+  assert.equal(history[0].to_initiative_id, a.id);
+  assert.equal(history[1].from_initiative_id, a.id);
+  assert.equal(history[1].to_initiative_id, b.id);
+  assert.equal(history[1].reason, 'deferred to phase 2');
+
+  const task = queryOne<{ initiative_id: string }>(
+    'SELECT initiative_id FROM tasks WHERE id = ?',
+    [taskId],
+  );
+  assert.equal(task?.initiative_id, b.id);
+});
+
+// ─── schema-level checks ──────────────────────────────────────────
+
+test("tasks.status='draft' is accepted by the CHECK constraint", () => {
+  const id = uuidv4();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, created_at, updated_at)
+     VALUES (?, 'D', 'draft', 'normal', 'default', 'default', datetime('now'), datetime('now'))`,
+    [id],
+  );
+  const row = queryOne<{ status: string }>('SELECT status FROM tasks WHERE id = ?', [id]);
+  assert.equal(row?.status, 'draft');
+});
+
+test('ideas.initiative_id is settable', () => {
+  const productId = seedProduct();
+  const init = createInitiative({ workspace_id: 'default', kind: 'story', title: 'idea-target' });
+  const ideaId = uuidv4();
+  run(
+    `INSERT INTO ideas (id, product_id, title, description, category, initiative_id, created_at, updated_at)
+     VALUES (?, ?, 'i', 'd', 'feature', ?, datetime('now'), datetime('now'))`,
+    [ideaId, productId, init.id],
+  );
+  const row = queryOne<{ initiative_id: string }>('SELECT initiative_id FROM ideas WHERE id = ?', [ideaId]);
+  assert.equal(row?.initiative_id, init.id);
+});

--- a/src/lib/db/initiatives.ts
+++ b/src/lib/db/initiatives.ts
@@ -1,0 +1,553 @@
+/**
+ * Initiative DB helpers (Phase 1 of the roadmap planning layer).
+ *
+ * Initiatives are planning-tree nodes (theme/milestone/epic/story).
+ * See specs/roadmap-and-pm-spec.md §3-§6 for the data model.
+ *
+ * Notes:
+ *   - All mutations write through the shared singleton db handle (`getDb`)
+ *     so they share connection-level pragmas (foreign_keys=ON).
+ *   - Tree moves (parent re-parent) and task re-parents go through
+ *     transactional helpers so the audit row is always written with the
+ *     state change.
+ *   - Cycle detection on move walks the parent chain of `to_parent_id`
+ *     looking for `id`. SQLite has no recursive CTE on this code path,
+ *     but the planning tree is small (< low thousands) so the linear
+ *     walk is fine.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { getDb, queryAll, queryOne, run, transaction } from '@/lib/db';
+
+export type InitiativeKind = 'theme' | 'milestone' | 'epic' | 'story';
+export type InitiativeStatus = 'planned' | 'in_progress' | 'at_risk' | 'blocked' | 'done' | 'cancelled';
+export type InitiativeDependencyKind = 'finish_to_start' | 'start_to_start' | 'blocking' | 'informational';
+
+export interface Initiative {
+  id: string;
+  workspace_id: string;
+  product_id: string | null;
+  parent_initiative_id: string | null;
+  kind: InitiativeKind;
+  title: string;
+  description: string | null;
+  status: InitiativeStatus;
+  owner_agent_id: string | null;
+  estimated_effort_hours: number | null;
+  complexity: 'S' | 'M' | 'L' | 'XL' | null;
+  target_start: string | null;
+  target_end: string | null;
+  derived_start: string | null;
+  derived_end: string | null;
+  committed_end: string | null;
+  status_check_md: string | null;
+  sort_order: number;
+  source_idea_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface InitiativeDependency {
+  id: string;
+  initiative_id: string;
+  depends_on_initiative_id: string;
+  kind: InitiativeDependencyKind;
+  note: string | null;
+  created_at: string;
+}
+
+export interface InitiativeParentHistoryRow {
+  id: string;
+  initiative_id: string;
+  from_parent_id: string | null;
+  to_parent_id: string | null;
+  moved_by_agent_id: string | null;
+  reason: string | null;
+  created_at: string;
+}
+
+export interface CreateInitiativeInput {
+  workspace_id: string;
+  kind: InitiativeKind;
+  title: string;
+  product_id?: string | null;
+  parent_initiative_id?: string | null;
+  description?: string | null;
+  status?: InitiativeStatus;
+  owner_agent_id?: string | null;
+  estimated_effort_hours?: number | null;
+  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+  target_start?: string | null;
+  target_end?: string | null;
+  committed_end?: string | null;
+  status_check_md?: string | null;
+  sort_order?: number;
+  source_idea_id?: string | null;
+}
+
+const KINDS: ReadonlySet<InitiativeKind> = new Set(['theme', 'milestone', 'epic', 'story']);
+
+function assertKind(kind: string): asserts kind is InitiativeKind {
+  if (!KINDS.has(kind as InitiativeKind)) {
+    throw new Error(`Invalid initiative kind: ${kind}`);
+  }
+}
+
+export function createInitiative(input: CreateInitiativeInput): Initiative {
+  assertKind(input.kind);
+
+  if (input.parent_initiative_id) {
+    const parent = queryOne<{ id: string }>(
+      'SELECT id FROM initiatives WHERE id = ?',
+      [input.parent_initiative_id],
+    );
+    if (!parent) {
+      throw new Error(`Parent initiative not found: ${input.parent_initiative_id}`);
+    }
+  }
+
+  const id = uuidv4();
+  const now = new Date().toISOString();
+
+  run(
+    `INSERT INTO initiatives (
+       id, workspace_id, product_id, parent_initiative_id, kind, title, description,
+       status, owner_agent_id, estimated_effort_hours, complexity,
+       target_start, target_end, committed_end, status_check_md, sort_order,
+       source_idea_id, created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      id,
+      input.workspace_id,
+      input.product_id ?? null,
+      input.parent_initiative_id ?? null,
+      input.kind,
+      input.title,
+      input.description ?? null,
+      input.status ?? 'planned',
+      input.owner_agent_id ?? null,
+      input.estimated_effort_hours ?? null,
+      input.complexity ?? null,
+      input.target_start ?? null,
+      input.target_end ?? null,
+      input.committed_end ?? null,
+      input.status_check_md ?? null,
+      input.sort_order ?? 0,
+      input.source_idea_id ?? null,
+      now,
+      now,
+    ],
+  );
+
+  const row = queryOne<Initiative>('SELECT * FROM initiatives WHERE id = ?', [id]);
+  if (!row) throw new Error('Insert succeeded but row not found');
+  return row;
+}
+
+export interface GetInitiativeOptions {
+  includeChildren?: boolean;
+  includeTasks?: boolean;
+}
+
+export interface InitiativeWithRelations extends Initiative {
+  children?: Initiative[];
+  tasks?: Array<{ id: string; title: string; status: string }>;
+}
+
+export function getInitiative(id: string, opts: GetInitiativeOptions = {}): InitiativeWithRelations | undefined {
+  const row = queryOne<Initiative>('SELECT * FROM initiatives WHERE id = ?', [id]);
+  if (!row) return undefined;
+
+  const result: InitiativeWithRelations = { ...row };
+
+  if (opts.includeChildren) {
+    result.children = queryAll<Initiative>(
+      'SELECT * FROM initiatives WHERE parent_initiative_id = ? ORDER BY sort_order, created_at',
+      [id],
+    );
+  }
+  if (opts.includeTasks) {
+    result.tasks = queryAll<{ id: string; title: string; status: string }>(
+      'SELECT id, title, status FROM tasks WHERE initiative_id = ? ORDER BY created_at',
+      [id],
+    );
+  }
+  return result;
+}
+
+export interface ListInitiativesFilters {
+  workspace_id?: string;
+  product_id?: string;
+  parent_id?: string | null; // null = root, string = that parent, undefined = any
+  status?: InitiativeStatus;
+  kind?: InitiativeKind;
+}
+
+export function listInitiatives(filters: ListInitiativesFilters = {}): Initiative[] {
+  const where: string[] = [];
+  const params: unknown[] = [];
+
+  if (filters.workspace_id) {
+    where.push('workspace_id = ?');
+    params.push(filters.workspace_id);
+  }
+  if (filters.product_id) {
+    where.push('product_id = ?');
+    params.push(filters.product_id);
+  }
+  if (filters.parent_id === null) {
+    where.push('parent_initiative_id IS NULL');
+  } else if (typeof filters.parent_id === 'string') {
+    where.push('parent_initiative_id = ?');
+    params.push(filters.parent_id);
+  }
+  if (filters.status) {
+    where.push('status = ?');
+    params.push(filters.status);
+  }
+  if (filters.kind) {
+    where.push('kind = ?');
+    params.push(filters.kind);
+  }
+
+  const sql = `SELECT * FROM initiatives ${where.length ? 'WHERE ' + where.join(' AND ') : ''} ORDER BY sort_order, created_at`;
+  return queryAll<Initiative>(sql, params);
+}
+
+export interface InitiativeTreeNode extends Initiative {
+  children: InitiativeTreeNode[];
+}
+
+/**
+ * Build a nested tree for one workspace. If `root_id` is provided, returns
+ * only that subtree; otherwise returns all root-level initiatives. Forest
+ * is flattened into a single array so callers can render a top-level list.
+ */
+export function getInitiativeTree(workspace_id: string, root_id?: string): InitiativeTreeNode[] {
+  const all = queryAll<Initiative>(
+    'SELECT * FROM initiatives WHERE workspace_id = ? ORDER BY sort_order, created_at',
+    [workspace_id],
+  );
+
+  const byParent = new Map<string | null, Initiative[]>();
+  for (const row of all) {
+    const key = row.parent_initiative_id ?? null;
+    const list = byParent.get(key) ?? [];
+    list.push(row);
+    byParent.set(key, list);
+  }
+
+  function build(parentId: string | null): InitiativeTreeNode[] {
+    const kids = byParent.get(parentId) ?? [];
+    return kids.map(k => ({ ...k, children: build(k.id) }));
+  }
+
+  if (root_id) {
+    const root = all.find(i => i.id === root_id);
+    if (!root) return [];
+    return [{ ...root, children: build(root.id) }];
+  }
+  return build(null);
+}
+
+export interface UpdateInitiativePatch {
+  title?: string;
+  description?: string | null;
+  status?: InitiativeStatus;
+  owner_agent_id?: string | null;
+  estimated_effort_hours?: number | null;
+  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+  target_start?: string | null;
+  target_end?: string | null;
+  committed_end?: string | null;
+  status_check_md?: string | null;
+  sort_order?: number;
+  product_id?: string | null;
+  source_idea_id?: string | null;
+  // Note: kind changes go through convertInitiative; parent changes go through moveInitiative.
+}
+
+export function updateInitiative(id: string, patch: UpdateInitiativePatch): Initiative {
+  const existing = queryOne<Initiative>('SELECT id FROM initiatives WHERE id = ?', [id]);
+  if (!existing) throw new Error(`Initiative not found: ${id}`);
+
+  const sets: string[] = [];
+  const values: unknown[] = [];
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) continue;
+    sets.push(`${key} = ?`);
+    values.push(value);
+  }
+  if (sets.length === 0) {
+    return queryOne<Initiative>('SELECT * FROM initiatives WHERE id = ?', [id])!;
+  }
+  sets.push('updated_at = ?');
+  values.push(new Date().toISOString());
+  values.push(id);
+  run(`UPDATE initiatives SET ${sets.join(', ')} WHERE id = ?`, values);
+  return queryOne<Initiative>('SELECT * FROM initiatives WHERE id = ?', [id])!;
+}
+
+/**
+ * Re-parent an initiative. Rejects cycles (where to_parent is the initiative
+ * itself or one of its descendants). Records an audit row in the same
+ * transaction as the parent change.
+ */
+export function moveInitiative(
+  id: string,
+  to_parent_id: string | null,
+  moved_by_agent_id?: string | null,
+  reason?: string | null,
+): Initiative {
+  const existing = queryOne<Initiative>('SELECT * FROM initiatives WHERE id = ?', [id]);
+  if (!existing) throw new Error(`Initiative not found: ${id}`);
+
+  if (to_parent_id) {
+    if (to_parent_id === id) {
+      throw new Error('Cannot move an initiative under itself');
+    }
+    const target = queryOne<{ id: string }>('SELECT id FROM initiatives WHERE id = ?', [to_parent_id]);
+    if (!target) throw new Error(`Target parent not found: ${to_parent_id}`);
+    if (isDescendant(to_parent_id, id)) {
+      throw new Error('Move would create a cycle');
+    }
+  }
+
+  return transaction(() => {
+    const now = new Date().toISOString();
+    run(
+      'UPDATE initiatives SET parent_initiative_id = ?, updated_at = ? WHERE id = ?',
+      [to_parent_id, now, id],
+    );
+    run(
+      `INSERT INTO initiative_parent_history (id, initiative_id, from_parent_id, to_parent_id, moved_by_agent_id, reason, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        uuidv4(),
+        id,
+        existing.parent_initiative_id,
+        to_parent_id,
+        moved_by_agent_id ?? null,
+        reason ?? null,
+        now,
+      ],
+    );
+    return queryOne<Initiative>('SELECT * FROM initiatives WHERE id = ?', [id])!;
+  });
+}
+
+/**
+ * Returns true if `candidate` is a descendant of `ancestor` (or equal to it).
+ * Walk down the tree from ancestor and look for candidate.
+ */
+function isDescendant(candidate: string, ancestor: string): boolean {
+  if (candidate === ancestor) return true;
+  const stack: string[] = [ancestor];
+  const seen = new Set<string>();
+  while (stack.length) {
+    const cur = stack.pop()!;
+    if (seen.has(cur)) continue;
+    seen.add(cur);
+    const kids = queryAll<{ id: string }>(
+      'SELECT id FROM initiatives WHERE parent_initiative_id = ?',
+      [cur],
+    );
+    for (const k of kids) {
+      if (k.id === candidate) return true;
+      stack.push(k.id);
+    }
+  }
+  return false;
+}
+
+/**
+ * Change an initiative's `kind`. v1: no separate audit table for kind changes —
+ * the caller can record context in the initiative's description or
+ * status_check_md. The /convert endpoint exists primarily so the UI distinguishes
+ * "convert to epic" from a generic PATCH (per spec §16 Q5).
+ */
+export function convertInitiative(
+  id: string,
+  new_kind: InitiativeKind,
+  _moved_by_agent_id?: string | null,
+  _reason?: string | null,
+): Initiative {
+  assertKind(new_kind);
+  const existing = queryOne<Initiative>('SELECT id FROM initiatives WHERE id = ?', [id]);
+  if (!existing) throw new Error(`Initiative not found: ${id}`);
+
+  run(
+    'UPDATE initiatives SET kind = ?, updated_at = ? WHERE id = ?',
+    [new_kind, new Date().toISOString(), id],
+  );
+  return queryOne<Initiative>('SELECT * FROM initiatives WHERE id = ?', [id])!;
+}
+
+/**
+ * Delete an initiative. Blocked when any descendant initiative or task
+ * references it (per spec §4.6) — operator must re-parent or cancel
+ * descendants first.
+ */
+export function deleteInitiative(id: string): void {
+  const existing = queryOne<Initiative>('SELECT id FROM initiatives WHERE id = ?', [id]);
+  if (!existing) throw new Error(`Initiative not found: ${id}`);
+
+  const childCount = queryOne<{ n: number }>(
+    'SELECT COUNT(*) as n FROM initiatives WHERE parent_initiative_id = ?',
+    [id],
+  );
+  if (childCount && childCount.n > 0) {
+    throw new Error(`Cannot delete initiative with ${childCount.n} child initiative(s)`);
+  }
+  const taskCount = queryOne<{ n: number }>(
+    'SELECT COUNT(*) as n FROM tasks WHERE initiative_id = ?',
+    [id],
+  );
+  if (taskCount && taskCount.n > 0) {
+    throw new Error(`Cannot delete initiative with ${taskCount.n} task(s) referencing it`);
+  }
+
+  run('DELETE FROM initiatives WHERE id = ?', [id]);
+}
+
+export interface AddDependencyInput {
+  initiative_id: string;
+  depends_on_initiative_id: string;
+  kind?: InitiativeDependencyKind;
+  note?: string | null;
+}
+
+export function addInitiativeDependency(input: AddDependencyInput): InitiativeDependency {
+  if (input.initiative_id === input.depends_on_initiative_id) {
+    throw new Error('Initiative cannot depend on itself');
+  }
+  const a = queryOne<{ id: string }>('SELECT id FROM initiatives WHERE id = ?', [input.initiative_id]);
+  if (!a) throw new Error(`Initiative not found: ${input.initiative_id}`);
+  const b = queryOne<{ id: string }>('SELECT id FROM initiatives WHERE id = ?', [input.depends_on_initiative_id]);
+  if (!b) throw new Error(`Depends-on initiative not found: ${input.depends_on_initiative_id}`);
+
+  const existing = queryOne<InitiativeDependency>(
+    'SELECT * FROM initiative_dependencies WHERE initiative_id = ? AND depends_on_initiative_id = ?',
+    [input.initiative_id, input.depends_on_initiative_id],
+  );
+  if (existing) throw new Error('Dependency already exists');
+
+  const id = uuidv4();
+  run(
+    `INSERT INTO initiative_dependencies (id, initiative_id, depends_on_initiative_id, kind, note, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      id,
+      input.initiative_id,
+      input.depends_on_initiative_id,
+      input.kind ?? 'finish_to_start',
+      input.note ?? null,
+      new Date().toISOString(),
+    ],
+  );
+  return queryOne<InitiativeDependency>('SELECT * FROM initiative_dependencies WHERE id = ?', [id])!;
+}
+
+export function removeInitiativeDependency(dependency_id: string): void {
+  const existing = queryOne<InitiativeDependency>(
+    'SELECT id FROM initiative_dependencies WHERE id = ?',
+    [dependency_id],
+  );
+  if (!existing) throw new Error(`Dependency not found: ${dependency_id}`);
+  run('DELETE FROM initiative_dependencies WHERE id = ?', [dependency_id]);
+}
+
+export interface InitiativeDependencyEdges {
+  outgoing: InitiativeDependency[]; // initiatives this one depends on
+  incoming: InitiativeDependency[]; // initiatives that depend on this one
+}
+
+export function getInitiativeDependencies(id: string): InitiativeDependencyEdges {
+  return {
+    outgoing: queryAll<InitiativeDependency>(
+      'SELECT * FROM initiative_dependencies WHERE initiative_id = ? ORDER BY created_at',
+      [id],
+    ),
+    incoming: queryAll<InitiativeDependency>(
+      'SELECT * FROM initiative_dependencies WHERE depends_on_initiative_id = ? ORDER BY created_at',
+      [id],
+    ),
+  };
+}
+
+export function getInitiativeHistory(id: string): InitiativeParentHistoryRow[] {
+  return queryAll<InitiativeParentHistoryRow>(
+    'SELECT * FROM initiative_parent_history WHERE initiative_id = ? ORDER BY created_at',
+    [id],
+  );
+}
+
+/**
+ * Internal helper used by tests (and Phase 2 promotion logic) to attach a
+ * task to an initiative with the initial audit row written. Exported so
+ * Phase 1 tests can exercise the `task_initiative_history` invariant
+ * without the promotion endpoint existing yet.
+ */
+export function attachTaskToInitiative(
+  task_id: string,
+  initiative_id: string,
+  moved_by_agent_id?: string | null,
+  reason?: string | null,
+): void {
+  transaction(() => {
+    run(
+      'UPDATE tasks SET initiative_id = ?, updated_at = ? WHERE id = ?',
+      [initiative_id, new Date().toISOString(), task_id],
+    );
+    run(
+      `INSERT INTO task_initiative_history (id, task_id, from_initiative_id, to_initiative_id, moved_by_agent_id, reason, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [uuidv4(), task_id, null, initiative_id, moved_by_agent_id ?? null, reason ?? null, new Date().toISOString()],
+    );
+  });
+}
+
+/**
+ * Move a task between initiatives, writing an audit row in the same
+ * transaction. Phase 2 will expose this via /api/tasks/[id]/move-initiative.
+ */
+export function moveTaskToInitiative(
+  task_id: string,
+  to_initiative_id: string | null,
+  moved_by_agent_id?: string | null,
+  reason?: string | null,
+): void {
+  const task = queryOne<{ id: string; initiative_id: string | null }>(
+    'SELECT id, initiative_id FROM tasks WHERE id = ?',
+    [task_id],
+  );
+  if (!task) throw new Error(`Task not found: ${task_id}`);
+
+  if (to_initiative_id) {
+    const target = queryOne<{ id: string }>('SELECT id FROM initiatives WHERE id = ?', [to_initiative_id]);
+    if (!target) throw new Error(`Target initiative not found: ${to_initiative_id}`);
+  }
+
+  // Use the shared db handle so the inner statements share the
+  // transaction created by `transaction()`.
+  const db = getDb();
+  db.transaction(() => {
+    db.prepare('UPDATE tasks SET initiative_id = ?, updated_at = ? WHERE id = ?').run(
+      to_initiative_id,
+      new Date().toISOString(),
+      task_id,
+    );
+    db.prepare(
+      `INSERT INTO task_initiative_history (id, task_id, from_initiative_id, to_initiative_id, moved_by_agent_id, reason, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      uuidv4(),
+      task_id,
+      task.initiative_id,
+      to_initiative_id,
+      moved_by_agent_id ?? null,
+      reason ?? null,
+      new Date().toISOString(),
+    );
+  })();
+}

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -2510,9 +2510,19 @@ const migrations: Migration[] = [
           db.pragma('writable_schema = OFF');
 
           const integrity = db.prepare('PRAGMA integrity_check').all() as { integrity_check: string }[];
-          const ok = integrity.length === 1 && integrity[0].integrity_check === 'ok';
-          if (!ok) {
-            throw new Error('[Migration 043] integrity_check failed after writable_schema patch: ' + JSON.stringify(integrity));
+          // "Page X: never used" is a benign leaked-space warning (orphan page
+          // from prior writes — does NOT indicate corruption). VACUUM cleans
+          // them up but can't run inside a transaction. Filter them out here
+          // and only fail on actual corruption messages.
+          const isBenign = (msg: string) =>
+            msg === 'ok' || /^Page \d+: never used$/.test(msg);
+          const realErrors = integrity.filter(r => !isBenign(r.integrity_check));
+          if (realErrors.length > 0) {
+            throw new Error('[Migration 043] integrity_check failed after writable_schema patch: ' + JSON.stringify(realErrors));
+          }
+          const orphans = integrity.filter(r => /^Page \d+: never used$/.test(r.integrity_check));
+          if (orphans.length > 0) {
+            console.warn(`[Migration 043] ${orphans.length} orphan page(s) detected (benign — run VACUUM to reclaim): ` + JSON.stringify(orphans));
           }
         } finally {
           db.unsafeMode(false);

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -2364,6 +2364,184 @@ const migrations: Migration[] = [
       );
       console.log('[Migration 042] Complete.');
     }
+  },
+  {
+    id: '043',
+    name: 'roadmap_planning_layer',
+    up: (db) => {
+      // Phase 1 of the roadmap & PM-agent feature (specs/roadmap-and-pm-spec.md).
+      // Schema-only migration — no logic on top of the new tables yet:
+      //   (a) initiatives + dependencies + parent/task audit logs
+      //   (b) owner_availability + pm_proposals (Phase 5 will use these)
+      //   (c) tasks gains initiative_id + status_check_md, status CHECK
+      //       extended to include 'draft' (planning-board task)
+      //   (d) ideas gains initiative_id (idea → initiative promotion path)
+      console.log('[Migration 043] Adding roadmap planning layer tables and columns...');
+
+      // ---- (a) New tables ----
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS initiatives (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+          product_id TEXT REFERENCES products(id),
+          parent_initiative_id TEXT REFERENCES initiatives(id),
+          kind TEXT NOT NULL CHECK (kind IN ('theme','milestone','epic','story')),
+          title TEXT NOT NULL,
+          description TEXT,
+          status TEXT NOT NULL DEFAULT 'planned'
+            CHECK (status IN ('planned','in_progress','at_risk','blocked','done','cancelled')),
+          owner_agent_id TEXT REFERENCES agents(id),
+          estimated_effort_hours REAL,
+          complexity TEXT CHECK (complexity IN ('S','M','L','XL')),
+          target_start TEXT,
+          target_end TEXT,
+          derived_start TEXT,
+          derived_end TEXT,
+          committed_end TEXT,
+          status_check_md TEXT,
+          sort_order INTEGER DEFAULT 0,
+          source_idea_id TEXT REFERENCES ideas(id),
+          created_at TEXT DEFAULT (datetime('now')),
+          updated_at TEXT DEFAULT (datetime('now'))
+        )
+      `);
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS initiative_dependencies (
+          id TEXT PRIMARY KEY,
+          initiative_id TEXT NOT NULL REFERENCES initiatives(id) ON DELETE CASCADE,
+          depends_on_initiative_id TEXT NOT NULL REFERENCES initiatives(id) ON DELETE CASCADE,
+          kind TEXT NOT NULL DEFAULT 'finish_to_start'
+            CHECK (kind IN ('finish_to_start','start_to_start','blocking','informational')),
+          note TEXT,
+          created_at TEXT DEFAULT (datetime('now')),
+          UNIQUE(initiative_id, depends_on_initiative_id)
+        )
+      `);
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS initiative_parent_history (
+          id TEXT PRIMARY KEY,
+          initiative_id TEXT NOT NULL REFERENCES initiatives(id) ON DELETE CASCADE,
+          from_parent_id TEXT REFERENCES initiatives(id),
+          to_parent_id TEXT REFERENCES initiatives(id),
+          moved_by_agent_id TEXT REFERENCES agents(id),
+          reason TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS task_initiative_history (
+          id TEXT PRIMARY KEY,
+          task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+          from_initiative_id TEXT REFERENCES initiatives(id),
+          to_initiative_id TEXT REFERENCES initiatives(id),
+          moved_by_agent_id TEXT REFERENCES agents(id),
+          reason TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS owner_availability (
+          id TEXT PRIMARY KEY,
+          agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+          unavailable_start TEXT NOT NULL,
+          unavailable_end TEXT NOT NULL,
+          reason TEXT,
+          created_at TEXT DEFAULT (datetime('now'))
+        )
+      `);
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS pm_proposals (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+          trigger_text TEXT NOT NULL,
+          trigger_kind TEXT NOT NULL DEFAULT 'manual'
+            CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation')),
+          impact_md TEXT NOT NULL,
+          proposed_changes TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'draft'
+            CHECK (status IN ('draft','accepted','rejected','superseded')),
+          applied_at TEXT,
+          applied_by_agent_id TEXT REFERENCES agents(id),
+          parent_proposal_id TEXT REFERENCES pm_proposals(id),
+          created_at TEXT DEFAULT (datetime('now'))
+        )
+      `);
+
+      // ---- (c) tasks: add initiative_id + status_check_md ----
+      const tasksInfo = db.prepare('PRAGMA table_info(tasks)').all() as { name: string }[];
+      const taskHas = (n: string) => tasksInfo.some(c => c.name === n);
+      if (!taskHas('initiative_id')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN initiative_id TEXT REFERENCES initiatives(id)`);
+      }
+      if (!taskHas('status_check_md')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN status_check_md TEXT`);
+      }
+
+      // ---- (c) extend tasks.status CHECK to include 'draft' ----
+      // Same writable_schema technique as migration 036/037 — surgical
+      // rewrite of the CREATE TABLE text. Migration 036 added
+      // 'needs_user_input', so the current CHECK shape includes it.
+      const tasksSchema = db.prepare(
+        `SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'`
+      ).get() as { sql: string } | undefined;
+
+      if (tasksSchema && !tasksSchema.sql.includes("'draft'")) {
+        const oldCheck = `status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done', 'cancelled', 'needs_user_input')`;
+        const newCheck = `status IN ('pending_dispatch', 'planning', 'inbox', 'draft', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done', 'cancelled', 'needs_user_input')`;
+
+        if (!tasksSchema.sql.includes(oldCheck)) {
+          console.warn('[Migration 043] tasks CHECK constraint shape unexpected; current schema:\n' + tasksSchema.sql);
+          throw new Error('[Migration 043] Unable to locate status CHECK clause in tasks CREATE TABLE — refusing to patch');
+        }
+
+        const patched = tasksSchema.sql.replace(oldCheck, newCheck);
+        const escaped = patched.replace(/'/g, "''");
+        db.unsafeMode(true);
+        try {
+          db.pragma('writable_schema = ON');
+          db.exec(
+            `UPDATE sqlite_master SET sql = '${escaped}' WHERE type='table' AND name='tasks'`
+          );
+          db.pragma('writable_schema = OFF');
+
+          const integrity = db.prepare('PRAGMA integrity_check').all() as { integrity_check: string }[];
+          const ok = integrity.length === 1 && integrity[0].integrity_check === 'ok';
+          if (!ok) {
+            throw new Error('[Migration 043] integrity_check failed after writable_schema patch: ' + JSON.stringify(integrity));
+          }
+        } finally {
+          db.unsafeMode(false);
+        }
+      }
+
+      // ---- (d) ideas: initiative_id ----
+      const ideasInfo = db.prepare('PRAGMA table_info(ideas)').all() as { name: string }[];
+      if (!ideasInfo.some(c => c.name === 'initiative_id')) {
+        db.exec(`ALTER TABLE ideas ADD COLUMN initiative_id TEXT REFERENCES initiatives(id)`);
+      }
+
+      // ---- Indexes (§5.3) ----
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_initiatives_workspace ON initiatives(workspace_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_initiatives_parent ON initiatives(parent_initiative_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_initiatives_product ON initiatives(product_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_initiatives_status ON initiatives(status)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_initiatives_target_window ON initiatives(target_start, target_end)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_initiative_deps_from ON initiative_dependencies(initiative_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_initiative_deps_to ON initiative_dependencies(depends_on_initiative_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_task_initiative_history_task ON task_initiative_history(task_id, created_at)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_initiative_parent_history ON initiative_parent_history(initiative_id, created_at)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_owner_availability_agent ON owner_availability(agent_id, unavailable_start)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_initiative ON tasks(initiative_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_draft ON tasks(status, initiative_id) WHERE status='draft'`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_status ON pm_proposals(status, created_at DESC)`);
+
+      console.log('[Migration 043] Complete.');
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS tasks (
   id TEXT PRIMARY KEY,
   title TEXT NOT NULL,
   description TEXT,
-  status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done', 'cancelled')),
+  status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'draft', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done', 'cancelled', 'needs_user_input')),
   priority TEXT DEFAULT 'normal' CHECK (priority IN ('low', 'normal', 'high', 'urgent')),
   assigned_agent_id TEXT REFERENCES agents(id),
   created_by_agent_id TEXT REFERENCES agents(id),
@@ -85,6 +85,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   is_archived INTEGER DEFAULT 0,
   archived_at TEXT,
   include_knowledge INTEGER DEFAULT 0,
+  initiative_id TEXT REFERENCES initiatives(id),
+  status_check_md TEXT,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -488,6 +490,7 @@ CREATE TABLE IF NOT EXISTS ideas (
   auto_suppressed INTEGER DEFAULT 0,
   suppress_reason TEXT,
   variant_id TEXT REFERENCES product_program_variants(id),
+  initiative_id TEXT REFERENCES initiatives(id),
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -829,6 +832,95 @@ CREATE TABLE IF NOT EXISTS debug_config (
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- Roadmap planning layer (see specs/roadmap-and-pm-spec.md §5).
+-- Initiatives form a tree (parent_initiative_id). Almost every column is
+-- nullable so a backlog item can be a one-line title with no other detail.
+CREATE TABLE IF NOT EXISTS initiatives (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+  product_id TEXT REFERENCES products(id),
+  parent_initiative_id TEXT REFERENCES initiatives(id),
+  kind TEXT NOT NULL CHECK (kind IN ('theme','milestone','epic','story')),
+  title TEXT NOT NULL,
+  description TEXT,
+  status TEXT NOT NULL DEFAULT 'planned'
+    CHECK (status IN ('planned','in_progress','at_risk','blocked','done','cancelled')),
+  owner_agent_id TEXT REFERENCES agents(id),
+  estimated_effort_hours REAL,
+  complexity TEXT CHECK (complexity IN ('S','M','L','XL')),
+  target_start TEXT,
+  target_end TEXT,
+  derived_start TEXT,
+  derived_end TEXT,
+  committed_end TEXT,
+  status_check_md TEXT,
+  sort_order INTEGER DEFAULT 0,
+  source_idea_id TEXT REFERENCES ideas(id),
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Cross-initiative dependency edges (DAG, many-to-many).
+CREATE TABLE IF NOT EXISTS initiative_dependencies (
+  id TEXT PRIMARY KEY,
+  initiative_id TEXT NOT NULL REFERENCES initiatives(id) ON DELETE CASCADE,
+  depends_on_initiative_id TEXT NOT NULL REFERENCES initiatives(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL DEFAULT 'finish_to_start'
+    CHECK (kind IN ('finish_to_start','start_to_start','blocking','informational')),
+  note TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  UNIQUE(initiative_id, depends_on_initiative_id)
+);
+
+-- Audit log of every initiative-tree move.
+CREATE TABLE IF NOT EXISTS initiative_parent_history (
+  id TEXT PRIMARY KEY,
+  initiative_id TEXT NOT NULL REFERENCES initiatives(id) ON DELETE CASCADE,
+  from_parent_id TEXT REFERENCES initiatives(id),
+  to_parent_id TEXT REFERENCES initiatives(id),
+  moved_by_agent_id TEXT REFERENCES agents(id),
+  reason TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Audit log of every task re-parent. First row per task has from = NULL.
+CREATE TABLE IF NOT EXISTS task_initiative_history (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  from_initiative_id TEXT REFERENCES initiatives(id),
+  to_initiative_id TEXT REFERENCES initiatives(id),
+  moved_by_agent_id TEXT REFERENCES agents(id),
+  reason TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Owner availability windows (PM impact-analysis input).
+CREATE TABLE IF NOT EXISTS owner_availability (
+  id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  unavailable_start TEXT NOT NULL,
+  unavailable_end TEXT NOT NULL,
+  reason TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- PM proposal artifacts (Phase 5 will populate these).
+CREATE TABLE IF NOT EXISTS pm_proposals (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+  trigger_text TEXT NOT NULL,
+  trigger_kind TEXT NOT NULL DEFAULT 'manual'
+    CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation')),
+  impact_md TEXT NOT NULL,
+  proposed_changes TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft','accepted','rejected','superseded')),
+  applied_at TEXT,
+  applied_by_agent_id TEXT REFERENCES agents(id),
+  parent_proposal_id TEXT REFERENCES pm_proposals(id),
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_assigned ON tasks(assigned_agent_id);
@@ -896,4 +988,17 @@ CREATE INDEX IF NOT EXISTS idx_skill_reports_skill ON skill_reports(skill_id);
 CREATE INDEX IF NOT EXISTS idx_debug_events_created ON debug_events(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_debug_events_task ON debug_events(task_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_debug_events_agent ON debug_events(agent_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_initiatives_workspace ON initiatives(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_initiatives_parent ON initiatives(parent_initiative_id);
+CREATE INDEX IF NOT EXISTS idx_initiatives_product ON initiatives(product_id);
+CREATE INDEX IF NOT EXISTS idx_initiatives_status ON initiatives(status);
+CREATE INDEX IF NOT EXISTS idx_initiatives_target_window ON initiatives(target_start, target_end);
+CREATE INDEX IF NOT EXISTS idx_initiative_deps_from ON initiative_dependencies(initiative_id);
+CREATE INDEX IF NOT EXISTS idx_initiative_deps_to ON initiative_dependencies(depends_on_initiative_id);
+CREATE INDEX IF NOT EXISTS idx_task_initiative_history_task ON task_initiative_history(task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_initiative_parent_history ON initiative_parent_history(initiative_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_owner_availability_agent ON owner_availability(agent_id, unavailable_start);
+CREATE INDEX IF NOT EXISTS idx_tasks_initiative ON tasks(initiative_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_draft ON tasks(status, initiative_id) WHERE status='draft';
+CREATE INDEX IF NOT EXISTS idx_pm_proposals_status ON pm_proposals(status, created_at DESC);
 `;


### PR DESCRIPTION
## Summary

Schema-only foundation for the roadmap & PM-agent planning layer. Adds the `initiatives` tree (with parent / kind / status / owner / dates / status check), cross-initiative dependencies, two audit logs (initiative-tree moves and task re-parents), `owner_availability` for PM impact analysis, and an empty `pm_proposals` table for Phase 5. The execution board is untouched: tasks gain a single `initiative_id` pointer plus a new `'draft'` status, but no dispatch logic changed.

## What landed

- **Migration 043** `roadmap_planning_layer` (`src/lib/db/migrations.ts`):
  - new tables: `initiatives`, `initiative_dependencies`, `initiative_parent_history`, `task_initiative_history`, `owner_availability`, `pm_proposals`
  - `tasks.initiative_id`, `tasks.status_check_md`, `tasks.status` CHECK extended to include `'draft'` (table-rebuild via `writable_schema = ON`, same pattern as migrations 036/037)
  - `ideas.initiative_id`
  - all indexes per spec §5.3
- **Schema.ts** updated so fresh DBs produce the same shape.
- **DB helpers** (`src/lib/db/initiatives.ts`): create / get / list / tree / update / move / convert / delete / addDependency / removeDependency / list-deps / history. Move helpers detect cycles, reject self-parent, and write the audit row inside the same `db.transaction(...)` as the mutation. `attachTaskToInitiative` + `moveTaskToInitiative` are exposed for tests (and Phase 2 will wire them to endpoints).
- **API routes** (Phase 1 subset only — promotion + PM proposals are Phase 2+):
  - `GET/POST /api/initiatives`
  - `GET/PATCH/DELETE /api/initiatives/[id]`
  - `POST /api/initiatives/[id]/move`
  - `POST /api/initiatives/[id]/convert`
  - `GET /api/initiatives/[id]/history`
  - `GET/POST /api/initiatives/[id]/dependencies`
  - `DELETE /api/initiative-dependencies/[depId]`
- **`/initiatives` page**: indented tree list, parent picker, create / edit / move / convert / delete modals, per-row expand panel that loads the parent-change audit log and the dependency edges with an "Add dependency" affordance.
- **Tests** (`src/lib/db/initiatives.test.ts`, 17 cases): container retention through decomposition, audit-on-move, cycle + self-loop rejection, multi-prerequisite deps, dependency edge survives child decomposition (spec §4.2), delete blocked by descendant initiatives or referencing tasks, partial PATCH, task re-parent appends two history rows, `'draft'` accepted by the new CHECK, `ideas.initiative_id` settable.
- **Spec committed** at `specs/roadmap-and-pm-spec.md`.

## Stacked PR series

This is **Phase 1 of a 6-phase series** — see `specs/roadmap-and-pm-spec.md §14`. Phase 2 (promotion endpoints + initiative-aware task UI) will be stacked on this branch and will not be merged until this one is. Per the project memory, when this PR is ready to land, Phase 2 must be retargeted to `main` *before* this is merged with `--delete-branch`, otherwise GitHub will close the child PR.

## Test plan

- [x] `npx tsx --test src/lib/db/initiatives.test.ts` → 17 / 17 pass.
- [x] `npx tsc --noEmit` clean.
- [x] Migration 043 runs idempotently against a fresh test DB; `tasks.status='draft'` insert accepted afterwards.
- [x] Container retention covered: A→C dep persists when A is decomposed by adding a B child.
- [x] `moveInitiative` rejects cycles (move A under one of its descendants) and self-parent.
- [x] `deleteInitiative` blocks when a child initiative or a referencing task exists; succeeds for a leaf.
- [x] Multi-prerequisite case: A→C and B→C as two rows; remove one leaves the other.
- [ ] Manual smoke through `/initiatives` page: create tree, move, add dep, delete leaf, expand row to see history. (Dev server wasn't reachable on `4001` from the agent — recommend a quick visual pass before merge.)

## Notes / open questions for spec

- **Convert audit log.** Spec §4.4 / §16 Q5 says `/convert` is the operator-facing endpoint but mechanically it's a `kind` change. I implemented `convertInitiative` as a plain `kind` update with `updated_at` bumped — no separate audit row, since the spec's only audit table for initiatives is parent-history. Worth confirming whether kind-change history is wanted (we'd need a dedicated table or a polymorphic audit row).
- **Pre-existing test infrastructure quirk** (not in scope here, but flagging): the npm `test` script is `tsx --test src/**/*.test.ts`; macOS bash without `globstar` only expands one level, so nested test files (`src/lib/db/*.test.ts`, `src/lib/autopilot/*.test.ts`, etc.) are silently skipped. Each file passes when run individually — verified locally for all 12 test files (147+ tests). Worth a follow-up to either enable globstar or list paths explicitly.
- **Owner pickers.** The edit modal accepts an owner agent id as a free-text field — Phase 2 will replace this with a proper agent picker once the broader agent UI primitives are reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>