### PR TITLE
Phase 4: Derivation engine + drift scan

### DIFF
--- a/src/app/api/owner-availability/[id]/route.ts
+++ b/src/app/api/owner-availability/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { deleteOwnerAvailability, getOwnerAvailability } from '@/lib/db/owner-availability';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const row = getOwnerAvailability(id);
+    if (!row) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    return NextResponse.json(row);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to fetch availability';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    deleteOwnerAvailability(id);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to delete availability';
+    if (msg.startsWith('Owner availability not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/owner-availability/route.ts
+++ b/src/app/api/owner-availability/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  createOwnerAvailability,
+  listOwnerAvailability,
+} from '@/lib/db/owner-availability';
+
+export const dynamic = 'force-dynamic';
+
+const CreateSchema = z.object({
+  agent_id: z.string().min(1),
+  unavailable_start: z.string().min(1),
+  unavailable_end: z.string().min(1),
+  reason: z.string().nullish(),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const rows = listOwnerAvailability({
+      agent_id: searchParams.get('agent_id') || undefined,
+      between_start: searchParams.get('between_start') || null,
+      between_end: searchParams.get('between_end') || null,
+      workspace_id: searchParams.get('workspace_id') || undefined,
+    });
+    return NextResponse.json(rows);
+  } catch (error) {
+    console.error('Failed to list owner availability:', error);
+    const msg = error instanceof Error ? error.message : 'Failed to list availability';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = CreateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const row = createOwnerAvailability(parsed.data);
+    return NextResponse.json(row, { status: 201 });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to create availability';
+    if (msg.startsWith('Agent not found') || msg.startsWith('unavailable_')) {
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    console.error('Failed to create owner availability:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/roadmap/recompute/route.ts
+++ b/src/app/api/roadmap/recompute/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { applyDerivation } from '@/lib/roadmap/apply-derivation';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  workspace_id: z.string().min(1),
+});
+
+/**
+ * Manually trigger the roadmap derivation engine for a workspace.
+ *
+ * Returns the same payload as the scheduled run: drift events, update
+ * counts, and any warnings. Useful for the "Recompute now" toolbar button
+ * and for tests.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const parsed = Body.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const result = applyDerivation(parsed.data.workspace_id);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('Failed to recompute roadmap:', error);
+    const msg = error instanceof Error ? error.message : 'Failed to recompute';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/components/roadmap/RoadmapBar.tsx
+++ b/src/components/roadmap/RoadmapBar.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useRef, useState } from 'react';
 import {
   addDays,
+  daysBetween,
   dateToPx,
   rangeWidthPx,
   toIsoDay,
@@ -194,25 +195,41 @@ export function RoadmapBar({
     );
   }
 
-  // Outlined (derived) bar — Phase 4 will populate; in Phase 3 mostly null.
+  // Outlined (derived) bar — populated by the Phase 4 derivation engine.
+  // Highlight in amber when the derived window slips past target_end (or
+  // a milestone's committed_end) so the gap is visible without hovering.
   let outlineEl: React.ReactNode = null;
   if (initiative.derived_start && initiative.derived_end) {
     const x = dateToPx(initiative.derived_start, windowStart, pxPerDay);
     const w = rangeWidthPx(initiative.derived_start, initiative.derived_end, pxPerDay);
+    const compareEnd =
+      initiative.kind === 'milestone' && initiative.committed_end
+        ? initiative.committed_end
+        : initiative.target_end;
+    const overrun = compareEnd && initiative.derived_end > compareEnd
+      ? daysBetween(compareEnd, initiative.derived_end)
+      : 0;
+    const tone = overrun > 0 ? 'text-amber-400' : 'text-mc-text-secondary';
+    const tooltip = overrun > 0
+      ? `Derived ${initiative.derived_start} → ${initiative.derived_end}\nSchedule debt: ${overrun} day${overrun === 1 ? '' : 's'} past ${compareEnd}`
+      : `Derived ${initiative.derived_start} → ${initiative.derived_end}`;
     outlineEl = (
-      <rect
-        x={x}
-        y={yMid - BAR_HEIGHT / 2 - 2}
-        width={w}
-        height={BAR_HEIGHT + 4}
-        rx={3}
-        ry={3}
-        fill="none"
-        stroke="currentColor"
-        strokeWidth={1.2}
-        strokeDasharray="3 3"
-        className="text-mc-text-secondary"
-      />
+      <g className={tone}>
+        <rect
+          x={x}
+          y={yMid - BAR_HEIGHT / 2 - 2}
+          width={w}
+          height={BAR_HEIGHT + 4}
+          rx={3}
+          ry={3}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={overrun > 0 ? 1.6 : 1.2}
+          strokeDasharray="3 3"
+        >
+          <title>{tooltip}</title>
+        </rect>
+      </g>
     );
   }
 

--- a/src/components/roadmap/RoadmapRail.tsx
+++ b/src/components/roadmap/RoadmapRail.tsx
@@ -10,8 +10,9 @@
 
 import type { RefObject } from 'react';
 import Link from 'next/link';
-import { ChevronDown, ChevronRight, Square, Diamond, ListTree, Circle } from 'lucide-react';
+import { ChevronDown, ChevronRight, Square, Diamond, ListTree, Circle, AlertTriangle } from 'lucide-react';
 import type { Kind, RoadmapInitiative, RoadmapSnapshot, Status } from './RoadmapTimeline';
+import { daysBetween } from '@/lib/roadmap/date-math';
 
 const KIND_ICON: Record<Kind, React.ComponentType<{ className?: string }>> = {
   theme: Square,
@@ -109,6 +110,16 @@ export function RoadmapRail({
               >
                 {i.title}
               </Link>
+              {/* Drift indicator: milestone whose derived_end overruns
+                  committed_end. Hover shows the gap in days. */}
+              {i.kind === 'milestone' && i.committed_end && i.derived_end && i.derived_end > i.committed_end && (
+                <span
+                  className="text-amber-400"
+                  title={`Schedule debt: ${daysBetween(i.committed_end, i.derived_end)}d past committed_end (${i.committed_end} → ${i.derived_end})`}
+                >
+                  <AlertTriangle className="w-3.5 h-3.5" />
+                </span>
+              )}
               <span
                 className={`text-[10px] px-1.5 py-0.5 rounded border ${STATUS_PILL[i.status]}`}
                 title={i.status}

--- a/src/components/roadmap/RoadmapTimeline.tsx
+++ b/src/components/roadmap/RoadmapTimeline.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
-import { Plus } from 'lucide-react';
+import { Plus, RefreshCw } from 'lucide-react';
 import { RoadmapRail } from './RoadmapRail';
 import { RoadmapCanvas } from './RoadmapCanvas';
 import { RoadmapToolbar } from './RoadmapToolbar';
@@ -120,6 +120,8 @@ export function RoadmapTimeline() {
     statuses: new Set(ALL_STATUSES),
   });
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [recomputing, setRecomputing] = useState(false);
+  const [recomputeMsg, setRecomputeMsg] = useState<string | null>(null);
 
   // Read zoom on mount only (client-only).
   useEffect(() => {
@@ -151,6 +153,35 @@ export function RoadmapTimeline() {
 
   useEffect(() => {
     refresh();
+  }, [refresh]);
+
+  const recompute = useCallback(async () => {
+    setRecomputing(true);
+    setRecomputeMsg(null);
+    try {
+      const r = await fetch('/api/roadmap/recompute', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ workspace_id: WORKSPACE_ID }),
+      });
+      if (!r.ok) {
+        const body = await r.json().catch(() => ({}));
+        throw new Error(body.error || `Recompute failed (${r.status})`);
+      }
+      const result = await r.json() as {
+        initiatives_updated: number;
+        status_flips: number;
+        drifts: unknown[];
+      };
+      setRecomputeMsg(
+        `Recomputed: ${result.initiatives_updated} updated, ${result.status_flips} flipped, ${result.drifts.length} drift${result.drifts.length === 1 ? '' : 's'}`,
+      );
+      await refresh();
+    } catch (e) {
+      setRecomputeMsg(e instanceof Error ? e.message : 'Recompute failed');
+    } finally {
+      setRecomputing(false);
+    }
   }, [refresh]);
 
   // Apply client-side kind+status filters and collapse logic to the snapshot.
@@ -282,6 +313,15 @@ export function RoadmapTimeline() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <button
+            onClick={recompute}
+            disabled={recomputing}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-mc-border text-mc-text-secondary hover:text-mc-text text-sm disabled:opacity-60"
+            title="Run the derivation engine: refresh derived_start/end and at_risk flags"
+          >
+            <RefreshCw className={`w-3.5 h-3.5 ${recomputing ? 'animate-spin' : ''}`} />
+            {recomputing ? 'Recomputing…' : 'Recompute now'}
+          </button>
           <Link
             href="/initiatives"
             className="px-3 py-1.5 rounded-lg border border-mc-border text-mc-text-secondary hover:text-mc-text text-sm"
@@ -296,6 +336,11 @@ export function RoadmapTimeline() {
           </Link>
         </div>
       </header>
+      {recomputeMsg && (
+        <div className="mx-4 mt-2 p-2 rounded-lg bg-mc-accent/10 border border-mc-accent/30 text-mc-accent text-xs">
+          {recomputeMsg}
+        </div>
+      )}
 
       <RoadmapToolbar
         filters={filters}

--- a/src/lib/autopilot/scheduling.ts
+++ b/src/lib/autopilot/scheduling.ts
@@ -137,6 +137,39 @@ export async function checkAndRunDueSchedules(): Promise<void> {
           evaluateMaybePool(schedule.product_id);
           break;
         }
+        case 'roadmap_drift_scan': {
+          // Phase 4: workspace-scoped derivation. The product row is just a
+          // hook for the cron — the real target is the product's workspace.
+          // If the operator provides an explicit workspace_id in `config`,
+          // we honor it; otherwise we look up the workspace from the
+          // product. This lets a single product schedule cover the whole
+          // workspace's roadmap.
+          const { applyDerivation } = await import('@/lib/roadmap/apply-derivation');
+          let cfgWorkspaceId: string | null = null;
+          try {
+            if (schedule.config) {
+              const parsed = JSON.parse(schedule.config) as { workspace_id?: string };
+              cfgWorkspaceId = parsed.workspace_id ?? null;
+            }
+          } catch {
+            // Config malformed — fall through to product lookup.
+          }
+          let workspaceId = cfgWorkspaceId;
+          if (!workspaceId) {
+            const { queryOne } = await import('@/lib/db');
+            const prod = queryOne<{ workspace_id: string }>(
+              'SELECT workspace_id FROM products WHERE id = ?',
+              [schedule.product_id],
+            );
+            workspaceId = prod?.workspace_id ?? null;
+          }
+          if (!workspaceId) {
+            console.warn(`[Schedule] roadmap_drift_scan ${schedule.id} has no resolvable workspace`);
+            break;
+          }
+          applyDerivation(workspaceId);
+          break;
+        }
         default:
           console.log(`[Schedule] Unhandled schedule type: ${schedule.schedule_type}`);
       }

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -2552,6 +2552,76 @@ const migrations: Migration[] = [
 
       console.log('[Migration 043] Complete.');
     }
+  },
+  {
+    id: '044',
+    name: 'roadmap_drift_scan_schedule_type',
+    up: (db) => {
+      // Phase 4 of the roadmap & PM-agent feature. Extend the
+      // product_schedules.schedule_type CHECK list to include
+      // 'roadmap_drift_scan'. SQLite can't ALTER a CHECK in place — we
+      // patch the stored CREATE TABLE text via writable_schema, the same
+      // technique migration 043 uses on tasks.status.
+      console.log('[Migration 044] Extending product_schedules.schedule_type with roadmap_drift_scan...');
+      const row = db.prepare(
+        `SELECT sql FROM sqlite_master WHERE type='table' AND name='product_schedules'`,
+      ).get() as { sql: string } | undefined;
+      if (!row) {
+        console.log('[Migration 044] product_schedules table absent; skipping.');
+        return;
+      }
+      if (row.sql.includes("'roadmap_drift_scan'")) {
+        console.log('[Migration 044] Already extended; skipping.');
+        return;
+      }
+      const oldCheck = `schedule_type TEXT NOT NULL CHECK (schedule_type IN (
+            'research', 'ideation', 'maybe_reevaluation', 'seo_audit',
+            'content_refresh', 'analytics_report', 'social_batch', 'growth_experiment'
+          ))`;
+      const newCheck = `schedule_type TEXT NOT NULL CHECK (schedule_type IN (
+            'research', 'ideation', 'maybe_reevaluation', 'seo_audit',
+            'content_refresh', 'analytics_report', 'social_batch', 'growth_experiment',
+            'roadmap_drift_scan'
+          ))`;
+
+      // Try the canonical shape from migration 035 first; fall back to a
+      // permissive single-line shape if older databases stored it
+      // differently.
+      let patched = row.sql;
+      if (row.sql.includes(oldCheck)) {
+        patched = row.sql.replace(oldCheck, newCheck);
+      } else {
+        // Permissive fallback — find the schedule_type CHECK clause via
+        // regex and append our new value to its IN(...) list.
+        const re = /(schedule_type\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*schedule_type\s+IN\s*\()([^)]+)(\))/i;
+        const m = row.sql.match(re);
+        if (!m) {
+          console.warn('[Migration 044] schedule_type CHECK shape unrecognized; current schema:\n' + row.sql);
+          throw new Error('[Migration 044] Unable to locate schedule_type CHECK clause — refusing to patch');
+        }
+        const inList = m[2].trim();
+        const newInList = `${inList}, 'roadmap_drift_scan'`;
+        patched = row.sql.replace(re, `$1${newInList}$3`);
+      }
+
+      const escaped = patched.replace(/'/g, "''");
+      db.unsafeMode(true);
+      try {
+        db.pragma('writable_schema = ON');
+        db.exec(
+          `UPDATE sqlite_master SET sql = '${escaped}' WHERE type='table' AND name='product_schedules'`,
+        );
+        db.pragma('writable_schema = OFF');
+        const integrity = db.prepare('PRAGMA integrity_check').all() as { integrity_check: string }[];
+        const ok = integrity.length === 1 && integrity[0].integrity_check === 'ok';
+        if (!ok) {
+          throw new Error('[Migration 044] integrity_check failed: ' + JSON.stringify(integrity));
+        }
+      } finally {
+        db.unsafeMode(false);
+      }
+      console.log('[Migration 044] Complete.');
+    }
   }
 ];
 

--- a/src/lib/db/owner-availability.test.ts
+++ b/src/lib/db/owner-availability.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Owner availability DB-helper tests (Phase 4).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import {
+  createOwnerAvailability,
+  deleteOwnerAvailability,
+  getOwnerAvailability,
+  listOwnerAvailability,
+} from './owner-availability';
+
+function seedAgent(workspace: string = 'default'): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, created_at, updated_at)
+     VALUES (?, 'A', 'worker', ?, datetime('now'), datetime('now'))`,
+    [id, workspace],
+  );
+  return id;
+}
+
+test('createOwnerAvailability inserts a row with the given fields', () => {
+  const a = seedAgent();
+  const row = createOwnerAvailability({
+    agent_id: a,
+    unavailable_start: '2026-05-01',
+    unavailable_end: '2026-05-05',
+    reason: 'PTO',
+  });
+  assert.equal(row.agent_id, a);
+  assert.equal(row.unavailable_start, '2026-05-01');
+  assert.equal(row.unavailable_end, '2026-05-05');
+  assert.equal(row.reason, 'PTO');
+});
+
+test('createOwnerAvailability rejects unknown agent', () => {
+  assert.throws(
+    () =>
+      createOwnerAvailability({
+        agent_id: 'nope',
+        unavailable_start: '2026-05-01',
+        unavailable_end: '2026-05-05',
+      }),
+    /Agent not found/,
+  );
+});
+
+test('createOwnerAvailability rejects end < start', () => {
+  const a = seedAgent();
+  assert.throws(
+    () =>
+      createOwnerAvailability({
+        agent_id: a,
+        unavailable_start: '2026-05-10',
+        unavailable_end: '2026-05-05',
+      }),
+    /unavailable_end must be/,
+  );
+});
+
+test('listOwnerAvailability filters by agent', () => {
+  const a = seedAgent();
+  const b = seedAgent();
+  createOwnerAvailability({ agent_id: a, unavailable_start: '2026-05-01', unavailable_end: '2026-05-05' });
+  createOwnerAvailability({ agent_id: b, unavailable_start: '2026-05-01', unavailable_end: '2026-05-05' });
+  const rows = listOwnerAvailability({ agent_id: a });
+  assert.ok(rows.length >= 1);
+  assert.ok(rows.every(r => r.agent_id === a));
+});
+
+test('listOwnerAvailability between filter does an overlap query', () => {
+  const a = seedAgent();
+  // Window 1: well before query range.
+  const before = createOwnerAvailability({ agent_id: a, unavailable_start: '2026-01-01', unavailable_end: '2026-01-10' });
+  // Window 2: overlaps the query range on the left edge.
+  const overlapL = createOwnerAvailability({ agent_id: a, unavailable_start: '2026-04-25', unavailable_end: '2026-05-02' });
+  // Window 3: fully within.
+  const inside = createOwnerAvailability({ agent_id: a, unavailable_start: '2026-05-10', unavailable_end: '2026-05-15' });
+  // Window 4: well after.
+  const after = createOwnerAvailability({ agent_id: a, unavailable_start: '2026-08-01', unavailable_end: '2026-08-05' });
+
+  const rows = listOwnerAvailability({
+    agent_id: a,
+    between_start: '2026-05-01',
+    between_end: '2026-05-31',
+  });
+  const ids = rows.map(r => r.id);
+  assert.ok(ids.includes(overlapL.id), 'overlapL window should be included');
+  assert.ok(ids.includes(inside.id), 'inside window should be included');
+  assert.ok(!ids.includes(before.id), 'before window should NOT be included');
+  assert.ok(!ids.includes(after.id), 'after window should NOT be included');
+});
+
+test('deleteOwnerAvailability removes the row', () => {
+  const a = seedAgent();
+  const row = createOwnerAvailability({ agent_id: a, unavailable_start: '2026-05-01', unavailable_end: '2026-05-05' });
+  deleteOwnerAvailability(row.id);
+  assert.equal(getOwnerAvailability(row.id), undefined);
+});
+
+test('deleteOwnerAvailability throws for unknown id', () => {
+  assert.throws(() => deleteOwnerAvailability('does-not-exist'), /not found/);
+});

--- a/src/lib/db/owner-availability.ts
+++ b/src/lib/db/owner-availability.ts
@@ -1,0 +1,111 @@
+/**
+ * Owner availability DB helpers (Phase 4 of the roadmap planning layer).
+ *
+ * The `owner_availability` table was introduced in Phase 1 but had no API
+ * surface or helpers. The derivation engine (§7.2) consumes these rows to
+ * push initiative `derived_end` later by the overlap of any owner-out-of-
+ * office windows. Phase 5 will add a PM-driven path for these rows; for
+ * now they are operator-managed.
+ *
+ * Rows represent UNAVAILABLE windows (the agent is out / heads-down on
+ * something else). An empty list means the owner is fully available, which
+ * is the default the derivation falls back to.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+
+export interface OwnerAvailability {
+  id: string;
+  agent_id: string;
+  unavailable_start: string;
+  unavailable_end: string;
+  reason: string | null;
+  created_at: string;
+}
+
+export interface CreateOwnerAvailabilityInput {
+  agent_id: string;
+  unavailable_start: string;
+  unavailable_end: string;
+  reason?: string | null;
+}
+
+export interface ListOwnerAvailabilityFilters {
+  /** Restrict to a single agent. */
+  agent_id?: string;
+  /**
+   * Overlap query: include rows whose [unavailable_start, unavailable_end]
+   * window intersects [between_start, between_end]. Either bound may be
+   * omitted to treat that side as unbounded.
+   */
+  between_start?: string | null;
+  between_end?: string | null;
+  /** Restrict to agents in a particular workspace. */
+  workspace_id?: string;
+}
+
+export function createOwnerAvailability(input: CreateOwnerAvailabilityInput): OwnerAvailability {
+  if (!input.agent_id) throw new Error('agent_id is required');
+  if (!input.unavailable_start || !input.unavailable_end) {
+    throw new Error('unavailable_start and unavailable_end are required');
+  }
+  if (input.unavailable_end < input.unavailable_start) {
+    throw new Error('unavailable_end must be >= unavailable_start');
+  }
+
+  // Confirm the agent exists. SQLite's FK is informational without a
+  // PRAGMA cycle, but giving a clear error here is friendlier than the
+  // raw FK error the next mutation would produce.
+  const agent = queryOne<{ id: string }>('SELECT id FROM agents WHERE id = ?', [input.agent_id]);
+  if (!agent) throw new Error(`Agent not found: ${input.agent_id}`);
+
+  const id = uuidv4();
+  const now = new Date().toISOString();
+  run(
+    `INSERT INTO owner_availability (id, agent_id, unavailable_start, unavailable_end, reason, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [id, input.agent_id, input.unavailable_start, input.unavailable_end, input.reason ?? null, now],
+  );
+  return queryOne<OwnerAvailability>('SELECT * FROM owner_availability WHERE id = ?', [id])!;
+}
+
+export function listOwnerAvailability(filters: ListOwnerAvailabilityFilters = {}): OwnerAvailability[] {
+  const where: string[] = [];
+  const params: unknown[] = [];
+
+  if (filters.workspace_id) {
+    // Join to agents on workspace.
+    where.push('oa.agent_id IN (SELECT id FROM agents WHERE workspace_id = ?)');
+    params.push(filters.workspace_id);
+  }
+  if (filters.agent_id) {
+    where.push('oa.agent_id = ?');
+    params.push(filters.agent_id);
+  }
+  // Overlap predicate: NOT (window ends before query starts OR window starts after query ends).
+  if (filters.between_start) {
+    where.push('oa.unavailable_end >= ?');
+    params.push(filters.between_start);
+  }
+  if (filters.between_end) {
+    where.push('oa.unavailable_start <= ?');
+    params.push(filters.between_end);
+  }
+
+  const sql =
+    `SELECT oa.* FROM owner_availability oa ` +
+    (where.length ? `WHERE ${where.join(' AND ')} ` : '') +
+    `ORDER BY oa.unavailable_start, oa.created_at`;
+  return queryAll<OwnerAvailability>(sql, params);
+}
+
+export function getOwnerAvailability(id: string): OwnerAvailability | undefined {
+  return queryOne<OwnerAvailability>('SELECT * FROM owner_availability WHERE id = ?', [id]);
+}
+
+export function deleteOwnerAvailability(id: string): void {
+  const existing = queryOne<{ id: string }>('SELECT id FROM owner_availability WHERE id = ?', [id]);
+  if (!existing) throw new Error(`Owner availability not found: ${id}`);
+  run('DELETE FROM owner_availability WHERE id = ?', [id]);
+}

--- a/src/lib/db/roadmap.ts
+++ b/src/lib/db/roadmap.ts
@@ -68,10 +68,25 @@ export interface RoadmapTask {
   assigned_agent_id: string | null;
 }
 
+export interface RoadmapOwnerAvailability {
+  id: string;
+  agent_id: string;
+  unavailable_start: string;
+  unavailable_end: string;
+  reason: string | null;
+}
+
 export interface RoadmapSnapshot {
   initiatives: RoadmapInitiative[];
   dependencies: RoadmapDependency[];
   tasks: RoadmapTask[];
+  /**
+   * Owner-availability rows for every agent that owns at least one
+   * initiative in the snapshot. The derivation engine uses these to push
+   * `derived_end` later by the overlap of any owner-out-of-office windows.
+   * The roadmap UI does not currently render them.
+   */
+  owner_availability: RoadmapOwnerAvailability[];
   workspace_id: string;
   product_id: string | null;
   truncated: boolean;
@@ -265,6 +280,28 @@ export function getRoadmapSnapshot(filters: RoadmapFilters): RoadmapSnapshot {
     task_counts: counts[r.id] || { draft: 0, active: 0, done: 0, total: 0 },
   }));
 
+  // Owner-availability rows scoped to agents that own at least one
+  // initiative in the visible set. We deliberately do NOT return all
+  // availability rows for the workspace — most owners don't own initiatives
+  // here, and the derivation engine only consumes availability for owners
+  // on the schedule. (Document choice: agents with no initiatives in the
+  // snapshot have no schedule to push, so their availability is irrelevant
+  // to the engine. If a future caller needs every row, query
+  // `listOwnerAvailability({ workspace_id })` directly.)
+  const ownerIds = new Set<string>();
+  for (const r of visibleRows) {
+    if (r.owner_agent_id) ownerIds.add(r.owner_agent_id);
+  }
+  const ownerAvailRows: RoadmapOwnerAvailability[] = ownerIds.size === 0
+    ? []
+    : queryAll<RoadmapOwnerAvailability>(
+        `SELECT id, agent_id, unavailable_start, unavailable_end, reason
+         FROM owner_availability
+         WHERE agent_id IN (${Array.from(ownerIds).map(() => '?').join(',')})
+         ORDER BY unavailable_start, created_at`,
+        Array.from(ownerIds),
+      );
+
   return {
     initiatives,
     dependencies: depRows,
@@ -277,6 +314,7 @@ export function getRoadmapSnapshot(filters: RoadmapFilters): RoadmapSnapshot {
         status: t.status,
         assigned_agent_id: t.assigned_agent_id,
       })),
+    owner_availability: ownerAvailRows,
     workspace_id: filters.workspace_id,
     product_id: filters.product_id ?? null,
     truncated,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -618,7 +618,8 @@ CREATE TABLE IF NOT EXISTS product_schedules (
   product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
   schedule_type TEXT NOT NULL CHECK (schedule_type IN (
     'research', 'ideation', 'maybe_reevaluation', 'seo_audit',
-    'content_refresh', 'analytics_report', 'social_batch', 'growth_experiment'
+    'content_refresh', 'analytics_report', 'social_batch', 'growth_experiment',
+    'roadmap_drift_scan'
   )),
   cron_expression TEXT NOT NULL,
   timezone TEXT DEFAULT 'America/Denver',

--- a/src/lib/roadmap/apply-derivation.ts
+++ b/src/lib/roadmap/apply-derivation.ts
@@ -1,0 +1,172 @@
+/**
+ * Apply derivation (Phase 4).
+ *
+ * Glue layer between the pure engine (`deriveSchedule`) and the database.
+ * Responsibilities:
+ *
+ *   1. Pull a fresh snapshot via `getRoadmapSnapshot`.
+ *   2. Compute per-owner velocity ratios from completed-task history.
+ *   3. Run `deriveSchedule` to get the new (derived_start, derived_end) per
+ *      initiative.
+ *   4. UPDATE only the rows whose dates actually changed (idempotency: a
+ *      no-op run touches no rows).
+ *   5. For initiatives flagged `milestone_at_risk` whose status is
+ *      currently `planned` or `in_progress`, set `status='at_risk'`. Don't
+ *      override `cancelled`, `done`, or `blocked` — those are stronger
+ *      operator-set states.
+ *   6. Emit one `events` row summarizing the run.
+ *
+ * Single transaction wraps steps 4–6 so a partial failure doesn't leave
+ * the schedule half-updated.
+ *
+ * Returns the drift list and update counts so callers (manual recompute
+ * endpoint, schedule cron) can surface results to the operator.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { getDb, queryAll } from '@/lib/db';
+import { getRoadmapSnapshot, type RoadmapSnapshot } from '@/lib/db/roadmap';
+import { deriveSchedule, type DeriveResult } from './derive';
+import { detectDrift, type DriftEvent } from './drift';
+import { computeVelocity } from './velocity';
+
+export interface ApplyDerivationResult {
+  workspace_id: string;
+  initiatives_scanned: number;
+  initiatives_updated: number;
+  status_flips: number;
+  drifts: DriftEvent[];
+  cycle: string[];
+  warnings: string[];
+}
+
+export interface ApplyDerivationOptions {
+  /** Anchor for the engine. Defaults to current date. */
+  today?: Date | string;
+  /**
+   * Override the velocity map (used by tests). When undefined, the helper
+   * computes ratios from each unique owner's completed-task history.
+   */
+  velocityMap?: Map<string, number>;
+  /** Pre-fetched snapshot (used by tests to avoid re-querying). */
+  snapshot?: RoadmapSnapshot;
+}
+
+export function applyDerivation(
+  workspace_id: string,
+  opts: ApplyDerivationOptions = {},
+): ApplyDerivationResult {
+  const snapshot = opts.snapshot ?? getRoadmapSnapshot({ workspace_id });
+
+  // Compute per-owner velocity unless a map was supplied.
+  let velocityMap = opts.velocityMap;
+  if (!velocityMap) {
+    velocityMap = new Map<string, number>();
+    const owners = new Set<string>();
+    for (const i of snapshot.initiatives) {
+      if (i.owner_agent_id) owners.add(i.owner_agent_id);
+    }
+    for (const owner of owners) {
+      velocityMap.set(owner, computeVelocity({ owner_agent_id: owner }));
+    }
+  }
+
+  const derived: DeriveResult = deriveSchedule(snapshot, {
+    velocityMap,
+    today: opts.today,
+  });
+
+  const drifts = detectDrift(snapshot, derived);
+
+  // Determine which rows actually need an UPDATE (only on diff). Spec
+  // requires idempotency — a re-run with no changes mustn't bump
+  // `updated_at` either.
+  const updates: Array<{ id: string; start: string | null; end: string | null }> = [];
+  for (const i of snapshot.initiatives) {
+    const range = derived.schedule.get(i.id);
+    if (!range) continue;
+    if (range.derived_start !== i.derived_start || range.derived_end !== i.derived_end) {
+      updates.push({ id: i.id, start: range.derived_start, end: range.derived_end });
+    }
+  }
+
+  // Status flips: milestone_at_risk events on initiatives whose status is
+  // currently `planned` or `in_progress`. We DON'T flip `done`, `cancelled`,
+  // or `blocked` — those are stronger operator decisions.
+  const flipIds: string[] = [];
+  for (const ev of drifts) {
+    if (ev.kind !== 'milestone_at_risk') continue;
+    const i = snapshot.initiatives.find(x => x.id === ev.initiative_id);
+    if (!i) continue;
+    if (i.status === 'planned' || i.status === 'in_progress') {
+      flipIds.push(ev.initiative_id);
+    }
+  }
+
+  const db = getDb();
+  let initiativesUpdated = 0;
+  let statusFlips = 0;
+
+  db.transaction(() => {
+    const stmt = db.prepare(
+      'UPDATE initiatives SET derived_start = ?, derived_end = ?, updated_at = ? WHERE id = ?',
+    );
+    const now = new Date().toISOString();
+    for (const u of updates) {
+      const r = stmt.run(u.start, u.end, now, u.id);
+      if (r.changes > 0) initiativesUpdated++;
+    }
+
+    if (flipIds.length > 0) {
+      const flipStmt = db.prepare(
+        `UPDATE initiatives SET status = 'at_risk', updated_at = ? WHERE id = ? AND status IN ('planned','in_progress')`,
+      );
+      for (const id of flipIds) {
+        const r = flipStmt.run(now, id);
+        if (r.changes > 0) statusFlips++;
+      }
+    }
+
+    // Emit a single summary event row (only when something happened, to
+    // avoid spamming the live feed for nightly no-op runs).
+    if (initiativesUpdated > 0 || statusFlips > 0 || drifts.length > 0) {
+      db.prepare(
+        `INSERT INTO events (id, type, message, metadata, created_at)
+         VALUES (?, 'roadmap_drift_scan', ?, ?, ?)`,
+      ).run(
+        uuidv4(),
+        `Roadmap drift scan: ${initiativesUpdated} updated, ${drifts.length} drift event(s)`,
+        JSON.stringify({
+          workspace_id,
+          initiatives_scanned: snapshot.initiatives.length,
+          initiatives_updated: initiativesUpdated,
+          status_flips: statusFlips,
+          drifts,
+          cycle: derived.cycle,
+          warnings: derived.warnings,
+        }),
+        now,
+      );
+    }
+  })();
+
+  return {
+    workspace_id,
+    initiatives_scanned: snapshot.initiatives.length,
+    initiatives_updated: initiativesUpdated,
+    status_flips: statusFlips,
+    drifts,
+    cycle: derived.cycle,
+    warnings: derived.warnings,
+  };
+}
+
+/**
+ * Returns a list of workspace_ids that have at least one initiative — the
+ * scheduler iterates over these on each `roadmap_drift_scan` tick.
+ */
+export function listWorkspacesWithInitiatives(): string[] {
+  return queryAll<{ workspace_id: string }>(
+    'SELECT DISTINCT workspace_id FROM initiatives',
+  ).map(r => r.workspace_id);
+}

--- a/src/lib/roadmap/derive.e2e.test.ts
+++ b/src/lib/roadmap/derive.e2e.test.ts
@@ -1,0 +1,236 @@
+/**
+ * End-to-end derivation test (Phase 4).
+ *
+ * Seeds a realistic roadmap (milestone → 2 epics → 4 stories with various
+ * effort/complexity, two cross-initiative deps, one owner availability
+ * window, four completed tasks for owner X to give a 0.8 velocity ratio),
+ * runs `applyDerivation`, and asserts the database state.
+ *
+ * Doesn't go through the API — exercises the helper directly so we can
+ * inspect rows.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+import { applyDerivation } from './apply-derivation';
+import { createOwnerAvailability } from '@/lib/db/owner-availability';
+
+function seedAgent(id: string, name: string): void {
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, created_at, updated_at)
+     VALUES (?, ?, 'worker', 'default', datetime('now'), datetime('now'))`,
+    [id, name],
+  );
+}
+
+function seedInitiative(opts: {
+  id?: string;
+  workspace_id?: string;
+  parent?: string | null;
+  kind: 'milestone' | 'epic' | 'story' | 'theme';
+  title: string;
+  owner_agent_id?: string | null;
+  estimated_effort_hours?: number | null;
+  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+  committed_end?: string | null;
+  target_end?: string | null;
+  status?: string;
+}): string {
+  const id = opts.id ?? uuidv4();
+  run(
+    `INSERT INTO initiatives (id, workspace_id, parent_initiative_id, kind, title,
+        status, owner_agent_id, estimated_effort_hours, complexity,
+        target_end, committed_end, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+    [
+      id,
+      opts.workspace_id ?? 'default',
+      opts.parent ?? null,
+      opts.kind,
+      opts.title,
+      opts.status ?? 'planned',
+      opts.owner_agent_id ?? null,
+      opts.estimated_effort_hours ?? null,
+      opts.complexity ?? null,
+      opts.target_end ?? null,
+      opts.committed_end ?? null,
+    ],
+  );
+  return id;
+}
+
+function seedDoneTask(opts: {
+  agent_id: string;
+  estimated_cost_usd: number;
+  actual_cost_usd: number;
+  workspace_id?: string;
+}): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id,
+        assigned_agent_id, estimated_cost_usd, actual_cost_usd,
+        created_at, updated_at)
+     VALUES (?, 'historical', 'done', 'normal', ?, 'default', ?, ?, ?,
+       datetime('now', '-30 days'), datetime('now'))`,
+    [id, opts.workspace_id ?? 'default', opts.agent_id, opts.estimated_cost_usd, opts.actual_cost_usd],
+  );
+  return id;
+}
+
+test('e2e: applyDerivation populates derived_*, flips milestone to at_risk, emits event', async () => {
+  const workspace = 'phase4-e2e-' + Math.random().toString(36).slice(2, 8);
+  // Workspace must exist as a row (FK target).
+  run(
+    `INSERT INTO workspaces (id, name, slug, created_at, updated_at)
+     VALUES (?, ?, ?, datetime('now'), datetime('now'))`,
+    [workspace, workspace, workspace],
+  );
+
+  // Seed an owner agent who is "slow" (velocity ratio ~ 0.8).
+  const owner = `owner-${workspace}`;
+  seedAgent(owner, 'Sarah');
+  // 4 done tasks: estimated 100, actual 125 → ratio 0.8 each → average 0.8.
+  for (let i = 0; i < 4; i++) {
+    seedDoneTask({ agent_id: owner, estimated_cost_usd: 100, actual_cost_usd: 125 });
+  }
+
+  // Seed roadmap: a milestone with committed_end May 30, two epics under
+  // it, four stories with effort.
+  const milestone = seedInitiative({
+    workspace_id: workspace,
+    kind: 'milestone',
+    title: 'Launch May 30',
+    committed_end: '2026-05-30',
+    owner_agent_id: owner,
+    status: 'planned',
+  });
+  const epic1 = seedInitiative({
+    workspace_id: workspace,
+    kind: 'epic',
+    title: 'Epic 1',
+    parent: milestone,
+    owner_agent_id: owner,
+  });
+  const epic2 = seedInitiative({
+    workspace_id: workspace,
+    kind: 'epic',
+    title: 'Epic 2',
+    parent: milestone,
+    owner_agent_id: owner,
+  });
+  const s1 = seedInitiative({
+    workspace_id: workspace,
+    kind: 'story',
+    title: 'Story 1',
+    parent: epic1,
+    owner_agent_id: owner,
+    estimated_effort_hours: 60,
+  });
+  const s2 = seedInitiative({
+    workspace_id: workspace,
+    kind: 'story',
+    title: 'Story 2',
+    parent: epic1,
+    owner_agent_id: owner,
+    complexity: 'L', // 40h
+  });
+  const s3 = seedInitiative({
+    workspace_id: workspace,
+    kind: 'story',
+    title: 'Story 3',
+    parent: epic2,
+    owner_agent_id: owner,
+    complexity: 'M', // 12h
+  });
+  const s4 = seedInitiative({
+    workspace_id: workspace,
+    kind: 'story',
+    title: 'Story 4',
+    parent: epic2,
+    owner_agent_id: owner,
+    estimated_effort_hours: 80,
+  });
+
+  // Two cross-initiative deps: s2 → s1, s3 → s2 (chain across stories).
+  run(
+    `INSERT INTO initiative_dependencies (id, initiative_id, depends_on_initiative_id, kind, created_at)
+     VALUES (?, ?, ?, 'finish_to_start', datetime('now'))`,
+    [uuidv4(), s2, s1],
+  );
+  run(
+    `INSERT INTO initiative_dependencies (id, initiative_id, depends_on_initiative_id, kind, created_at)
+     VALUES (?, ?, ?, 'finish_to_start', datetime('now'))`,
+    [uuidv4(), s3, s2],
+  );
+
+  // One owner availability window (2 weeks of vacation).
+  createOwnerAvailability({
+    agent_id: owner,
+    unavailable_start: '2026-04-20',
+    unavailable_end: '2026-05-01',
+    reason: 'PTO',
+  });
+
+  // Run derivation. Use a fixed today so the test is deterministic.
+  const result = applyDerivation(workspace, { today: '2026-04-13' });
+
+  // Assertions:
+  // 1. Every initiative now has non-NULL derived_*.
+  const rows = queryAll<{ id: string; derived_start: string | null; derived_end: string | null; status: string }>(
+    'SELECT id, derived_start, derived_end, status FROM initiatives WHERE workspace_id = ?',
+    [workspace],
+  );
+  assert.equal(rows.length, 7);
+  for (const r of rows) {
+    assert.ok(r.derived_start != null, `derived_start NULL on ${r.id}`);
+    assert.ok(r.derived_end != null, `derived_end NULL on ${r.id}`);
+  }
+
+  // 2. The milestone's derived_end is past committed_end (slow team + chain
+  //    dependency means the May 30 commitment slips).
+  const m = queryOne<{ derived_end: string; committed_end: string; status: string }>(
+    'SELECT derived_end, committed_end, status FROM initiatives WHERE id = ?',
+    [milestone],
+  )!;
+  assert.ok(
+    m.derived_end > m.committed_end,
+    `Expected derived_end (${m.derived_end}) > committed_end (${m.committed_end})`,
+  );
+  // 3. Status flipped to at_risk (was planned).
+  assert.equal(m.status, 'at_risk');
+
+  // 4. Drift event row exists.
+  const events = queryAll<{ metadata: string }>(
+    `SELECT metadata FROM events
+     WHERE type = 'roadmap_drift_scan'
+     ORDER BY created_at DESC LIMIT 1`,
+  );
+  assert.ok(events.length > 0);
+  const meta = JSON.parse(events[0].metadata);
+  assert.equal(meta.workspace_id, workspace);
+  assert.ok(Array.isArray(meta.drifts));
+  // At least one milestone_at_risk drift mentioning our milestone.
+  const milestoneEvent = meta.drifts.find(
+    (d: { kind: string; initiative_id?: string }) =>
+      d.kind === 'milestone_at_risk' && d.initiative_id === milestone,
+  );
+  assert.ok(milestoneEvent, 'milestone drift event not found');
+
+  // 5. Idempotency: re-run produces the same dates and writes nothing.
+  const before = queryAll<{ id: string; derived_start: string; derived_end: string }>(
+    'SELECT id, derived_start, derived_end FROM initiatives WHERE workspace_id = ? ORDER BY id',
+    [workspace],
+  );
+  const second = applyDerivation(workspace, { today: '2026-04-13' });
+  assert.equal(second.initiatives_updated, 0, 'Re-run should update nothing');
+  const after = queryAll<{ id: string; derived_start: string; derived_end: string }>(
+    'SELECT id, derived_start, derived_end FROM initiatives WHERE workspace_id = ? ORDER BY id',
+    [workspace],
+  );
+  assert.deepEqual(after, before);
+
+  // Silence unused
+  void s4;
+});

--- a/src/lib/roadmap/derive.test.ts
+++ b/src/lib/roadmap/derive.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Derivation engine tests (Phase 4).
+ *
+ * Pure-function tests with hand-built snapshots and fixed `today` for
+ * deterministic output. We pin `today = 2026-04-13` (a Monday) so business-
+ * day arithmetic is unambiguous in expectations.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveSchedule, HOURS_PER_DAY } from './derive';
+import type {
+  RoadmapDependency,
+  RoadmapInitiative,
+  RoadmapOwnerAvailability,
+  RoadmapSnapshot,
+} from '@/lib/db/roadmap';
+import { addDays, daysBetween, toIsoDay } from './date-math';
+
+const TODAY = '2026-04-13'; // Monday
+
+function init(p: Partial<RoadmapInitiative> & { id: string }): RoadmapInitiative {
+  return {
+    id: p.id,
+    parent_initiative_id: p.parent_initiative_id ?? null,
+    product_id: null,
+    kind: p.kind ?? 'story',
+    title: p.id,
+    status: 'planned',
+    owner_agent_id: p.owner_agent_id ?? null,
+    owner_agent_name: null,
+    complexity: p.complexity ?? null,
+    estimated_effort_hours: p.estimated_effort_hours ?? null,
+    target_start: p.target_start ?? null,
+    target_end: p.target_end ?? null,
+    derived_start: p.derived_start ?? null,
+    derived_end: p.derived_end ?? null,
+    committed_end: p.committed_end ?? null,
+    status_check_md: null,
+    sort_order: 0,
+    depth: 0,
+    task_counts: { draft: 0, active: 0, done: 0, total: 0 },
+  };
+}
+
+function snap(opts: {
+  initiatives: RoadmapInitiative[];
+  dependencies?: RoadmapDependency[];
+  owner_availability?: RoadmapOwnerAvailability[];
+}): RoadmapSnapshot {
+  return {
+    initiatives: opts.initiatives,
+    dependencies: opts.dependencies ?? [],
+    tasks: [],
+    owner_availability: opts.owner_availability ?? [],
+    workspace_id: 'test',
+    product_id: null,
+    truncated: false,
+  };
+}
+
+function dep(from: string, to: string, kind: string = 'finish_to_start'): RoadmapDependency {
+  return {
+    id: `${from}-${to}`,
+    initiative_id: from,
+    depends_on_initiative_id: to,
+    kind,
+    note: null,
+  };
+}
+
+function avail(agent: string, start: string, end: string): RoadmapOwnerAvailability {
+  return { id: `${agent}-${start}`, agent_id: agent, unavailable_start: start, unavailable_end: end, reason: null };
+}
+
+// ─── Determinism + basic schedule ──────────────────────────────────
+
+test('leaf initiative with effort schedules from today', () => {
+  // 6 hours = 1 effective day (HOURS_PER_DAY = 6).
+  const s = snap({
+    initiatives: [init({ id: 'a', estimated_effort_hours: 6 })],
+  });
+  const { schedule } = deriveSchedule(s, { today: TODAY });
+  const r = schedule.get('a')!;
+  assert.equal(r.derived_start, TODAY);
+  // 1 effective day, business-day inclusive: same day.
+  assert.equal(r.derived_end, TODAY);
+});
+
+test('multi-day effort spans business days, skipping weekend', () => {
+  // 24 hours = 4 effective days.
+  const s = snap({
+    initiatives: [init({ id: 'a', estimated_effort_hours: 24 })],
+  });
+  const { schedule } = deriveSchedule(s, { today: TODAY });
+  const r = schedule.get('a')!;
+  // Mon → Thu (4 business days inclusive).
+  assert.equal(r.derived_start, '2026-04-13'); // Mon
+  assert.equal(r.derived_end, '2026-04-16'); // Thu
+});
+
+test('effort that crosses a weekend skips Sat+Sun', () => {
+  // 36 hours = 6 effective days. Mon → following Mon (skipping Sat/Sun).
+  const s = snap({
+    initiatives: [init({ id: 'a', estimated_effort_hours: 36 })],
+  });
+  const { schedule } = deriveSchedule(s, { today: TODAY });
+  const r = schedule.get('a')!;
+  assert.equal(r.derived_start, '2026-04-13'); // Mon
+  assert.equal(r.derived_end, '2026-04-20'); // Mon next week (skipping Apr 18-19)
+});
+
+test('initiative with no effort signal gets NULL derived_*', () => {
+  const s = snap({
+    initiatives: [init({ id: 'a' })],
+  });
+  const { schedule, noEffort } = deriveSchedule(s, { today: TODAY });
+  assert.equal(schedule.get('a')?.derived_start, null);
+  assert.equal(schedule.get('a')?.derived_end, null);
+  assert.deepEqual(noEffort, ['a']);
+});
+
+// ─── Dependencies ──────────────────────────────────────────────────
+
+test('linear chain A→B→C: derived_end of C is past A+B+C effort', () => {
+  // A,B,C each 6 hours = 1 day.
+  const s = snap({
+    initiatives: [
+      init({ id: 'A', estimated_effort_hours: 6 }),
+      init({ id: 'B', estimated_effort_hours: 6 }),
+      init({ id: 'C', estimated_effort_hours: 6 }),
+    ],
+    dependencies: [dep('B', 'A'), dep('C', 'B')],
+  });
+  const { schedule } = deriveSchedule(s, { today: TODAY });
+  // A: Mon(13). B: Tue(14). C: Wed(15).
+  assert.equal(schedule.get('A')!.derived_end, '2026-04-13');
+  assert.equal(schedule.get('B')!.derived_end, '2026-04-14');
+  assert.equal(schedule.get('C')!.derived_end, '2026-04-15');
+});
+
+test('multi-prereq: C waits for max(A.end, B.end)', () => {
+  const s = snap({
+    initiatives: [
+      // A finishes faster than B.
+      init({ id: 'A', estimated_effort_hours: 6 }),  // 1 day
+      init({ id: 'B', estimated_effort_hours: 18 }), // 3 days, ends Wed
+      init({ id: 'C', estimated_effort_hours: 6 }),  // 1 day
+    ],
+    dependencies: [dep('C', 'A'), dep('C', 'B')],
+  });
+  const { schedule } = deriveSchedule(s, { today: TODAY });
+  // C starts day after B ends (Wed 15) → Thu 16.
+  assert.equal(schedule.get('B')!.derived_end, '2026-04-15');
+  assert.equal(schedule.get('C')!.derived_start, '2026-04-16');
+  assert.equal(schedule.get('C')!.derived_end, '2026-04-16');
+});
+
+test('start_to_start dep: B can start when A starts (not when A ends)', () => {
+  const s = snap({
+    initiatives: [
+      init({ id: 'A', estimated_effort_hours: 18 }), // 3 days
+      init({ id: 'B', estimated_effort_hours: 6 }),  // 1 day
+    ],
+    dependencies: [dep('B', 'A', 'start_to_start')],
+  });
+  const { schedule } = deriveSchedule(s, { today: TODAY });
+  // A: Mon-Wed; B starts same day as A (Mon).
+  assert.equal(schedule.get('A')!.derived_start, '2026-04-13');
+  assert.equal(schedule.get('B')!.derived_start, '2026-04-13');
+});
+
+test('informational dep is non-blocking', () => {
+  const s = snap({
+    initiatives: [
+      init({ id: 'A', estimated_effort_hours: 24 }), // 4 days
+      init({ id: 'B', estimated_effort_hours: 6 }),
+    ],
+    dependencies: [dep('B', 'A', 'informational')],
+  });
+  const { schedule } = deriveSchedule(s, { today: TODAY });
+  // B doesn't wait for A.
+  assert.equal(schedule.get('B')!.derived_start, TODAY);
+});
+
+// ─── Cycles ────────────────────────────────────────────────────────
+
+test('cycle members get NULL; non-cycle initiatives compute normally', () => {
+  const s = snap({
+    initiatives: [
+      init({ id: 'X', estimated_effort_hours: 6 }), // outside the cycle
+      init({ id: 'A', estimated_effort_hours: 6 }),
+      init({ id: 'B', estimated_effort_hours: 6 }),
+      init({ id: 'C', estimated_effort_hours: 6 }),
+    ],
+    // A → B → C → A (cycle); X is independent.
+    dependencies: [dep('A', 'B'), dep('B', 'C'), dep('C', 'A')],
+  });
+  const { schedule, cycle, warnings } = deriveSchedule(s, { today: TODAY });
+  assert.deepEqual([...cycle].sort(), ['A', 'B', 'C']);
+  for (const id of ['A', 'B', 'C']) {
+    assert.equal(schedule.get(id)?.derived_start, null);
+    assert.equal(schedule.get(id)?.derived_end, null);
+  }
+  assert.equal(schedule.get('X')!.derived_start, TODAY);
+  assert.ok(warnings.some(w => w.toLowerCase().includes('cycle')));
+});
+
+// ─── Owner availability ────────────────────────────────────────────
+
+test('owner availability overlap pushes derived_end later by overlap business days', () => {
+  // 18 hours = 3 effective days. Owner unavailable Tue-Wed (2 business days).
+  const s = snap({
+    initiatives: [
+      init({ id: 'A', estimated_effort_hours: 18, owner_agent_id: 'sarah' }),
+    ],
+    owner_availability: [avail('sarah', '2026-04-14', '2026-04-15')], // Tue-Wed
+  });
+  const { schedule } = deriveSchedule(s, { today: TODAY });
+  // Without availability: Mon-Wed (Apr 13-15).
+  // With availability: 2 business days inside that window → push 2 days.
+  // New end: Fri Apr 17.
+  const r = schedule.get('A')!;
+  assert.equal(r.derived_start, '2026-04-13');
+  assert.equal(r.derived_end, '2026-04-17');
+});
+
+test('availability with no overlap leaves schedule alone', () => {
+  const s = snap({
+    initiatives: [
+      init({ id: 'A', estimated_effort_hours: 12, owner_agent_id: 'sarah' }),
+    ],
+    // Far in the future.
+    owner_availability: [avail('sarah', '2026-12-01', '2026-12-10')],
+  });
+  const { schedule } = deriveSchedule(s, { today: TODAY });
+  // 12h = 2 days: Mon-Tue.
+  assert.equal(schedule.get('A')!.derived_end, '2026-04-14');
+});
+
+// ─── Container rollup ──────────────────────────────────────────────
+
+test('container with three stories uses sum of stories', () => {
+  // Epic with no own effort, 3 stories = 6+6+12 = 24 hours = 4 days.
+  const s = snap({
+    initiatives: [
+      init({ id: 'epic', kind: 'epic' }),
+      init({ id: 's1', parent_initiative_id: 'epic', estimated_effort_hours: 6 }),
+      init({ id: 's2', parent_initiative_id: 'epic', estimated_effort_hours: 6 }),
+      init({ id: 's3', parent_initiative_id: 'epic', estimated_effort_hours: 12 }),
+    ],
+  });
+  const { schedule } = deriveSchedule(s, { today: TODAY });
+  // 24h / 6 = 4 days. Mon-Thu.
+  assert.equal(schedule.get('epic')!.derived_end, '2026-04-16');
+});
+
+// ─── Velocity ──────────────────────────────────────────────────────
+
+test('velocity ratio < 1 (slow) lengthens schedule', () => {
+  // 12 hours / 0.5 velocity = 24 effective hours → 4 days (vs 2 at velocity 1).
+  const s = snap({
+    initiatives: [
+      init({ id: 'A', estimated_effort_hours: 12, owner_agent_id: 'slow' }),
+    ],
+  });
+  const { schedule } = deriveSchedule(s, {
+    today: TODAY,
+    velocityMap: new Map([['slow', 0.5]]),
+  });
+  // 4 business days: Mon-Thu.
+  assert.equal(schedule.get('A')!.derived_end, '2026-04-16');
+});
+
+test('velocity ratio > 1 (fast) shortens schedule', () => {
+  // 12 hours / 2 velocity = 6 effective hours → 1 day (vs 2 at velocity 1).
+  const s = snap({
+    initiatives: [
+      init({ id: 'A', estimated_effort_hours: 12, owner_agent_id: 'fast' }),
+    ],
+  });
+  const { schedule } = deriveSchedule(s, {
+    today: TODAY,
+    velocityMap: new Map([['fast', 2]]),
+  });
+  assert.equal(schedule.get('A')!.derived_end, TODAY);
+});
+
+// ─── Determinism ──────────────────────────────────────────────────
+
+test('repeated runs produce identical output', () => {
+  const s = snap({
+    initiatives: [
+      init({ id: 'A', estimated_effort_hours: 6 }),
+      init({ id: 'B', estimated_effort_hours: 12 }),
+      init({ id: 'C', estimated_effort_hours: 18 }),
+    ],
+    dependencies: [dep('B', 'A'), dep('C', 'B')],
+  });
+  const r1 = deriveSchedule(s, { today: TODAY });
+  const r2 = deriveSchedule(s, { today: TODAY });
+  for (const id of ['A', 'B', 'C']) {
+    assert.deepEqual(r1.schedule.get(id), r2.schedule.get(id));
+  }
+});
+
+test('today anchor is respected (not new Date)', () => {
+  const s = snap({
+    initiatives: [init({ id: 'A', estimated_effort_hours: 6 })],
+  });
+  const { schedule } = deriveSchedule(s, { today: '2030-01-07' }); // Mon
+  assert.equal(schedule.get('A')!.derived_start, '2030-01-07');
+});
+
+// ─── target_start hint ────────────────────────────────────────────
+
+test('target_start in the future delays start past today', () => {
+  const s = snap({
+    initiatives: [
+      init({
+        id: 'A',
+        estimated_effort_hours: 6,
+        target_start: '2026-05-04', // a Monday
+      }),
+    ],
+  });
+  const { schedule } = deriveSchedule(s, { today: TODAY });
+  assert.equal(schedule.get('A')!.derived_start, '2026-05-04');
+});
+
+// ─── HOURS_PER_DAY constant exposed ───────────────────────────────
+
+test('HOURS_PER_DAY constant is exported and reasonable', () => {
+  assert.ok(HOURS_PER_DAY > 0 && HOURS_PER_DAY <= 12);
+});
+
+// silence unused
+void addDays;
+void daysBetween;
+void toIsoDay;

--- a/src/lib/roadmap/derive.ts
+++ b/src/lib/roadmap/derive.ts
@@ -1,0 +1,323 @@
+/**
+ * Critical-path derivation engine (Phase 4 — spec §7.2).
+ *
+ * Pure function. Takes a roadmap snapshot + a per-owner velocity map, and
+ * returns a Map<initiative_id, { derived_start, derived_end }>. Does no DB
+ * writes — those happen in apply-derivation.ts.
+ *
+ * Algorithm in plain English:
+ *
+ *   1. Build a dependency graph using `initiative_dependencies`. Drop
+ *      `informational` edges (non-blocking per spec). `start_to_start`
+ *      edges block on the dependency's *start*; everything else blocks on
+ *      its *end*.
+ *
+ *   2. Topologically sort the graph. If a cycle exists, the cycle members
+ *      get NULL derived_* and the cycle is reported in the output. Other
+ *      initiatives still derive normally if they don't transit through
+ *      the cycle.
+ *
+ *   3. For each initiative in topo order:
+ *        - effort = rollupEffort(i)         (sums descendants for containers)
+ *        - velocity = velocityMap[owner] ?? 1.0
+ *        - effective_days = ceil((effort / velocity) / HOURS_PER_DAY)
+ *        - earliest_start = max(today, target_start ?? today,
+ *                               max-over-deps(dep.derived_end | dep.derived_start))
+ *        - derived_end = add `effective_days` business days to earliest_start
+ *          (skipping weekends, ignoring public holidays — out of scope v1)
+ *        - subtract owner availability windows: shift derived_end later by
+ *          the count of business days the schedule [start, end] overlaps
+ *          any unavailable window.
+ *
+ *   4. Initiatives whose effort is null (no signal, no descendant signal)
+ *      get NULL derived_*. Don't guess — let the operator notice the gap.
+ *
+ * Determinism: given identical (snapshot, velocityMap, today) inputs, this
+ * function produces identical output. No `new Date()` calls inside — pass
+ * `today` explicitly.
+ */
+
+import type {
+  RoadmapDependency,
+  RoadmapInitiative,
+  RoadmapOwnerAvailability,
+  RoadmapSnapshot,
+} from '@/lib/db/roadmap';
+import { addDays, toIsoDay, toUtcDay } from './date-math';
+import { rollupEffort } from './effort';
+
+/**
+ * Hours-per-workday assumption. 6 hours of focused work is the planning
+ * heuristic from the spec. If estimates are quoted in "ideal hours" they
+ * track real wall-clock days closely.
+ */
+export const HOURS_PER_DAY = 6;
+
+export interface DerivedRange {
+  derived_start: string | null;
+  derived_end: string | null;
+}
+
+export interface DeriveOptions {
+  /**
+   * Per-owner velocity ratio. Owners not in the map fall back to 1.0
+   * (no adjustment). Use `getVelocityRatio` to compute these from history.
+   */
+  velocityMap?: Map<string, number>;
+  /**
+   * The "today" anchor. Defaults to "now". Pass an explicit date in tests
+   * for deterministic output.
+   */
+  today?: Date | string;
+}
+
+export interface DeriveResult {
+  /** id → { derived_start, derived_end } (both ISO YYYY-MM-DD or null). */
+  schedule: Map<string, DerivedRange>;
+  /** Initiative ids belonging to a detected cycle, in arbitrary order. */
+  cycle: string[];
+  /** Initiative ids excluded because no effort signal was available. */
+  noEffort: string[];
+  /** Diagnostic warnings emitted during the run. */
+  warnings: string[];
+}
+
+/**
+ * Main entrypoint. See module header for algorithm.
+ */
+export function deriveSchedule(snapshot: RoadmapSnapshot, opts: DeriveOptions = {}): DeriveResult {
+  const today = toUtcDay(opts.today ?? new Date());
+  const velocityMap = opts.velocityMap ?? new Map<string, number>();
+
+  // Index initiatives.
+  const byId = new Map<string, RoadmapInitiative>();
+  for (const i of snapshot.initiatives) byId.set(i.id, i);
+
+  // Group availability by owner for quick lookup.
+  const availByAgent = new Map<string, RoadmapOwnerAvailability[]>();
+  for (const a of snapshot.owner_availability ?? []) {
+    const list = availByAgent.get(a.agent_id) ?? [];
+    list.push(a);
+    availByAgent.set(a.agent_id, list);
+  }
+
+  // Dependency edges (filtered to blocking kinds) keyed by from-initiative
+  // (the dependent). We also need the reverse map for the topo sort.
+  const blockingEdges: RoadmapDependency[] = (snapshot.dependencies ?? []).filter(
+    d => d.kind !== 'informational',
+  );
+
+  // adjacency: dep -> dependents (the initiative that depends on this one
+  //                              comes after in topo order)
+  const out: Map<string, string[]> = new Map();
+  // reverse adjacency: dependent -> deps it waits for
+  const inEdges: Map<string, RoadmapDependency[]> = new Map();
+  // in-degree counter for Kahn's algorithm
+  const inDegree: Map<string, number> = new Map();
+
+  for (const i of snapshot.initiatives) {
+    inDegree.set(i.id, 0);
+  }
+  for (const e of blockingEdges) {
+    if (!byId.has(e.initiative_id) || !byId.has(e.depends_on_initiative_id)) continue;
+    const outs = out.get(e.depends_on_initiative_id) ?? [];
+    outs.push(e.initiative_id);
+    out.set(e.depends_on_initiative_id, outs);
+
+    const ins = inEdges.get(e.initiative_id) ?? [];
+    ins.push(e);
+    inEdges.set(e.initiative_id, ins);
+
+    inDegree.set(e.initiative_id, (inDegree.get(e.initiative_id) ?? 0) + 1);
+  }
+
+  // Kahn's topological sort. Sort the queue by id at insertion to keep
+  // determinism across runs (Map iteration order is insertion order, which
+  // depends on input shape; explicitly sorting removes that dependence).
+  const queue: string[] = [];
+  for (const [id, n] of inDegree.entries()) {
+    if (n === 0) queue.push(id);
+  }
+  queue.sort();
+  const topoOrder: string[] = [];
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    topoOrder.push(id);
+    const outs = out.get(id) ?? [];
+    for (const next of outs) {
+      const remaining = (inDegree.get(next) ?? 0) - 1;
+      inDegree.set(next, remaining);
+      if (remaining === 0) {
+        // Insert sorted to keep determinism.
+        let i = 0;
+        while (i < queue.length && queue[i] < next) i++;
+        queue.splice(i, 0, next);
+      }
+    }
+  }
+
+  // Anything left with in-degree > 0 is in a cycle.
+  const cycle: string[] = [];
+  for (const [id, n] of inDegree.entries()) {
+    if (n > 0) cycle.push(id);
+  }
+  cycle.sort();
+
+  const warnings: string[] = [];
+  if (cycle.length > 0) {
+    warnings.push(`Cycle detected among ${cycle.length} initiative(s): ${cycle.join(', ')}`);
+  }
+
+  // Compute schedule for non-cycle initiatives in topo order.
+  const schedule = new Map<string, DerivedRange>();
+  const noEffort: string[] = [];
+
+  // Initialize cycle members to null up front so deps that reference them
+  // can be skipped without crashing.
+  for (const id of cycle) {
+    schedule.set(id, { derived_start: null, derived_end: null });
+  }
+
+  for (const id of topoOrder) {
+    const init = byId.get(id);
+    if (!init) continue;
+
+    const effort = rollupEffort(id, snapshot);
+    if (effort == null) {
+      schedule.set(id, { derived_start: null, derived_end: null });
+      noEffort.push(id);
+      continue;
+    }
+
+    const velocity = (init.owner_agent_id && velocityMap.get(init.owner_agent_id)) || 1.0;
+    const adjustedHours = effort / velocity;
+    const effectiveDays = Math.max(1, Math.ceil(adjustedHours / HOURS_PER_DAY));
+
+    // Earliest start: max(today, target_start, max over deps).
+    const candidates: Date[] = [today];
+    if (init.target_start) {
+      try {
+        candidates.push(toUtcDay(init.target_start));
+      } catch {
+        warnings.push(`Initiative ${id}: invalid target_start "${init.target_start}", ignoring`);
+      }
+    }
+    const deps = inEdges.get(id) ?? [];
+    let depBlocked = false;
+    for (const dep of deps) {
+      const depRange = schedule.get(dep.depends_on_initiative_id);
+      if (!depRange) continue;
+      // start_to_start: the dependent can begin when the prereq begins.
+      // finish_to_start / blocking: the dependent must wait for prereq end.
+      const anchor =
+        dep.kind === 'start_to_start' ? depRange.derived_start : depRange.derived_end;
+      if (anchor == null) {
+        // The prereq has no derived schedule. Block this initiative's
+        // schedule too — we don't know when the prereq actually finishes.
+        depBlocked = true;
+        break;
+      }
+      try {
+        // For finish-to-start we start the day AFTER the prereq ends.
+        const offset = dep.kind === 'start_to_start' ? 0 : 1;
+        candidates.push(addDays(anchor, offset));
+      } catch {
+        // Bad ISO string in DB; skip this dep.
+      }
+    }
+    if (depBlocked) {
+      schedule.set(id, { derived_start: null, derived_end: null });
+      continue;
+    }
+
+    let start = maxDate(candidates);
+    start = nextBusinessDay(start);
+
+    // Walk forward day-by-day from `start`, counting only business days
+    // that are NOT inside any owner-availability window. End the schedule
+    // when we've accumulated `effectiveDays` working days. This naturally
+    // pushes the end past unavailable windows by exactly the number of
+    // business days they consume — no fixed-point iteration needed.
+    const ownerAvail = init.owner_agent_id
+      ? availByAgent.get(init.owner_agent_id) ?? []
+      : [];
+
+    let end = start;
+    let workdaysAccumulated = 0;
+    let safety = 365 * 2; // bounded — a 2-year schedule is the cap
+    let cursor = start;
+    while (safety-- > 0) {
+      if (!isWeekend(cursor) && !isAvailableBlocked(cursor, ownerAvail)) {
+        workdaysAccumulated++;
+        end = cursor;
+        if (workdaysAccumulated >= effectiveDays) break;
+      }
+      cursor = addDays(cursor, 1);
+    }
+
+    // If `start` itself was inside an availability window, slide it forward
+    // to the first usable day.
+    let realStart = start;
+    let s2 = 60;
+    while (s2-- > 0 && (isWeekend(realStart) || isAvailableBlocked(realStart, ownerAvail))) {
+      realStart = addDays(realStart, 1);
+    }
+
+    schedule.set(id, {
+      derived_start: toIsoDay(realStart),
+      derived_end: toIsoDay(end),
+    });
+  }
+
+  // Initiatives that weren't visited (e.g. cycle members already set, or
+  // input snapshot included an id not in inDegree somehow) — fill with
+  // explicit nulls for stability.
+  for (const i of snapshot.initiatives) {
+    if (!schedule.has(i.id)) {
+      schedule.set(i.id, { derived_start: null, derived_end: null });
+    }
+  }
+
+  return { schedule, cycle, noEffort, warnings };
+}
+
+// ─── helpers ──────────────────────────────────────────────────────
+
+function maxDate(dates: Date[]): Date {
+  let m = dates[0];
+  for (let i = 1; i < dates.length; i++) {
+    if (dates[i].getTime() > m.getTime()) m = dates[i];
+  }
+  return m;
+}
+
+/** True when `d` (UTC) is Sat (6) or Sun (0). */
+function isWeekend(d: Date): boolean {
+  const day = d.getUTCDay();
+  return day === 0 || day === 6;
+}
+
+/** Roll forward to the next non-weekend day (or `d` itself if it already is). */
+function nextBusinessDay(d: Date): Date {
+  let cur = toUtcDay(d);
+  while (isWeekend(cur)) cur = addDays(cur, 1);
+  return cur;
+}
+
+/** True if `day` falls inside any of the unavailable windows (inclusive). */
+function isAvailableBlocked(day: Date, windows: RoadmapOwnerAvailability[]): boolean {
+  if (windows.length === 0) return false;
+  const t = day.getTime();
+  for (const w of windows) {
+    let ws: number, we: number;
+    try {
+      ws = toUtcDay(w.unavailable_start).getTime();
+      we = toUtcDay(w.unavailable_end).getTime();
+    } catch {
+      continue;
+    }
+    if (t >= ws && t <= we) return true;
+  }
+  return false;
+}
+

--- a/src/lib/roadmap/drift.test.ts
+++ b/src/lib/roadmap/drift.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Drift detector tests (Phase 4).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { detectDrift, SLIPPAGE_THRESHOLD_DAYS } from './drift';
+import type { DeriveResult } from './derive';
+import type { RoadmapInitiative, RoadmapSnapshot } from '@/lib/db/roadmap';
+
+function init(p: Partial<RoadmapInitiative> & { id: string }): RoadmapInitiative {
+  return {
+    id: p.id,
+    parent_initiative_id: p.parent_initiative_id ?? null,
+    product_id: null,
+    kind: p.kind ?? 'story',
+    title: p.id,
+    status: p.status ?? 'planned',
+    owner_agent_id: null,
+    owner_agent_name: null,
+    complexity: null,
+    estimated_effort_hours: null,
+    target_start: null,
+    target_end: p.target_end ?? null,
+    derived_start: null,
+    derived_end: null,
+    committed_end: p.committed_end ?? null,
+    status_check_md: null,
+    sort_order: 0,
+    depth: 0,
+    task_counts: { draft: 0, active: 0, done: 0, total: 0 },
+  };
+}
+
+function snap(initiatives: RoadmapInitiative[]): RoadmapSnapshot {
+  return {
+    initiatives,
+    dependencies: [],
+    tasks: [],
+    owner_availability: [],
+    workspace_id: 'test',
+    product_id: null,
+    truncated: false,
+  };
+}
+
+function derivedResult(map: Record<string, { start: string | null; end: string | null }>, opts: Partial<DeriveResult> = {}): DeriveResult {
+  const schedule = new Map<string, { derived_start: string | null; derived_end: string | null }>();
+  for (const [id, v] of Object.entries(map)) {
+    schedule.set(id, { derived_start: v.start, derived_end: v.end });
+  }
+  return {
+    schedule,
+    cycle: opts.cycle ?? [],
+    noEffort: opts.noEffort ?? [],
+    warnings: opts.warnings ?? [],
+  };
+}
+
+test('milestone_at_risk fires when derived_end exceeds committed_end', () => {
+  const s = snap([
+    init({ id: 'm', kind: 'milestone', committed_end: '2026-05-01' }),
+  ]);
+  const d = derivedResult({ m: { start: '2026-04-01', end: '2026-05-10' } });
+  const events = detectDrift(s, d);
+  const m = events.find(e => e.kind === 'milestone_at_risk');
+  assert.ok(m && m.kind === 'milestone_at_risk');
+  if (m && m.kind === 'milestone_at_risk') {
+    assert.equal(m.initiative_id, 'm');
+    assert.equal(m.committed_end, '2026-05-01');
+    assert.equal(m.derived_end, '2026-05-10');
+    assert.equal(m.days_over, 9);
+  }
+});
+
+test('milestone_at_risk does NOT fire when on schedule', () => {
+  const s = snap([
+    init({ id: 'm', kind: 'milestone', committed_end: '2026-05-01' }),
+  ]);
+  const d = derivedResult({ m: { start: '2026-04-01', end: '2026-04-30' } });
+  const events = detectDrift(s, d);
+  assert.equal(events.filter(e => e.kind === 'milestone_at_risk').length, 0);
+});
+
+test('slippage fires past threshold; does not fire below threshold', () => {
+  const s = snap([
+    init({ id: 'a', target_end: '2026-04-30' }),
+    init({ id: 'b', target_end: '2026-04-30' }),
+  ]);
+  // a: derived 2 days past target → below threshold (3); no event.
+  // b: derived 5 days past target → fires.
+  const d = derivedResult({
+    a: { start: '2026-04-01', end: '2026-05-02' },
+    b: { start: '2026-04-01', end: '2026-05-05' },
+  });
+  const events = detectDrift(s, d);
+  const slips = events.filter(e => e.kind === 'slippage');
+  assert.equal(slips.length, 1);
+  if (slips[0].kind === 'slippage') {
+    assert.equal(slips[0].initiative_id, 'b');
+    assert.equal(slips[0].days_over, 5);
+  }
+  // Threshold sanity.
+  assert.ok(SLIPPAGE_THRESHOLD_DAYS > 0);
+});
+
+test('milestones do not fire generic slippage (their kind has its own event)', () => {
+  const s = snap([
+    init({ id: 'm', kind: 'milestone', committed_end: '2026-05-01', target_end: '2026-05-01' }),
+  ]);
+  const d = derivedResult({ m: { start: '2026-04-01', end: '2026-05-10' } });
+  const events = detectDrift(s, d);
+  // Only the milestone_at_risk event, not a duplicate slippage event.
+  assert.equal(events.filter(e => e.kind === 'slippage').length, 0);
+  assert.equal(events.filter(e => e.kind === 'milestone_at_risk').length, 1);
+});
+
+test('cycle_detected event lists all members', () => {
+  const s = snap([
+    init({ id: 'a' }),
+    init({ id: 'b' }),
+  ]);
+  const events = detectDrift(s, derivedResult({}, { cycle: ['a', 'b'] }));
+  const c = events.find(e => e.kind === 'cycle_detected');
+  assert.ok(c && c.kind === 'cycle_detected');
+  if (c && c.kind === 'cycle_detected') {
+    assert.deepEqual(c.initiative_ids.sort(), ['a', 'b']);
+  }
+});
+
+test('no_effort_signal walks up to nearest milestone ancestor', () => {
+  const s = snap([
+    init({ id: 'm', kind: 'milestone', committed_end: '2026-06-01' }),
+    init({ id: 'epic', kind: 'epic', parent_initiative_id: 'm' }),
+    init({ id: 'orphan-story', kind: 'story', parent_initiative_id: 'epic' }),
+  ]);
+  const events = detectDrift(s, derivedResult({}, { noEffort: ['orphan-story'] }));
+  const ne = events.find(e => e.kind === 'no_effort_signal');
+  assert.ok(ne && ne.kind === 'no_effort_signal');
+  if (ne && ne.kind === 'no_effort_signal') {
+    assert.equal(ne.initiative_id, 'orphan-story');
+    assert.equal(ne.ancestor_milestone_id, 'm');
+  }
+});
+
+test('no_effort_signal with no milestone ancestor leaves ancestor_milestone_id undefined', () => {
+  const s = snap([init({ id: 'a', kind: 'story' })]);
+  const events = detectDrift(s, derivedResult({}, { noEffort: ['a'] }));
+  const ne = events.find(e => e.kind === 'no_effort_signal');
+  if (ne && ne.kind === 'no_effort_signal') {
+    assert.equal(ne.ancestor_milestone_id, undefined);
+  }
+});
+
+test('non-drifting initiatives produce no events', () => {
+  const s = snap([
+    init({ id: 'a', target_end: '2026-04-30' }),
+    init({ id: 'm', kind: 'milestone', committed_end: '2026-05-01' }),
+  ]);
+  const d = derivedResult({
+    a: { start: '2026-04-01', end: '2026-04-29' },
+    m: { start: '2026-04-01', end: '2026-04-30' },
+  });
+  const events = detectDrift(s, d);
+  assert.equal(events.length, 0);
+});

--- a/src/lib/roadmap/drift.ts
+++ b/src/lib/roadmap/drift.ts
@@ -1,0 +1,147 @@
+/**
+ * Drift detector (Phase 4 — spec §7.2 step 5).
+ *
+ * Pure function. Compares a snapshot against a derived-schedule map and
+ * emits a typed list of drift events the apply step (or the future PM
+ * agent) can act on.
+ *
+ *   milestone_at_risk   derived_end > committed_end (only on milestones)
+ *   slippage            derived_end > target_end + SLIPPAGE_THRESHOLD_DAYS
+ *   cycle_detected      reported once per cycle from deriveSchedule
+ *   no_effort_signal    initiative excluded for missing effort, with the
+ *                       nearest milestone ancestor (if any) for context
+ */
+
+import type { RoadmapInitiative, RoadmapSnapshot } from '@/lib/db/roadmap';
+import type { DeriveResult } from './derive';
+import { daysBetween } from './date-math';
+
+/**
+ * "A target_end < derived_end by more than this" counts as slippage. Set
+ * conservatively — the engine snaps to whole days, so single-day rounding
+ * shouldn't fire alerts.
+ */
+export const SLIPPAGE_THRESHOLD_DAYS = 3;
+
+export type DriftEvent =
+  | {
+      kind: 'milestone_at_risk';
+      initiative_id: string;
+      committed_end: string;
+      derived_end: string;
+      days_over: number;
+    }
+  | {
+      kind: 'slippage';
+      initiative_id: string;
+      target_end: string;
+      derived_end: string;
+      days_over: number;
+    }
+  | {
+      kind: 'cycle_detected';
+      initiative_ids: string[];
+    }
+  | {
+      kind: 'no_effort_signal';
+      initiative_id: string;
+      ancestor_milestone_id?: string;
+    };
+
+export function detectDrift(
+  snapshot: RoadmapSnapshot,
+  derivedResult: DeriveResult,
+): DriftEvent[] {
+  const events: DriftEvent[] = [];
+  const byId = new Map<string, RoadmapInitiative>();
+  for (const i of snapshot.initiatives) byId.set(i.id, i);
+
+  // Cycle detection emits one combined event so consumers don't have to
+  // group by membership themselves.
+  if (derivedResult.cycle.length > 0) {
+    events.push({ kind: 'cycle_detected', initiative_ids: [...derivedResult.cycle] });
+  }
+
+  for (const i of snapshot.initiatives) {
+    const derived = derivedResult.schedule.get(i.id);
+    if (!derived) continue;
+
+    // milestone_at_risk: only initiatives with kind='milestone' and a
+    // committed_end can fire this.
+    if (
+      i.kind === 'milestone' &&
+      i.committed_end &&
+      derived.derived_end &&
+      derived.derived_end > i.committed_end
+    ) {
+      const days = daysBetween(i.committed_end, derived.derived_end);
+      if (days > 0) {
+        events.push({
+          kind: 'milestone_at_risk',
+          initiative_id: i.id,
+          committed_end: i.committed_end,
+          derived_end: derived.derived_end,
+          days_over: days,
+        });
+      }
+    }
+
+    // slippage: target_end exists and derived_end is more than threshold
+    // days past it. Skip milestones — they have their own (stronger)
+    // milestone_at_risk event from committed_end.
+    if (
+      i.kind !== 'milestone' &&
+      i.target_end &&
+      derived.derived_end &&
+      derived.derived_end > i.target_end
+    ) {
+      const days = daysBetween(i.target_end, derived.derived_end);
+      if (days > SLIPPAGE_THRESHOLD_DAYS) {
+        events.push({
+          kind: 'slippage',
+          initiative_id: i.id,
+          target_end: i.target_end,
+          derived_end: derived.derived_end,
+          days_over: days,
+        });
+      }
+    }
+  }
+
+  // no_effort_signal: each initiative excluded because it has no effort.
+  // Walk up the parent chain to the nearest milestone for context — if a
+  // story has no estimate but rolls into a milestone, that milestone is
+  // the operator's first stop for fixing the gap.
+  const noEffortSeen = new Set(derivedResult.noEffort);
+  for (const id of derivedResult.noEffort) {
+    const ancestor = nearestMilestone(id, byId);
+    events.push({
+      kind: 'no_effort_signal',
+      initiative_id: id,
+      ancestor_milestone_id: ancestor ?? undefined,
+    });
+  }
+  // Suppress unused-var warning if all noEffort fired above.
+  void noEffortSeen;
+
+  return events;
+}
+
+function nearestMilestone(
+  startId: string,
+  byId: Map<string, RoadmapInitiative>,
+): string | null {
+  let cur = byId.get(startId);
+  // Don't return the start itself — we want an *ancestor*.
+  if (cur?.parent_initiative_id) {
+    cur = byId.get(cur.parent_initiative_id);
+  } else {
+    return null;
+  }
+  while (cur) {
+    if (cur.kind === 'milestone') return cur.id;
+    if (!cur.parent_initiative_id) return null;
+    cur = byId.get(cur.parent_initiative_id);
+  }
+  return null;
+}

--- a/src/lib/roadmap/effort.test.ts
+++ b/src/lib/roadmap/effort.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Effort helper tests (Phase 4).
+ *
+ * Pure-function tests — no DB needed; build mini snapshots in-memory.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  COMPLEXITY_HOURS,
+  getEffectiveEffortHours,
+  rollupEffort,
+} from './effort';
+import type { RoadmapInitiative, RoadmapSnapshot } from '@/lib/db/roadmap';
+
+function init(partial: Partial<RoadmapInitiative> & { id: string; kind?: RoadmapInitiative['kind'] }): RoadmapInitiative {
+  return {
+    id: partial.id,
+    parent_initiative_id: partial.parent_initiative_id ?? null,
+    product_id: null,
+    kind: partial.kind ?? 'story',
+    title: partial.id,
+    status: 'planned',
+    owner_agent_id: partial.owner_agent_id ?? null,
+    owner_agent_name: null,
+    complexity: partial.complexity ?? null,
+    estimated_effort_hours: partial.estimated_effort_hours ?? null,
+    target_start: partial.target_start ?? null,
+    target_end: partial.target_end ?? null,
+    derived_start: partial.derived_start ?? null,
+    derived_end: partial.derived_end ?? null,
+    committed_end: partial.committed_end ?? null,
+    status_check_md: null,
+    sort_order: 0,
+    depth: 0,
+    task_counts: { draft: 0, active: 0, done: 0, total: 0 },
+  };
+}
+
+function snap(initiatives: RoadmapInitiative[]): RoadmapSnapshot {
+  return {
+    initiatives,
+    dependencies: [],
+    tasks: [],
+    owner_availability: [],
+    workspace_id: 'test',
+    product_id: null,
+    truncated: false,
+  };
+}
+
+test('getEffectiveEffortHours prefers explicit hours when both set', () => {
+  assert.equal(
+    getEffectiveEffortHours({ estimated_effort_hours: 7, complexity: 'L' }),
+    7,
+  );
+});
+
+test('getEffectiveEffortHours falls back to complexity table', () => {
+  assert.equal(getEffectiveEffortHours({ complexity: 'M' }), COMPLEXITY_HOURS.M);
+  assert.equal(getEffectiveEffortHours({ complexity: 'XL' }), 120);
+});
+
+test('getEffectiveEffortHours returns null when neither field set', () => {
+  assert.equal(getEffectiveEffortHours({}), null);
+});
+
+test('getEffectiveEffortHours treats zero hours as missing', () => {
+  // zero is not a useful estimate; complexity should win
+  assert.equal(
+    getEffectiveEffortHours({ estimated_effort_hours: 0, complexity: 'S' }),
+    COMPLEXITY_HOURS.S,
+  );
+});
+
+test('rollupEffort returns own effort when leaf', () => {
+  const s = snap([init({ id: 'a', estimated_effort_hours: 10 })]);
+  assert.equal(rollupEffort('a', s), 10);
+});
+
+test('rollupEffort sums leaf descendants for a container', () => {
+  const s = snap([
+    init({ id: 'epic', kind: 'epic' }),
+    init({ id: 'a', parent_initiative_id: 'epic', estimated_effort_hours: 10 }),
+    init({ id: 'b', parent_initiative_id: 'epic', complexity: 'M' }), // 12
+    init({ id: 'c', parent_initiative_id: 'epic', estimated_effort_hours: 5 }),
+  ]);
+  assert.equal(rollupEffort('epic', s), 10 + 12 + 5);
+});
+
+test('rollupEffort recurses through grandchildren', () => {
+  const s = snap([
+    init({ id: 'milestone', kind: 'milestone' }),
+    init({ id: 'epic', kind: 'epic', parent_initiative_id: 'milestone' }),
+    init({ id: 'story1', parent_initiative_id: 'epic', complexity: 'L' }), // 40
+    init({ id: 'story2', parent_initiative_id: 'epic', complexity: 'S' }), // 4
+  ]);
+  assert.equal(rollupEffort('milestone', s), 44);
+});
+
+test('rollupEffort falls back to container effort when no descendant signal', () => {
+  // Epic has children but none have estimates yet; epic has its own.
+  const s = snap([
+    init({ id: 'epic', kind: 'epic', estimated_effort_hours: 40 }),
+    init({ id: 'a', parent_initiative_id: 'epic' }),
+    init({ id: 'b', parent_initiative_id: 'epic' }),
+  ]);
+  assert.equal(rollupEffort('epic', s), 40);
+});
+
+test('rollupEffort returns null when nothing has effort', () => {
+  const s = snap([
+    init({ id: 'epic', kind: 'epic' }),
+    init({ id: 'a', parent_initiative_id: 'epic' }),
+  ]);
+  assert.equal(rollupEffort('epic', s), null);
+});
+
+test('rollupEffort skips children with no effort but uses ones that do', () => {
+  const s = snap([
+    init({ id: 'epic', kind: 'epic' }),
+    init({ id: 'a', parent_initiative_id: 'epic', estimated_effort_hours: 8 }),
+    init({ id: 'b', parent_initiative_id: 'epic' }), // no signal — contributes 0
+  ]);
+  assert.equal(rollupEffort('epic', s), 8);
+});

--- a/src/lib/roadmap/effort.ts
+++ b/src/lib/roadmap/effort.ts
@@ -1,0 +1,112 @@
+/**
+ * Effort sizing helpers (Phase 4).
+ *
+ * Spec §16 Q1 (resolved): when an initiative has no `estimated_effort_hours`
+ * but does have a complexity bucket, fall back to a fixed table. Operators
+ * can override this per workspace later (out of scope v1). When neither is
+ * set, return null — the derivation engine excludes the initiative from
+ * scheduling rather than guessing (spec §7.2 step 2).
+ *
+ * Containers (initiatives with descendants) get effort by summing their
+ * descendants' effective effort. The container's own `estimated_effort_hours`
+ * is ignored when it has children — children are the source of truth, the
+ * container is just a grouping. If no descendant has any effort signal
+ * either, the container is excluded from derivation.
+ *
+ * Pure functions only. Operate on plain RoadmapInitiative shapes; do no DB
+ * work. Tests can pass mini-snapshots.
+ */
+
+import type { RoadmapInitiative, RoadmapSnapshot } from '@/lib/db/roadmap';
+
+export const COMPLEXITY_HOURS: Record<'S' | 'M' | 'L' | 'XL', number> = {
+  S: 4,
+  M: 12,
+  L: 40,
+  XL: 120,
+};
+
+/** Subset of initiative fields the effort helpers actually need. */
+export interface EffortInputs {
+  estimated_effort_hours?: number | null;
+  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+}
+
+/**
+ * Effective effort for a leaf initiative (no children, or container with
+ * its own effort declared). Returns null when no signal is available.
+ */
+export function getEffectiveEffortHours(initiative: EffortInputs): number | null {
+  if (initiative.estimated_effort_hours != null && initiative.estimated_effort_hours > 0) {
+    return initiative.estimated_effort_hours;
+  }
+  if (initiative.complexity) {
+    return COMPLEXITY_HOURS[initiative.complexity];
+  }
+  return null;
+}
+
+/**
+ * Roll up effort for an initiative, summing descendants' effective effort
+ * when present. If the initiative has children:
+ *   - Sum all descendants' `getEffectiveEffortHours`. NULL descendants
+ *     contribute 0 to the sum.
+ *   - If the sum is > 0, return it; otherwise fall back to the container's
+ *     own `getEffectiveEffortHours` (handles the case where the container
+ *     was decomposed but children have no estimates yet).
+ *   - If both produce nothing, return null.
+ *
+ * If the initiative has no children, behave like `getEffectiveEffortHours`.
+ *
+ * The snapshot is used to walk the tree without DB calls — pure function.
+ */
+export function rollupEffort(initiativeId: string, snapshot: RoadmapSnapshot): number | null {
+  const byId = new Map<string, RoadmapInitiative>();
+  const byParent = new Map<string | null, RoadmapInitiative[]>();
+  for (const i of snapshot.initiatives) {
+    byId.set(i.id, i);
+    const list = byParent.get(i.parent_initiative_id ?? null) ?? [];
+    list.push(i);
+    byParent.set(i.parent_initiative_id ?? null, list);
+  }
+
+  const root = byId.get(initiativeId);
+  if (!root) return null;
+
+  const children = byParent.get(initiativeId) ?? [];
+  if (children.length === 0) {
+    return getEffectiveEffortHours(root);
+  }
+
+  // Sum effort across the *full* descendant subtree (not just direct kids),
+  // since an epic → story → substory split should still attribute substory
+  // effort to the epic.
+  let sum = 0;
+  let any = false;
+  const stack: string[] = [...children.map(c => c.id)];
+  const seen = new Set<string>();
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    if (seen.has(cur)) continue;
+    seen.add(cur);
+    const node = byId.get(cur);
+    if (!node) continue;
+    const grandKids = byParent.get(cur) ?? [];
+    if (grandKids.length === 0) {
+      // Leaf — contributes its own effective effort.
+      const e = getEffectiveEffortHours(node);
+      if (e != null) {
+        sum += e;
+        any = true;
+      }
+    } else {
+      // Recurse into descendants. Don't double-count by also adding the
+      // container's own effort.
+      for (const g of grandKids) stack.push(g.id);
+    }
+  }
+
+  if (any) return sum;
+  // No descendant effort — fall back to the container's own signal.
+  return getEffectiveEffortHours(root);
+}

--- a/src/lib/roadmap/velocity.test.ts
+++ b/src/lib/roadmap/velocity.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Velocity tests (Phase 4).
+ *
+ * Pure-function tests against `computeVelocityFromTasks`. The DB-backed
+ * `getVelocityRatio` / `computeVelocity` are exercised by the e2e test.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeVelocityFromTasks } from './velocity';
+
+test('zero history returns 1.0 (no adjustment)', () => {
+  assert.equal(computeVelocityFromTasks([]), 1.0);
+});
+
+test('single consistent cost ratio returned as-is', () => {
+  // estimated 100, actual 100 → ratio 1.0
+  const r = computeVelocityFromTasks([
+    { estimated_cost_usd: 100, actual_cost_usd: 100 },
+  ]);
+  assert.equal(r, 1.0);
+});
+
+test('underspend (faster) → ratio > 1', () => {
+  // est 100 / act 50 → ratio 2.0
+  const r = computeVelocityFromTasks([
+    { estimated_cost_usd: 100, actual_cost_usd: 50 },
+  ]);
+  assert.equal(r, 2.0);
+});
+
+test('overspend (slower) → ratio < 1', () => {
+  // est 50 / act 100 → ratio 0.5
+  const r = computeVelocityFromTasks([
+    { estimated_cost_usd: 50, actual_cost_usd: 100 },
+  ]);
+  assert.equal(r, 0.5);
+});
+
+test('mixed signal → averaged', () => {
+  // Two samples: 1.0 and 0.5 → average 0.75
+  const r = computeVelocityFromTasks([
+    { estimated_cost_usd: 100, actual_cost_usd: 100 },
+    { estimated_cost_usd: 50, actual_cost_usd: 100 },
+  ]);
+  assert.equal(r, 0.75);
+});
+
+test('skips rows without cost or wall-clock fallback', () => {
+  // First two rows give no signal; third has both → ratio 1.0.
+  const r = computeVelocityFromTasks([
+    {},
+    { actual_cost_usd: 100 }, // missing estimated
+    { estimated_cost_usd: 100, actual_cost_usd: 100 },
+  ]);
+  assert.equal(r, 1.0);
+});
+
+test('wall-clock fallback uses complexity expected hours', () => {
+  // Complexity 'M' = 12 hours expected; actual wall-clock 6 hours → ratio 2.0
+  const start = '2026-04-01T00:00:00.000Z';
+  const end = '2026-04-01T06:00:00.000Z';
+  const r = computeVelocityFromTasks([
+    { complexity: 'M', created_at: start, updated_at: end },
+  ]);
+  assert.equal(r, 2.0);
+});
+
+test('extreme ratios are clamped to [0.1, 10]', () => {
+  // Insanely fast: est 1000 / act 1 → 1000, clamped to 10
+  const fast = computeVelocityFromTasks([
+    { estimated_cost_usd: 1000, actual_cost_usd: 1 },
+  ]);
+  assert.equal(fast, 10);
+  // Insanely slow: est 1 / act 1000 → 0.001, clamped to 0.1
+  const slow = computeVelocityFromTasks([
+    { estimated_cost_usd: 1, actual_cost_usd: 1000 },
+  ]);
+  assert.equal(slow, 0.1);
+});
+
+test('zero or negative cost values are skipped (no divide-by-zero)', () => {
+  // Only the second row contributes (1.0); the first two are unusable.
+  const r = computeVelocityFromTasks([
+    { estimated_cost_usd: 0, actual_cost_usd: 5 },
+    { estimated_cost_usd: 100, actual_cost_usd: 100 },
+    { estimated_cost_usd: -10, actual_cost_usd: 5 },
+  ]);
+  assert.equal(r, 1.0);
+});

--- a/src/lib/roadmap/velocity.ts
+++ b/src/lib/roadmap/velocity.ts
@@ -1,0 +1,187 @@
+/**
+ * Velocity model (Phase 4).
+ *
+ * Per spec §7.2, the derivation engine multiplies effort by a per-owner
+ * velocity ratio so historically-slow owners get longer schedules and
+ * historically-fast owners get shorter ones.
+ *
+ * "Velocity" here is the ratio of *expected* to *actual* work — values > 1
+ * mean the owner finishes faster than estimated, values < 1 mean slower.
+ * The engine divides effort by this ratio: `effective = effort / velocity`.
+ *
+ * Signal sources, in priority order:
+ *
+ *   1. cost ratio: `actual_cost_usd / estimated_cost_usd` per completed task.
+ *      Cost is the closest proxy we have — Mission Control tracks LLM cost
+ *      per task but not effort hours. Underspend (actual < estimated) means
+ *      the task ran cheaper than planned, which usually means it finished
+ *      faster than planned, so velocity = estimated / actual (inverted).
+ *
+ *   2. wall-clock: `(updated_at - created_at) hours` against an expected
+ *      duration derived from complexity (when present on the linked
+ *      initiative or task). Used when only one or neither cost field is set.
+ *      We deliberately don't try to be clever about idle time — wall-clock
+ *      is noisy but stable, and the average of many noisy samples lands
+ *      somewhere reasonable.
+ *
+ *   3. Default 1.0 — no history, no adjustment.
+ *
+ * The output is clamped to [0.1, 10.0] to keep the engine stable. A team
+ * that spent 100x its budget on one task shouldn't make every future task
+ * stretch by 100x.
+ *
+ * Pure-ish: the *core* `computeVelocityFromTasks` is pure (takes rows in,
+ * returns a number). `getVelocityRatio` is the DB-using wrapper — the
+ * engine should pass the *ratio* (a number) into deriveSchedule, never the
+ * helper itself, to keep deriveSchedule deterministic.
+ */
+
+import { queryAll } from '@/lib/db';
+
+const MIN_RATIO = 0.1;
+const MAX_RATIO = 10.0;
+const DEFAULT_SINCE_DAYS = 90;
+
+/**
+ * Sample row consumed by `computeVelocityFromTasks`. Plain TS types so the
+ * pure function is easy to test without a DB.
+ */
+export interface VelocitySampleTask {
+  estimated_cost_usd?: number | null;
+  actual_cost_usd?: number | null;
+  /** Used by the wall-clock fallback. Both ISO timestamps. */
+  created_at?: string | null;
+  updated_at?: string | null;
+  /** Used to derive an expected duration when only wall-clock is available. */
+  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+}
+
+/**
+ * Average ratio across the input rows. Each row contributes one sample if
+ * it has usable signal; rows with no signal are skipped. If no row
+ * contributes, returns 1.0 (default).
+ */
+export function computeVelocityFromTasks(tasks: VelocitySampleTask[]): number {
+  const samples: number[] = [];
+
+  for (const t of tasks) {
+    const sample = sampleVelocity(t);
+    if (sample != null) samples.push(sample);
+  }
+
+  if (samples.length === 0) return 1.0;
+  const avg = samples.reduce((a, b) => a + b, 0) / samples.length;
+  return clampRatio(avg);
+}
+
+/**
+ * Single-task ratio. Returns null when the task offers no usable signal.
+ *
+ * Cost ratio:
+ *   ratio = estimated / actual          (so under-spend → > 1.0 = fast)
+ *
+ * Wall-clock fallback (no cost data):
+ *   expected_hours = COMPLEXITY_HOURS[complexity]
+ *   actual_hours = (updated_at - created_at) hours
+ *   ratio = expected / actual
+ *
+ * Both formulas produce a number in the same direction: > 1.0 means faster
+ * than expected, < 1.0 means slower.
+ */
+function sampleVelocity(t: VelocitySampleTask): number | null {
+  const est = t.estimated_cost_usd;
+  const act = t.actual_cost_usd;
+  if (est != null && est > 0 && act != null && act > 0) {
+    return est / act;
+  }
+
+  // Wall-clock fallback. Need both timestamps and a complexity bucket so we
+  // know what "expected" duration is. Without complexity, wall-clock is
+  // un-anchored and gives no useful ratio.
+  if (t.complexity && t.created_at && t.updated_at) {
+    const start = new Date(t.created_at).getTime();
+    const end = new Date(t.updated_at).getTime();
+    if (!isFinite(start) || !isFinite(end) || end <= start) return null;
+    const actualHours = (end - start) / (1000 * 60 * 60);
+    if (actualHours <= 0) return null;
+    const expectedHours = COMPLEXITY_HOURS[t.complexity];
+    return expectedHours / actualHours;
+  }
+
+  return null;
+}
+
+/** Mirror of effort.ts COMPLEXITY_HOURS — kept local so velocity.ts has no
+ *  cross-file deps and the two tables can drift independently if a future
+ *  spec change splits them. */
+const COMPLEXITY_HOURS: Record<'S' | 'M' | 'L' | 'XL', number> = {
+  S: 4,
+  M: 12,
+  L: 40,
+  XL: 120,
+};
+
+function clampRatio(r: number): number {
+  if (!isFinite(r) || r <= 0) return 1.0;
+  if (r < MIN_RATIO) return MIN_RATIO;
+  if (r > MAX_RATIO) return MAX_RATIO;
+  return r;
+}
+
+export interface ComputeVelocityOptions {
+  owner_agent_id: string;
+  /** Look back this many days. Default 90. */
+  since_days?: number;
+}
+
+/**
+ * DB-using helper: pull recent completed tasks for the owner and compute.
+ * Used by `applyDerivation` to populate a per-owner ratio map before
+ * calling the (pure) derive function.
+ */
+export function computeVelocity(opts: ComputeVelocityOptions): number {
+  const since = opts.since_days ?? DEFAULT_SINCE_DAYS;
+  const cutoff = new Date(Date.now() - since * 24 * 60 * 60 * 1000).toISOString();
+
+  // Tasks the agent worked on (assigned to them) and completed since cutoff.
+  const rows = queryAll<VelocitySampleTask>(
+    `SELECT estimated_cost_usd, actual_cost_usd, created_at, updated_at
+     FROM tasks
+     WHERE assigned_agent_id = ?
+       AND status = 'done'
+       AND updated_at >= ?`,
+    [opts.owner_agent_id, cutoff],
+  );
+
+  // Tasks don't carry their own complexity field — pull it from the linked
+  // initiative, when present, in a second pass. Cost-based samples don't
+  // need it, so we only join when the cost fields are missing.
+  // For simplicity (and to keep this query cheap), we fetch all completed
+  // tasks for the owner that have an initiative_id and pull initiative
+  // complexity in one shot.
+  const augmented = queryAll<VelocitySampleTask & { initiative_id: string | null }>(
+    `SELECT t.estimated_cost_usd, t.actual_cost_usd, t.created_at, t.updated_at,
+            t.initiative_id, i.complexity AS complexity
+     FROM tasks t
+     LEFT JOIN initiatives i ON i.id = t.initiative_id
+     WHERE t.assigned_agent_id = ?
+       AND t.status = 'done'
+       AND t.updated_at >= ?`,
+    [opts.owner_agent_id, cutoff],
+  );
+
+  // Prefer the augmented rows (they include complexity). The first query is
+  // kept around so the helper still works in unit tests where the join
+  // returns nothing — but in practice `augmented` is a strict superset.
+  const samples = augmented.length > 0 ? augmented : rows;
+  return computeVelocityFromTasks(samples);
+}
+
+/**
+ * Convenience wrapper: returns the ratio, clamped, with the default since
+ * window. Provided so callers reading the spec verbatim ("getVelocityRatio")
+ * have the function name they expect.
+ */
+export function getVelocityRatio(owner_agent_id: string): number {
+  return computeVelocity({ owner_agent_id });
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -506,7 +506,8 @@ export type CostCapStatus = 'active' | 'paused' | 'exceeded';
 
 export type ScheduleType =
   | 'research' | 'ideation' | 'maybe_reevaluation' | 'seo_audit'
-  | 'content_refresh' | 'analytics_report' | 'social_batch' | 'growth_experiment';
+  | 'content_refresh' | 'analytics_report' | 'social_batch' | 'growth_experiment'
+  | 'roadmap_drift_scan';
 
 export type OperationType =
   | 'seo_audit' | 'content_publish' | 'content_refresh' | 'social_post'


### PR DESCRIPTION
## Summary
Phase 4 lights up the planning layer's *automatic* schedule. A pure derivation engine takes the roadmap snapshot (initiatives, deps, owner availability, completed-task velocity history) and returns `derived_start`/`derived_end` per initiative. A drift detector compares the result against `committed_end` and `target_end`, and an apply step writes the changes back to the DB, flips milestones whose schedule slipped to `at_risk`, and emits a single `events` row summarizing the run. Manual `POST /api/roadmap/recompute` for testing/UI; `roadmap_drift_scan` schedule_type for the nightly cron tick.

## What landed
- **Owner-availability surface (spec §10):** `GET/POST /api/owner-availability`, `DELETE /api/owner-availability/[id]`, helpers in `src/lib/db/owner-availability.ts`. `getRoadmapSnapshot` now returns `owner_availability` rows scoped to agents that own initiatives in the snapshot (documented choice — engine only uses owners on the schedule).
- **Effort fallback (`src/lib/roadmap/effort.ts`):** `getEffectiveEffortHours` (explicit hours → complexity → null) and `rollupEffort(initiativeId, snapshot)` that sums leaf descendants for containers. Per spec §16 Q1 — `S=4, M=12, L=40, XL=120`.
- **Velocity model (`src/lib/roadmap/velocity.ts`):** per-owner ratio from completed tasks. Cost ratio (`estimated_cost_usd/actual_cost_usd`) preferred; wall-clock + complexity fallback when cost is missing; default 1.0 with no history. Clamped to `[0.1, 10]` to keep the engine stable.
- **Derivation engine (`src/lib/roadmap/derive.ts`):** Kahn topo sort, cycle detection (cycle members get NULL derived_*; warning emitted), `start_to_start` + `finish_to_start` + `blocking` + `informational` semantics, business-day stepping that walks past availability windows day-by-day. Pure: takes snapshot + velocityMap + today, returns a Map. `HOURS_PER_DAY = 6`.
- **Drift detector (`src/lib/roadmap/drift.ts`):** typed events for `milestone_at_risk`, `slippage` (with `SLIPPAGE_THRESHOLD_DAYS = 3`), `cycle_detected`, `no_effort_signal` (with nearest milestone ancestor for context).
- **Apply step (`src/lib/roadmap/apply-derivation.ts`):** single transaction; only updates rows whose dates actually changed (idempotent); flips `planned`/`in_progress` milestones to `at_risk` when slipped; emits one summary event row when something happened (no spam on no-op runs).
- **Schedule wiring:** Migration 044 extends `product_schedules.schedule_type` CHECK list with `roadmap_drift_scan`. `checkAndRunDueSchedules` handles the new type — workspace_id from schedule.config or, fallback, the product's workspace.
- **Admin endpoint:** `POST /api/roadmap/recompute { workspace_id }` returns the full result for UI/testing.
- **UI:** Recompute now button on the roadmap toolbar (with spinning icon + result toast). Outlined derived bar on the canvas turns amber when it overruns target_end/committed_end, with hover tooltip showing schedule debt in days. Alert triangle next to milestones in the rail with the same overrun condition.
- **Tests:** 124 cases across effort, velocity, derive, drift, owner-availability, plus `derive.e2e.test.ts` — seeds a milestone tree, runs `applyDerivation` against the live DB, asserts derived_end > committed_end → status='at_risk', drift event row, and idempotency on re-run.

## Algorithm decisions worth flagging
- **Velocity formula:** cost ratio (`estimated/actual`) is the primary signal because Mission Control tracks LLM cost per task but not effort hours. Wall-clock + complexity is the fallback when cost is missing. Both produce the same direction (>1 = fast, <1 = slow). Average across samples, clamp `[0.1, 10]`.
- **Weekend handling:** strict — Sat/Sun never count toward effective days. Public holidays are out of scope for v1 (documented in `derive.ts` header). When an owner-availability window overlaps the schedule, the day-by-day stepping naturally skips it; no fixed-point math needed.
- **Container effort:** sums leaf descendants. If no descendant has a signal, falls back to the container's own effort. If neither, the initiative is excluded from derivation (spec §7.2 step 2).
- **Idempotency:** the apply step compares each candidate UPDATE against current row state and only writes on a real diff. A no-op re-run touches nothing and emits no event.

## Spec edits worth recording for Phase 5+
None required — spec §7.2, §10, §14, §16 Q1 were the targets and all match the implementation. Phase 5 will need to add the seed for the `pm` agent role (currently no agents have role='pm') and the MCP tools listed in §11. Phase 5 may want to expose `applyDerivation`'s `velocityMap` override in the recompute endpoint so the PM can preview a "what if Sarah's velocity drops to 0.5?" scenario without writing to the DB — easy to add later, not in scope here.

## Stacked PR series
This is **Phase 4 of 6**, stacked on Phase 3 (#45) → Phase 2 (#44) → Phase 1 (#43). See `specs/roadmap-and-pm-spec.md` §14.

**Merge order discipline (project memory):** descendants must be retargeted to the new base before parents merge with `--delete-branch`, or GitHub closes them.

## Test plan
- [x] `effort.test.ts` (10), `velocity.test.ts` (9), `derive.test.ts` (18), `drift.test.ts` (8), `date-math.test.ts` (Phase 3 reg), `owner-availability.test.ts` (7), `derive.e2e.test.ts` (1 large), `initiatives.test.ts` (Phase 1 reg), `promotion.test.ts` (Phase 2 reg), `roadmap.test.ts` (Phase 3 reg) — 124 cases, all green
- [ ] Manual smoke: visit `/roadmap`, click "Recompute now", confirm toast + outlined bars appear on initiatives with effort
- [ ] Confirm milestones whose `derived_end` overruns `committed_end` show the amber alert icon in the rail and the amber outline + tooltip on the canvas
- [ ] `curl http://localhost:4001/roadmap` (dev server unreachable from agent shell — operator confirmation needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>