### PR TITLE
test infra: fix npm test glob + health.test.ts hang

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start -p ${PORT:-4000}",
     "lint": "eslint .",
-    "test": "mkdir -p .tmp && rm -f .tmp/mission-control-test.db* && NODE_ENV=test DATABASE_PATH=.tmp/mission-control-test.db tsx --test src/**/*.test.ts",
+    "test": "mkdir -p .tmp && rm -f .tmp/mission-control-test.db* && find src -name '*.test.ts' -print0 | NODE_ENV=test DATABASE_PATH=.tmp/mission-control-test.db xargs -0 tsx --test",
     "mcp:smoke": "cd mcp-launcher && npm run smoke",
     "mcp:integration": "tsx scripts/mcp-integration-test.mjs",
     "mcp:e2e:next": "node scripts/mcp-next-e2e.mjs",

--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -151,6 +151,9 @@ export class OpenClawClient extends EventEmitter {
         // Perform cleanup even if no new events have arrived
         this.performCacheCleanup();
       }, this.PERIODIC_CLEANUP_INTERVAL_MS);
+      // Don't keep the event loop alive solely for this maintenance timer —
+      // otherwise tests (and short-lived scripts) hang on exit.
+      timer.unref?.();
 
       // Store the timer globally so all instances share it
       (globalThis as Record<string, unknown>)[GLOBAL_CACHE_CLEANUP_KEY] = timer;


### PR DESCRIPTION
## Summary

Two pre-existing test-infrastructure bugs surfaced by the roadmap stacked PR series:

- **`npm test` was silently skipping nested test files.** The script used `tsx --test src/**/*.test.ts`, but `sh` (which `npm` invokes) doesn't recurse `**` — it expanded to a single level only, so `src/lib/db/*.test.ts`, `src/lib/authz/*.test.ts`, etc. were never run. Replaced with `find src -name '*.test.ts' -print0 | xargs -0 tsx --test`, which is portable and recurses correctly. Env vars moved to the right side of the pipe so they reach `tsx`.
- **`health.test.ts` hung the runner.** `getHealthDetail()` instantiates the OpenClaw client singleton, whose constructor starts a 5-minute `setInterval` for cache cleanup. The timer kept the event loop alive indefinitely after tests finished. Added `timer.unref?.()` so the maintenance timer doesn't block process exit. Production behavior is unchanged — the timer still fires while the process is alive for other reasons.

## Verification

- `find src -name '*.test.ts' | wc -l` → 11 files
- `npm test` from clean checkout → **130 tests pass, exits cleanly (EXIT 0)** vs prior behavior of running only the 4 top-level files and hanging.
- `tsx --test src/lib/health.test.ts` in isolation → exits cleanly.

## Test plan
- [x] `npm test` runs all 11 test files
- [x] `npm test` exits cleanly without `^C`
- [x] Diff is 4 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)