### PR TITLE
Phase 3: Roadmap timeline view

### DIFF
--- a/src/app/api/roadmap/route.ts
+++ b/src/app/api/roadmap/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getRoadmapSnapshot,
+  type InitiativeKind,
+  type InitiativeStatus,
+} from '@/lib/db/roadmap';
+
+export const dynamic = 'force-dynamic';
+
+const KINDS: ReadonlySet<InitiativeKind> = new Set(['theme', 'milestone', 'epic', 'story']);
+const STATUSES: ReadonlySet<InitiativeStatus> = new Set([
+  'planned',
+  'in_progress',
+  'at_risk',
+  'blocked',
+  'done',
+  'cancelled',
+]);
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const workspace_id = searchParams.get('workspace_id');
+    if (!workspace_id) {
+      return NextResponse.json(
+        { error: 'workspace_id is required' },
+        { status: 400 },
+      );
+    }
+
+    const kind = searchParams.get('kind');
+    const status = searchParams.get('status');
+    if (kind && !KINDS.has(kind as InitiativeKind)) {
+      return NextResponse.json({ error: `Invalid kind: ${kind}` }, { status: 400 });
+    }
+    if (status && !STATUSES.has(status as InitiativeStatus)) {
+      return NextResponse.json({ error: `Invalid status: ${status}` }, { status: 400 });
+    }
+
+    const snapshot = getRoadmapSnapshot({
+      workspace_id,
+      product_id: searchParams.get('product_id') || null,
+      owner_agent_id: searchParams.get('owner_agent_id') || null,
+      kind: (kind as InitiativeKind) || undefined,
+      status: (status as InitiativeStatus) || undefined,
+      from: searchParams.get('from') || null,
+      to: searchParams.get('to') || null,
+    });
+
+    return NextResponse.json(snapshot);
+  } catch (error) {
+    console.error('Failed to build roadmap snapshot:', error);
+    const msg = error instanceof Error ? error.message : 'Failed to build roadmap';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+// Pull the heavy timeline shell as a client-only chunk. SSR'ing the SVG
+// canvas isn't useful — it depends on viewport width and localStorage zoom
+// preference — and keeping it dynamic avoids hydration churn.
+const RoadmapTimeline = dynamic(
+  () => import('@/components/roadmap/RoadmapTimeline').then(m => m.RoadmapTimeline),
+  { ssr: false },
+);
+
+export default function RoadmapPage() {
+  return <RoadmapTimeline />;
+}

--- a/src/components/roadmap/README.md
+++ b/src/components/roadmap/README.md
@@ -1,0 +1,40 @@
+# Roadmap timeline (Phase 3)
+
+Lightweight Gantt-style timeline for the planning layer. SVG + CSS grid only — no external Gantt library. See `specs/roadmap-and-pm-spec.md` §12.2 and §14 for the full design.
+
+## Component layout
+
+```
+RoadmapTimeline               ── shell, owns snapshot + filters + drag handler
+├── RoadmapToolbar            ── filters (product/owner/kind/status) + zoom switch
+├── RoadmapRail               ── left column: indented initiative tree
+└── RoadmapCanvas             ── right column: SVG time canvas
+    ├── RoadmapDependencies   ── overlay: arrows between bars
+    └── RoadmapBar            ── per-row: solid + outlined bars, diamond, chips
+```
+
+Pure date math sits in `src/lib/roadmap/date-math.ts`. The aggregated read endpoint lives at `src/app/api/roadmap/route.ts`, with the helper in `src/lib/db/roadmap.ts`.
+
+## What's covered by tests
+
+| Surface | File | Status |
+|---|---|---|
+| Date math (px↔date round-trip, snap-to-day, range clipping, axis ticks, window overlap) | `src/lib/roadmap/date-math.test.ts` | 28 tests, all passing |
+| Snapshot helper (depth, task_counts, deps, filters by kind/status/product/from-to, owner join, empty workspace) | `src/lib/db/roadmap.test.ts` | 10 tests, all passing |
+
+## What's manual-test-only
+
+The repo doesn't currently have a Vitest/RTL setup or a Playwright runner wired into the test script. Rather than introducing one for Phase 3 alone, the following surfaces are manual-test gates:
+
+1. **Drag-to-update target dates.** Body-drag, left-edge resize, right-edge resize, with optimistic UI and revert-on-error. Verified manually against the dev server. Phase 4 should consider adding a Playwright smoke that loads `/roadmap` with a seeded fixture, drags a bar 7 days, and asserts on the resulting PATCH.
+2. **Status colour rendering.** All six initiative statuses produce distinct bar fills/strokes. Pure mapping in `RoadmapBar.tsx :: STATUS_BAR`.
+3. **Empty-state UI.** When zero initiatives match the filters, a "Create initiative" CTA links to `/initiatives`.
+4. **Dependency arrows.** Edges between bars when both endpoints are visible and have target dates; skipped otherwise.
+5. **Today line and axis ticks.** Visual.
+6. **Zoom persistence.** Picking a zoom level writes to `localStorage["roadmap.zoom"]` and survives reload.
+
+Verifying #2–#6 by eye on `http://localhost:4001/roadmap` is fine for v1.
+
+## Phase 4 hand-off
+
+Phase 4 fills `derived_*` columns. The bar component already renders the dashed outline when those values are present, so no UI changes are needed once the derivation engine ships — the slippage gap will appear on its own.

--- a/src/components/roadmap/RoadmapBar.tsx
+++ b/src/components/roadmap/RoadmapBar.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+/**
+ * One initiative row's bars: solid (target window), outlined (derived window),
+ * milestone diamond, and (cosmetic) task chips.
+ *
+ * Drag-to-update is handled here. Three handles per solid bar:
+ *   - body: drag to shift both target_start and target_end equally
+ *   - left edge: drag to resize target_start
+ *   - right edge: drag to resize target_end
+ *
+ * The component is positioned at the row's Y coordinate via a parent
+ * `transform: translateY(...)`. We use absolute positioning + transform
+ * (translate3d) for the bar X to keep drag re-renders cheap.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  addDays,
+  dateToPx,
+  rangeWidthPx,
+  toIsoDay,
+  toUtcDay,
+  type ZoomLevel,
+} from '@/lib/roadmap/date-math';
+import type { Kind, RoadmapInitiative, RoadmapTask, Status } from './RoadmapTimeline';
+
+const STATUS_BAR: Record<Status, { fill: string; stroke: string }> = {
+  planned: { fill: 'fill-slate-500/40', stroke: 'stroke-slate-300' },
+  in_progress: { fill: 'fill-blue-500/60', stroke: 'stroke-blue-300' },
+  at_risk: { fill: 'fill-amber-500/60', stroke: 'stroke-amber-300' },
+  blocked: { fill: 'fill-red-500/60', stroke: 'stroke-red-300' },
+  done: { fill: 'fill-emerald-500/60', stroke: 'stroke-emerald-300' },
+  cancelled: { fill: 'fill-slate-700/40', stroke: 'stroke-slate-500' },
+};
+
+// Tint by kind: subtle saturation difference so a milestone bar reads
+// differently from an epic at a glance even at the same status.
+const KIND_TINT: Record<Kind, number> = {
+  theme: 0.7,
+  milestone: 1.0,
+  epic: 0.85,
+  story: 0.7,
+};
+
+const BAR_HEIGHT = 18;
+const DIAMOND_SIZE = 12;
+const EDGE_HANDLE = 6;
+
+type DragState =
+  | { mode: 'shift'; startX: number; origStart: string; origEnd: string }
+  | { mode: 'resize-start'; startX: number; origStart: string; end: string }
+  | { mode: 'resize-end'; startX: number; start: string; origEnd: string }
+  | null;
+
+export function RoadmapBar({
+  initiative,
+  tasks,
+  windowStart,
+  pxPerDay,
+  rowHeight,
+  zoom,
+  onUpdateDates,
+}: {
+  initiative: RoadmapInitiative;
+  tasks: RoadmapTask[];
+  windowStart: Date;
+  pxPerDay: number;
+  rowHeight: number;
+  zoom: ZoomLevel;
+  onUpdateDates: (id: string, start: string | null, end: string | null) => void;
+}) {
+  // Local override during drag — ISO day strings.
+  const [override, setOverride] = useState<{ start: string; end: string } | null>(null);
+  const dragState = useRef<DragState>(null);
+
+  const start = override?.start ?? initiative.target_start;
+  const end = override?.end ?? initiative.target_end;
+  const tint = KIND_TINT[initiative.kind];
+
+  // ── pointer drag plumbing ───────────────────────────────────────
+  useEffect(() => {
+    function onMove(e: PointerEvent) {
+      const ds = dragState.current;
+      if (!ds) return;
+      const dx = e.clientX - ds.startX;
+      const dDays = Math.round(dx / pxPerDay);
+      if (ds.mode === 'shift') {
+        const ns = toIsoDay(addDays(ds.origStart, dDays));
+        const ne = toIsoDay(addDays(ds.origEnd, dDays));
+        setOverride({ start: ns, end: ne });
+      } else if (ds.mode === 'resize-start') {
+        const ns = toIsoDay(addDays(ds.origStart, dDays));
+        // Don't let start cross past end.
+        if (toUtcDay(ns) <= toUtcDay(ds.end)) {
+          setOverride({ start: ns, end: ds.end });
+        }
+      } else {
+        const ne = toIsoDay(addDays(ds.origEnd, dDays));
+        if (toUtcDay(ne) >= toUtcDay(ds.start)) {
+          setOverride({ start: ds.start, end: ne });
+        }
+      }
+    }
+    function onUp() {
+      const ds = dragState.current;
+      if (!ds) return;
+      dragState.current = null;
+      // Commit if the override differs from the current value.
+      if (override) {
+        const orig = { start: initiative.target_start, end: initiative.target_end };
+        if (override.start !== orig.start || override.end !== orig.end) {
+          onUpdateDates(initiative.id, override.start, override.end);
+        }
+      }
+      setOverride(null);
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    }
+    if (dragState.current) {
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+      return () => {
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onUp);
+      };
+    }
+  });
+
+  function startDrag(mode: NonNullable<DragState>['mode'], e: React.PointerEvent) {
+    if (!start || !end) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (mode === 'shift') {
+      dragState.current = { mode, startX: e.clientX, origStart: start, origEnd: end };
+    } else if (mode === 'resize-start') {
+      dragState.current = { mode, startX: e.clientX, origStart: start, end };
+    } else {
+      dragState.current = { mode, startX: e.clientX, start, origEnd: end };
+    }
+    // Force a re-render so the useEffect attaches its listeners.
+    setOverride(o => o ?? { start: start!, end: end! });
+  }
+
+  // ── geometry ────────────────────────────────────────────────────
+  const yMid = rowHeight / 2;
+
+  // Solid (target) bar
+  let solidEl: React.ReactNode = null;
+  if (start && end) {
+    const x = dateToPx(start, windowStart, pxPerDay);
+    const w = rangeWidthPx(start, end, pxPerDay);
+    const colors = STATUS_BAR[initiative.status];
+    solidEl = (
+      <g
+        style={{
+          opacity: tint,
+          cursor: 'grab',
+        }}
+      >
+        {/* Body: shift on drag */}
+        <rect
+          x={x}
+          y={yMid - BAR_HEIGHT / 2}
+          width={w}
+          height={BAR_HEIGHT}
+          rx={3}
+          ry={3}
+          className={`${colors.fill} ${colors.stroke}`}
+          strokeWidth={1.5}
+          onPointerDown={e => startDrag('shift', e)}
+        />
+        {/* Left edge handle */}
+        <rect
+          x={x}
+          y={yMid - BAR_HEIGHT / 2}
+          width={EDGE_HANDLE}
+          height={BAR_HEIGHT}
+          fill="transparent"
+          style={{ cursor: 'ew-resize' }}
+          onPointerDown={e => startDrag('resize-start', e)}
+        />
+        {/* Right edge handle */}
+        <rect
+          x={x + w - EDGE_HANDLE}
+          y={yMid - BAR_HEIGHT / 2}
+          width={EDGE_HANDLE}
+          height={BAR_HEIGHT}
+          fill="transparent"
+          style={{ cursor: 'ew-resize' }}
+          onPointerDown={e => startDrag('resize-end', e)}
+        />
+      </g>
+    );
+  }
+
+  // Outlined (derived) bar — Phase 4 will populate; in Phase 3 mostly null.
+  let outlineEl: React.ReactNode = null;
+  if (initiative.derived_start && initiative.derived_end) {
+    const x = dateToPx(initiative.derived_start, windowStart, pxPerDay);
+    const w = rangeWidthPx(initiative.derived_start, initiative.derived_end, pxPerDay);
+    outlineEl = (
+      <rect
+        x={x}
+        y={yMid - BAR_HEIGHT / 2 - 2}
+        width={w}
+        height={BAR_HEIGHT + 4}
+        rx={3}
+        ry={3}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.2}
+        strokeDasharray="3 3"
+        className="text-mc-text-secondary"
+      />
+    );
+  }
+
+  // Milestone diamond at committed_end (rendered for milestone kind).
+  let diamondEl: React.ReactNode = null;
+  if (initiative.kind === 'milestone' && initiative.committed_end) {
+    const cx = dateToPx(initiative.committed_end, windowStart, pxPerDay);
+    diamondEl = (
+      <polygon
+        points={`${cx},${yMid - DIAMOND_SIZE / 2} ${cx + DIAMOND_SIZE / 2},${yMid} ${cx},${yMid + DIAMOND_SIZE / 2} ${cx - DIAMOND_SIZE / 2},${yMid}`}
+        className="fill-amber-400 stroke-amber-200"
+        strokeWidth={1.5}
+      />
+    );
+  }
+
+  // Task chips: cosmetic only (don't carry per-day positions). Anchor to
+  // the right end of the solid bar; if no bar, anchor to the left edge of
+  // the row.
+  const chipAnchor =
+    start && end
+      ? dateToPx(end, windowStart, pxPerDay) + rangeWidthPx(end, end, pxPerDay) / 2
+      : 0;
+  const chipsEl = tasks.length > 0 && (
+    <g transform={`translate(${chipAnchor + 4}, ${yMid - 6})`}>
+      {tasks.slice(0, 5).map((t, idx) => (
+        <TaskChip key={t.id} task={t} x={idx * 14} />
+      ))}
+    </g>
+  );
+
+  // "no schedule" indicator if neither target nor committed dates: a small
+  // ghosted pill at the left of the row.
+  let noScheduleEl: React.ReactNode = null;
+  if (!start && !end && !initiative.committed_end && !initiative.derived_start) {
+    noScheduleEl = (
+      <g transform={`translate(0, ${yMid})`}>
+        <rect
+          x={2}
+          y={-7}
+          width={70}
+          height={14}
+          rx={7}
+          ry={7}
+          className="fill-mc-bg stroke-mc-border"
+          strokeDasharray="2 2"
+        />
+        <text x={36} y={3} textAnchor="middle" className="fill-mc-text-secondary" fontSize={10}>
+          no schedule
+        </text>
+      </g>
+    );
+  }
+
+  // `zoom` is in the signature for future tick alignment but currently unused.
+  void zoom;
+
+  return (
+    <g>
+      {outlineEl}
+      {solidEl}
+      {diamondEl}
+      {chipsEl}
+      {noScheduleEl}
+    </g>
+  );
+}
+
+function TaskChip({ task, x }: { task: RoadmapTask; x: number }) {
+  const filled =
+    task.status !== 'draft' && task.status !== 'done' && task.status !== 'cancelled';
+  const done = task.status === 'done';
+  return (
+    <g transform={`translate(${x}, 0)`} style={{ pointerEvents: 'none' }}>
+      <circle
+        cx={5}
+        cy={5}
+        r={5}
+        className={
+          done
+            ? 'fill-emerald-500/70 stroke-emerald-300'
+            : filled
+              ? 'fill-blue-500/70 stroke-blue-300'
+              : 'fill-transparent stroke-slate-400'
+        }
+        strokeWidth={1}
+        strokeDasharray={task.status === 'draft' ? '2 1' : undefined}
+      >
+        <title>{`${task.title} · ${task.status}`}</title>
+      </circle>
+      {done && (
+        <path
+          d="M 2.5 5 L 4.5 7 L 7.5 3.5"
+          className="stroke-emerald-100"
+          fill="none"
+          strokeWidth={1.2}
+          strokeLinecap="round"
+        />
+      )}
+    </g>
+  );
+}

--- a/src/components/roadmap/RoadmapCanvas.tsx
+++ b/src/components/roadmap/RoadmapCanvas.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+/**
+ * Right-hand timeline canvas. Owns the time axis, the today line, the
+ * per-row bars, and the dependency overlay. Lays out absolutely so the
+ * bar SVG and the dependency SVG can stack.
+ *
+ * The "canvas" is one big horizontally-scrolling div. Bar SVGs are sized
+ * to the same total width so the time axis, bars, and arrows align.
+ */
+
+import { useMemo, type RefObject } from 'react';
+import {
+  axisTicks,
+  daysBetween,
+  dateToPx,
+  formatTick,
+  type ZoomLevel,
+} from '@/lib/roadmap/date-math';
+import { RoadmapBar } from './RoadmapBar';
+import { RoadmapDependencies } from './RoadmapDependencies';
+import type {
+  RoadmapDependency,
+  RoadmapInitiative,
+  RoadmapTask,
+} from './RoadmapTimeline';
+
+export function RoadmapCanvas({
+  initiatives,
+  visibleIds,
+  dependencies,
+  tasks,
+  windowStart,
+  windowEnd,
+  pxPerDay,
+  zoom,
+  rowHeight,
+  onUpdateDates,
+  scrollRef,
+  onScroll,
+}: {
+  initiatives: RoadmapInitiative[];
+  visibleIds: Set<string>;
+  dependencies: RoadmapDependency[];
+  tasks: RoadmapTask[];
+  windowStart: Date;
+  windowEnd: Date;
+  pxPerDay: number;
+  zoom: ZoomLevel;
+  rowHeight: number;
+  onUpdateDates: (id: string, start: string | null, end: string | null) => void;
+  scrollRef: RefObject<HTMLDivElement | null>;
+  onScroll: () => void;
+}) {
+  // Width = days in window * pxPerDay.
+  const totalDays = daysBetween(windowStart, windowEnd) + 1;
+  const totalWidth = Math.max(640, totalDays * pxPerDay);
+  const totalHeight = initiatives.length * rowHeight;
+
+  const ticks = useMemo(
+    () => axisTicks(windowStart, windowEnd, zoom),
+    [windowStart, windowEnd, zoom],
+  );
+
+  // Today line position. May be off-canvas; that's fine — the overflow:hidden
+  // on the wrapper clips it cleanly.
+  const todayX = dateToPx(new Date(), windowStart, pxPerDay);
+
+  const tasksByInit = useMemo(() => {
+    const m = new Map<string, RoadmapTask[]>();
+    for (const t of tasks) {
+      const list = m.get(t.initiative_id) ?? [];
+      list.push(t);
+      m.set(t.initiative_id, list);
+    }
+    return m;
+  }, [tasks]);
+
+  return (
+    <section className="flex-1 flex flex-col min-h-0 min-w-0">
+      {/* Axis row — sticky at top, scrolls with the body horizontally. */}
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className="flex-1 overflow-auto bg-mc-bg"
+      >
+        <div style={{ width: totalWidth, position: 'relative' }}>
+          {/* Axis */}
+          <div
+            className="sticky top-0 z-10 h-12 border-b border-mc-border bg-mc-bg-secondary"
+            style={{ width: totalWidth }}
+          >
+            <svg width={totalWidth} height={48} style={{ display: 'block' }}>
+              {ticks.map((t, i) => {
+                const x = dateToPx(t, windowStart, pxPerDay);
+                return (
+                  <g key={i}>
+                    <line
+                      x1={x}
+                      x2={x}
+                      y1={0}
+                      y2={48}
+                      stroke="currentColor"
+                      className="text-mc-border"
+                    />
+                    <text
+                      x={x + 4}
+                      y={30}
+                      className="fill-mc-text-secondary"
+                      fontSize={11}
+                    >
+                      {formatTick(t, zoom)}
+                    </text>
+                  </g>
+                );
+              })}
+              {/* Today line label */}
+              {todayX >= 0 && todayX <= totalWidth && (
+                <g>
+                  <line
+                    x1={todayX}
+                    x2={todayX}
+                    y1={0}
+                    y2={48}
+                    stroke="currentColor"
+                    className="text-mc-accent"
+                    strokeWidth={1.5}
+                  />
+                  <text
+                    x={todayX + 4}
+                    y={14}
+                    className="fill-mc-accent"
+                    fontSize={10}
+                    fontWeight={600}
+                  >
+                    today
+                  </text>
+                </g>
+              )}
+            </svg>
+          </div>
+
+          {/* Body: row gridlines + dependency arrows + bars */}
+          <div
+            style={{ position: 'relative', width: totalWidth, height: totalHeight }}
+          >
+            {/* Row backgrounds + horizontal separators */}
+            <svg
+              width={totalWidth}
+              height={totalHeight}
+              style={{ position: 'absolute', top: 0, left: 0 }}
+            >
+              {initiatives.map((_, i) => (
+                <line
+                  key={i}
+                  x1={0}
+                  x2={totalWidth}
+                  y1={(i + 1) * rowHeight}
+                  y2={(i + 1) * rowHeight}
+                  stroke="currentColor"
+                  className="text-mc-border/40"
+                />
+              ))}
+              {/* Tick gridlines */}
+              {ticks.map((t, i) => {
+                const x = dateToPx(t, windowStart, pxPerDay);
+                return (
+                  <line
+                    key={`tg-${i}`}
+                    x1={x}
+                    x2={x}
+                    y1={0}
+                    y2={totalHeight}
+                    stroke="currentColor"
+                    className="text-mc-border/30"
+                  />
+                );
+              })}
+              {/* Today line through the body */}
+              {todayX >= 0 && todayX <= totalWidth && (
+                <line
+                  x1={todayX}
+                  x2={todayX}
+                  y1={0}
+                  y2={totalHeight}
+                  stroke="currentColor"
+                  className="text-mc-accent/50"
+                  strokeWidth={1}
+                />
+              )}
+            </svg>
+
+            {/* Dependency arrows */}
+            <RoadmapDependencies
+              dependencies={dependencies}
+              initiatives={initiatives}
+              visibleIds={visibleIds}
+              windowStart={windowStart}
+              pxPerDay={pxPerDay}
+              rowHeight={rowHeight}
+              width={totalWidth}
+              height={totalHeight}
+            />
+
+            {/* Bar layer: one SVG per row keeps the drag handler local. */}
+            {initiatives.map((init, i) => (
+              <svg
+                key={init.id}
+                width={totalWidth}
+                height={rowHeight}
+                style={{
+                  position: 'absolute',
+                  top: i * rowHeight,
+                  left: 0,
+                  display: 'block',
+                  // pointerEvents 'none' would break drag — we want this
+                  // layer to receive events but the dependency layer above
+                  // is already pointerEvents:none.
+                }}
+              >
+                <RoadmapBar
+                  initiative={init}
+                  tasks={tasksByInit.get(init.id) ?? []}
+                  windowStart={windowStart}
+                  pxPerDay={pxPerDay}
+                  rowHeight={rowHeight}
+                  zoom={zoom}
+                  onUpdateDates={onUpdateDates}
+                />
+              </svg>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/roadmap/RoadmapDependencies.tsx
+++ b/src/components/roadmap/RoadmapDependencies.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * Dependency arrows overlay — drawn behind the bars in its own SVG layer.
+ *
+ * Conventions:
+ *   - An edge from A → B means "B depends on A". Render an arrow from
+ *     A's right edge (its target_end) to B's left edge (its target_start).
+ *   - We curve via a simple cubic Bézier with horizontal handles.
+ *   - Edges where either endpoint is filtered out are skipped (or could
+ *     be rendered dimmed pointing off-canvas — kept simple in v1).
+ *   - Edges where either initiative has no target_start/target_end are
+ *     skipped — there's nothing to anchor to.
+ */
+
+import {
+  dateToPx,
+  rangeWidthPx,
+} from '@/lib/roadmap/date-math';
+import type { RoadmapDependency, RoadmapInitiative } from './RoadmapTimeline';
+
+export function RoadmapDependencies({
+  dependencies,
+  initiatives,
+  visibleIds,
+  windowStart,
+  pxPerDay,
+  rowHeight,
+  width,
+  height,
+}: {
+  dependencies: RoadmapDependency[];
+  initiatives: RoadmapInitiative[];
+  visibleIds: Set<string>;
+  windowStart: Date;
+  pxPerDay: number;
+  rowHeight: number;
+  width: number;
+  height: number;
+}) {
+  // Position lookup: id → row index in the visible list.
+  const idx = new Map<string, number>();
+  initiatives.forEach((i, k) => idx.set(i.id, k));
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none' }}
+    >
+      <defs>
+        <marker
+          id="roadmap-arrow"
+          viewBox="0 0 8 8"
+          refX="7"
+          refY="4"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto"
+        >
+          <path d="M0,0 L8,4 L0,8 z" className="fill-mc-text-secondary" />
+        </marker>
+      </defs>
+      {dependencies.map(dep => {
+        // dep.depends_on_initiative_id (source) → dep.initiative_id (target)
+        const src = initiatives.find(i => i.id === dep.depends_on_initiative_id);
+        const tgt = initiatives.find(i => i.id === dep.initiative_id);
+        if (!src || !tgt) return null;
+        if (!visibleIds.has(src.id) || !visibleIds.has(tgt.id)) return null;
+        if (!src.target_end || !tgt.target_start) return null;
+
+        const srcRow = idx.get(src.id);
+        const tgtRow = idx.get(tgt.id);
+        if (srcRow == null || tgtRow == null) return null;
+
+        const x1 = dateToPx(src.target_end, windowStart, pxPerDay)
+          + rangeWidthPx(src.target_end, src.target_end, pxPerDay);
+        const y1 = srcRow * rowHeight + rowHeight / 2;
+        const x2 = dateToPx(tgt.target_start, windowStart, pxPerDay);
+        const y2 = tgtRow * rowHeight + rowHeight / 2;
+
+        // Cubic with horizontal control points proportional to the gap.
+        const dx = Math.max(20, Math.abs(x2 - x1) / 2);
+        const path = `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`;
+
+        return (
+          <path
+            key={dep.id}
+            d={path}
+            stroke="currentColor"
+            className="text-mc-text-secondary/60"
+            strokeWidth={1.2}
+            fill="none"
+            markerEnd="url(#roadmap-arrow)"
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/components/roadmap/RoadmapRail.tsx
+++ b/src/components/roadmap/RoadmapRail.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+/**
+ * Left rail: indented initiative list with collapse/expand, kind icon,
+ * title link, status pill, and task-count badge.
+ *
+ * Visual contract: each row is exactly `rowHeight` px tall so the canvas
+ * can index by row with index*rowHeight without re-measuring.
+ */
+
+import type { RefObject } from 'react';
+import Link from 'next/link';
+import { ChevronDown, ChevronRight, Square, Diamond, ListTree, Circle } from 'lucide-react';
+import type { Kind, RoadmapInitiative, RoadmapSnapshot, Status } from './RoadmapTimeline';
+
+const KIND_ICON: Record<Kind, React.ComponentType<{ className?: string }>> = {
+  theme: Square,
+  milestone: Diamond,
+  epic: ListTree,
+  story: Circle,
+};
+
+const KIND_COLOR: Record<Kind, string> = {
+  theme: 'text-purple-300',
+  milestone: 'text-amber-300',
+  epic: 'text-blue-300',
+  story: 'text-emerald-300',
+};
+
+export const STATUS_PILL: Record<Status, string> = {
+  planned: 'bg-slate-500/20 text-slate-300 border-slate-500/40',
+  in_progress: 'bg-blue-500/20 text-blue-300 border-blue-500/40',
+  at_risk: 'bg-amber-500/20 text-amber-300 border-amber-500/40',
+  blocked: 'bg-red-500/20 text-red-300 border-red-500/40',
+  done: 'bg-emerald-500/20 text-emerald-300 border-emerald-500/40',
+  cancelled: 'bg-mc-bg text-mc-text-secondary border-mc-border',
+};
+
+export function RoadmapRail({
+  initiatives,
+  width,
+  rowHeight,
+  collapsed,
+  onToggleCollapsed,
+  snapshot,
+  scrollRef,
+  onScroll,
+}: {
+  initiatives: RoadmapInitiative[];
+  width: number;
+  rowHeight: number;
+  collapsed: Set<string>;
+  onToggleCollapsed: (id: string) => void;
+  snapshot: RoadmapSnapshot | null;
+  scrollRef: RefObject<HTMLDivElement | null>;
+  onScroll: () => void;
+}) {
+  // Map id → has-children. Use the *full* snapshot (not the filtered set) so
+  // a parent that's been hidden by filter/collapse but has children doesn't
+  // lose its caret if it's still visible.
+  const hasChildren = new Map<string, boolean>();
+  for (const i of snapshot?.initiatives ?? []) {
+    if (i.parent_initiative_id) {
+      hasChildren.set(i.parent_initiative_id, true);
+    }
+  }
+
+  return (
+    <aside
+      className="border-r border-mc-border bg-mc-bg flex flex-col min-h-0"
+      style={{ width, minWidth: width }}
+    >
+      {/* Spacer matching the timeline axis row */}
+      <div className="h-12 border-b border-mc-border bg-mc-bg-secondary flex items-center px-3 text-[11px] uppercase tracking-wide text-mc-text-secondary">
+        Initiative
+      </div>
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className="overflow-y-auto overflow-x-hidden flex-1"
+      >
+        {initiatives.map(i => {
+          const Icon = KIND_ICON[i.kind];
+          const expanded = !collapsed.has(i.id);
+          const showCaret = !!hasChildren.get(i.id);
+          const counts = i.task_counts;
+          return (
+            <div
+              key={i.id}
+              className="flex items-center gap-1.5 px-2 border-b border-mc-border/40"
+              style={{ height: rowHeight, paddingLeft: 8 + i.depth * 14 }}
+              title={i.title}
+            >
+              {showCaret ? (
+                <button
+                  onClick={() => onToggleCollapsed(i.id)}
+                  className="p-0.5 rounded hover:bg-mc-bg-secondary text-mc-text-secondary"
+                  title={expanded ? 'Collapse' : 'Expand'}
+                >
+                  {expanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                </button>
+              ) : (
+                <span className="w-4" />
+              )}
+              <Icon className={`w-3.5 h-3.5 ${KIND_COLOR[i.kind]}`} />
+              <Link
+                href={`/initiatives/${i.id}`}
+                className="text-sm text-mc-text hover:text-mc-accent truncate flex-1 min-w-0"
+              >
+                {i.title}
+              </Link>
+              <span
+                className={`text-[10px] px-1.5 py-0.5 rounded border ${STATUS_PILL[i.status]}`}
+                title={i.status}
+              >
+                {i.status === 'in_progress'
+                  ? 'wip'
+                  : i.status === 'at_risk'
+                    ? 'risk'
+                    : i.status.slice(0, 4)}
+              </span>
+              {counts.total > 0 && (
+                <span
+                  className="text-[10px] text-mc-text-secondary"
+                  title={`${counts.total} tasks: ${counts.draft} draft, ${counts.active} active, ${counts.done} done`}
+                >
+                  {counts.total}
+                  {counts.draft > 0 && <span className="text-slate-400">·{counts.draft}d</span>}
+                  {counts.active > 0 && <span className="text-blue-400">·{counts.active}a</span>}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/roadmap/RoadmapTimeline.tsx
+++ b/src/components/roadmap/RoadmapTimeline.tsx
@@ -1,0 +1,365 @@
+'use client';
+
+/**
+ * Top-level roadmap shell (Phase 3).
+ *
+ * Owns:
+ *   - Snapshot fetching from /api/roadmap.
+ *   - Filter and zoom state (with localStorage persistence for zoom).
+ *   - The drag-to-update-target-dates handler.
+ *   - The optimistic mutation buffer (so dropped bars don't snap back
+ *     before the server confirms).
+ *
+ * Layout: header → toolbar → split (rail | canvas).
+ * The rail and canvas share a vertical scroll position so rows stay aligned.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { Plus } from 'lucide-react';
+import { RoadmapRail } from './RoadmapRail';
+import { RoadmapCanvas } from './RoadmapCanvas';
+import { RoadmapToolbar } from './RoadmapToolbar';
+import {
+  PX_PER_DAY,
+  defaultWindow,
+  toIsoDay,
+  type ZoomLevel,
+} from '@/lib/roadmap/date-math';
+
+const WORKSPACE_ID = 'default';
+const ZOOM_KEY = 'roadmap.zoom';
+const RAIL_WIDTH = 300; // px
+const ROW_HEIGHT = 36;  // px — must match RoadmapRail row height
+
+export type Kind = 'theme' | 'milestone' | 'epic' | 'story';
+export type Status = 'planned' | 'in_progress' | 'at_risk' | 'blocked' | 'done' | 'cancelled';
+
+export interface RoadmapInitiative {
+  id: string;
+  parent_initiative_id: string | null;
+  product_id: string | null;
+  kind: Kind;
+  title: string;
+  status: Status;
+  owner_agent_id: string | null;
+  owner_agent_name: string | null;
+  complexity: 'S' | 'M' | 'L' | 'XL' | null;
+  estimated_effort_hours: number | null;
+  target_start: string | null;
+  target_end: string | null;
+  derived_start: string | null;
+  derived_end: string | null;
+  committed_end: string | null;
+  status_check_md: string | null;
+  sort_order: number;
+  depth: number;
+  task_counts: { draft: number; active: number; done: number; total: number };
+}
+
+export interface RoadmapDependency {
+  id: string;
+  initiative_id: string;
+  depends_on_initiative_id: string;
+  kind: string;
+  note: string | null;
+}
+
+export interface RoadmapTask {
+  id: string;
+  initiative_id: string;
+  title: string;
+  status: string;
+  assigned_agent_id: string | null;
+}
+
+export interface RoadmapSnapshot {
+  initiatives: RoadmapInitiative[];
+  dependencies: RoadmapDependency[];
+  tasks: RoadmapTask[];
+  workspace_id: string;
+  product_id: string | null;
+  truncated: boolean;
+}
+
+export interface RoadmapFilters {
+  product_id: string | null;
+  owner_agent_id: string | null;
+  kinds: Set<Kind>;
+  statuses: Set<Status>;
+}
+
+const ALL_KINDS: Kind[] = ['theme', 'milestone', 'epic', 'story'];
+const ALL_STATUSES: Status[] = ['planned', 'in_progress', 'at_risk', 'blocked', 'done', 'cancelled'];
+
+function readZoom(): ZoomLevel {
+  if (typeof window === 'undefined') return 'month';
+  const v = window.localStorage.getItem(ZOOM_KEY);
+  if (v === 'week' || v === 'month' || v === 'quarter') return v;
+  return 'month';
+}
+
+function writeZoom(z: ZoomLevel) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(ZOOM_KEY, z);
+  } catch {
+    // localStorage can be disabled (private mode); ignore.
+  }
+}
+
+export function RoadmapTimeline() {
+  const [snapshot, setSnapshot] = useState<RoadmapSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [zoom, setZoomState] = useState<ZoomLevel>('month');
+  const [filters, setFilters] = useState<RoadmapFilters>({
+    product_id: null,
+    owner_agent_id: null,
+    kinds: new Set(ALL_KINDS),
+    statuses: new Set(ALL_STATUSES),
+  });
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  // Read zoom on mount only (client-only).
+  useEffect(() => {
+    setZoomState(readZoom());
+  }, []);
+
+  const setZoom = useCallback((z: ZoomLevel) => {
+    setZoomState(z);
+    writeZoom(z);
+  }, []);
+
+  const refresh = useCallback(async () => {
+    try {
+      setError(null);
+      const params = new URLSearchParams();
+      params.set('workspace_id', WORKSPACE_ID);
+      if (filters.product_id) params.set('product_id', filters.product_id);
+      if (filters.owner_agent_id) params.set('owner_agent_id', filters.owner_agent_id);
+      const r = await fetch(`/api/roadmap?${params.toString()}`);
+      if (!r.ok) throw new Error(`Failed to load roadmap (${r.status})`);
+      const snap: RoadmapSnapshot = await r.json();
+      setSnapshot(snap);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load roadmap');
+    } finally {
+      setLoading(false);
+    }
+  }, [filters.product_id, filters.owner_agent_id]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Apply client-side kind+status filters and collapse logic to the snapshot.
+  const visibleInitiatives = useMemo(() => {
+    if (!snapshot) return [] as RoadmapInitiative[];
+    const byId = new Map(snapshot.initiatives.map(i => [i.id, i]));
+    // Determine if any ancestor is collapsed.
+    function ancestorCollapsed(i: RoadmapInitiative): boolean {
+      let cur = i.parent_initiative_id ? byId.get(i.parent_initiative_id) : undefined;
+      while (cur) {
+        if (collapsed.has(cur.id)) return true;
+        cur = cur.parent_initiative_id ? byId.get(cur.parent_initiative_id) : undefined;
+      }
+      return false;
+    }
+    return snapshot.initiatives.filter(i => {
+      if (!filters.kinds.has(i.kind)) return false;
+      if (!filters.statuses.has(i.status)) return false;
+      if (ancestorCollapsed(i)) return false;
+      return true;
+    });
+  }, [snapshot, filters.kinds, filters.statuses, collapsed]);
+
+  const visibleIds = useMemo(
+    () => new Set(visibleInitiatives.map(i => i.id)),
+    [visibleInitiatives],
+  );
+
+  // Derive a sensible default render window from all dates in scope. We
+  // include target_*, derived_*, and committed_end so milestones with only
+  // a committed date still get a slot in the canvas.
+  const window_ = useMemo(() => {
+    const dates: Array<string | null | undefined> = [];
+    for (const i of visibleInitiatives) {
+      dates.push(i.target_start, i.target_end, i.derived_start, i.derived_end, i.committed_end);
+    }
+    return defaultWindow(dates, new Date());
+  }, [visibleInitiatives]);
+
+  const pxPerDay = PX_PER_DAY[zoom];
+
+  const toggleCollapsed = useCallback((id: string) => {
+    setCollapsed(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  // Optimistic patch buffer: while a drag is in flight we mutate the
+  // local snapshot so the bar stays put. On success we keep it; on error
+  // we refetch. Keyed by initiative id.
+  const applyLocalDateChange = useCallback(
+    (id: string, target_start: string | null, target_end: string | null) => {
+      setSnapshot(s => {
+        if (!s) return s;
+        return {
+          ...s,
+          initiatives: s.initiatives.map(i =>
+            i.id === id ? { ...i, target_start, target_end } : i,
+          ),
+        };
+      });
+    },
+    [],
+  );
+
+  const updateInitiativeDates = useCallback(
+    async (id: string, start: string | null, end: string | null) => {
+      // Snapshot the previous values so we can revert.
+      const prev = snapshot?.initiatives.find(i => i.id === id);
+      if (!prev) return;
+      applyLocalDateChange(id, start, end);
+      try {
+        const r = await fetch(`/api/initiatives/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ target_start: start, target_end: end }),
+        });
+        if (!r.ok) {
+          const body = await r.json().catch(() => ({}));
+          throw new Error(body.error || `PATCH failed (${r.status})`);
+        }
+      } catch (e) {
+        console.error('Failed to update initiative dates:', e);
+        // Revert on failure.
+        applyLocalDateChange(id, prev.target_start, prev.target_end);
+        setError(e instanceof Error ? e.message : 'Failed to update dates');
+      }
+    },
+    [snapshot, applyLocalDateChange],
+  );
+
+  // Wired refs so the rail and canvas share a vertical scroll. We listen on
+  // the scroll containers and mirror scrollTop both ways.
+  const railScrollRef = useRef<HTMLDivElement>(null);
+  const canvasScrollRef = useRef<HTMLDivElement>(null);
+  const syncingScroll = useRef(false);
+  const onRailScroll = () => {
+    if (syncingScroll.current) return;
+    syncingScroll.current = true;
+    if (canvasScrollRef.current && railScrollRef.current) {
+      canvasScrollRef.current.scrollTop = railScrollRef.current.scrollTop;
+    }
+    syncingScroll.current = false;
+  };
+  const onCanvasScroll = () => {
+    if (syncingScroll.current) return;
+    syncingScroll.current = true;
+    if (railScrollRef.current && canvasScrollRef.current) {
+      railScrollRef.current.scrollTop = canvasScrollRef.current.scrollTop;
+    }
+    syncingScroll.current = false;
+  };
+
+  const truncatedNote = snapshot?.truncated
+    ? `Showing first ${snapshot.initiatives.length} of a larger workspace; refine filters for the full set.`
+    : null;
+
+  return (
+    <div className="min-h-screen bg-mc-bg flex flex-col">
+      <header className="px-6 py-4 flex items-center justify-between border-b border-mc-border bg-mc-bg-secondary">
+        <div>
+          <h1 className="text-xl font-semibold text-mc-text">Roadmap</h1>
+          <p className="text-xs text-mc-text-secondary">
+            Timeline view · {visibleInitiatives.length} initiative{visibleInitiatives.length === 1 ? '' : 's'} ·
+            today {toIsoDay(new Date())}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/initiatives"
+            className="px-3 py-1.5 rounded-lg border border-mc-border text-mc-text-secondary hover:text-mc-text text-sm"
+          >
+            Initiative tree
+          </Link>
+          <Link
+            href="/"
+            className="px-3 py-1.5 rounded-lg border border-mc-border text-mc-text-secondary hover:text-mc-text text-sm"
+          >
+            Workspaces
+          </Link>
+        </div>
+      </header>
+
+      <RoadmapToolbar
+        filters={filters}
+        setFilters={setFilters}
+        zoom={zoom}
+        setZoom={setZoom}
+        snapshot={snapshot}
+      />
+
+      {error && (
+        <div className="m-4 p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+      {truncatedNote && (
+        <div className="mx-4 mt-2 p-2 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-300 text-xs">
+          {truncatedNote}
+        </div>
+      )}
+
+      <main className="flex-1 flex min-h-0 overflow-hidden">
+        {loading ? (
+          <p className="m-6 text-mc-text-secondary">Loading roadmap…</p>
+        ) : visibleInitiatives.length === 0 ? (
+          <div className="m-auto text-center max-w-md">
+            <p className="text-mc-text-secondary mb-3">
+              No initiatives match the current filters.
+            </p>
+            <Link
+              href="/initiatives"
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-mc-accent text-white hover:bg-mc-accent/90 text-sm"
+            >
+              <Plus className="w-4 h-4" /> Create initiative
+            </Link>
+          </div>
+        ) : (
+          <>
+            <RoadmapRail
+              initiatives={visibleInitiatives}
+              width={RAIL_WIDTH}
+              rowHeight={ROW_HEIGHT}
+              collapsed={collapsed}
+              onToggleCollapsed={toggleCollapsed}
+              snapshot={snapshot}
+              scrollRef={railScrollRef}
+              onScroll={onRailScroll}
+            />
+            <RoadmapCanvas
+              initiatives={visibleInitiatives}
+              visibleIds={visibleIds}
+              dependencies={snapshot?.dependencies ?? []}
+              tasks={snapshot?.tasks ?? []}
+              windowStart={window_.start}
+              windowEnd={window_.end}
+              pxPerDay={pxPerDay}
+              zoom={zoom}
+              rowHeight={ROW_HEIGHT}
+              onUpdateDates={updateInitiativeDates}
+              scrollRef={canvasScrollRef}
+              onScroll={onCanvasScroll}
+            />
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/components/roadmap/RoadmapToolbar.tsx
+++ b/src/components/roadmap/RoadmapToolbar.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+/**
+ * Top-of-page filters and zoom controls for the roadmap.
+ *
+ * Filters are kept dumb here — state lives in RoadmapTimeline; this just
+ * renders inputs and toggles via setFilters. Product/owner pickers source
+ * their options from the loaded snapshot so we don't make extra requests.
+ */
+
+import { useMemo } from 'react';
+import { Layers, Filter } from 'lucide-react';
+import type { ZoomLevel } from '@/lib/roadmap/date-math';
+import type {
+  Kind,
+  RoadmapFilters,
+  RoadmapSnapshot,
+  Status,
+} from './RoadmapTimeline';
+
+const KIND_LABEL: Record<Kind, string> = {
+  theme: 'Theme',
+  milestone: 'Milestone',
+  epic: 'Epic',
+  story: 'Story',
+};
+
+const STATUS_LABEL: Record<Status, string> = {
+  planned: 'Planned',
+  in_progress: 'In progress',
+  at_risk: 'At risk',
+  blocked: 'Blocked',
+  done: 'Done',
+  cancelled: 'Cancelled',
+};
+
+export function RoadmapToolbar({
+  filters,
+  setFilters,
+  zoom,
+  setZoom,
+  snapshot,
+}: {
+  filters: RoadmapFilters;
+  setFilters: (next: RoadmapFilters) => void;
+  zoom: ZoomLevel;
+  setZoom: (z: ZoomLevel) => void;
+  snapshot: RoadmapSnapshot | null;
+}) {
+  const productOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const i of snapshot?.initiatives ?? []) {
+      if (i.product_id) set.add(i.product_id);
+    }
+    return Array.from(set).sort();
+  }, [snapshot]);
+
+  const ownerOptions = useMemo(() => {
+    const map = new Map<string, string | null>();
+    for (const i of snapshot?.initiatives ?? []) {
+      if (i.owner_agent_id) map.set(i.owner_agent_id, i.owner_agent_name);
+    }
+    return Array.from(map.entries()).sort((a, b) => (a[1] ?? '').localeCompare(b[1] ?? ''));
+  }, [snapshot]);
+
+  const toggleKind = (k: Kind) => {
+    const next = new Set(filters.kinds);
+    if (next.has(k)) next.delete(k);
+    else next.add(k);
+    setFilters({ ...filters, kinds: next });
+  };
+
+  const toggleStatus = (s: Status) => {
+    const next = new Set(filters.statuses);
+    if (next.has(s)) next.delete(s);
+    else next.add(s);
+    setFilters({ ...filters, statuses: next });
+  };
+
+  return (
+    <div className="px-4 py-2 flex flex-wrap items-center gap-2 border-b border-mc-border bg-mc-bg-secondary">
+      <div className="flex items-center gap-1 mr-2 text-xs text-mc-text-secondary">
+        <Filter className="w-3.5 h-3.5" /> Filters
+      </div>
+
+      {/* Product */}
+      <select
+        value={filters.product_id ?? ''}
+        onChange={e => setFilters({ ...filters, product_id: e.target.value || null })}
+        className="px-2 py-1 rounded bg-mc-bg border border-mc-border text-xs"
+      >
+        <option value="">All products</option>
+        {productOptions.map(p => (
+          <option key={p} value={p}>
+            {p.slice(0, 8)}…
+          </option>
+        ))}
+      </select>
+
+      {/* Owner */}
+      <select
+        value={filters.owner_agent_id ?? ''}
+        onChange={e => setFilters({ ...filters, owner_agent_id: e.target.value || null })}
+        className="px-2 py-1 rounded bg-mc-bg border border-mc-border text-xs"
+      >
+        <option value="">All owners</option>
+        {ownerOptions.map(([id, name]) => (
+          <option key={id} value={id}>
+            {name ?? id.slice(0, 8)}
+          </option>
+        ))}
+      </select>
+
+      {/* Kinds — checkboxes */}
+      <div className="flex items-center gap-1 ml-2">
+        {(Object.keys(KIND_LABEL) as Kind[]).map(k => (
+          <label
+            key={k}
+            className={`px-2 py-0.5 rounded border text-xs cursor-pointer ${
+              filters.kinds.has(k)
+                ? 'border-mc-accent/60 bg-mc-accent/10 text-mc-text'
+                : 'border-mc-border text-mc-text-secondary'
+            }`}
+          >
+            <input
+              type="checkbox"
+              className="hidden"
+              checked={filters.kinds.has(k)}
+              onChange={() => toggleKind(k)}
+            />
+            {KIND_LABEL[k]}
+          </label>
+        ))}
+      </div>
+
+      {/* Statuses */}
+      <div className="flex items-center gap-1">
+        {(Object.keys(STATUS_LABEL) as Status[]).map(s => (
+          <label
+            key={s}
+            className={`px-2 py-0.5 rounded border text-xs cursor-pointer ${
+              filters.statuses.has(s)
+                ? 'border-mc-accent/60 bg-mc-accent/10 text-mc-text'
+                : 'border-mc-border text-mc-text-secondary'
+            }`}
+          >
+            <input
+              type="checkbox"
+              className="hidden"
+              checked={filters.statuses.has(s)}
+              onChange={() => toggleStatus(s)}
+            />
+            {STATUS_LABEL[s]}
+          </label>
+        ))}
+      </div>
+
+      {/* Zoom */}
+      <div className="ml-auto flex items-center gap-1">
+        <Layers className="w-3.5 h-3.5 text-mc-text-secondary" />
+        {(['week', 'month', 'quarter'] as const).map(z => (
+          <button
+            key={z}
+            onClick={() => setZoom(z)}
+            className={`px-2 py-1 rounded text-xs border ${
+              zoom === z
+                ? 'border-mc-accent bg-mc-accent/20 text-mc-text'
+                : 'border-mc-border text-mc-text-secondary hover:text-mc-text'
+            }`}
+            title={`Zoom: ${z}`}
+          >
+            {z[0].toUpperCase() + z.slice(1)}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/db/roadmap.test.ts
+++ b/src/lib/db/roadmap.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for the roadmap snapshot helper (Phase 3).
+ *
+ * Fixture: 1 milestone, 2 epics, 3 stories (one under each epic, plus one
+ * orphan), 1 dependency, 4 tasks of mixed status. Verifies depth, task
+ * counts, dependency wiring, and filter semantics (kind, status,
+ * product_id, from/to).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import {
+  addInitiativeDependency,
+  attachTaskToInitiative,
+  createInitiative,
+} from './initiatives';
+import { getRoadmapSnapshot } from './roadmap';
+
+interface Fixture {
+  workspace: string;
+  productA: string;
+  productB: string;
+  milestoneId: string;
+  epicAId: string;
+  epicBId: string;
+  storyAId: string;
+  storyBId: string;
+  storyOrphanId: string;
+  depId: string;
+  taskDraftId: string;
+  taskInboxId: string;
+  taskInProgId: string;
+  taskDoneId: string;
+}
+
+function seedTask(opts: { initiativeId?: string | null; status?: string; workspace_id?: string } = {}): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, initiative_id, created_at, updated_at)
+     VALUES (?, 'T', ?, 'normal', ?, 'default', ?, datetime('now'), datetime('now'))`,
+    [id, opts.status ?? 'inbox', opts.workspace_id ?? 'default', opts.initiativeId ?? null],
+  );
+  return id;
+}
+
+function seedProduct(workspace_id: string): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO products (id, workspace_id, name, created_at, updated_at)
+     VALUES (?, ?, 'P', datetime('now'), datetime('now'))`,
+    [id, workspace_id],
+  );
+  return id;
+}
+
+function buildFixture(): Fixture {
+  // Use a dedicated workspace per test run to avoid cross-test pollution.
+  const ws = `ws-roadmap-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT INTO workspaces (id, name, slug, created_at, updated_at)
+     VALUES (?, 'roadmap-test-ws', ?, datetime('now'), datetime('now'))`,
+    [ws, ws],
+  );
+  const productA = seedProduct(ws);
+  const productB = seedProduct(ws);
+
+  // Tree:
+  //   milestone (target_end 2026-05-15)
+  //     epicA (productA, target 2026-04-20..2026-05-10)
+  //       storyA (productA, target 2026-04-22..2026-04-30)
+  //     epicB (productB, target 2026-06-01..2026-06-30)
+  //       storyB (productB, target 2026-06-05..2026-06-20)
+  //   storyOrphan (no parent, no dates)
+  //
+  // Dependency: epicB depends on epicA.
+
+  const milestone = createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Launch milestone',
+    target_end: '2026-05-15',
+    committed_end: '2026-05-15',
+  });
+  const epicA = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Epic A',
+    parent_initiative_id: milestone.id,
+    product_id: productA,
+    target_start: '2026-04-20',
+    target_end: '2026-05-10',
+  });
+  const epicB = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Epic B',
+    parent_initiative_id: milestone.id,
+    product_id: productB,
+    target_start: '2026-06-01',
+    target_end: '2026-06-30',
+    status: 'at_risk',
+  });
+  const storyA = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'Story A',
+    parent_initiative_id: epicA.id,
+    product_id: productA,
+    target_start: '2026-04-22',
+    target_end: '2026-04-30',
+  });
+  const storyB = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'Story B',
+    parent_initiative_id: epicB.id,
+    product_id: productB,
+    target_start: '2026-06-05',
+    target_end: '2026-06-20',
+  });
+  const storyOrphan = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'Backlog story (no dates)',
+  });
+
+  const dep = addInitiativeDependency({
+    initiative_id: epicB.id,
+    depends_on_initiative_id: epicA.id,
+  });
+
+  // Four tasks of mixed status, all under storyA.
+  const taskDraft = seedTask({ workspace_id: ws, status: 'draft' });
+  attachTaskToInitiative(taskDraft, storyA.id);
+  const taskInbox = seedTask({ workspace_id: ws, status: 'inbox' });
+  attachTaskToInitiative(taskInbox, storyA.id);
+  const taskInProg = seedTask({ workspace_id: ws, status: 'in_progress' });
+  attachTaskToInitiative(taskInProg, storyA.id);
+  const taskDone = seedTask({ workspace_id: ws, status: 'done' });
+  attachTaskToInitiative(taskDone, storyA.id);
+
+  return {
+    workspace: ws,
+    productA,
+    productB,
+    milestoneId: milestone.id,
+    epicAId: epicA.id,
+    epicBId: epicB.id,
+    storyAId: storyA.id,
+    storyBId: storyB.id,
+    storyOrphanId: storyOrphan.id,
+    depId: dep.id,
+    taskDraftId: taskDraft,
+    taskInboxId: taskInbox,
+    taskInProgId: taskInProg,
+    taskDoneId: taskDone,
+  };
+}
+
+test('snapshot returns all initiatives in workspace with correct depth', () => {
+  const f = buildFixture();
+  const snap = getRoadmapSnapshot({ workspace_id: f.workspace });
+  assert.equal(snap.workspace_id, f.workspace);
+  assert.equal(snap.truncated, false);
+  assert.equal(snap.initiatives.length, 6);
+
+  const byId = new Map(snap.initiatives.map(i => [i.id, i]));
+  assert.equal(byId.get(f.milestoneId)?.depth, 0);
+  assert.equal(byId.get(f.epicAId)?.depth, 1);
+  assert.equal(byId.get(f.epicBId)?.depth, 1);
+  assert.equal(byId.get(f.storyAId)?.depth, 2);
+  assert.equal(byId.get(f.storyBId)?.depth, 2);
+  assert.equal(byId.get(f.storyOrphanId)?.depth, 0);
+});
+
+test('task_counts reflect status families', () => {
+  const f = buildFixture();
+  const snap = getRoadmapSnapshot({ workspace_id: f.workspace });
+  const storyA = snap.initiatives.find(i => i.id === f.storyAId);
+  assert.ok(storyA);
+  assert.deepEqual(storyA.task_counts, { draft: 1, active: 2, done: 1, total: 4 });
+
+  // No tasks on milestone.
+  const milestone = snap.initiatives.find(i => i.id === f.milestoneId);
+  assert.deepEqual(milestone?.task_counts, { draft: 0, active: 0, done: 0, total: 0 });
+});
+
+test('dependencies array contains the seeded edge and only that', () => {
+  const f = buildFixture();
+  const snap = getRoadmapSnapshot({ workspace_id: f.workspace });
+  assert.equal(snap.dependencies.length, 1);
+  assert.equal(snap.dependencies[0].id, f.depId);
+  assert.equal(snap.dependencies[0].initiative_id, f.epicBId);
+  assert.equal(snap.dependencies[0].depends_on_initiative_id, f.epicAId);
+});
+
+test('tasks array exposes only initiative-linked tasks', () => {
+  const f = buildFixture();
+  const snap = getRoadmapSnapshot({ workspace_id: f.workspace });
+  assert.equal(snap.tasks.length, 4);
+  for (const t of snap.tasks) {
+    assert.ok(t.initiative_id, 'tasks without initiative_id should not appear');
+  }
+});
+
+test('filter by kind', () => {
+  const f = buildFixture();
+  const snap = getRoadmapSnapshot({ workspace_id: f.workspace, kind: 'epic' });
+  assert.equal(snap.initiatives.length, 2);
+  for (const i of snap.initiatives) {
+    assert.equal(i.kind, 'epic');
+  }
+  // Depth recomputes against the visible set — epics are now roots.
+  for (const i of snap.initiatives) assert.equal(i.depth, 0);
+});
+
+test('filter by status', () => {
+  const f = buildFixture();
+  const snap = getRoadmapSnapshot({ workspace_id: f.workspace, status: 'at_risk' });
+  assert.equal(snap.initiatives.length, 1);
+  assert.equal(snap.initiatives[0].id, f.epicBId);
+});
+
+test('filter by product_id keeps only matching initiatives', () => {
+  const f = buildFixture();
+  const snapA = getRoadmapSnapshot({ workspace_id: f.workspace, product_id: f.productA });
+  const ids = snapA.initiatives.map(i => i.id).sort();
+  assert.deepEqual(ids, [f.epicAId, f.storyAId].sort());
+});
+
+test('from/to date window clips by target overlap; null-date rows kept', () => {
+  const f = buildFixture();
+  // Window covers April only — should keep epicA (Apr 20–May 10), storyA
+  // (Apr 22–30), and storyOrphan (no dates).  Should drop epicB and storyB
+  // (entirely in June) and the milestone (only end = May 15).
+  const snap = getRoadmapSnapshot({
+    workspace_id: f.workspace,
+    from: '2026-04-01',
+    to: '2026-04-30',
+  });
+  const ids = new Set(snap.initiatives.map(i => i.id));
+  assert.ok(ids.has(f.epicAId));
+  assert.ok(ids.has(f.storyAId));
+  assert.ok(ids.has(f.storyOrphanId));
+  assert.ok(!ids.has(f.epicBId));
+  assert.ok(!ids.has(f.storyBId));
+});
+
+test('owner_agent_name joined when owner is set', () => {
+  const f = buildFixture();
+  const agentId = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id) VALUES (?, 'Sarah', 'worker', ?)`,
+    [agentId, f.workspace],
+  );
+  // Update epicA to have an owner.
+  run('UPDATE initiatives SET owner_agent_id = ? WHERE id = ?', [agentId, f.epicAId]);
+
+  const snap = getRoadmapSnapshot({ workspace_id: f.workspace });
+  const epicA = snap.initiatives.find(i => i.id === f.epicAId);
+  assert.equal(epicA?.owner_agent_id, agentId);
+  assert.equal(epicA?.owner_agent_name, 'Sarah');
+
+  const storyA = snap.initiatives.find(i => i.id === f.storyAId);
+  assert.equal(storyA?.owner_agent_id, null);
+  assert.equal(storyA?.owner_agent_name, null);
+});
+
+test('snapshot in another workspace returns empty', () => {
+  const f = buildFixture();
+  void f;
+  const snap = getRoadmapSnapshot({ workspace_id: 'no-such-ws' });
+  assert.equal(snap.initiatives.length, 0);
+  assert.equal(snap.dependencies.length, 0);
+  assert.equal(snap.tasks.length, 0);
+  assert.equal(snap.truncated, false);
+});

--- a/src/lib/db/roadmap.ts
+++ b/src/lib/db/roadmap.ts
@@ -1,0 +1,284 @@
+/**
+ * Roadmap snapshot helper (Phase 3).
+ *
+ * Aggregates initiative tree, dependencies, and tasks for a workspace into
+ * a single payload optimized for the timeline view. Keeps the DB round-trips
+ * to a fixed number (one per logical group) so a 500-initiative workspace
+ * still loads in a single tick.
+ *
+ * Filter semantics:
+ *   - `workspace_id` (required): hard filter, applies before paging.
+ *   - `product_id`: filter initiatives by product; tasks/deps are also
+ *     restricted to the surviving initiative set.
+ *   - `owner_agent_id`, `kind`, `status`: filter the initiative set.
+ *   - `from`/`to`: clip by target window overlap (initiatives whose
+ *     [target_start, target_end] window intersects [from, to] are kept).
+ *     Initiatives with no target dates are kept regardless — the UI
+ *     renders them as "no schedule" rows.
+ *   - `MAX` cap: returns at most 500 rows; `truncated: true` is set if
+ *     the underlying set was larger.
+ *
+ * Pure data — does no rendering, holds no React state. Callable from API
+ * routes and (later) from MCP tools.
+ */
+
+import { queryAll } from '@/lib/db';
+import { windowsOverlap } from '@/lib/roadmap/date-math';
+
+const MAX = 500;
+
+export type InitiativeKind = 'theme' | 'milestone' | 'epic' | 'story';
+export type InitiativeStatus = 'planned' | 'in_progress' | 'at_risk' | 'blocked' | 'done' | 'cancelled';
+
+export interface RoadmapInitiative {
+  id: string;
+  parent_initiative_id: string | null;
+  product_id: string | null;
+  kind: InitiativeKind;
+  title: string;
+  status: InitiativeStatus;
+  owner_agent_id: string | null;
+  owner_agent_name: string | null;
+  complexity: 'S' | 'M' | 'L' | 'XL' | null;
+  estimated_effort_hours: number | null;
+  target_start: string | null;
+  target_end: string | null;
+  derived_start: string | null;
+  derived_end: string | null;
+  committed_end: string | null;
+  status_check_md: string | null;
+  sort_order: number;
+  depth: number;
+  task_counts: { draft: number; active: number; done: number; total: number };
+}
+
+export interface RoadmapDependency {
+  id: string;
+  initiative_id: string;
+  depends_on_initiative_id: string;
+  kind: string;
+  note: string | null;
+}
+
+export interface RoadmapTask {
+  id: string;
+  initiative_id: string;
+  title: string;
+  status: string;
+  assigned_agent_id: string | null;
+}
+
+export interface RoadmapSnapshot {
+  initiatives: RoadmapInitiative[];
+  dependencies: RoadmapDependency[];
+  tasks: RoadmapTask[];
+  workspace_id: string;
+  product_id: string | null;
+  truncated: boolean;
+}
+
+export interface RoadmapFilters {
+  workspace_id: string;
+  product_id?: string | null;
+  owner_agent_id?: string | null;
+  kind?: InitiativeKind;
+  status?: InitiativeStatus;
+  from?: string | null;
+  to?: string | null;
+}
+
+/** Status families for task chip rendering. Mirrors initiatives page. */
+const ACTIVE_STATUSES = new Set([
+  'inbox',
+  'planning',
+  'assigned',
+  'in_progress',
+  'convoy_active',
+  'testing',
+  'review',
+  'verification',
+]);
+
+interface RawInitiativeRow {
+  id: string;
+  workspace_id: string;
+  product_id: string | null;
+  parent_initiative_id: string | null;
+  kind: InitiativeKind;
+  title: string;
+  status: InitiativeStatus;
+  owner_agent_id: string | null;
+  owner_agent_name: string | null;
+  complexity: 'S' | 'M' | 'L' | 'XL' | null;
+  estimated_effort_hours: number | null;
+  target_start: string | null;
+  target_end: string | null;
+  derived_start: string | null;
+  derived_end: string | null;
+  committed_end: string | null;
+  status_check_md: string | null;
+  sort_order: number;
+}
+
+/**
+ * Build the snapshot. Returns deterministic-order arrays — callers may
+ * rely on `initiatives` being in (parent, sort_order, created_at) order
+ * for the rail tree render.
+ */
+export function getRoadmapSnapshot(filters: RoadmapFilters): RoadmapSnapshot {
+  const where: string[] = ['i.workspace_id = ?'];
+  const params: unknown[] = [filters.workspace_id];
+
+  if (filters.product_id) {
+    where.push('i.product_id = ?');
+    params.push(filters.product_id);
+  }
+  if (filters.owner_agent_id) {
+    where.push('i.owner_agent_id = ?');
+    params.push(filters.owner_agent_id);
+  }
+  if (filters.kind) {
+    where.push('i.kind = ?');
+    params.push(filters.kind);
+  }
+  if (filters.status) {
+    where.push('i.status = ?');
+    params.push(filters.status);
+  }
+
+  // Pull rows + owner agent name in one shot via LEFT JOIN.
+  const sql = `
+    SELECT
+      i.id, i.workspace_id, i.product_id, i.parent_initiative_id,
+      i.kind, i.title, i.status, i.owner_agent_id,
+      a.name AS owner_agent_name,
+      i.complexity, i.estimated_effort_hours,
+      i.target_start, i.target_end,
+      i.derived_start, i.derived_end, i.committed_end,
+      i.status_check_md, i.sort_order
+    FROM initiatives i
+    LEFT JOIN agents a ON a.id = i.owner_agent_id
+    WHERE ${where.join(' AND ')}
+    ORDER BY i.sort_order, i.created_at
+  `;
+  const rawRows = queryAll<RawInitiativeRow>(sql, params);
+
+  // Date-window filter (post-query because the predicate uses the windowsOverlap
+  // helper, which handles NULL endpoints uniformly with the JS code).
+  const dateFiltered = (filters.from || filters.to)
+    ? rawRows.filter(r => {
+        // Initiatives with neither target_start nor target_end are kept —
+        // they're "no schedule" backlog items, useful regardless of clip.
+        if (r.target_start == null && r.target_end == null) return true;
+        return windowsOverlap(r.target_start, r.target_end, filters.from ?? null, filters.to ?? null);
+      })
+    : rawRows;
+
+  const truncated = dateFiltered.length > MAX;
+  const visibleRows = truncated ? dateFiltered.slice(0, MAX) : dateFiltered;
+
+  // Compute tree depth — distance from root, walking parent_initiative_id.
+  // Done in JS so we don't need a recursive CTE. Built in an in-memory map
+  // keyed on id to avoid O(n²) walks.
+  const byId = new Map<string, RawInitiativeRow>();
+  for (const r of visibleRows) byId.set(r.id, r);
+
+  const depthCache = new Map<string, number>();
+  function depthOf(id: string): number {
+    const cached = depthCache.get(id);
+    if (cached !== undefined) return cached;
+    const row = byId.get(id);
+    if (!row) {
+      // Parent isn't in the visible set (filtered out). Treat as root.
+      depthCache.set(id, 0);
+      return 0;
+    }
+    if (!row.parent_initiative_id || !byId.has(row.parent_initiative_id)) {
+      depthCache.set(id, 0);
+      return 0;
+    }
+    const d = depthOf(row.parent_initiative_id) + 1;
+    depthCache.set(id, d);
+    return d;
+  }
+
+  const visibleIds = new Set(visibleRows.map(r => r.id));
+
+  // Tasks for the visible initiatives — single query, then bucketed.
+  const taskRows: Array<{
+    id: string;
+    initiative_id: string | null;
+    title: string;
+    status: string;
+    assigned_agent_id: string | null;
+  }> = visibleIds.size === 0
+    ? []
+    : queryAll(
+        `SELECT id, initiative_id, title, status, assigned_agent_id
+         FROM tasks
+         WHERE initiative_id IN (${Array.from(visibleIds).map(() => '?').join(',')})
+         ORDER BY created_at`,
+        Array.from(visibleIds),
+      );
+
+  // Dependencies between visible initiatives.
+  const depRows: RoadmapDependency[] = visibleIds.size === 0
+    ? []
+    : queryAll<RoadmapDependency>(
+        `SELECT id, initiative_id, depends_on_initiative_id, kind, note
+         FROM initiative_dependencies
+         WHERE initiative_id IN (${Array.from(visibleIds).map(() => '?').join(',')})
+            OR depends_on_initiative_id IN (${Array.from(visibleIds).map(() => '?').join(',')})`,
+        [...Array.from(visibleIds), ...Array.from(visibleIds)],
+      );
+
+  // task_counts per initiative_id, bucketed by status family.
+  const counts: Record<string, { draft: number; active: number; done: number; total: number }> = {};
+  for (const t of taskRows) {
+    if (!t.initiative_id) continue;
+    const c = counts[t.initiative_id] || (counts[t.initiative_id] = { draft: 0, active: 0, done: 0, total: 0 });
+    c.total += 1;
+    if (t.status === 'draft') c.draft += 1;
+    else if (t.status === 'done') c.done += 1;
+    else if (ACTIVE_STATUSES.has(t.status)) c.active += 1;
+  }
+
+  const initiatives: RoadmapInitiative[] = visibleRows.map(r => ({
+    id: r.id,
+    parent_initiative_id: r.parent_initiative_id,
+    product_id: r.product_id,
+    kind: r.kind,
+    title: r.title,
+    status: r.status,
+    owner_agent_id: r.owner_agent_id,
+    owner_agent_name: r.owner_agent_name,
+    complexity: r.complexity,
+    estimated_effort_hours: r.estimated_effort_hours,
+    target_start: r.target_start,
+    target_end: r.target_end,
+    derived_start: r.derived_start,
+    derived_end: r.derived_end,
+    committed_end: r.committed_end,
+    status_check_md: r.status_check_md,
+    sort_order: r.sort_order,
+    depth: depthOf(r.id),
+    task_counts: counts[r.id] || { draft: 0, active: 0, done: 0, total: 0 },
+  }));
+
+  return {
+    initiatives,
+    dependencies: depRows,
+    tasks: taskRows
+      .filter((t): t is RoadmapTask => t.initiative_id != null)
+      .map(t => ({
+        id: t.id,
+        initiative_id: t.initiative_id!,
+        title: t.title,
+        status: t.status,
+        assigned_agent_id: t.assigned_agent_id,
+      })),
+    workspace_id: filters.workspace_id,
+    product_id: filters.product_id ?? null,
+    truncated,
+  };
+}

--- a/src/lib/roadmap/date-math.test.ts
+++ b/src/lib/roadmap/date-math.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for the roadmap date-math helpers (Phase 3).
+ *
+ * Focus: round-trip, snap-to-day, range clipping, edge cases.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PX_PER_DAY,
+  addDays,
+  axisTicks,
+  daysBetween,
+  dateToPx,
+  defaultWindow,
+  formatTick,
+  pxToDate,
+  rangeWidthPx,
+  snapToDay,
+  toIsoDay,
+  toUtcDay,
+  windowsOverlap,
+} from './date-math';
+
+// ─── toUtcDay / addDays / daysBetween ──────────────────────────────
+
+test('toUtcDay normalizes ISO date strings to UTC midnight', () => {
+  const d = toUtcDay('2026-04-24');
+  assert.equal(d.getUTCFullYear(), 2026);
+  assert.equal(d.getUTCMonth(), 3); // April
+  assert.equal(d.getUTCDate(), 24);
+  assert.equal(d.getUTCHours(), 0);
+});
+
+test('toUtcDay accepts full ISO timestamps and snaps to that day', () => {
+  const d = toUtcDay('2026-04-24T17:30:00Z');
+  assert.equal(toIsoDay(d), '2026-04-24');
+});
+
+test('toUtcDay throws on garbage input', () => {
+  assert.throws(() => toUtcDay('not-a-date'));
+});
+
+test('daysBetween is signed and integer', () => {
+  assert.equal(daysBetween('2026-04-24', '2026-04-25'), 1);
+  assert.equal(daysBetween('2026-04-25', '2026-04-24'), -1);
+  assert.equal(daysBetween('2026-04-24', '2026-04-24'), 0);
+});
+
+test('daysBetween crosses month/year boundaries cleanly', () => {
+  assert.equal(daysBetween('2026-01-31', '2026-02-01'), 1);
+  assert.equal(daysBetween('2026-12-31', '2027-01-01'), 1);
+  assert.equal(daysBetween('2026-04-01', '2026-05-01'), 30);
+});
+
+test('addDays plus daysBetween round-trip', () => {
+  const start = '2026-04-24';
+  for (const n of [-30, -1, 0, 1, 7, 90, 365]) {
+    const d = addDays(start, n);
+    assert.equal(daysBetween(start, d), n);
+  }
+});
+
+// ─── dateToPx / pxToDate round-trip ────────────────────────────────
+
+test('dateToPx is linear in days', () => {
+  const ws = '2026-04-01';
+  for (const z of ['week', 'month', 'quarter'] as const) {
+    const ppd = PX_PER_DAY[z];
+    assert.equal(dateToPx(ws, ws, ppd), 0);
+    assert.equal(dateToPx('2026-04-15', ws, ppd), 14 * ppd);
+    assert.equal(dateToPx('2026-03-25', ws, ppd), -7 * ppd);
+  }
+});
+
+test('pxToDate inverts dateToPx for snapped values', () => {
+  const ws = '2026-04-01';
+  const ppd = PX_PER_DAY.month;
+  for (const days of [-10, 0, 1, 14, 90]) {
+    const date = addDays(ws, days);
+    const px = dateToPx(date, ws, ppd);
+    const back = pxToDate(px, ws, ppd);
+    assert.equal(toIsoDay(back), toIsoDay(date));
+  }
+});
+
+test('pxToDate snaps to nearest day at fractional pixel offsets', () => {
+  const ws = '2026-04-01';
+  const ppd = PX_PER_DAY.month; // 8 px/day
+  // 12 px → 1.5 days → rounds to 2 → Apr 03
+  assert.equal(toIsoDay(pxToDate(12, ws, ppd)), '2026-04-03');
+  // 3 px → 0.375 → rounds to 0 → Apr 01
+  assert.equal(toIsoDay(pxToDate(3, ws, ppd)), '2026-04-01');
+});
+
+test('pxToDate rejects non-positive pxPerDay', () => {
+  assert.throws(() => pxToDate(10, '2026-04-01', 0));
+  assert.throws(() => pxToDate(10, '2026-04-01', -1));
+});
+
+test('snapToDay alias matches toUtcDay', () => {
+  const a = snapToDay('2026-04-24T13:00:00Z');
+  const b = toUtcDay('2026-04-24T13:00:00Z');
+  assert.equal(a.getTime(), b.getTime());
+});
+
+// ─── rangeWidthPx ──────────────────────────────────────────────────
+
+test('rangeWidthPx is inclusive: same-day is one day wide', () => {
+  const ppd = 8;
+  assert.equal(rangeWidthPx('2026-04-24', '2026-04-24', ppd), ppd);
+});
+
+test('rangeWidthPx grows linearly with span', () => {
+  const ppd = 8;
+  assert.equal(rangeWidthPx('2026-04-01', '2026-04-08', ppd), 8 * ppd);
+});
+
+test('rangeWidthPx returns 0 when end < start', () => {
+  assert.equal(rangeWidthPx('2026-04-08', '2026-04-01', 8), 0);
+});
+
+// ─── windowsOverlap ────────────────────────────────────────────────
+
+test('windowsOverlap: clear overlap', () => {
+  assert.equal(windowsOverlap('2026-04-01', '2026-04-30', '2026-04-15', '2026-05-15'), true);
+});
+
+test('windowsOverlap: clear miss', () => {
+  assert.equal(windowsOverlap('2026-04-01', '2026-04-15', '2026-05-01', '2026-05-15'), false);
+});
+
+test('windowsOverlap: edge-touching counts as overlap (inclusive)', () => {
+  assert.equal(windowsOverlap('2026-04-01', '2026-04-15', '2026-04-15', '2026-04-30'), true);
+});
+
+test('windowsOverlap: missing endpoints behave as unbounded', () => {
+  // a is unbounded → always overlaps anything
+  assert.equal(windowsOverlap(null, null, '2026-04-01', '2026-04-15'), true);
+  // a starts before, no upper bound → overlaps later windows
+  assert.equal(windowsOverlap('2026-04-01', null, '2030-01-01', '2030-12-31'), true);
+});
+
+// ─── defaultWindow ─────────────────────────────────────────────────
+
+test('defaultWindow includes today and pads', () => {
+  const today = '2026-04-24';
+  const w = defaultWindow([], today);
+  assert.ok(daysBetween(w.start, today) >= 14);
+  assert.ok(daysBetween(today, w.end) >= 14);
+});
+
+test('defaultWindow expands to cover provided dates', () => {
+  const today = '2026-04-24';
+  const w = defaultWindow(['2026-01-01', '2026-12-31'], today);
+  assert.ok(toIsoDay(w.start) <= '2025-12-18'); // padded by 14d before Jan 1
+  assert.ok(toIsoDay(w.end) >= '2027-01-14');
+});
+
+test('defaultWindow ignores nulls', () => {
+  // Should not throw or produce NaN.
+  const w = defaultWindow([null, undefined, '2026-04-24'], '2026-04-24');
+  assert.ok(w.start instanceof Date);
+  assert.ok(!isNaN(w.start.getTime()));
+});
+
+// ─── axisTicks / formatTick ────────────────────────────────────────
+
+test('axisTicks: month zoom returns month boundaries', () => {
+  const t = axisTicks('2026-04-10', '2026-07-15', 'month');
+  // First-of-May, June, July.
+  assert.deepEqual(t.map(toIsoDay), ['2026-05-01', '2026-06-01', '2026-07-01']);
+});
+
+test('axisTicks: quarter zoom returns quarter starts', () => {
+  const t = axisTicks('2026-02-01', '2026-12-31', 'quarter');
+  assert.deepEqual(t.map(toIsoDay), ['2026-04-01', '2026-07-01', '2026-10-01']);
+});
+
+test('axisTicks: week zoom returns Mondays', () => {
+  // 2026-04-20 is a Monday.
+  const t = axisTicks('2026-04-18', '2026-05-05', 'week');
+  assert.deepEqual(t.map(toIsoDay), ['2026-04-20', '2026-04-27', '2026-05-04']);
+});
+
+test('axisTicks: returns empty when end < start', () => {
+  assert.deepEqual(axisTicks('2026-04-30', '2026-04-01', 'month'), []);
+});
+
+test('formatTick produces stable labels', () => {
+  assert.equal(formatTick(toUtcDay('2026-04-01'), 'month'), 'Apr');
+  assert.equal(formatTick(toUtcDay('2026-01-01'), 'month'), 'Jan 2026');
+  assert.equal(formatTick(toUtcDay('2026-04-01'), 'quarter'), 'Q2 2026');
+  assert.equal(formatTick(toUtcDay('2026-04-20'), 'week'), 'Apr 20');
+});
+
+// ─── degenerate / zero-length ranges ───────────────────────────────
+
+test('zero-length range still renders one day wide', () => {
+  const ws = '2026-04-01';
+  const ppd = PX_PER_DAY.month;
+  const start = dateToPx('2026-04-15', ws, ppd);
+  const w = rangeWidthPx('2026-04-15', '2026-04-15', ppd);
+  assert.equal(start, 14 * ppd);
+  assert.equal(w, ppd);
+});
+
+test('range outside the visible window: dateToPx still produces signed coords', () => {
+  // Caller is responsible for clipping in render; date math doesn't constrain.
+  const ws = '2026-04-01';
+  const ppd = PX_PER_DAY.month;
+  // 90 days before window start.
+  assert.equal(dateToPx('2026-01-01', ws, ppd), -90 * ppd);
+  // Far into future.
+  assert.ok(dateToPx('2027-04-01', ws, ppd) > 0);
+});

--- a/src/lib/roadmap/date-math.ts
+++ b/src/lib/roadmap/date-math.ts
@@ -1,0 +1,242 @@
+/**
+ * Pure date-math helpers for the roadmap timeline (Phase 3).
+ *
+ * The timeline canvas maps dates to pixels along the X axis. We always
+ * normalize to "day buckets" — the canvas resolution is one day. Higher
+ * zoom levels (week/month/quarter) just change how many pixels-per-day
+ * we render at; the math stays the same.
+ *
+ * All functions are pure, deterministic, and timezone-agnostic. Inputs
+ * may be Date objects or ISO-8601 date strings ("YYYY-MM-DD" or full
+ * ISO timestamps). Outputs are pixel offsets relative to a `windowStart`
+ * anchor (also normalized to UTC midnight).
+ */
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type ZoomLevel = 'week' | 'month' | 'quarter';
+
+/** Pixels per day for each zoom level. Tuned for ~1280px viewports. */
+export const PX_PER_DAY: Record<ZoomLevel, number> = {
+  week: 32,    // 1 day = 32px → 1 week ≈ 224px
+  month: 8,    // 1 day = 8px  → 1 month ≈ 240px
+  quarter: 3,  // 1 day = 3px  → 1 quarter ≈ 270px
+};
+
+/**
+ * Normalize a date input to a UTC-midnight Date. Accepts:
+ *   - Date instances (any time)
+ *   - ISO date strings "YYYY-MM-DD"
+ *   - Full ISO timestamps "YYYY-MM-DDTHH:MM:SS..."
+ *
+ * Throws on invalid input.
+ */
+export function toUtcDay(input: Date | string): Date {
+  let d: Date;
+  if (input instanceof Date) {
+    d = input;
+  } else if (typeof input === 'string') {
+    // Accept "YYYY-MM-DD" by appending T00:00:00Z (Date parses it as UTC).
+    const isoDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(input);
+    d = new Date(isoDateOnly ? `${input}T00:00:00.000Z` : input);
+  } else {
+    throw new Error(`Invalid date input: ${String(input)}`);
+  }
+  if (isNaN(d.getTime())) {
+    throw new Error(`Invalid date: ${String(input)}`);
+  }
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+/** Number of whole days between two date inputs (b - a). */
+export function daysBetween(a: Date | string, b: Date | string): number {
+  const ad = toUtcDay(a).getTime();
+  const bd = toUtcDay(b).getTime();
+  return Math.round((bd - ad) / MS_PER_DAY);
+}
+
+/** Add `n` days to a date, returning a new UTC-midnight Date. */
+export function addDays(d: Date | string, n: number): Date {
+  const base = toUtcDay(d);
+  return new Date(base.getTime() + n * MS_PER_DAY);
+}
+
+/** ISO "YYYY-MM-DD" format for a date. */
+export function toIsoDay(d: Date | string): string {
+  const utc = toUtcDay(d);
+  return utc.toISOString().slice(0, 10);
+}
+
+/**
+ * Convert a date to a pixel offset along the timeline.
+ *   px = daysBetween(windowStart, date) * pxPerDay
+ * Negative if `date` is before `windowStart`.
+ */
+export function dateToPx(
+  date: Date | string,
+  windowStart: Date | string,
+  pxPerDay: number,
+): number {
+  return daysBetween(windowStart, date) * pxPerDay;
+}
+
+/**
+ * Inverse of dateToPx. Snaps to the nearest day. Returns a UTC-midnight Date.
+ */
+export function pxToDate(
+  px: number,
+  windowStart: Date | string,
+  pxPerDay: number,
+): Date {
+  if (pxPerDay <= 0) {
+    throw new Error('pxPerDay must be positive');
+  }
+  const days = Math.round(px / pxPerDay);
+  return addDays(windowStart, days);
+}
+
+/**
+ * Width in pixels of a [start, end] range.
+ * Convention: end is inclusive (so a 1-day bar with start==end has width pxPerDay).
+ * If end < start, returns 0 (degenerate ranges don't render).
+ */
+export function rangeWidthPx(
+  start: Date | string,
+  end: Date | string,
+  pxPerDay: number,
+): number {
+  const days = daysBetween(start, end);
+  if (days < 0) return 0;
+  return (days + 1) * pxPerDay;
+}
+
+/**
+ * Snap a date to the start of a day (alias for toUtcDay, for callers
+ * that prefer reading `snapToDay(...)` at the drag-end site).
+ */
+export function snapToDay(input: Date | string): Date {
+  return toUtcDay(input);
+}
+
+/**
+ * Returns true if the [aStart, aEnd] window overlaps [bStart, bEnd].
+ * All inclusive. Either side may be null/undefined → treat as unbounded
+ * on that side. If both sides of one window are missing, returns true
+ * (no-filter semantics).
+ */
+export function windowsOverlap(
+  aStart: Date | string | null | undefined,
+  aEnd: Date | string | null | undefined,
+  bStart: Date | string | null | undefined,
+  bEnd: Date | string | null | undefined,
+): boolean {
+  // Missing both ends on side A or side B → no constraint, overlap is true.
+  const aS = aStart != null ? toUtcDay(aStart).getTime() : null;
+  const aE = aEnd != null ? toUtcDay(aEnd).getTime() : null;
+  const bS = bStart != null ? toUtcDay(bStart).getTime() : null;
+  const bE = bEnd != null ? toUtcDay(bEnd).getTime() : null;
+
+  // a ends before b starts.
+  if (aE != null && bS != null && aE < bS) return false;
+  // b ends before a starts.
+  if (bE != null && aS != null && bE < aS) return false;
+  return true;
+}
+
+/**
+ * Compute a default render window around a list of dates. Used to choose
+ * the canvas bounds when filters don't pin them. Pads by ~14 days on each
+ * side and ensures `today` is included.
+ */
+export function defaultWindow(
+  dates: Array<Date | string | null | undefined>,
+  today: Date | string = new Date(),
+): { start: Date; end: Date } {
+  const stamps: number[] = [];
+  for (const d of dates) {
+    if (d == null) continue;
+    try {
+      stamps.push(toUtcDay(d).getTime());
+    } catch {
+      // Ignore unparseable strings — they shouldn't influence the window.
+    }
+  }
+  const todayMs = toUtcDay(today).getTime();
+  stamps.push(todayMs);
+
+  const min = Math.min(...stamps);
+  const max = Math.max(...stamps);
+  return {
+    start: new Date(min - 14 * MS_PER_DAY),
+    end: new Date(max + 14 * MS_PER_DAY),
+  };
+}
+
+/**
+ * Tick generator for the time axis. Returns sorted UTC-midnight dates that
+ * land on natural boundaries for the chosen zoom level.
+ *
+ *   - week: every Monday in window
+ *   - month: 1st of every month in window
+ *   - quarter: 1st of every quarter (Jan/Apr/Jul/Oct)
+ */
+export function axisTicks(
+  start: Date | string,
+  end: Date | string,
+  zoom: ZoomLevel,
+): Date[] {
+  const s = toUtcDay(start);
+  const e = toUtcDay(end);
+  const ticks: Date[] = [];
+  if (e < s) return ticks;
+
+  if (zoom === 'week') {
+    // Roll forward to next Monday (UTC). getUTCDay: 0=Sun..6=Sat. Monday=1.
+    const cursor = new Date(s);
+    const dow = cursor.getUTCDay();
+    const offset = (1 - dow + 7) % 7;
+    cursor.setUTCDate(cursor.getUTCDate() + offset);
+    while (cursor <= e) {
+      ticks.push(new Date(cursor));
+      cursor.setUTCDate(cursor.getUTCDate() + 7);
+    }
+  } else if (zoom === 'month') {
+    const cursor = new Date(Date.UTC(s.getUTCFullYear(), s.getUTCMonth(), 1));
+    if (cursor < s) cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+    while (cursor <= e) {
+      ticks.push(new Date(cursor));
+      cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+    }
+  } else {
+    // quarter
+    const month = s.getUTCMonth();
+    const qStart = month - (month % 3);
+    const cursor = new Date(Date.UTC(s.getUTCFullYear(), qStart, 1));
+    if (cursor < s) cursor.setUTCMonth(cursor.getUTCMonth() + 3);
+    while (cursor <= e) {
+      ticks.push(new Date(cursor));
+      cursor.setUTCMonth(cursor.getUTCMonth() + 3);
+    }
+  }
+  return ticks;
+}
+
+/**
+ * Format a tick date for the axis label, given a zoom level.
+ *   week: "Apr 27"
+ *   month: "Apr" or "Apr 2026" on Jan
+ *   quarter: "Q2 2026"
+ */
+export function formatTick(d: Date, zoom: ZoomLevel): string {
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const m = d.getUTCMonth();
+  const y = d.getUTCFullYear();
+  if (zoom === 'week') {
+    return `${months[m]} ${d.getUTCDate()}`;
+  }
+  if (zoom === 'month') {
+    return m === 0 ? `${months[m]} ${y}` : months[m];
+  }
+  const q = Math.floor(m / 3) + 1;
+  return `Q${q} ${y}`;
+}


### PR DESCRIPTION
## Summary

Builds the visual planning surface on top of Phases 1–2: a `/roadmap` timeline view with an aggregated `/api/roadmap` read endpoint behind it. Initiatives render as draggable target-date bars, milestones as committed-date diamonds, dependencies as SVG arrows, and tasks as cosmetic status chips. No external Gantt library — pure SVG + CSS grid keeps the bundle small. The derivation engine (which fills `derived_*`) is Phase 4; the dashed outline bars are wired up but mostly invisible until Phase 4 populates the columns.

## What landed

**Aggregated read endpoint** (`src/app/api/roadmap/route.ts`, `src/lib/db/roadmap.ts`)
- `GET /api/roadmap?workspace_id=...` returns `{ initiatives, dependencies, tasks, workspace_id, product_id, truncated }` in one round trip.
- Query params: `product_id`, `owner_agent_id`, `kind`, `status`, `from`, `to`. Date window clips by target overlap; rows with no dates always survive (backlog items must remain visible).
- Owner agent name joined inline. Tree depth and task counts computed in JS so the planning tree isn't bottlenecked by recursive CTEs.
- 500-initiative cap with a `truncated: true` flag for huge workspaces.

**Roadmap UI** (`src/app/roadmap/page.tsx`, `src/components/roadmap/`)
- `RoadmapTimeline` shell: snapshot fetch, filter and zoom state, optimistic-with-revert drag handler, mirrored vertical scroll between rail and canvas.
- `RoadmapToolbar`: product/owner/kind/status filters and a week / month / quarter zoom switch (zoom persists to `localStorage`).
- `RoadmapRail`: indented initiative tree, kind icons (lucide), status pills, task-count badges (e.g. `4·1d·2a`), expand/collapse carets, links to `/initiatives/[id]`.
- `RoadmapCanvas`: time axis with zoom-aware ticks, today line, gridlines, one SVG per row for cheap drag re-renders.
- `RoadmapBar`: solid bar with body-shift + left/right edge-resize drag handles. PATCH on drop, revert on error. Outlined derived bar renders only when Phase 4 populates `derived_*`. Milestone diamonds at `committed_end` always render. Cosmetic task chips at bar end. "no schedule" pill for date-less rows.
- `RoadmapDependencies`: cubic Bézier arrows between visible bars with target dates; skipped if either endpoint is filtered out or undated.

**Date-math helpers** (`src/lib/roadmap/date-math.ts`)
- Pure functions: `dateToPx`/`pxToDate` round-trip, `addDays`/`daysBetween`, `rangeWidthPx`, `axisTicks` (week/month/quarter), `formatTick`, `windowsOverlap`, `defaultWindow`, `snapToDay`. UTC-midnight throughout.

**Tests**
- `src/lib/roadmap/date-math.test.ts`: 28 tests — round-trip, snap-to-day, range clipping, axis ticks, window overlap, edge cases (zero-length range, dates outside window).
- `src/lib/db/roadmap.test.ts`: 10 tests — fixture (1 milestone, 2 epics, 3 stories, 1 dep, 4 tasks of mixed status); covers depth, task_counts, dependency wiring, filters by kind / status / product / from-to, owner join, empty workspace.
- `src/components/roadmap/README.md` documents the manual-test-only gates (drag, status colour rendering, empty state, dependency arrows, today line, zoom persistence). The repo doesn't yet have a Vitest/RTL or Playwright test runner wired into `npm test`; rather than introduce one in Phase 3 alone, those gates are manual against `http://localhost:4001/roadmap`.

71 tests pass across the relevant slice (Phase 1 initiatives, Phase 2 promotion, Phase 3 date-math + snapshot).

## Stacked PR series

This is **Phase 3 of 6**, stacked on Phase 2 (#44), which is stacked on Phase 1 (#43). See `specs/roadmap-and-pm-spec.md` §14.

**Merge order discipline (project memory):** when each parent merges with `--delete-branch`, retarget descendant PRs to the new base BEFORE that merge or GitHub auto-closes them. Phase 4–6 will rebase onto whatever this branch becomes after Phase 1/2 merge.

## Test plan

- [ ] `npm test` passes (or `find src -name '*.test.ts' -print0 | xargs -0 npx tsx --test --test-concurrency=1` if the npm-test glob is still broken from the parallel side task).
- [ ] Visit `http://localhost:4001/roadmap` — page renders with no console errors. The toolbar, rail, and canvas all align vertically; horizontal scroll moves the canvas without misaligning the rail.
- [ ] Create an initiative with target dates and verify the solid bar renders. Drag it 7 days right; the bar moves, drops cleanly, and the change persists across a refresh.
- [ ] Drag a left/right edge — only that edge moves; can't push it past the opposite edge.
- [ ] Add a dependency between two date-bearing initiatives — an arrow appears between them.
- [ ] Add a milestone with `committed_end` set and `target_*` empty — the diamond still renders.
- [ ] Toggle each filter (product / owner / kind / status) — rows filter accordingly. Filtering everything out yields the "Create initiative" empty state.
- [ ] Change zoom (week / month / quarter) — axis ticks update; reload preserves the choice.

## Notes for Phase 4

- `derived_*` columns are unpopulated; bars render solid only. Phase 4's derivation engine fills `derived_start/end` and the dashed outlined bars (already wired in `RoadmapBar.tsx`) plus the implicit slippage gap will appear automatically with no UI changes needed here.
- The snapshot helper already returns `derived_start`, `derived_end`, and `committed_end` per row, and exposes `complexity` + `estimated_effort_hours` so Phase 4's velocity model has everything it needs without a second query.
- Spec gap to consider in Phase 4: the snapshot doesn't return `owner_availability` rows yet — the derivation algorithm needs them. Add either a separate query in the snapshot or a sibling `/api/owner-availability` endpoint to keep the read path simple.
- Filter UX punt: the product filter shows truncated UUIDs ("ab12cdef…") because Phase 1+2 didn't expose product names in the initiative read shape. When a `products.name` join is added, swap the display string in `RoadmapToolbar.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>