### PR TITLE
Phase 2: Promotion endpoints + initiative-aware task UI

### DIFF
--- a/src/app/api/ideas/[id]/promote-to-initiative/route.ts
+++ b/src/app/api/ideas/[id]/promote-to-initiative/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { promoteIdeaToInitiative } from '@/lib/db/promotion';
+
+export const dynamic = 'force-dynamic';
+
+const KindEnum = z.enum(['theme', 'milestone', 'epic', 'story']);
+
+const Schema = z.object({
+  kind: KindEnum.optional(),
+  parent_initiative_id: z.string().nullish(),
+  copy_description: z.boolean().optional(),
+  created_by_agent_id: z.string().nullish(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    const parsed = Schema.safeParse(body ?? {});
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const result = promoteIdeaToInitiative(id, {
+      kind: parsed.data.kind,
+      parent_initiative_id: parsed.data.parent_initiative_id ?? null,
+      copy_description: parsed.data.copy_description,
+      created_by_agent_id: parsed.data.created_by_agent_id ?? null,
+    });
+    if (result.alreadyPromoted) {
+      return NextResponse.json(
+        { error: 'Idea already promoted', initiative: result.initiative },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json(result.initiative, { status: 201 });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to promote idea';
+    if (msg.startsWith('Idea not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    if (msg.startsWith('Parent initiative not found')) {
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    if (msg.includes('references missing initiative')) {
+      return NextResponse.json({ error: msg }, { status: 409 });
+    }
+    console.error('Failed to promote idea to initiative:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/initiatives/[id]/convert/route.ts
+++ b/src/app/api/initiatives/[id]/convert/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { convertInitiative } from '@/lib/db/initiatives';
+import { convertInitiative, getInitiative } from '@/lib/db/initiatives';
+import { emitConvertEvent } from '@/lib/db/promotion';
 
 export const dynamic = 'force-dynamic';
 
@@ -24,12 +25,26 @@ export async function POST(
         { status: 400 },
       );
     }
+    // Capture from_kind before mutation so the event records the actual
+    // transition (spec §16 #5).
+    const before = getInitiative(id);
+    if (!before) {
+      return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
+    }
     const updated = convertInitiative(
       id,
       parsed.data.new_kind,
       parsed.data.moved_by_agent_id ?? null,
       parsed.data.reason ?? null,
     );
+    emitConvertEvent({
+      initiative_id: id,
+      initiative_title: updated.title,
+      from_kind: before.kind,
+      to_kind: updated.kind,
+      agent_id: parsed.data.moved_by_agent_id ?? null,
+      reason: parsed.data.reason ?? null,
+    });
     return NextResponse.json(updated);
   } catch (error) {
     const msg = error instanceof Error ? error.message : 'Failed to convert initiative';

--- a/src/app/api/initiatives/[id]/promote-to-task/route.ts
+++ b/src/app/api/initiatives/[id]/promote-to-task/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { queryOne } from '@/lib/db';
+import { promoteInitiativeToTask } from '@/lib/db/promotion';
+import type { Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const Schema = z.object({
+  task_title: z.string().min(1).max(500).optional(),
+  task_description: z.string().max(10000).nullish(),
+  status_check_md: z.string().nullish(),
+  created_by_agent_id: z.string().nullish(),
+  reason: z.string().max(2000).nullish(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    const parsed = Schema.safeParse(body ?? {});
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const { id: taskId } = promoteInitiativeToTask(id, parsed.data);
+    const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    return NextResponse.json(task, { status: 201 });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to promote initiative';
+    if (msg.startsWith('Initiative not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    if (msg.startsWith('Only story-kind')) {
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    console.error('Failed to promote initiative to task:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/initiative-history/route.ts
+++ b/src/app/api/tasks/[id]/initiative-history/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { queryOne } from '@/lib/db';
+import { getTaskInitiativeHistory } from '@/lib/db/promotion';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const task = queryOne<{ id: string }>('SELECT id FROM tasks WHERE id = ?', [id]);
+    if (!task) {
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    }
+    const rows = getTaskInitiativeHistory(id);
+    return NextResponse.json(rows);
+  } catch (error) {
+    console.error('Failed to fetch task initiative history:', error);
+    return NextResponse.json({ error: 'Failed to fetch task initiative history' }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/move-initiative/route.ts
+++ b/src/app/api/tasks/[id]/move-initiative/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { queryOne } from '@/lib/db';
+import { moveTaskToInitiative } from '@/lib/db/initiatives';
+import type { Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const Schema = z.object({
+  to_initiative_id: z.string().nullable(),
+  reason: z.string().max(2000).nullish(),
+  moved_by_agent_id: z.string().nullish(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    const parsed = Schema.safeParse(body ?? {});
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    moveTaskToInitiative(
+      id,
+      parsed.data.to_initiative_id,
+      parsed.data.moved_by_agent_id ?? null,
+      parsed.data.reason ?? null,
+    );
+    const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [id]);
+    return NextResponse.json(task);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to move task';
+    if (msg.startsWith('Task not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    if (msg.startsWith('Target initiative not found')) {
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    console.error('Failed to move task to initiative:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/promote/route.ts
+++ b/src/app/api/tasks/[id]/promote/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { queryOne } from '@/lib/db';
+import { promoteTaskToInbox } from '@/lib/db/promotion';
+import type { Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const Schema = z.object({
+  reason: z.string().max(2000).nullish(),
+  promoted_by_agent_id: z.string().nullish(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    const parsed = Schema.safeParse(body ?? {});
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    promoteTaskToInbox(id, parsed.data);
+    const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [id]);
+    return NextResponse.json(task);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to promote task';
+    if (msg.startsWith('Task not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    if (msg.startsWith('Task is not in draft')) {
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    console.error('Failed to promote task:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/initiatives/[id]/page.tsx
+++ b/src/app/initiatives/[id]/page.tsx
@@ -1,0 +1,560 @@
+'use client';
+
+import { useState, useEffect, useCallback, use } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, ChevronRight, Plus, Send, History, Link2 } from 'lucide-react';
+
+type Kind = 'theme' | 'milestone' | 'epic' | 'story';
+type Status = 'planned' | 'in_progress' | 'at_risk' | 'blocked' | 'done' | 'cancelled';
+
+interface Initiative {
+  id: string;
+  workspace_id: string;
+  product_id: string | null;
+  parent_initiative_id: string | null;
+  kind: Kind;
+  title: string;
+  description: string | null;
+  status: Status;
+  owner_agent_id: string | null;
+  estimated_effort_hours: number | null;
+  complexity: 'S' | 'M' | 'L' | 'XL' | null;
+  target_start: string | null;
+  target_end: string | null;
+  derived_start: string | null;
+  derived_end: string | null;
+  committed_end: string | null;
+  status_check_md: string | null;
+  source_idea_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface InitiativeWithRelations extends Initiative {
+  children?: Initiative[];
+  tasks?: TaskRow[];
+}
+
+interface TaskRow {
+  id: string;
+  title: string;
+  status: string;
+}
+
+interface HistoryRow {
+  id: string;
+  from_parent_id: string | null;
+  to_parent_id: string | null;
+  reason: string | null;
+  created_at: string;
+}
+
+interface DepRow {
+  id: string;
+  initiative_id: string;
+  depends_on_initiative_id: string;
+  kind: string;
+  note: string | null;
+  created_at: string;
+}
+
+interface DepEdges {
+  outgoing: DepRow[];
+  incoming: DepRow[];
+}
+
+const KIND_BADGE: Record<Kind, string> = {
+  theme: 'bg-purple-500/20 text-purple-300',
+  milestone: 'bg-amber-500/20 text-amber-300',
+  epic: 'bg-blue-500/20 text-blue-300',
+  story: 'bg-emerald-500/20 text-emerald-300',
+};
+
+const STATUS_BADGE: Record<string, string> = {
+  draft: 'bg-slate-500/20 text-slate-300 border-slate-500/30',
+  inbox: 'bg-pink-500/20 text-pink-300',
+  planning: 'bg-purple-500/20 text-purple-300',
+  assigned: 'bg-yellow-500/20 text-yellow-300',
+  in_progress: 'bg-blue-500/20 text-blue-300',
+  convoy_active: 'bg-cyan-500/20 text-cyan-300',
+  testing: 'bg-cyan-500/20 text-cyan-300',
+  review: 'bg-purple-500/20 text-purple-300',
+  verification: 'bg-orange-500/20 text-orange-300',
+  done: 'bg-emerald-500/20 text-emerald-300',
+};
+
+const ACTIVE_STATUSES = new Set([
+  'inbox',
+  'planning',
+  'assigned',
+  'in_progress',
+  'convoy_active',
+  'testing',
+  'review',
+  'verification',
+]);
+
+export default function InitiativeDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const [initiative, setInitiative] = useState<InitiativeWithRelations | null>(null);
+  const [allInitiatives, setAllInitiatives] = useState<Initiative[]>([]);
+  const [history, setHistory] = useState<HistoryRow[]>([]);
+  const [deps, setDeps] = useState<DepEdges | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [showPromoteModal, setShowPromoteModal] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const [detailRes, listRes, histRes, depsRes] = await Promise.all([
+        fetch(`/api/initiatives/${id}?include=children,tasks`),
+        fetch(`/api/initiatives`),
+        fetch(`/api/initiatives/${id}/history`),
+        fetch(`/api/initiatives/${id}/dependencies`),
+      ]);
+      if (!detailRes.ok) {
+        throw new Error(`Failed to load initiative (${detailRes.status})`);
+      }
+      const detail: InitiativeWithRelations = await detailRes.json();
+      setInitiative(detail);
+      setAllInitiatives(listRes.ok ? await listRes.json() : []);
+      setHistory(histRes.ok ? await histRes.json() : []);
+      setDeps(depsRes.ok ? await depsRes.json() : { outgoing: [], incoming: [] });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const titleFor = useCallback(
+    (initId: string | null) => {
+      if (!initId) return '(root)';
+      return allInitiatives.find(i => i.id === initId)?.title ?? initId;
+    },
+    [allInitiatives],
+  );
+
+  const promoteDraft = async (taskId: string) => {
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/tasks/${taskId}/promote`, { method: 'POST' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Promote failed (${res.status})`);
+      }
+      refresh();
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : 'Promote failed');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-mc-bg p-6 text-mc-text-secondary">Loading…</div>
+    );
+  }
+  if (error || !initiative) {
+    return (
+      <div className="min-h-screen bg-mc-bg p-6">
+        <div className="max-w-3xl mx-auto p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300 text-sm">
+          {error || 'Initiative not found'}
+        </div>
+        <div className="max-w-3xl mx-auto mt-4">
+          <Link href="/initiatives" className="text-mc-text-secondary hover:text-mc-text text-sm">
+            ← Back to initiatives
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const tasks = initiative.tasks ?? [];
+  const drafts = tasks.filter(t => t.status === 'draft');
+  const active = tasks.filter(t => ACTIVE_STATUSES.has(t.status));
+  const done = tasks.filter(t => t.status === 'done');
+  const other = tasks.filter(
+    t => t.status !== 'draft' && !ACTIVE_STATUSES.has(t.status) && t.status !== 'done',
+  );
+
+  return (
+    <div className="min-h-screen bg-mc-bg p-6">
+      <div className="max-w-4xl mx-auto">
+        <div className="mb-4 flex items-center gap-2">
+          <Link
+            href="/initiatives"
+            className="inline-flex items-center gap-1 px-2 py-1 rounded text-mc-text-secondary hover:text-mc-text text-sm"
+          >
+            <ArrowLeft className="w-4 h-4" /> Initiatives
+          </Link>
+          {initiative.parent_initiative_id && (
+            <>
+              <ChevronRight className="w-4 h-4 text-mc-text-secondary" />
+              <Link
+                href={`/initiatives/${initiative.parent_initiative_id}`}
+                className="text-mc-text-secondary hover:text-mc-text text-sm"
+              >
+                {titleFor(initiative.parent_initiative_id)}
+              </Link>
+            </>
+          )}
+        </div>
+
+        <header className="mb-6 p-5 rounded-lg bg-mc-bg-secondary border border-mc-border">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <span className={`px-2 py-0.5 rounded text-xs uppercase tracking-wide ${KIND_BADGE[initiative.kind]}`}>
+                  {initiative.kind}
+                </span>
+                <span className="text-xs text-mc-text-secondary uppercase">{initiative.status}</span>
+              </div>
+              <h1 className="text-2xl font-semibold text-mc-text">{initiative.title}</h1>
+              {initiative.description && (
+                <p className="text-mc-text-secondary mt-2 whitespace-pre-wrap">{initiative.description}</p>
+              )}
+            </div>
+            <div className="flex flex-col items-end gap-2">
+              <PromoteButton
+                kind={initiative.kind}
+                onClick={() => setShowPromoteModal(true)}
+              />
+            </div>
+          </div>
+
+          <dl className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4 text-xs text-mc-text-secondary">
+            <div>
+              <dt className="uppercase tracking-wide">Target start</dt>
+              <dd className="text-mc-text">{initiative.target_start ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="uppercase tracking-wide">Target end</dt>
+              <dd className="text-mc-text">{initiative.target_end ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="uppercase tracking-wide">Committed end</dt>
+              <dd className="text-mc-text">{initiative.committed_end ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="uppercase tracking-wide">Owner</dt>
+              <dd className="text-mc-text">{initiative.owner_agent_id ?? '—'}</dd>
+            </div>
+          </dl>
+
+          {initiative.status_check_md && (
+            <div className="mt-4 p-3 rounded border border-mc-border/60 bg-mc-bg text-sm text-mc-text-secondary whitespace-pre-wrap font-mono text-xs">
+              <div className="uppercase tracking-wide text-[10px] text-mc-text-secondary/70 mb-1">
+                Status check
+              </div>
+              {initiative.status_check_md}
+            </div>
+          )}
+        </header>
+
+        {actionError && (
+          <div className="mb-4 p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300 text-sm">
+            {actionError}
+          </div>
+        )}
+
+        {/* Children */}
+        {initiative.children && initiative.children.length > 0 && (
+          <Section title={`Children (${initiative.children.length})`}>
+            <ul className="space-y-1">
+              {initiative.children.map(c => (
+                <li
+                  key={c.id}
+                  className="flex items-center gap-2 p-2 rounded bg-mc-bg-secondary border border-mc-border"
+                >
+                  <span className={`px-2 py-0.5 rounded text-xs uppercase tracking-wide ${KIND_BADGE[c.kind]}`}>
+                    {c.kind}
+                  </span>
+                  <Link
+                    href={`/initiatives/${c.id}`}
+                    className="font-medium text-mc-text hover:text-mc-accent"
+                  >
+                    {c.title}
+                  </Link>
+                  <span className="text-xs text-mc-text-secondary ml-auto">{c.status}</span>
+                </li>
+              ))}
+            </ul>
+          </Section>
+        )}
+
+        {/* Tasks */}
+        <Section title={`Tasks (${tasks.length})`}>
+          {tasks.length === 0 ? (
+            <p className="text-sm text-mc-text-secondary">
+              No tasks yet. {initiative.kind === 'story' ? 'Use “Promote to task” to create one.' : ''}
+            </p>
+          ) : (
+            <div className="space-y-3">
+              <TaskGroup
+                label="Draft (planning)"
+                rows={drafts}
+                onPromote={promoteDraft}
+              />
+              <TaskGroup label="Active" rows={active} />
+              {other.length > 0 && <TaskGroup label="Other" rows={other} />}
+              <TaskGroup label="Done" rows={done} />
+            </div>
+          )}
+        </Section>
+
+        {/* Dependencies */}
+        <Section title="Dependencies" icon={<Link2 className="w-4 h-4" />}>
+          {!deps || (deps.outgoing.length === 0 && deps.incoming.length === 0) ? (
+            <p className="text-sm text-mc-text-secondary">No dependencies.</p>
+          ) : (
+            <ul className="text-sm space-y-1">
+              {deps.outgoing.map(d => (
+                <li key={d.id} className="text-mc-text-secondary">
+                  depends on{' '}
+                  <Link
+                    href={`/initiatives/${d.depends_on_initiative_id}`}
+                    className="text-mc-text hover:text-mc-accent"
+                  >
+                    {titleFor(d.depends_on_initiative_id)}
+                  </Link>
+                </li>
+              ))}
+              {deps.incoming.map(d => (
+                <li key={d.id} className="text-mc-text-secondary">
+                  blocks{' '}
+                  <Link
+                    href={`/initiatives/${d.initiative_id}`}
+                    className="text-mc-text hover:text-mc-accent"
+                  >
+                    {titleFor(d.initiative_id)}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Section>
+
+        {/* History */}
+        <Section title="Parent-change history" icon={<History className="w-4 h-4" />}>
+          {history.length === 0 ? (
+            <p className="text-sm text-mc-text-secondary">No moves recorded.</p>
+          ) : (
+            <ul className="space-y-1 text-sm">
+              {history.map(h => (
+                <li key={h.id} className="flex flex-wrap items-center gap-2">
+                  <span className="text-xs text-mc-text-secondary">
+                    {h.created_at.replace('T', ' ').slice(0, 19)}
+                  </span>
+                  <span className="text-mc-text">
+                    {titleFor(h.from_parent_id)} → {titleFor(h.to_parent_id)}
+                  </span>
+                  {h.reason && (
+                    <span className="text-mc-text-secondary italic">— {h.reason}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </Section>
+      </div>
+
+      {showPromoteModal && (
+        <PromoteToTaskModal
+          initiative={initiative}
+          onClose={() => setShowPromoteModal(false)}
+          onSaved={() => {
+            setShowPromoteModal(false);
+            refresh();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function PromoteButton({ kind, onClick }: { kind: Kind; onClick: () => void }) {
+  const isStory = kind === 'story';
+  return (
+    <button
+      onClick={isStory ? onClick : undefined}
+      disabled={!isStory}
+      title={
+        isStory
+          ? 'Create a draft task linked to this initiative'
+          : 'Only story-kind initiatives can be promoted to tasks. Convert this initiative to a story first.'
+      }
+      className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors ${
+        isStory
+          ? 'bg-mc-accent text-white hover:bg-mc-accent/90'
+          : 'bg-mc-bg-tertiary text-mc-text-secondary cursor-not-allowed border border-mc-border'
+      }`}
+    >
+      <Plus className="w-4 h-4" /> Promote to task
+    </button>
+  );
+}
+
+function Section({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-6 p-4 rounded-lg bg-mc-bg-secondary border border-mc-border">
+      <h2 className="font-medium text-mc-text mb-3 flex items-center gap-2">
+        {icon}
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function TaskGroup({
+  label,
+  rows,
+  onPromote,
+}: {
+  label: string;
+  rows: TaskRow[];
+  onPromote?: (taskId: string) => void;
+}) {
+  if (rows.length === 0) return null;
+  return (
+    <div>
+      <div className="text-xs uppercase tracking-wide text-mc-text-secondary mb-1">
+        {label} ({rows.length})
+      </div>
+      <ul className="space-y-1">
+        {rows.map(t => (
+          <li
+            key={t.id}
+            className="flex items-center gap-2 p-2 rounded bg-mc-bg border border-mc-border/60"
+          >
+            <span
+              className={`px-2 py-0.5 rounded text-[10px] uppercase tracking-wide border ${
+                STATUS_BADGE[t.status] || 'bg-slate-500/20 text-slate-300 border-slate-500/30'
+              }`}
+            >
+              {t.status}
+            </span>
+            <span className="text-sm text-mc-text flex-1">{t.title}</span>
+            {onPromote && t.status === 'draft' && (
+              <button
+                onClick={() => onPromote(t.id)}
+                className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-mc-accent/15 text-mc-accent border border-mc-accent/30 hover:bg-mc-accent/25"
+                title="Promote draft to execution queue (status → inbox)"
+              >
+                <Send className="w-3 h-3" /> Promote
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function PromoteToTaskModal({
+  initiative,
+  onClose,
+  onSaved,
+}: {
+  initiative: Initiative;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [title, setTitle] = useState(initiative.title);
+  const [description, setDescription] = useState(initiative.description ?? '');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const submit = async () => {
+    setSubmitting(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/initiatives/${initiative.id}/promote-to-task`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          task_title: title,
+          task_description: description || null,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Promote failed (${res.status})`);
+      }
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Promote failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50" onClick={onClose}>
+      <div
+        className="bg-mc-bg-secondary border border-mc-border rounded-lg p-6 w-full max-w-lg text-mc-text"
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold mb-4">Promote story to task draft</h2>
+        <p className="text-sm text-mc-text-secondary mb-4">
+          Creates one task in <code>status=draft</code>, linked to this initiative.
+          The draft lives on the planning board until you explicitly promote it
+          to the execution queue.
+        </p>
+        <div className="space-y-3">
+          <label className="block">
+            <span className="text-sm text-mc-text-secondary">Task title</span>
+            <input
+              className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              autoFocus
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm text-mc-text-secondary">Description (optional)</span>
+            <textarea
+              className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border h-28"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+            />
+          </label>
+          {err && <div className="text-red-400 text-sm">{err}</div>}
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              onClick={onClose}
+              className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={submit}
+              disabled={submitting || !title.trim()}
+              className="px-3 py-2 rounded bg-mc-accent text-white disabled:opacity-50 text-sm"
+            >
+              Promote to draft
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/initiatives/page.tsx
+++ b/src/app/initiatives/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
-import { Plus, ChevronRight, ChevronDown, Pencil, Trash2, MoveRight, Shuffle, Link2, History } from 'lucide-react';
+import { Plus, ChevronRight, ChevronDown, Pencil, Trash2, MoveRight, Shuffle, Link2, History, Send } from 'lucide-react';
 
 // Local types (kept separate from src/lib/types.ts so Phase 1 doesn't touch
 // the central type module — Phase 2 can promote these once the broader API
@@ -29,6 +29,26 @@ interface TreeNode extends Initiative {
   children: TreeNode[];
 }
 
+// Counts of tasks linked to an initiative, broken out by status family so
+// the tree can render "3 tasks: 1 draft, 2 active" inline.
+interface TaskCounts {
+  total: number;
+  draft: number;
+  active: number;
+  done: number;
+}
+
+const ACTIVE_STATUSES = new Set([
+  'inbox',
+  'planning',
+  'assigned',
+  'in_progress',
+  'convoy_active',
+  'testing',
+  'review',
+  'verification',
+]);
+
 const KIND_BADGE: Record<Kind, string> = {
   theme: 'bg-purple-500/20 text-purple-300',
   milestone: 'bg-amber-500/20 text-amber-300',
@@ -41,21 +61,43 @@ const WORKSPACE_ID = 'default';
 export default function InitiativesPage() {
   const [tree, setTree] = useState<TreeNode[]>([]);
   const [flat, setFlat] = useState<Initiative[]>([]);
+  const [taskCounts, setTaskCounts] = useState<Record<string, TaskCounts>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState<Initiative | null>(null);
   const [creating, setCreating] = useState<{ parent_id: string | null } | null>(null);
   const [moving, setMoving] = useState<Initiative | null>(null);
   const [converting, setConverting] = useState<Initiative | null>(null);
+  const [promoting, setPromoting] = useState<Initiative | null>(null);
 
   const refresh = useCallback(async () => {
     setError(null);
     try {
-      const res = await fetch(`/api/initiatives?workspace_id=${WORKSPACE_ID}`);
-      if (!res.ok) throw new Error(`Failed to load (${res.status})`);
-      const rows: Initiative[] = await res.json();
+      const [iRes, tRes] = await Promise.all([
+        fetch(`/api/initiatives?workspace_id=${WORKSPACE_ID}`),
+        fetch(`/api/tasks?workspace_id=${WORKSPACE_ID}`),
+      ]);
+      if (!iRes.ok) throw new Error(`Failed to load (${iRes.status})`);
+      const rows: Initiative[] = await iRes.json();
       setFlat(rows);
       setTree(buildTree(rows));
+
+      // Count tasks per initiative_id, partitioned by status family.
+      const counts: Record<string, TaskCounts> = {};
+      if (tRes.ok) {
+        const tasks: Array<{ initiative_id: string | null; status: string }> = await tRes.json();
+        for (const t of tasks) {
+          if (!t.initiative_id) continue;
+          const entry =
+            counts[t.initiative_id] ||
+            (counts[t.initiative_id] = { total: 0, draft: 0, active: 0, done: 0 });
+          entry.total += 1;
+          if (t.status === 'draft') entry.draft += 1;
+          else if (t.status === 'done') entry.done += 1;
+          else if (ACTIVE_STATUSES.has(t.status)) entry.active += 1;
+        }
+      }
+      setTaskCounts(counts);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load');
     } finally {
@@ -105,10 +147,12 @@ export default function InitiativesPage() {
                 node={node}
                 depth={0}
                 allInitiatives={flat}
+                taskCounts={taskCounts}
                 onEdit={setEditing}
                 onAddChild={parent => setCreating({ parent_id: parent.id })}
                 onMove={setMoving}
                 onConvert={setConverting}
+                onPromote={setPromoting}
                 onDelete={async (init) => {
                   if (!confirm(`Delete "${init.title}"?`)) return;
                   const res = await fetch(`/api/initiatives/${init.id}`, { method: 'DELETE' });
@@ -167,6 +211,16 @@ export default function InitiativesPage() {
           }}
         />
       )}
+      {promoting && (
+        <PromoteModal
+          initiative={promoting}
+          onClose={() => setPromoting(null)}
+          onSaved={() => {
+            setPromoting(null);
+            refresh();
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -190,22 +244,28 @@ function InitiativeRow({
   node,
   depth,
   allInitiatives,
+  taskCounts,
   onEdit,
   onAddChild,
   onMove,
   onConvert,
+  onPromote,
   onDelete,
 }: {
   node: TreeNode;
   depth: number;
   allInitiatives: Initiative[];
+  taskCounts: Record<string, TaskCounts>;
   onEdit: (init: Initiative) => void;
   onAddChild: (parent: Initiative) => void;
   onMove: (init: Initiative) => void;
   onConvert: (init: Initiative) => void;
+  onPromote: (init: Initiative) => void;
   onDelete: (init: Initiative) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const counts = taskCounts[node.id];
+  const isStory = node.kind === 'story';
 
   return (
     <>
@@ -217,8 +277,31 @@ function InitiativeRow({
         <span className={`px-2 py-0.5 rounded text-xs uppercase tracking-wide ${KIND_BADGE[node.kind]}`}>
           {node.kind}
         </span>
-        <span className="font-medium text-mc-text">{node.title}</span>
+        <Link
+          href={`/initiatives/${node.id}`}
+          className="font-medium text-mc-text hover:text-mc-accent"
+          title="Open initiative detail"
+        >
+          {node.title}
+        </Link>
         <span className="text-xs text-mc-text-secondary">{node.status}</span>
+        {counts && counts.total > 0 && (
+          <span
+            className="text-[11px] text-mc-text-secondary"
+            title={`${counts.total} tasks: ${counts.draft} draft, ${counts.active} active, ${counts.done} done`}
+          >
+            · {counts.total} task{counts.total === 1 ? '' : 's'}
+            {counts.draft > 0 && (
+              <span className="ml-1 px-1 rounded bg-slate-500/20 text-slate-300">{counts.draft} draft</span>
+            )}
+            {counts.active > 0 && (
+              <span className="ml-1 px-1 rounded bg-blue-500/20 text-blue-300">{counts.active} active</span>
+            )}
+            {counts.done > 0 && (
+              <span className="ml-1 px-1 rounded bg-emerald-500/20 text-emerald-300">{counts.done} done</span>
+            )}
+          </span>
+        )}
         <div className="ml-auto flex items-center gap-1">
           <button
             title={expanded ? 'Hide details' : 'Show details (history + dependencies)'}
@@ -233,6 +316,22 @@ function InitiativeRow({
             className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text"
           >
             <Plus className="w-4 h-4" />
+          </button>
+          <button
+            title={
+              isStory
+                ? 'Promote story to draft task'
+                : 'Only story-kind initiatives can be promoted to tasks. Convert this initiative to a story first.'
+            }
+            onClick={() => isStory && onPromote(node)}
+            disabled={!isStory}
+            className={`p-1.5 rounded ${
+              isStory
+                ? 'hover:bg-mc-bg text-mc-accent hover:text-mc-accent'
+                : 'text-mc-text-secondary/40 cursor-not-allowed'
+            }`}
+          >
+            <Send className="w-4 h-4" />
           </button>
           <button
             title="Edit"
@@ -278,10 +377,12 @@ function InitiativeRow({
           node={c}
           depth={depth + 1}
           allInitiatives={allInitiatives}
+          taskCounts={taskCounts}
           onEdit={onEdit}
           onAddChild={onAddChild}
           onMove={onMove}
           onConvert={onConvert}
+          onPromote={onPromote}
           onDelete={onDelete}
         />
       ))}
@@ -951,6 +1052,87 @@ function ConvertModal({
             className="px-3 py-2 rounded bg-mc-accent text-white disabled:opacity-50 text-sm"
           >
             Convert
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+function PromoteModal({
+  initiative,
+  onClose,
+  onSaved,
+}: {
+  initiative: Initiative;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [title, setTitle] = useState(initiative.title);
+  const [description, setDescription] = useState(initiative.description ?? '');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const submit = async () => {
+    setSubmitting(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/initiatives/${initiative.id}/promote-to-task`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          task_title: title,
+          task_description: description || null,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Promote failed (${res.status})`);
+      }
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Promote failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <ModalShell title={`Promote "${initiative.title}" to task draft`} onClose={onClose}>
+      <div className="space-y-3">
+        <p className="text-xs text-mc-text-secondary">
+          Creates one task in <code>status=draft</code>, linked to this initiative.
+          The draft stays on the planning board until you promote it to the
+          execution queue.
+        </p>
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Task title</span>
+          <input
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            autoFocus
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm text-mc-text-secondary">Description (optional)</span>
+          <textarea
+            className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border h-24"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+          />
+        </label>
+        {err && <div className="text-red-400 text-sm">{err}</div>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button onClick={onClose} className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm">
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={submitting || !title.trim()}
+            className="px-3 py-2 rounded bg-mc-accent text-white disabled:opacity-50 text-sm"
+          >
+            Promote to draft
           </button>
         </div>
       </div>

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -29,10 +29,40 @@ const COLUMNS: { id: TaskStatus; label: string; color: string }[] = [
   { id: 'done', label: 'Done', color: 'border-t-mc-accent-green' },
 ];
 
+interface InitiativeMini {
+  id: string;
+  title: string;
+}
+
 export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = true }: MissionQueueProps) {
   const { tasks, updateTaskStatus, addEvent } = useMissionControl();
   const [compactEmptyColumns, setCompactEmptyColumns] = useState(true);
   const [showArchived, setShowArchived] = useState(false);
+  // Light-weight lookup so task cards can render the owning initiative's
+  // title without a per-card fetch. Refreshed when workspaceId changes.
+  const [initiativeTitles, setInitiativeTitles] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          workspaceId ? `/api/initiatives?workspace_id=${workspaceId}` : '/api/initiatives',
+        );
+        if (!res.ok) return;
+        const rows: InitiativeMini[] = await res.json();
+        if (cancelled) return;
+        const map: Record<string, string> = {};
+        for (const r of rows) map[r.id] = r.title;
+        setInitiativeTitles(map);
+      } catch {
+        /* non-fatal — badge falls back to id */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]);
   // Per-column manual override. Without an entry, the column uses the default
   // (empty = collapsed to a vertical rail, non-empty = expanded).
   const [columnOverride, setColumnOverride] = useState<Record<string, 'expanded' | 'collapsed'>>({});
@@ -71,8 +101,15 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
   const [statusMoveTask, setStatusMoveTask] = useState<Task | null>(null);
   const [pendingMove, setPendingMove] = useState<{ task: Task; targetStatus: TaskStatus } | null>(null);
 
+  // Drafts (status='draft') belong to the planning board only — see spec
+  // §13.2 (Workflow Unification). They never appear in the execution queue.
   const getTasksByStatus = (status: TaskStatus) =>
-    tasks.filter((task) => task.status === status && (showArchived || !task.is_archived));
+    tasks.filter(
+      (task) =>
+        task.status === status &&
+        task.status !== ('draft' as TaskStatus) &&
+        (showArchived || !task.is_archived),
+    );
 
   // Active pipeline states where manual moves are dangerous
   const ACTIVE_PIPELINE_STATES: TaskStatus[] = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification'];
@@ -279,6 +316,7 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
                       mobileMode={false}
                       portraitMode={false}
                       unreadCount={unreadCounts[task.id] || 0}
+                      initiativeTitles={initiativeTitles}
                     />
                   ))}
                 </div>
@@ -325,6 +363,7 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
                   mobileMode
                   portraitMode={isPortrait}
                   unreadCount={unreadCounts[task.id] || 0}
+                  initiativeTitles={initiativeTitles}
                 />
               ))
             )}
@@ -467,9 +506,10 @@ interface TaskCardProps {
   mobileMode: boolean;
   portraitMode?: boolean;
   unreadCount?: number;
+  initiativeTitles?: Record<string, string>;
 }
 
-function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobileMode, portraitMode = true, unreadCount = 0 }: TaskCardProps) {
+function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobileMode, portraitMode = true, unreadCount = 0, initiativeTitles = {} }: TaskCardProps) {
   const priorityStyles = {
     low: 'text-mc-text-secondary',
     normal: 'text-mc-accent',
@@ -528,6 +568,23 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
             </span>
           )}
         </div>
+
+        {task.initiative_id && (
+          // Quiet initiative badge — clicking it stops propagation so the
+          // card click (open modal) doesn't fire when the operator wants
+          // to navigate to the initiative detail page.
+          <a
+            href={`/initiatives/${task.initiative_id}`}
+            onClick={(e) => e.stopPropagation()}
+            className={`inline-flex items-center gap-1 ${portraitMode ? 'mb-2' : 'mb-1.5'} max-w-full text-[10px] px-1.5 py-0.5 rounded-sm bg-emerald-500/10 text-emerald-300 border border-emerald-500/20 hover:bg-emerald-500/20 truncate`}
+            title="Linked to initiative"
+          >
+            <span className="opacity-70">↳</span>
+            <span className="truncate">
+              {initiativeTitles[task.initiative_id] ?? `Initiative ${task.initiative_id.slice(0, 6)}…`}
+            </span>
+          </a>
+        )}
 
         {isPlanning && (
           <div className={`flex items-center gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-purple-500/10 rounded-md border border-purple-500/20`}>

--- a/src/components/TaskInitiativePanel.tsx
+++ b/src/components/TaskInitiativePanel.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+/**
+ * Task → Initiative panel rendered inside the task modal Overview tab.
+ *
+ * Surfaces:
+ *   - Owning initiative (if any) with a link to /initiatives/[id].
+ *   - Provenance trail (collapsed) — every task_initiative_history row.
+ *   - "Move to initiative" picker (workspace-scoped).
+ *   - "Detach from initiative" button.
+ *   - Promote-from-draft action when status='draft'.
+ *
+ * All mutations go through the Phase 2 API endpoints:
+ *   POST /api/tasks/[id]/move-initiative
+ *   POST /api/tasks/[id]/promote
+ *   GET  /api/tasks/[id]/initiative-history
+ *
+ * Designed to be self-contained — owns its own state, refresh, and error
+ * surface so TaskModal doesn't need to thread props for it.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { Send, MoveRight, Unlink, ChevronDown, ChevronRight as Chevron } from 'lucide-react';
+
+interface InitiativeLite {
+  id: string;
+  title: string;
+  kind: string;
+  workspace_id: string;
+}
+
+interface HistoryRow {
+  id: string;
+  from_initiative_id: string | null;
+  from_initiative_title: string | null;
+  to_initiative_id: string | null;
+  to_initiative_title: string | null;
+  reason: string | null;
+  moved_by_agent_id: string | null;
+  created_at: string;
+}
+
+interface Props {
+  taskId: string;
+  taskStatus: string;
+  workspaceId: string;
+  initiativeId: string | null;
+  /**
+   * Notified after a successful mutation so the parent modal can refresh
+   * its task object (status flip on promote, initiative_id change on move).
+   */
+  onChanged: () => void;
+}
+
+export function TaskInitiativePanel({
+  taskId,
+  taskStatus,
+  workspaceId,
+  initiativeId,
+  onChanged,
+}: Props) {
+  const [initiatives, setInitiatives] = useState<InitiativeLite[]>([]);
+  const [history, setHistory] = useState<HistoryRow[]>([]);
+  const [chosen, setChosen] = useState<string>('');
+  const [reason, setReason] = useState('');
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [busy, setBusy] = useState<'move' | 'detach' | 'promote' | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const loadHistory = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/tasks/${taskId}/initiative-history`);
+      if (res.ok) setHistory(await res.json());
+    } catch {
+      /* non-fatal */
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/initiatives?workspace_id=${workspaceId}`);
+        if (res.ok && !cancelled) setInitiatives(await res.json());
+      } catch {
+        /* non-fatal */
+      }
+    })();
+    loadHistory();
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, loadHistory]);
+
+  const owning = initiativeId ? initiatives.find(i => i.id === initiativeId) : null;
+
+  const move = async (toId: string | null, action: 'move' | 'detach') => {
+    setBusy(action);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/tasks/${taskId}/move-initiative`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          to_initiative_id: toId,
+          reason: reason || null,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Move failed (${res.status})`);
+      }
+      setChosen('');
+      setReason('');
+      await loadHistory();
+      onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Move failed');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const promote = async () => {
+    setBusy('promote');
+    setErr(null);
+    try {
+      const res = await fetch(`/api/tasks/${taskId}/promote`, { method: 'POST' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Promote failed (${res.status})`);
+      }
+      onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Promote failed');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="p-3 bg-mc-bg rounded-lg border border-mc-border space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <h4 className="text-sm font-medium text-mc-text">Initiative</h4>
+        {taskStatus === 'draft' && (
+          <button
+            type="button"
+            onClick={promote}
+            disabled={busy === 'promote'}
+            className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-mc-accent/20 text-mc-accent border border-mc-accent/30 hover:bg-mc-accent/30 disabled:opacity-50"
+            title="Promote draft to execution queue (status → inbox)"
+          >
+            <Send className="w-3 h-3" />
+            {busy === 'promote' ? 'Promoting…' : 'Promote draft → inbox'}
+          </button>
+        )}
+      </div>
+
+      <div className="text-sm">
+        {owning ? (
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-mc-text-secondary">Owning initiative:</span>
+            <Link
+              href={`/initiatives/${owning.id}`}
+              className="text-mc-accent hover:underline"
+            >
+              {owning.title}
+            </Link>
+            <span className="text-[10px] uppercase tracking-wide text-mc-text-secondary">
+              ({owning.kind})
+            </span>
+          </div>
+        ) : initiativeId ? (
+          <span className="text-mc-text-secondary">
+            Initiative {initiativeId.slice(0, 8)}…
+          </span>
+        ) : (
+          <span className="text-mc-text-secondary italic">Not linked to an initiative.</span>
+        )}
+      </div>
+
+      {/* Move / detach controls */}
+      <div className="space-y-2">
+        <div className="flex gap-2">
+          <select
+            className="flex-1 min-h-9 px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border text-xs"
+            value={chosen}
+            onChange={e => setChosen(e.target.value)}
+          >
+            <option value="">(choose initiative to move to)</option>
+            {initiatives
+              .filter(i => i.id !== initiativeId)
+              .map(i => (
+                <option key={i.id} value={i.id}>
+                  {i.kind} — {i.title}
+                </option>
+              ))}
+          </select>
+          <button
+            type="button"
+            disabled={!chosen || busy === 'move'}
+            onClick={() => move(chosen, 'move')}
+            className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border hover:border-mc-accent/40 disabled:opacity-50"
+          >
+            <MoveRight className="w-3 h-3" />
+            {busy === 'move' ? 'Moving…' : 'Move'}
+          </button>
+          {initiativeId && (
+            <button
+              type="button"
+              disabled={busy === 'detach'}
+              onClick={() => move(null, 'detach')}
+              className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border hover:border-red-500/40 hover:text-red-300 disabled:opacity-50"
+              title="Detach (set initiative_id=NULL); audit row recorded"
+            >
+              <Unlink className="w-3 h-3" />
+              Detach
+            </button>
+          )}
+        </div>
+        <input
+          className="w-full px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border text-xs"
+          placeholder="Reason (optional, recorded in audit history)"
+          value={reason}
+          onChange={e => setReason(e.target.value)}
+        />
+      </div>
+
+      {err && <div className="text-xs text-red-400">{err}</div>}
+
+      {/* Provenance trail */}
+      <div>
+        <button
+          type="button"
+          onClick={() => setHistoryOpen(v => !v)}
+          className="inline-flex items-center gap-1 text-xs text-mc-text-secondary hover:text-mc-text"
+        >
+          {historyOpen ? <ChevronDown className="w-3 h-3" /> : <Chevron className="w-3 h-3" />}
+          Provenance ({history.length})
+        </button>
+        {historyOpen && (
+          history.length === 0 ? (
+            <p className="text-xs text-mc-text-secondary mt-2">No history rows.</p>
+          ) : (
+            <ul className="space-y-1 text-xs mt-2">
+              {history.map(h => (
+                <li key={h.id} className="flex flex-wrap items-center gap-2 p-2 rounded bg-mc-bg-secondary border border-mc-border/60">
+                  <span className="text-mc-text-secondary">
+                    {h.created_at.replace('T', ' ').slice(0, 19)}
+                  </span>
+                  <span className="text-mc-text">
+                    {h.from_initiative_title ?? '—'} → {h.to_initiative_title ?? '—'}
+                  </span>
+                  {h.reason && (
+                    <span className="text-mc-text-secondary italic">— {h.reason}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -16,6 +16,7 @@ import { AgentLiveTab } from './AgentLiveTab';
 import { TaskChatTab } from './TaskChatTab';
 import { WorkspaceTab } from './WorkspaceTab';
 import { DeliverablePicker, type PickerDeliverable } from './DeliverablePicker';
+import { TaskInitiativePanel } from './TaskInitiativePanel';
 import type { Task, TaskPriority, TaskStatus } from '@/lib/types';
 
 const MAX_UPLOAD_BYTES = 100 * 1024 * 1024; // 100 MB — server enforces the same cap
@@ -637,6 +638,17 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
               </div>
             )}
           </div>
+
+          {/* Initiative + provenance — only meaningful for existing tasks */}
+          {task && (
+            <TaskInitiativePanel
+              taskId={task.id}
+              taskStatus={task.status}
+              workspaceId={task.workspace_id || workspaceId || 'default'}
+              initiativeId={task.initiative_id ?? null}
+              onChanged={handleSpecLocked}
+            />
+          )}
 
           {/* Pull Request section */}
           {task?.pr_url && (

--- a/src/components/autopilot/IdeasList.tsx
+++ b/src/components/autopilot/IdeasList.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { Sparkles, ArrowUpRight } from 'lucide-react';
 import { IdeaCard } from './IdeaCard';
 import type { Idea } from '@/lib/types';
 
@@ -8,27 +10,83 @@ interface IdeasListProps {
   productId: string;
 }
 
+interface InitiativeMini {
+  id: string;
+  title: string;
+}
+
 export function IdeasList({ productId }: IdeasListProps) {
   const [ideas, setIdeas] = useState<Idea[]>([]);
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState('');
   const [categoryFilter, setCategoryFilter] = useState('');
+  const [initiatives, setInitiatives] = useState<Record<string, InitiativeMini>>({});
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const params = new URLSearchParams();
+      if (statusFilter) params.set('status', statusFilter);
+      if (categoryFilter) params.set('category', categoryFilter);
+      const res = await fetch(`/api/products/${productId}/ideas?${params}`);
+      if (res.ok) setIdeas(await res.json());
+    } catch (error) {
+      console.error('Failed to load ideas:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [productId, statusFilter, categoryFilter]);
 
   useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Cache initiative titles referenced by these ideas so the "→ Initiative"
+  // link reads as a real title rather than a UUID. We only need workspace-
+  // scoped data; pulling the unfiltered list keeps the call cheap and
+  // matches how /initiatives renders.
+  useEffect(() => {
+    let cancelled = false;
     (async () => {
       try {
-        const params = new URLSearchParams();
-        if (statusFilter) params.set('status', statusFilter);
-        if (categoryFilter) params.set('category', categoryFilter);
-        const res = await fetch(`/api/products/${productId}/ideas?${params}`);
-        if (res.ok) setIdeas(await res.json());
-      } catch (error) {
-        console.error('Failed to load ideas:', error);
-      } finally {
-        setLoading(false);
+        const res = await fetch('/api/initiatives');
+        if (!res.ok || cancelled) return;
+        const rows: InitiativeMini[] = await res.json();
+        const map: Record<string, InitiativeMini> = {};
+        for (const r of rows) map[r.id] = r;
+        setInitiatives(map);
+      } catch {
+        /* non-fatal */
       }
     })();
-  }, [productId, statusFilter, categoryFilter]);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const promote = async (idea: Idea) => {
+    setActionError(null);
+    setBusyId(idea.id);
+    try {
+      const res = await fetch(`/api/ideas/${idea.id}/promote-to-initiative`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ kind: 'story', copy_description: true }),
+      });
+      if (!res.ok && res.status !== 409) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Promote failed (${res.status})`);
+      }
+      // 409 means already promoted — we still want to refresh so the UI shows
+      // the existing initiative link.
+      await refresh();
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : 'Promote failed');
+    } finally {
+      setBusyId(null);
+    }
+  };
 
   const statuses = ['', 'pending', 'approved', 'rejected', 'maybe', 'building', 'built', 'shipped'];
   const categories = ['', 'feature', 'improvement', 'ux', 'performance', 'integration', 'infrastructure', 'content', 'growth', 'monetization', 'operations', 'security'];
@@ -57,15 +115,56 @@ export function IdeasList({ productId }: IdeasListProps) {
         <span className="text-sm text-mc-text-secondary self-center">{ideas.length} ideas</span>
       </div>
 
+      {actionError && (
+        <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300 text-sm">
+          {actionError}
+        </div>
+      )}
+
       {loading ? (
         <div className="text-mc-text-secondary animate-pulse py-8 text-center">Loading ideas...</div>
       ) : ideas.length === 0 ? (
         <div className="text-center py-12 text-mc-text-secondary">No ideas found</div>
       ) : (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {ideas.map(idea => (
-            <IdeaCard key={idea.id} idea={idea} showActions={false} compact />
-          ))}
+          {ideas.map(idea => {
+            const owningInitiative = idea.initiative_id ? initiatives[idea.initiative_id] : null;
+            return (
+              <div key={idea.id} className="space-y-2">
+                <IdeaCard idea={idea} showActions={false} compact />
+                {/* Roadmap path indicator: distinct from the autopilot
+                    `task_id` path so operators can see which routes the
+                    idea has taken. */}
+                <div className="flex flex-wrap gap-2 px-1">
+                  {idea.task_id && (
+                    <span className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-blue-500/10 text-blue-300 border border-blue-500/20">
+                      <ArrowUpRight className="w-3 h-3" />
+                      Autopilot task
+                    </span>
+                  )}
+                  {owningInitiative ? (
+                    <Link
+                      href={`/initiatives/${owningInitiative.id}`}
+                      className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-emerald-500/10 text-emerald-300 border border-emerald-500/20 hover:bg-emerald-500/20"
+                    >
+                      <Sparkles className="w-3 h-3" />
+                      → Initiative: {owningInitiative.title}
+                    </Link>
+                  ) : (
+                    <button
+                      onClick={() => promote(idea)}
+                      disabled={busyId === idea.id}
+                      className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-emerald-500/10 text-emerald-300 border border-emerald-500/20 hover:bg-emerald-500/20 disabled:opacity-50"
+                      title="Create a planning-layer initiative from this idea (does not affect autopilot)"
+                    >
+                      <Sparkles className="w-3 h-3" />
+                      {busyId === idea.id ? 'Promoting…' : 'Promote to initiative'}
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/lib/db/promotion.test.ts
+++ b/src/lib/db/promotion.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Promotion DB-helper tests (Phase 2 of the roadmap planning layer).
+ *
+ * Covers spec §3.3, §6, and §13:
+ *   - story → task(draft) promotion is rejected for non-story kinds
+ *   - draft → inbox flips status, emits event, rejects already-inbox tasks
+ *   - idea → initiative is idempotent (re-promotion returns the existing one)
+ *   - mid-execution re-parenting works and writes audit rows
+ *   - history join returns rows in order with both titles
+ *   - convert emits initiative_kind_changed event
+ *   - end-to-end provenance trace: idea → initiative → draft → move → inbox
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+import {
+  createInitiative,
+  moveTaskToInitiative,
+  convertInitiative,
+} from './initiatives';
+import {
+  promoteInitiativeToTask,
+  promoteTaskToInbox,
+  promoteIdeaToInitiative,
+  getTaskInitiativeHistory,
+  emitConvertEvent,
+} from './promotion';
+
+function seedProduct(workspaceId = 'default'): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO products (id, workspace_id, name, created_at, updated_at)
+     VALUES (?, ?, 'P', datetime('now'), datetime('now'))`,
+    [id, workspaceId],
+  );
+  return id;
+}
+
+function seedIdea(opts: { productId?: string; title?: string; description?: string } = {}): string {
+  const productId = opts.productId ?? seedProduct();
+  const id = uuidv4();
+  run(
+    `INSERT INTO ideas (id, product_id, title, description, category, source, status, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 'feature', 'manual', 'pending', datetime('now'), datetime('now'))`,
+    [id, productId, opts.title ?? 'Idea', opts.description ?? 'Idea desc'],
+  );
+  return id;
+}
+
+function seedTask(opts: { initiativeId?: string | null; status?: string } = {}): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, initiative_id, created_at, updated_at)
+     VALUES (?, 'T', ?, 'normal', 'default', 'default', ?, datetime('now'), datetime('now'))`,
+    [id, opts.status ?? 'inbox', opts.initiativeId ?? null],
+  );
+  return id;
+}
+
+// ─── promoteInitiativeToTask ───────────────────────────────────────────
+
+test('promoteInitiativeToTask creates a draft task with correct workspace + audit row', () => {
+  const init = createInitiative({
+    workspace_id: 'default',
+    kind: 'story',
+    title: 'Build feature X',
+    description: 'Big plans',
+  });
+  const { id: taskId } = promoteInitiativeToTask(init.id);
+
+  const task = queryOne<{
+    title: string;
+    status: string;
+    workspace_id: string;
+    initiative_id: string;
+    description: string | null;
+  }>(
+    'SELECT title, status, workspace_id, initiative_id, description FROM tasks WHERE id = ?',
+    [taskId],
+  );
+  assert.equal(task?.status, 'draft');
+  assert.equal(task?.workspace_id, 'default');
+  assert.equal(task?.initiative_id, init.id);
+  assert.equal(task?.title, 'Build feature X');
+  assert.equal(task?.description, 'Big plans');
+
+  const history = queryAll<{ from_initiative_id: string | null; to_initiative_id: string | null; reason: string | null }>(
+    'SELECT from_initiative_id, to_initiative_id, reason FROM task_initiative_history WHERE task_id = ?',
+    [taskId],
+  );
+  assert.equal(history.length, 1);
+  assert.equal(history[0].from_initiative_id, null);
+  assert.equal(history[0].to_initiative_id, init.id);
+  assert.equal(history[0].reason, 'initial promotion');
+});
+
+test('promoteInitiativeToTask rejects non-story initiatives with the spec-required error', () => {
+  for (const kind of ['theme', 'milestone', 'epic'] as const) {
+    const init = createInitiative({ workspace_id: 'default', kind, title: kind });
+    assert.throws(
+      () => promoteInitiativeToTask(init.id),
+      /Only story-kind initiatives can be promoted/,
+    );
+  }
+});
+
+test('promoteInitiativeToTask honours overridden title and description', () => {
+  const init = createInitiative({ workspace_id: 'default', kind: 'story', title: 'Original' });
+  const { id: taskId } = promoteInitiativeToTask(init.id, {
+    task_title: 'Custom title',
+    task_description: 'Custom description',
+    status_check_md: 'PR pending',
+  });
+  const task = queryOne<{ title: string; description: string | null; status_check_md: string | null }>(
+    'SELECT title, description, status_check_md FROM tasks WHERE id = ?',
+    [taskId],
+  );
+  assert.equal(task?.title, 'Custom title');
+  assert.equal(task?.description, 'Custom description');
+  assert.equal(task?.status_check_md, 'PR pending');
+});
+
+// ─── promoteTaskToInbox ────────────────────────────────────────────────
+
+test('promoteTaskToInbox flips draft → inbox and emits an event', () => {
+  const init = createInitiative({ workspace_id: 'default', kind: 'story', title: 's' });
+  const { id: taskId } = promoteInitiativeToTask(init.id);
+
+  promoteTaskToInbox(taskId);
+
+  const task = queryOne<{ status: string }>('SELECT status FROM tasks WHERE id = ?', [taskId]);
+  assert.equal(task?.status, 'inbox');
+
+  const events = queryAll<{ type: string; task_id: string }>(
+    "SELECT type, task_id FROM events WHERE task_id = ? AND type = 'task_promoted_to_inbox'",
+    [taskId],
+  );
+  assert.equal(events.length, 1);
+});
+
+test('promoteTaskToInbox throws when task is not in draft', () => {
+  const taskId = seedTask({ status: 'inbox' });
+  assert.throws(
+    () => promoteTaskToInbox(taskId),
+    /not in draft/,
+  );
+});
+
+test('promoteTaskToInbox throws on missing task', () => {
+  assert.throws(() => promoteTaskToInbox('does-not-exist'), /Task not found/);
+});
+
+// ─── promoteIdeaToInitiative ───────────────────────────────────────────
+
+test('promoteIdeaToInitiative creates initiative with source_idea_id and updates idea pointer', () => {
+  const productId = seedProduct();
+  const ideaId = seedIdea({ productId, title: 'Idea X', description: 'Description' });
+
+  const result = promoteIdeaToInitiative(ideaId);
+  assert.equal(result.alreadyPromoted, false);
+  assert.equal(result.initiative.source_idea_id, ideaId);
+  assert.equal(result.initiative.title, 'Idea X');
+  assert.equal(result.initiative.description, 'Description');
+  assert.equal(result.initiative.kind, 'story');
+  assert.equal(result.initiative.product_id, productId);
+
+  const idea = queryOne<{ initiative_id: string }>(
+    'SELECT initiative_id FROM ideas WHERE id = ?',
+    [ideaId],
+  );
+  assert.equal(idea?.initiative_id, result.initiative.id);
+});
+
+test('promoteIdeaToInitiative is idempotent — re-promotion returns alreadyPromoted=true', () => {
+  const ideaId = seedIdea();
+  const first = promoteIdeaToInitiative(ideaId);
+  const second = promoteIdeaToInitiative(ideaId);
+  assert.equal(second.alreadyPromoted, true);
+  assert.equal(second.initiative.id, first.initiative.id);
+});
+
+test('promoteIdeaToInitiative honours kind override and copy_description=false', () => {
+  const ideaId = seedIdea({ description: 'should not copy' });
+  const result = promoteIdeaToInitiative(ideaId, {
+    kind: 'epic',
+    copy_description: false,
+  });
+  assert.equal(result.initiative.kind, 'epic');
+  assert.equal(result.initiative.description, null);
+});
+
+test('idea→task autopilot path is unaffected by the new idea→initiative path', () => {
+  // Smoke test: an idea may have task_id (autopilot) AND initiative_id
+  // (planning) simultaneously. Promotion should not collide.
+  const productId = seedProduct();
+  const ideaId = seedIdea({ productId });
+  const taskId = seedTask();
+  run('UPDATE ideas SET task_id = ? WHERE id = ?', [taskId, ideaId]);
+
+  const result = promoteIdeaToInitiative(ideaId);
+  const idea = queryOne<{ task_id: string | null; initiative_id: string | null }>(
+    'SELECT task_id, initiative_id FROM ideas WHERE id = ?',
+    [ideaId],
+  );
+  assert.equal(idea?.task_id, taskId);
+  assert.equal(idea?.initiative_id, result.initiative.id);
+});
+
+// ─── moveTaskToInitiative mid-execution + detach ───────────────────────
+
+test('moveTaskToInitiative on an in_progress task preserves status and writes audit row', async () => {
+  const a = createInitiative({ workspace_id: 'default', kind: 'story', title: 'A' });
+  const b = createInitiative({ workspace_id: 'default', kind: 'story', title: 'B' });
+  // Promote A→draft, manually flip status to in_progress to mimic mid-execution.
+  const { id: taskId } = promoteInitiativeToTask(a.id);
+  run("UPDATE tasks SET status = 'in_progress' WHERE id = ?", [taskId]);
+  await new Promise(r => setTimeout(r, 5));
+
+  moveTaskToInitiative(taskId, b.id, null, 'rescoped to B');
+
+  const task = queryOne<{ status: string; initiative_id: string }>(
+    'SELECT status, initiative_id FROM tasks WHERE id = ?',
+    [taskId],
+  );
+  assert.equal(task?.status, 'in_progress');
+  assert.equal(task?.initiative_id, b.id);
+
+  const history = queryAll<{ from_initiative_id: string | null; to_initiative_id: string | null }>(
+    'SELECT from_initiative_id, to_initiative_id FROM task_initiative_history WHERE task_id = ? ORDER BY created_at',
+    [taskId],
+  );
+  assert.equal(history.length, 2);
+  assert.equal(history[1].from_initiative_id, a.id);
+  assert.equal(history[1].to_initiative_id, b.id);
+});
+
+test('detaching a task (to_initiative_id=null) writes a null audit row', () => {
+  const a = createInitiative({ workspace_id: 'default', kind: 'story', title: 'A' });
+  const { id: taskId } = promoteInitiativeToTask(a.id);
+
+  moveTaskToInitiative(taskId, null, null, 'orphaning');
+
+  const task = queryOne<{ initiative_id: string | null }>(
+    'SELECT initiative_id FROM tasks WHERE id = ?',
+    [taskId],
+  );
+  assert.equal(task?.initiative_id, null);
+
+  const history = queryAll<{ to_initiative_id: string | null }>(
+    'SELECT to_initiative_id FROM task_initiative_history WHERE task_id = ? ORDER BY created_at',
+    [taskId],
+  );
+  assert.equal(history[history.length - 1].to_initiative_id, null);
+});
+
+// ─── getTaskInitiativeHistory join ────────────────────────────────────
+
+test('getTaskInitiativeHistory returns chronological rows with both titles joined', async () => {
+  const a = createInitiative({ workspace_id: 'default', kind: 'story', title: 'Alpha' });
+  const b = createInitiative({ workspace_id: 'default', kind: 'story', title: 'Beta' });
+  const { id: taskId } = promoteInitiativeToTask(a.id);
+  // ISO created_at is millisecond-precision but consecutive helpers can
+  // collide on the same ms; force a 2ms gap so ordering is deterministic.
+  await new Promise(r => setTimeout(r, 5));
+  moveTaskToInitiative(taskId, b.id, null, 'shift');
+  await new Promise(r => setTimeout(r, 5));
+  moveTaskToInitiative(taskId, null, null, 'detach');
+
+  const rows = getTaskInitiativeHistory(taskId);
+  assert.equal(rows.length, 3);
+  assert.equal(rows[0].from_initiative_id, null);
+  assert.equal(rows[0].to_initiative_title, 'Alpha');
+  assert.equal(rows[1].from_initiative_title, 'Alpha');
+  assert.equal(rows[1].to_initiative_title, 'Beta');
+  // null initiative_id must not break the join — column is null, not undefined.
+  assert.equal(rows[2].to_initiative_id, null);
+  assert.equal(rows[2].to_initiative_title, null);
+});
+
+// ─── emitConvertEvent ─────────────────────────────────────────────────
+
+test('emitConvertEvent writes an initiative_kind_changed row when kinds differ', () => {
+  const init = createInitiative({ workspace_id: 'default', kind: 'story', title: 'C' });
+  convertInitiative(init.id, 'epic');
+  emitConvertEvent({
+    initiative_id: init.id,
+    initiative_title: init.title,
+    from_kind: 'story',
+    to_kind: 'epic',
+    reason: 'scope grew',
+  });
+
+  const events = queryAll<{ type: string; metadata: string | null }>(
+    "SELECT type, metadata FROM events WHERE type = 'initiative_kind_changed'",
+  );
+  const matching = events.find(e => e.metadata && e.metadata.includes(init.id));
+  assert.ok(matching, 'event row not found');
+  const meta = JSON.parse(matching!.metadata!);
+  assert.equal(meta.from_kind, 'story');
+  assert.equal(meta.to_kind, 'epic');
+  assert.equal(meta.reason, 'scope grew');
+});
+
+test('emitConvertEvent is a no-op when from_kind === to_kind', () => {
+  const init = createInitiative({ workspace_id: 'default', kind: 'story', title: 'D' });
+  const beforeCount = queryOne<{ n: number }>(
+    "SELECT COUNT(*) as n FROM events WHERE type = 'initiative_kind_changed'",
+  )!.n;
+  emitConvertEvent({
+    initiative_id: init.id,
+    initiative_title: init.title,
+    from_kind: 'story',
+    to_kind: 'story',
+  });
+  const afterCount = queryOne<{ n: number }>(
+    "SELECT COUNT(*) as n FROM events WHERE type = 'initiative_kind_changed'",
+  )!.n;
+  assert.equal(afterCount, beforeCount);
+});
+
+// ─── end-to-end provenance trace ──────────────────────────────────────
+
+test('end-to-end: idea → initiative → draft → move → promote-to-inbox preserves full provenance', async () => {
+  // Idea
+  const productId = seedProduct();
+  const ideaId = seedIdea({ productId, title: 'Big idea' });
+
+  // Promote idea → initiative A
+  const { initiative: a } = promoteIdeaToInitiative(ideaId);
+  assert.equal(a.title, 'Big idea');
+  assert.equal(a.source_idea_id, ideaId);
+
+  // Decompose: another initiative B in the same workspace
+  const b = createInitiative({ workspace_id: a.workspace_id, kind: 'story', title: 'Spinoff' });
+
+  // Promote A to draft task
+  const { id: taskId } = promoteInitiativeToTask(a.id, { task_title: 'Build it' });
+
+  // Re-parent draft to B (gap ensures audit row ordering is deterministic).
+  await new Promise(r => setTimeout(r, 5));
+  moveTaskToInitiative(taskId, b.id, null, 'rescoped');
+
+  // Promote draft → inbox
+  promoteTaskToInbox(taskId);
+
+  // Final state
+  const task = queryOne<{ initiative_id: string; status: string }>(
+    'SELECT initiative_id, status FROM tasks WHERE id = ?',
+    [taskId],
+  );
+  assert.equal(task?.initiative_id, b.id);
+  assert.equal(task?.status, 'inbox');
+
+  const history = queryAll<{ from_initiative_id: string | null; to_initiative_id: string | null }>(
+    'SELECT from_initiative_id, to_initiative_id FROM task_initiative_history WHERE task_id = ? ORDER BY created_at',
+    [taskId],
+  );
+  assert.equal(history.length, 2);
+  assert.equal(history[0].from_initiative_id, null);
+  assert.equal(history[0].to_initiative_id, a.id);
+  assert.equal(history[1].from_initiative_id, a.id);
+  assert.equal(history[1].to_initiative_id, b.id);
+
+  // Idea still references its original initiative A
+  const idea = queryOne<{ initiative_id: string }>(
+    'SELECT initiative_id FROM ideas WHERE id = ?',
+    [ideaId],
+  );
+  assert.equal(idea?.initiative_id, a.id);
+});

--- a/src/lib/db/promotion.ts
+++ b/src/lib/db/promotion.ts
@@ -1,0 +1,368 @@
+/**
+ * Promotion DB helpers (Phase 2 of the roadmap planning layer).
+ *
+ * Three operator-driven promotion edges, all atomic, all audited:
+ *   1. idea  → initiative   (creates initiative, idea retained, idea.initiative_id set)
+ *   2. story → task(draft)  (creates task in status='draft', writes initial audit row)
+ *   3. task(draft) → task(inbox) (status flip, event emitted)
+ *
+ * See specs/roadmap-and-pm-spec.md §3.3 (Promotion edges) and §13 (Workflow
+ * unification). Phase 1 already implemented attachTaskToInitiative and
+ * moveTaskToInitiative — those are reused here, not reimplemented.
+ *
+ * All multi-row writes go through `transaction()` so the audit row and the
+ * state change are atomic per the spec invariant in §6.1.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { getDb, queryAll, queryOne, run } from '@/lib/db';
+import type { Initiative } from './initiatives';
+
+/**
+ * Internal row shape for the JOIN we expose via getTaskInitiativeHistory.
+ * The route handler returns this shape directly (callers don't need a
+ * separate type — the field set is API-stable).
+ */
+export interface TaskInitiativeHistoryRow {
+  id: string;
+  task_id: string;
+  from_initiative_id: string | null;
+  from_initiative_title: string | null;
+  to_initiative_id: string | null;
+  to_initiative_title: string | null;
+  reason: string | null;
+  moved_by_agent_id: string | null;
+  created_at: string;
+}
+
+export interface PromoteInitiativeToTaskInput {
+  task_title?: string;
+  task_description?: string | null;
+  status_check_md?: string | null;
+  created_by_agent_id?: string | null;
+  reason?: string | null;
+}
+
+/**
+ * Promote a story-kind initiative to a draft task. Creates one task row
+ * with status='draft' and initiative_id set, plus an initial
+ * task_initiative_history row (from_initiative_id=NULL).
+ *
+ * Throws when the initiative isn't kind='story' — the operator must convert
+ * theme/milestone/epic to story first (per spec §3.3).
+ */
+export function promoteInitiativeToTask(
+  initiative_id: string,
+  input: PromoteInitiativeToTaskInput = {},
+): { id: string } {
+  const initiative = queryOne<Initiative>(
+    'SELECT * FROM initiatives WHERE id = ?',
+    [initiative_id],
+  );
+  if (!initiative) {
+    throw new Error(`Initiative not found: ${initiative_id}`);
+  }
+  if (initiative.kind !== 'story') {
+    throw new Error(
+      'Only story-kind initiatives can be promoted to tasks. Convert this initiative to a story first.',
+    );
+  }
+
+  const taskId = uuidv4();
+  const now = new Date().toISOString();
+  const title = (input.task_title ?? initiative.title).trim() || initiative.title;
+
+  // The default workflow template, like /api/tasks POST does, so promoted
+  // drafts behave consistently when later moved to inbox.
+  const defaultTemplate = queryOne<{ id: string }>(
+    'SELECT id FROM workflow_templates WHERE workspace_id = ? AND is_default = 1 LIMIT 1',
+    [initiative.workspace_id],
+  );
+  const workflowTemplateId = defaultTemplate?.id ?? null;
+
+  // Single transaction: insert task, audit row, event.
+  const db = getDb();
+  db.transaction(() => {
+    db.prepare(
+      `INSERT INTO tasks (
+         id, title, description, status, priority, workspace_id, business_id,
+         workflow_template_id, initiative_id, status_check_md,
+         created_by_agent_id, created_at, updated_at
+       ) VALUES (?, ?, ?, 'draft', 'normal', ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      taskId,
+      title,
+      input.task_description ?? initiative.description ?? null,
+      initiative.workspace_id,
+      // Tasks have a NOT NULL business_id; reuse the workspace_id as the
+      // legacy business_id when none is set, matching seed and existing
+      // task creation defaults.
+      initiative.workspace_id,
+      workflowTemplateId,
+      initiative_id,
+      input.status_check_md ?? null,
+      input.created_by_agent_id ?? null,
+      now,
+      now,
+    );
+    db.prepare(
+      `INSERT INTO task_initiative_history (
+         id, task_id, from_initiative_id, to_initiative_id,
+         moved_by_agent_id, reason, created_at
+       ) VALUES (?, ?, NULL, ?, ?, ?, ?)`,
+    ).run(
+      uuidv4(),
+      taskId,
+      initiative_id,
+      input.created_by_agent_id ?? null,
+      input.reason ?? 'initial promotion',
+      now,
+    );
+    db.prepare(
+      `INSERT INTO events (id, type, agent_id, task_id, message, metadata, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      uuidv4(),
+      'task_promoted_from_initiative',
+      input.created_by_agent_id ?? null,
+      taskId,
+      `Task drafted from initiative: ${initiative.title}`,
+      JSON.stringify({ initiative_id }),
+      now,
+    );
+  })();
+
+  return { id: taskId };
+}
+
+export interface PromoteTaskToInboxInput {
+  reason?: string | null;
+  promoted_by_agent_id?: string | null;
+}
+
+/**
+ * Transition a draft task to inbox. Throws when the current status isn't
+ * 'draft' — promotion is the *only* draft → inbox edge per spec §13.2.
+ * Emits a `task_promoted_to_inbox` event row in the same transaction.
+ */
+export function promoteTaskToInbox(
+  task_id: string,
+  input: PromoteTaskToInboxInput = {},
+): { id: string; status: string } {
+  const task = queryOne<{ id: string; title: string; status: string }>(
+    'SELECT id, title, status FROM tasks WHERE id = ?',
+    [task_id],
+  );
+  if (!task) {
+    throw new Error(`Task not found: ${task_id}`);
+  }
+  if (task.status !== 'draft') {
+    throw new Error(
+      `Task is not in draft status (current: ${task.status}). Only drafts can be promoted to inbox.`,
+    );
+  }
+
+  const now = new Date().toISOString();
+  const db = getDb();
+  db.transaction(() => {
+    db.prepare(
+      "UPDATE tasks SET status = 'inbox', updated_at = ? WHERE id = ?",
+    ).run(now, task_id);
+    db.prepare(
+      `INSERT INTO events (id, type, agent_id, task_id, message, metadata, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      uuidv4(),
+      'task_promoted_to_inbox',
+      input.promoted_by_agent_id ?? null,
+      task_id,
+      `Promoted draft to inbox: ${task.title}`,
+      input.reason ? JSON.stringify({ reason: input.reason }) : null,
+      now,
+    );
+  })();
+
+  return { id: task_id, status: 'inbox' };
+}
+
+export interface PromoteIdeaToInitiativeInput {
+  kind?: 'theme' | 'milestone' | 'epic' | 'story';
+  parent_initiative_id?: string | null;
+  copy_description?: boolean;
+  created_by_agent_id?: string | null;
+}
+
+export interface PromoteIdeaResult {
+  initiative: Initiative;
+  alreadyPromoted: boolean;
+}
+
+/**
+ * Promote an idea to an initiative. Sibling of the existing idea→task
+ * autopilot path; both can coexist on the same idea.
+ *
+ * Idempotency: when ideas.initiative_id is already set, returns the
+ * existing initiative with alreadyPromoted=true (the route handler maps
+ * this to HTTP 409, per spec §10).
+ */
+export function promoteIdeaToInitiative(
+  idea_id: string,
+  input: PromoteIdeaToInitiativeInput = {},
+): PromoteIdeaResult {
+  const idea = queryOne<{
+    id: string;
+    title: string;
+    description: string | null;
+    product_id: string | null;
+    initiative_id: string | null;
+  }>(
+    'SELECT id, title, description, product_id, initiative_id FROM ideas WHERE id = ?',
+    [idea_id],
+  );
+  if (!idea) {
+    throw new Error(`Idea not found: ${idea_id}`);
+  }
+  if (idea.initiative_id) {
+    const existing = queryOne<Initiative>(
+      'SELECT * FROM initiatives WHERE id = ?',
+      [idea.initiative_id],
+    );
+    if (existing) {
+      return { initiative: existing, alreadyPromoted: true };
+    }
+    // Stale pointer — fall through and let the operator (or this call)
+    // create a fresh initiative; we don't auto-clear because that would
+    // hide a data-integrity issue from the operator.
+    throw new Error(
+      `Idea references missing initiative ${idea.initiative_id}; resolve manually before re-promoting`,
+    );
+  }
+
+  // Resolve the workspace from the product, since ideas don't carry it
+  // directly. Falls back to 'default' to mirror the rest of the codebase.
+  const productRow = idea.product_id
+    ? queryOne<{ workspace_id: string }>(
+        'SELECT workspace_id FROM products WHERE id = ?',
+        [idea.product_id],
+      )
+    : null;
+  const workspace_id = productRow?.workspace_id ?? 'default';
+
+  const initiativeId = uuidv4();
+  const now = new Date().toISOString();
+  const kind = input.kind ?? 'story';
+  const copyDescription = input.copy_description ?? true;
+
+  if (input.parent_initiative_id) {
+    const parent = queryOne<{ id: string }>(
+      'SELECT id FROM initiatives WHERE id = ?',
+      [input.parent_initiative_id],
+    );
+    if (!parent) {
+      throw new Error(`Parent initiative not found: ${input.parent_initiative_id}`);
+    }
+  }
+
+  const db = getDb();
+  db.transaction(() => {
+    db.prepare(
+      `INSERT INTO initiatives (
+         id, workspace_id, product_id, parent_initiative_id, kind, title,
+         description, status, source_idea_id, sort_order, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, 'planned', ?, 0, ?, ?)`,
+    ).run(
+      initiativeId,
+      workspace_id,
+      idea.product_id ?? null,
+      input.parent_initiative_id ?? null,
+      kind,
+      idea.title,
+      copyDescription ? idea.description : null,
+      idea_id,
+      now,
+      now,
+    );
+    db.prepare(
+      'UPDATE ideas SET initiative_id = ?, updated_at = ? WHERE id = ?',
+    ).run(initiativeId, now, idea_id);
+    db.prepare(
+      `INSERT INTO events (id, type, agent_id, message, metadata, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      uuidv4(),
+      'idea_promoted_to_initiative',
+      input.created_by_agent_id ?? null,
+      `Idea promoted to initiative (${kind}): ${idea.title}`,
+      JSON.stringify({ idea_id, initiative_id: initiativeId, kind }),
+      now,
+    );
+  })();
+
+  const created = queryOne<Initiative>(
+    'SELECT * FROM initiatives WHERE id = ?',
+    [initiativeId],
+  )!;
+  return { initiative: created, alreadyPromoted: false };
+}
+
+/**
+ * Provenance trail for one task: every task_initiative_history row in
+ * chronological order, with both initiative titles joined for convenience.
+ * Null initiative ids stay null in the join (LEFT JOIN), preserving the
+ * "first row from_initiative_id=NULL" invariant from spec §6.1.
+ */
+export function getTaskInitiativeHistory(task_id: string): TaskInitiativeHistoryRow[] {
+  return queryAll<TaskInitiativeHistoryRow>(
+    `SELECT
+       h.id,
+       h.task_id,
+       h.from_initiative_id,
+       i_from.title AS from_initiative_title,
+       h.to_initiative_id,
+       i_to.title AS to_initiative_title,
+       h.reason,
+       h.moved_by_agent_id,
+       h.created_at
+     FROM task_initiative_history h
+     LEFT JOIN initiatives i_from ON i_from.id = h.from_initiative_id
+     LEFT JOIN initiatives i_to   ON i_to.id   = h.to_initiative_id
+     WHERE h.task_id = ?
+     ORDER BY h.created_at ASC, h.id ASC`,
+    [task_id],
+  );
+}
+
+/**
+ * Emit the `initiative_kind_changed` event row that resolves spec §16 #5.
+ * Phase 1's convertInitiative helper intentionally took agent/reason params
+ * but did not emit an event; this is the Phase 2 follow-up that the
+ * /convert route handler now calls.
+ */
+export function emitConvertEvent(opts: {
+  initiative_id: string;
+  initiative_title: string;
+  from_kind: string;
+  to_kind: string;
+  agent_id?: string | null;
+  reason?: string | null;
+}): void {
+  if (opts.from_kind === opts.to_kind) return;
+  run(
+    `INSERT INTO events (id, type, agent_id, message, metadata, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      uuidv4(),
+      'initiative_kind_changed',
+      opts.agent_id ?? null,
+      `Initiative converted: ${opts.initiative_title} (${opts.from_kind} → ${opts.to_kind})`,
+      JSON.stringify({
+        initiative_id: opts.initiative_id,
+        from_kind: opts.from_kind,
+        to_kind: opts.to_kind,
+        ...(opts.reason ? { reason: opts.reason } : {}),
+      }),
+      new Date().toISOString(),
+    ],
+  );
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -122,6 +122,10 @@ export interface Task {
   merge_pr_url?: string;
   is_archived?: number;
   archived_at?: string;
+  // Roadmap planning layer (v0.2): pointer to the owning initiative and an
+  // optional freeform status check string. See specs/roadmap-and-pm-spec.md.
+  initiative_id?: string | null;
+  status_check_md?: string | null;
   /**
    * Opt-in: when truthy, dispatch injects a PREVIOUS LESSONS LEARNED
    * block from workspace knowledge. Off by default because the legacy
@@ -726,6 +730,11 @@ export interface Idea {
   auto_suppressed?: number; // 1 = suppressed due to similarity
   suppress_reason?: string;
   variant_id?: string;
+  // Roadmap planning layer (v0.2): when the operator promotes an idea to
+  // an initiative (sibling of the existing autopilot idea→task path), this
+  // holds the resulting initiatives.id. The two paths can coexist on the
+  // same idea — task_id covers autopilot, initiative_id covers planning.
+  initiative_id?: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary

Phase 2 of the roadmap planning layer. Lights up the three operator-driven promotion edges from spec §3.3 (idea → initiative, story → draft task, draft task → inbox), exposes the Phase 1 audit infrastructure through new APIs and UI, and wires draft/initiative awareness into the task modal, Mission Queue, initiatives tree, and ideas list. The execution pipeline is unchanged — drafts only enter the queue when an operator explicitly promotes them.

## What landed

**API endpoints** (`src/app/api/`)
- `POST /api/initiatives/[id]/promote-to-task` — story-only, creates one task with `status='draft'`, writes initial `task_initiative_history` row.
- `POST /api/tasks/[id]/promote` — flips `draft` → `inbox`, emits `task_promoted_to_inbox` event.
- `POST /api/tasks/[id]/move-initiative` — re-parent at any status (incl. mid-execution); accepts `to_initiative_id=null` for detach.
- `GET  /api/tasks/[id]/initiative-history` — chronological provenance trail with both initiative titles joined.
- `POST /api/ideas/[id]/promote-to-initiative` — sibling of the existing autopilot path; idempotent (409 + existing initiative if already promoted).
- `POST /api/initiatives/[id]/convert` now emits `initiative_kind_changed` events (resolves spec §16 #5).

**DB helpers** (`src/lib/db/promotion.ts`)
- `promoteInitiativeToTask`, `promoteTaskToInbox`, `promoteIdeaToInitiative`, `getTaskInitiativeHistory`, `emitConvertEvent`. All multi-row writes are transactional. Phase 1 helpers (`attachTaskToInitiative`, `moveTaskToInitiative`) are reused unchanged.

**UI**
- `/initiatives/[id]` detail page (NEW): header, children, tasks grouped by status (draft / active / done), deps, parent-change history, status check, "Promote to task" modal, draft-promote buttons next to each draft task.
- `/initiatives` tree: per-row task-count pill (`3 tasks: 1 draft, 2 active`), titles link to detail page, "Promote" button on story-kind rows (disabled with tooltip otherwise).
- `TaskInitiativePanel` (NEW component) inside `TaskModal` overview tab: owning initiative link, move-to-initiative picker, detach button, optional reason input, collapsed provenance trail, draft-promote button when `status='draft'`.
- `MissionQueue`: filters tasks with `status='draft'` from all columns (spec §13.2 requirement), shows a quiet emerald initiative-name badge on each task card linking to the detail page.
- `IdeasList`: "Promote to initiative" action alongside the existing autopilot path; surfaces whichever paths are taken (`task_id` and/or `initiative_id`).

**Tests** (`src/lib/db/promotion.test.ts`, 16 new cases)
- `promoteInitiativeToTask` happy path, non-story rejection, title/description override.
- `promoteTaskToInbox` happy path, non-draft rejection, missing-task rejection.
- `promoteIdeaToInitiative` happy path, idempotency, kind override, autopilot non-interference.
- `moveTaskToInitiative` mid-execution preserves status, detach writes null audit row.
- `getTaskInitiativeHistory` chronological order, both titles joined, null safety.
- `emitConvertEvent` writes `initiative_kind_changed`, no-op when kind unchanged.
- End-to-end provenance trace: idea → initiative → draft → re-parent → inbox.

`Task` and `Idea` types in `src/lib/types.ts` gain optional `initiative_id` / `status_check_md` fields.

## Stacked PR series

This is **Phase 2 of 6**, stacked on Phase 1 (#43). See `specs/roadmap-and-pm-spec.md` §14.

**Merge order discipline (project memory):** Before Phase 1 merges with `--delete-branch`, this PR's base must be retargeted to `main`, or GitHub will auto-close it.

## Test plan

- [ ] `npx tsx --test src/lib/db/promotion.test.ts` — 16 pass
- [ ] `npx tsx --test src/lib/db/initiatives.test.ts` — Phase 1's 17 still pass
- [ ] All db/lib test files run sequentially: 159 / 159 pass (143 existing + 16 new)
- [ ] `npx tsc --noEmit` clean
- [ ] Manually: create story initiative → "Promote to task" → verify draft created and visible only on `/initiatives/[id]`, not Mission Queue
- [ ] Manually: open the draft from initiative detail page → "Promote draft → inbox" → confirm it appears in Mission Queue
- [ ] Manually: in TaskModal, "Move to initiative" with reason → verify history row appears in the collapsed provenance trail
- [ ] Manually: on an idea card with no initiative, click "Promote to initiative" → verify the green link appears, original idea still has its `task_id` (if autopilot path was used)

## Notes / spec gaps

- The existing `npm test` script uses a shell glob (`src/**/*.test.ts`) that only expands top-level in `sh`, and `health.test.ts` has a pre-existing open-handle issue that prevents `tsx --test` from exiting cleanly. Tests were validated by running each file via `npx tsx --test <path>` directly. This is unrelated to Phase 2 — both issues exist on `main`.
- API-level route handler tests (Next.js route imports) aren't an established pattern in this repo, so coverage here is at the helper layer. Helpers are deterministic and the routes are thin wrappers over them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>