### PR TITLE
Phase 5: PM agent (reactive) + MCP surface

### DIFF
--- a/src/app/api/pm/proposals/[id]/accept/route.ts
+++ b/src/app/api/pm/proposals/[id]/accept/route.ts
@@ -1,0 +1,76 @@
+/**
+ * POST /api/pm/proposals/[id]/accept
+ *
+ *   body: { applied_by_agent_id?: string }
+ *
+ * Applies the proposal's diff list transactionally. Returns the updated
+ * proposal + a count of changes applied.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { acceptProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { postPmChatMessage } from '@/lib/agents/pm-dispatch';
+import { queryOne } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  applied_by_agent_id: z.string().min(1).nullish(),
+});
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  let body: unknown = {};
+  try {
+    body = await request.json();
+  } catch {
+    /* empty body is fine */
+  }
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.issues }, { status: 400 });
+  }
+
+  try {
+    const result = acceptProposal(id, parsed.data.applied_by_agent_id ?? null);
+
+    // Best-effort: post a confirmation chat message so the operator sees
+    // "Applied — N changes" inline. Silent on failure.
+    if (!result.idempotent_noop) {
+      try {
+        const proposal = result.proposal;
+        const text =
+          `Applied — ${result.changes_applied} change${result.changes_applied === 1 ? '' : 's'}. ` +
+          `[View affected initiatives](/roadmap?workspace=${encodeURIComponent(proposal.workspace_id)})`;
+        // Need workspace_id from the proposal to find the PM agent.
+        const w = queryOne<{ workspace_id: string }>(
+          'SELECT workspace_id FROM pm_proposals WHERE id = ?',
+          [id],
+        );
+        if (w) {
+          postPmChatMessage({
+            workspace_id: w.workspace_id,
+            role: 'assistant',
+            content: text,
+          });
+        }
+      } catch (err) {
+        console.warn('[pm-accept] chat insert failed:', (err as Error).message);
+      }
+    }
+
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof PmProposalValidationError) {
+      return NextResponse.json({ error: err.message, hints: err.hints }, { status: 400 });
+    }
+    const msg = err instanceof Error ? err.message : 'Failed to accept proposal';
+    console.error('Failed to accept proposal:', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -1,0 +1,92 @@
+/**
+ * POST /api/pm/proposals/[id]/refine
+ *
+ *   body: { additional_constraint: string }
+ *
+ * Marks the parent `superseded`, creates a new draft slot with
+ * parent_proposal_id set, then re-synthesizes a fresh impact + diff list
+ * incorporating the operator's additional constraint. Returns the new
+ * proposal.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getProposal, refineProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { dispatchPm } from '@/lib/agents/pm-dispatch';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  additional_constraint: z.string().min(1).max(5000),
+});
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Body required' }, { status: 400 });
+  }
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.issues }, { status: 400 });
+  }
+
+  try {
+    const parent = getProposal(id);
+    if (!parent) {
+      return NextResponse.json({ error: 'Parent proposal not found' }, { status: 404 });
+    }
+
+    // refineProposal creates the (empty) draft slot and supersedes the
+    // parent; we then re-dispatch with the combined trigger so the slot
+    // is filled with the new impact + diffs. We do this in two steps so
+    // the supersede + new-id pair is visible even if dispatch fails.
+    const { child } = refineProposal(id, parsed.data.additional_constraint);
+
+    // Re-dispatch using the parent's full trigger + the additional
+    // constraint as a free-text bolt-on. We then patch the child row
+    // with the new impact + changes by deleting/recreating — simplest
+    // reliable path that doesn't require an "update_proposal" helper.
+    // Call dispatchPm separately (without parent_proposal_id) so it
+    // returns a freshly-synthesized result we copy onto `child`.
+    const synthesized = dispatchPm({
+      workspace_id: parent.workspace_id,
+      trigger_text: child.trigger_text,
+      trigger_kind: parent.trigger_kind,
+      // We do NOT pass parent_proposal_id here — that would create a
+      // SECOND child. The freshly-synthesized proposal exists; we
+      // delete it and update our pre-allocated slot below.
+    });
+
+    // Move the synthesized impact + changes onto our pre-allocated child
+    // row, then delete the side-effect row created by dispatchPm.
+    // Rationale: refineProposal already produced the supersede chain we
+    // want — we're only borrowing dispatchPm's synthesizer.
+    const { run } = await import('@/lib/db');
+    run(
+      `UPDATE pm_proposals SET impact_md = ?, proposed_changes = ? WHERE id = ?`,
+      [
+        synthesized.proposal.impact_md,
+        JSON.stringify(synthesized.proposal.proposed_changes),
+        child.id,
+      ],
+    );
+    run(`DELETE FROM pm_proposals WHERE id = ?`, [synthesized.proposal.id]);
+
+    const refreshed = getProposal(child.id)!;
+    return NextResponse.json({ proposal: refreshed }, { status: 201 });
+  } catch (err) {
+    if (err instanceof PmProposalValidationError) {
+      return NextResponse.json({ error: err.message, hints: err.hints }, { status: 400 });
+    }
+    const msg = err instanceof Error ? err.message : 'Failed to refine proposal';
+    console.error('Failed to refine proposal:', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/pm/proposals/[id]/reject/route.ts
+++ b/src/app/api/pm/proposals/[id]/reject/route.ts
@@ -1,0 +1,27 @@
+/**
+ * POST /api/pm/proposals/[id]/reject — mark proposal rejected.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { rejectProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(_request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  try {
+    const proposal = rejectProposal(id);
+    return NextResponse.json({ proposal });
+  } catch (err) {
+    if (err instanceof PmProposalValidationError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    const msg = err instanceof Error ? err.message : 'Failed to reject proposal';
+    console.error('Failed to reject proposal:', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/pm/proposals/[id]/route.ts
+++ b/src/app/api/pm/proposals/[id]/route.ts
@@ -1,0 +1,21 @@
+/**
+ * GET /api/pm/proposals/[id] — fetch one proposal.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getProposal } from '@/lib/db/pm-proposals';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  const proposal = getProposal(id);
+  if (!proposal) {
+    return NextResponse.json({ error: 'Proposal not found' }, { status: 404 });
+  }
+  return NextResponse.json(proposal);
+}

--- a/src/app/api/pm/proposals/route.ts
+++ b/src/app/api/pm/proposals/route.ts
@@ -1,0 +1,73 @@
+/**
+ * /api/pm/proposals
+ *
+ *   POST  body { workspace_id, trigger_text, trigger_kind? }
+ *         → triggers PM dispatch, returns the new draft proposal.
+ *   GET   query { workspace_id?, status?, since?, limit? }
+ *         → list proposals.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { listProposals, type PmProposalStatus } from '@/lib/db/pm-proposals';
+import { dispatchPm } from '@/lib/agents/pm-dispatch';
+
+export const dynamic = 'force-dynamic';
+
+const PostSchema = z.object({
+  workspace_id: z.string().min(1),
+  trigger_text: z.string().min(1).max(20000),
+  trigger_kind: z
+    .enum(['manual', 'scheduled_drift_scan', 'disruption_event', 'status_check_investigation'])
+    .optional(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = PostSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const result = dispatchPm(parsed.data);
+    return NextResponse.json(
+      {
+        proposal: result.proposal,
+        used_synthesize_fallback: result.used_synthesize_fallback,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to create proposal';
+    console.error('Failed to create PM proposal:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+const STATUS_VALUES: PmProposalStatus[] = ['draft', 'accepted', 'rejected', 'superseded'];
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get('status');
+    const limitRaw = searchParams.get('limit');
+    const filters = {
+      workspace_id: searchParams.get('workspace_id') || undefined,
+      status:
+        status && (STATUS_VALUES as string[]).includes(status)
+          ? (status as PmProposalStatus)
+          : undefined,
+      since: searchParams.get('since') || undefined,
+      limit: limitRaw ? Math.max(1, parseInt(limitRaw, 10) || 50) : undefined,
+    };
+    const rows = listProposals(filters);
+    return NextResponse.json(rows);
+  } catch (error) {
+    console.error('Failed to list PM proposals:', error);
+    const msg = error instanceof Error ? error.message : 'Failed to list proposals';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
-import { bootstrapCoreAgents, cloneWorkflowTemplates } from '@/lib/bootstrap-agents';
+import { bootstrapCoreAgents, cloneWorkflowTemplates, ensurePmAgent } from '@/lib/bootstrap-agents';
 import type { Workspace, WorkspaceStats, TaskStatus } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -108,6 +108,8 @@ export async function POST(request: NextRequest) {
     // Clone workflow templates and bootstrap core agents for the new workspace
     cloneWorkflowTemplates(db, id);
     bootstrapCoreAgents(id);
+    // Seed the workspace's PM agent (planning layer, role='pm'). Idempotent.
+    ensurePmAgent(id);
 
     const workspace = db.prepare('SELECT * FROM workspaces WHERE id = ?').get(id);
     return NextResponse.json(workspace, { status: 201 });

--- a/src/app/pm/page.tsx
+++ b/src/app/pm/page.tsx
@@ -11,7 +11,7 @@
  * proposals" sidebar on the right with proposal status chips.
  */
 
-import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef, Suspense } from 'react';
 import Link from 'next/link';
 import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox } from 'lucide-react';
 
@@ -78,6 +78,16 @@ const STATUS_BADGE: Record<PmProposal['status'], string> = {
 };
 
 export default function PmChatPage() {
+  // useSearchParams() requires a Suspense boundary during static prerender
+  // (Next 16). The actual page contents live in PmChatPageInner below.
+  return (
+    <Suspense fallback={null}>
+      <PmChatPageInner />
+    </Suspense>
+  );
+}
+
+function PmChatPageInner() {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [workspaceId, setWorkspaceId] = useState<string>('default');
   const [pmAgent, setPmAgent] = useState<AgentLite | null>(null);

--- a/src/app/pm/page.tsx
+++ b/src/app/pm/page.tsx
@@ -1,0 +1,560 @@
+'use client';
+
+/**
+ * /pm — operator chat with the PM agent (Phase 5 of the roadmap & PM
+ * feature). Reuses the agent_chat_messages table for the chat thread,
+ * but sends operator turns through the dedicated PM dispatch path
+ * (POST /api/pm/proposals) so each disruption produces a structured
+ * proposal card the operator can refine / accept / reject.
+ *
+ * Layout: workspace selector at top, chat thread on the left, "Recent
+ * proposals" sidebar on the right with proposal status chips.
+ */
+
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import Link from 'next/link';
+import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox } from 'lucide-react';
+
+interface Workspace {
+  id: string;
+  name: string;
+  slug: string;
+  icon?: string;
+}
+
+interface AgentChatMessage {
+  id: string;
+  agent_id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  status: 'pending' | 'delivered';
+  metadata?: string;
+  created_at: string;
+}
+
+interface PmDiff {
+  kind: string;
+  initiative_id?: string;
+  agent_id?: string;
+  status?: string;
+  target_start?: string;
+  target_end?: string;
+  start?: string;
+  end?: string;
+  reason?: string;
+  status_check_md?: string;
+  depends_on_initiative_id?: string;
+  dependency_id?: string;
+  parent_id?: string | null;
+  child_ids_in_order?: string[];
+  note?: string;
+}
+
+interface PmProposal {
+  id: string;
+  workspace_id: string;
+  trigger_text: string;
+  trigger_kind: string;
+  impact_md: string;
+  proposed_changes: PmDiff[];
+  status: 'draft' | 'accepted' | 'rejected' | 'superseded';
+  applied_at: string | null;
+  parent_proposal_id: string | null;
+  created_at: string;
+}
+
+interface AgentLite {
+  id: string;
+  name: string;
+  role: string;
+  workspace_id: string;
+}
+
+const STATUS_BADGE: Record<PmProposal['status'], string> = {
+  draft: 'bg-amber-500/20 text-amber-300',
+  accepted: 'bg-emerald-500/20 text-emerald-300',
+  rejected: 'bg-red-500/20 text-red-300',
+  superseded: 'bg-zinc-500/20 text-zinc-300',
+};
+
+export default function PmChatPage() {
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [workspaceId, setWorkspaceId] = useState<string>('default');
+  const [pmAgent, setPmAgent] = useState<AgentLite | null>(null);
+  const [messages, setMessages] = useState<AgentChatMessage[]>([]);
+  const [proposals, setProposals] = useState<Record<string, PmProposal>>({});
+  const [recentProposals, setRecentProposals] = useState<PmProposal[]>([]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refining, setRefining] = useState<string | null>(null);
+  const [refineText, setRefineText] = useState('');
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Load workspace list once.
+  useEffect(() => {
+    fetch('/api/workspaces')
+      .then(r => r.json())
+      .then((rows: Workspace[]) => {
+        setWorkspaces(rows);
+        if (rows.length > 0 && !rows.find(w => w.id === 'default')) {
+          setWorkspaceId(rows[0].id);
+        }
+      })
+      .catch(() => { /* leave empty */ });
+  }, []);
+
+  // Resolve the PM agent for the selected workspace.
+  useEffect(() => {
+    if (!workspaceId) return;
+    fetch(`/api/agents?workspace_id=${encodeURIComponent(workspaceId)}`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then((agents: AgentLite[]) => {
+        const pm = agents.find(a => a.role === 'pm');
+        setPmAgent(pm ?? null);
+        if (!pm) {
+          setError(
+            'No PM agent for this workspace. Migration 045 should have seeded one — try restarting the dev server, or create the workspace anew.',
+          );
+        } else {
+          setError(null);
+        }
+      })
+      .catch(() => setError('Failed to load workspace agents'));
+  }, [workspaceId]);
+
+  const loadMessages = useCallback(async () => {
+    if (!pmAgent) return;
+    try {
+      const res = await fetch(`/api/agents/${pmAgent.id}/chat`);
+      if (!res.ok) return;
+      const rows: AgentChatMessage[] = await res.json();
+      setMessages(rows);
+
+      // Find proposal_ids referenced from metadata; fetch those proposals.
+      const ids = new Set<string>();
+      for (const m of rows) {
+        if (!m.metadata) continue;
+        try {
+          const parsed = JSON.parse(m.metadata) as { proposal_id?: string };
+          if (parsed.proposal_id) ids.add(parsed.proposal_id);
+        } catch { /* ignore */ }
+      }
+      if (ids.size > 0) {
+        const fetched = await Promise.all(
+          [...ids].map(id =>
+            fetch(`/api/pm/proposals/${id}`)
+              .then(r => (r.ok ? r.json() : null))
+              .catch(() => null),
+          ),
+        );
+        const next: Record<string, PmProposal> = {};
+        for (const p of fetched) {
+          if (p) next[p.id] = p;
+        }
+        setProposals(next);
+      }
+    } catch { /* silent retry */ }
+  }, [pmAgent]);
+
+  const loadRecent = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/pm/proposals?workspace_id=${encodeURIComponent(workspaceId)}&limit=20`,
+      );
+      if (res.ok) setRecentProposals(await res.json());
+    } catch { /* ignore */ }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (!pmAgent) return;
+    loadMessages();
+    loadRecent();
+    const id = setInterval(() => {
+      loadMessages();
+      loadRecent();
+    }, 3000);
+    return () => clearInterval(id);
+  }, [pmAgent, loadMessages, loadRecent]);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  const handleSend = async () => {
+    if (!input.trim() || sending) return;
+    setSending(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/pm/proposals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          workspace_id: workspaceId,
+          trigger_text: input.trim(),
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Failed to dispatch (${res.status})`);
+      }
+      setInput('');
+      await loadMessages();
+      await loadRecent();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const onAccept = async (proposalId: string) => {
+    try {
+      const res = await fetch(`/api/pm/proposals/${proposalId}/accept`, { method: 'POST' });
+      if (!res.ok) throw new Error('Accept failed');
+      await loadMessages();
+      await loadRecent();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const onReject = async (proposalId: string) => {
+    try {
+      const res = await fetch(`/api/pm/proposals/${proposalId}/reject`, { method: 'POST' });
+      if (!res.ok) throw new Error('Reject failed');
+      await loadMessages();
+      await loadRecent();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const onRefineSubmit = async (parentId: string) => {
+    if (!refineText.trim()) return;
+    try {
+      const res = await fetch(`/api/pm/proposals/${parentId}/refine`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ additional_constraint: refineText.trim() }),
+      });
+      if (!res.ok) throw new Error('Refine failed');
+      setRefining(null);
+      setRefineText('');
+      await loadMessages();
+      await loadRecent();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const proposalCount = useMemo(() => {
+    const draft = recentProposals.filter(p => p.status === 'draft').length;
+    return { draft, total: recentProposals.length };
+  }, [recentProposals]);
+
+  return (
+    <div className="flex flex-col h-screen bg-mc-bg text-mc-text">
+      {/* Header */}
+      <header className="border-b border-mc-border px-4 py-3 flex items-center gap-4 shrink-0">
+        <h1 className="text-lg font-semibold">📋 PM Chat</h1>
+        <select
+          value={workspaceId}
+          onChange={e => setWorkspaceId(e.target.value)}
+          className="bg-mc-bg border border-mc-border rounded-sm px-3 py-1.5 text-sm focus:outline-hidden focus:border-mc-accent"
+        >
+          {workspaces.length === 0 && <option value="default">default</option>}
+          {workspaces.map(w => (
+            <option key={w.id} value={w.id}>
+              {w.icon ?? '📁'} {w.name}
+            </option>
+          ))}
+        </select>
+        <div className="ml-auto text-xs text-mc-text-secondary">
+          {proposalCount.draft} draft · {proposalCount.total} total
+        </div>
+        <Link href="/roadmap" className="text-xs text-mc-accent hover:underline">
+          View roadmap →
+        </Link>
+      </header>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Chat thread */}
+        <main className="flex flex-col flex-1 min-w-0">
+          {error && (
+            <div className="m-3 px-3 py-2 bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-sm flex items-center gap-2">
+              <AlertTriangle className="w-4 h-4" /> {error}
+            </div>
+          )}
+          <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-3">
+            {messages.length === 0 && pmAgent && (
+              <div className="text-center py-12 text-mc-text-secondary">
+                <Inbox className="w-8 h-8 mx-auto mb-3 opacity-50" />
+                <p className="text-sm">Drop a disruption to get started.</p>
+                <p className="text-xs mt-1 opacity-70">
+                  Examples: &quot;Sarah out next week&quot; · &quot;API X delayed until 2026-05-03&quot; · &quot;We&apos;re cutting Phase 2&quot;
+                </p>
+              </div>
+            )}
+
+            {messages.map(m => (
+              <ChatMessageRow
+                key={m.id}
+                message={m}
+                proposal={parseProposalId(m) ? proposals[parseProposalId(m)!] : undefined}
+                onAccept={onAccept}
+                onReject={onReject}
+                refining={refining}
+                refineText={refineText}
+                onRefineStart={(id) => { setRefining(id); setRefineText(''); }}
+                onRefineCancel={() => { setRefining(null); setRefineText(''); }}
+                onRefineSubmit={onRefineSubmit}
+                onRefineTextChange={setRefineText}
+              />
+            ))}
+          </div>
+
+          <div className="border-t border-mc-border p-3 space-y-2 shrink-0">
+            <div className="flex gap-2">
+              <textarea
+                value={input}
+                onChange={e => setInput(e.target.value)}
+                onKeyDown={onKeyDown}
+                rows={2}
+                placeholder={
+                  pmAgent
+                    ? 'Drop a disruption — the PM will respond with a proposal card.'
+                    : 'No PM agent in this workspace.'
+                }
+                disabled={!pmAgent || sending}
+                className="flex-1 bg-mc-bg border border-mc-border rounded-sm px-3 py-2 text-sm focus:outline-hidden focus:border-mc-accent resize-none disabled:opacity-50"
+              />
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={!pmAgent || !input.trim() || sending}
+                className="self-end flex items-center gap-2 px-3 py-2 bg-mc-accent text-mc-bg rounded-sm text-sm font-medium hover:bg-mc-accent/90 disabled:opacity-50"
+              >
+                {sending ? <Loader className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
+                Dispatch
+              </button>
+            </div>
+          </div>
+        </main>
+
+        {/* Sidebar: recent proposals */}
+        <aside className="w-80 border-l border-mc-border overflow-y-auto shrink-0 hidden lg:block">
+          <div className="px-4 py-3 border-b border-mc-border flex items-center justify-between">
+            <h2 className="text-sm font-semibold">Recent proposals</h2>
+            <button
+              type="button"
+              onClick={loadRecent}
+              className="text-xs text-mc-text-secondary hover:text-mc-text"
+              title="Refresh"
+            >
+              <RefreshCw className="w-3.5 h-3.5" />
+            </button>
+          </div>
+          <ul className="divide-y divide-mc-border">
+            {recentProposals.length === 0 && (
+              <li className="px-4 py-6 text-center text-xs text-mc-text-secondary">
+                No proposals yet.
+              </li>
+            )}
+            {recentProposals.map(p => (
+              <li key={p.id} className="px-4 py-3 hover:bg-mc-bg/50">
+                <div className="flex items-center gap-2 text-xs mb-1">
+                  <span className={`px-2 py-0.5 rounded-sm ${STATUS_BADGE[p.status]}`}>{p.status}</span>
+                  <span className="text-mc-text-secondary">
+                    {p.proposed_changes.length} change{p.proposed_changes.length === 1 ? '' : 's'}
+                  </span>
+                  <span className="ml-auto text-mc-text-secondary/70">
+                    {new Date(p.created_at.endsWith('Z') ? p.created_at : p.created_at + 'Z').toLocaleString()}
+                  </span>
+                </div>
+                <p className="text-xs text-mc-text-secondary line-clamp-2 break-words">
+                  {p.trigger_text}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function parseProposalId(m: AgentChatMessage): string | null {
+  if (!m.metadata) return null;
+  try {
+    const parsed = JSON.parse(m.metadata) as { proposal_id?: string };
+    return parsed.proposal_id ?? null;
+  } catch { return null; }
+}
+
+interface ChatMessageRowProps {
+  message: AgentChatMessage;
+  proposal?: PmProposal;
+  onAccept: (id: string) => void;
+  onReject: (id: string) => void;
+  refining: string | null;
+  refineText: string;
+  onRefineStart: (id: string) => void;
+  onRefineCancel: () => void;
+  onRefineSubmit: (id: string) => void;
+  onRefineTextChange: (s: string) => void;
+}
+
+function ChatMessageRow({
+  message,
+  proposal,
+  onAccept,
+  onReject,
+  refining,
+  refineText,
+  onRefineStart,
+  onRefineCancel,
+  onRefineSubmit,
+  onRefineTextChange,
+}: ChatMessageRowProps) {
+  const isUser = message.role === 'user';
+
+  // Bare chat bubble for messages that aren't proposal cards.
+  if (!proposal) {
+    return (
+      <div className={isUser ? 'ml-12' : 'mr-12'}>
+        <div className={`border rounded-md px-3 py-2 ${
+          isUser
+            ? 'bg-blue-500/10 border-blue-500/20'
+            : 'bg-emerald-500/10 border-emerald-500/20'
+        }`}>
+          <div className="text-xs font-medium text-mc-text-secondary mb-1">
+            {isUser ? 'You' : 'PM'}
+          </div>
+          <div className="text-sm whitespace-pre-wrap">{message.content}</div>
+        </div>
+      </div>
+    );
+  }
+
+  // Proposal card
+  return (
+    <div className="mr-12">
+      <div className="border border-amber-500/40 bg-amber-500/5 rounded-md overflow-hidden">
+        <div className="px-3 py-2 bg-amber-500/10 border-b border-amber-500/30 flex items-center gap-2">
+          <AlertTriangle className="w-4 h-4 text-amber-300" />
+          <span className="text-sm font-semibold text-amber-200">
+            Proposal — {proposal.proposed_changes.length} change{proposal.proposed_changes.length === 1 ? '' : 's'}
+          </span>
+          <span className={`ml-auto px-2 py-0.5 text-xs rounded-sm ${STATUS_BADGE[proposal.status]}`}>
+            {proposal.status}
+          </span>
+        </div>
+        <div className="p-3 text-sm whitespace-pre-wrap">
+          {message.content}
+        </div>
+        {proposal.proposed_changes.length > 0 && (
+          <div className="px-3 pb-3 space-y-1 text-xs text-mc-text-secondary">
+            {proposal.proposed_changes.slice(0, 6).map((c, idx) => (
+              <div key={idx} className="font-mono">
+                · {summarizeDiff(c)}
+              </div>
+            ))}
+            {proposal.proposed_changes.length > 6 && (
+              <div className="font-mono">…and {proposal.proposed_changes.length - 6} more</div>
+            )}
+          </div>
+        )}
+        {proposal.status === 'draft' && (
+          <div className="px-3 py-2 border-t border-amber-500/30 bg-amber-500/5 flex items-center gap-2">
+            {refining === proposal.id ? (
+              <>
+                <input
+                  type="text"
+                  autoFocus
+                  value={refineText}
+                  onChange={e => onRefineTextChange(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') { e.preventDefault(); onRefineSubmit(proposal.id); }
+                    if (e.key === 'Escape') { onRefineCancel(); }
+                  }}
+                  placeholder="Add a constraint (e.g. don't slip launch)"
+                  className="flex-1 bg-mc-bg border border-mc-border rounded-sm px-2 py-1 text-xs focus:outline-hidden focus:border-mc-accent"
+                />
+                <button
+                  type="button"
+                  onClick={() => onRefineSubmit(proposal.id)}
+                  className="text-xs px-2 py-1 bg-mc-accent text-mc-bg rounded-sm hover:bg-mc-accent/90"
+                >Send</button>
+                <button
+                  type="button"
+                  onClick={onRefineCancel}
+                  className="text-xs px-2 py-1 text-mc-text-secondary hover:text-mc-text"
+                >Cancel</button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={() => onRefineStart(proposal.id)}
+                  className="text-xs px-2 py-1 border border-mc-border rounded-sm hover:bg-mc-bg/50 flex items-center gap-1"
+                >
+                  <RefreshCw className="w-3 h-3" /> Refine
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onAccept(proposal.id)}
+                  className="text-xs px-2 py-1 bg-emerald-500/20 border border-emerald-500/40 text-emerald-200 rounded-sm hover:bg-emerald-500/30 flex items-center gap-1"
+                >
+                  <Check className="w-3 h-3" /> Accept
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onReject(proposal.id)}
+                  className="text-xs px-2 py-1 bg-red-500/20 border border-red-500/40 text-red-200 rounded-sm hover:bg-red-500/30 flex items-center gap-1"
+                >
+                  <X className="w-3 h-3" /> Reject
+                </button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function summarizeDiff(c: PmDiff): string {
+  switch (c.kind) {
+    case 'shift_initiative_target':
+      return `shift ${shortId(c.initiative_id)}: ${c.target_start ?? '∅'} → ${c.target_end ?? '∅'}`;
+    case 'add_availability':
+      return `availability ${shortId(c.agent_id)}: ${c.start} – ${c.end}`;
+    case 'set_initiative_status':
+      return `${shortId(c.initiative_id)} → ${c.status}`;
+    case 'add_dependency':
+      return `dep ${shortId(c.initiative_id)} blocks on ${shortId(c.depends_on_initiative_id)}`;
+    case 'remove_dependency':
+      return `remove dep ${shortId(c.dependency_id)}`;
+    case 'reorder_initiatives':
+      return `reorder under ${shortId(c.parent_id ?? null) || 'root'} (${c.child_ids_in_order?.length ?? 0})`;
+    case 'update_status_check':
+      return `status_check ${shortId(c.initiative_id)}`;
+    default:
+      return c.kind ?? '?';
+  }
+}
+
+function shortId(id: string | null | undefined): string {
+  if (!id) return '∅';
+  return id.slice(0, 8);
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Zap, Settings, ChevronLeft, LayoutGrid, Rocket } from 'lucide-react';
+import { Zap, Settings, ChevronLeft, LayoutGrid, Rocket, GanttChart, ListTree, Bot } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import { format } from 'date-fns';
 import type { Workspace, Agent, Task, TaskStatus } from '@/lib/types';
@@ -136,6 +136,15 @@ export function Header({ workspace, isPortrait = true }: HeaderProps) {
               </div>
             </div>
 
+            <Link href="/roadmap" className="min-h-11 min-w-11 p-2 hover:bg-mc-bg-tertiary rounded-sm text-mc-text-secondary" title="Roadmap">
+              <GanttChart className="w-5 h-5" />
+            </Link>
+            <Link href="/initiatives" className="min-h-11 min-w-11 p-2 hover:bg-mc-bg-tertiary rounded-sm text-mc-text-secondary" title="Initiatives">
+              <ListTree className="w-5 h-5" />
+            </Link>
+            <Link href="/pm" className="min-h-11 min-w-11 p-2 hover:bg-mc-bg-tertiary rounded-sm text-mc-text-secondary" title="PM agent">
+              <Bot className="w-5 h-5" />
+            </Link>
             <Link href="/autopilot" className="min-h-11 min-w-11 p-2 hover:bg-mc-bg-tertiary rounded-sm text-mc-text-secondary" title="Autopilot">
               <Rocket className="w-5 h-5" />
             </Link>
@@ -237,6 +246,15 @@ export function Header({ workspace, isPortrait = true }: HeaderProps) {
               <span className={`w-2 h-2 rounded-full ${isOnline ? 'bg-mc-accent-green animate-pulse' : 'bg-mc-accent-red'}`} />
               {isOnline ? 'ONLINE' : 'OFFLINE'}
             </div>
+            <Link href="/roadmap" className="min-h-11 min-w-11 p-2 hover:bg-mc-bg-tertiary rounded-sm text-mc-text-secondary" title="Roadmap">
+              <GanttChart className="w-5 h-5" />
+            </Link>
+            <Link href="/initiatives" className="min-h-11 min-w-11 p-2 hover:bg-mc-bg-tertiary rounded-sm text-mc-text-secondary" title="Initiatives">
+              <ListTree className="w-5 h-5" />
+            </Link>
+            <Link href="/pm" className="min-h-11 min-w-11 p-2 hover:bg-mc-bg-tertiary rounded-sm text-mc-text-secondary" title="PM agent">
+              <Bot className="w-5 h-5" />
+            </Link>
             <Link href="/autopilot" className="min-h-11 min-w-11 p-2 hover:bg-mc-bg-tertiary rounded-sm text-mc-text-secondary" title="Autopilot">
               <Rocket className="w-5 h-5" />
             </Link>

--- a/src/lib/agents/pm-agent.ts
+++ b/src/lib/agents/pm-agent.ts
@@ -1,0 +1,59 @@
+/**
+ * PM agent definition + soul_md loader.
+ *
+ * Phase 5 of the roadmap & PM-agent feature (specs/roadmap-and-pm-spec.md).
+ * The PM is a planning-layer agent: one per workspace, role='pm', seeded
+ * via migration. It reacts to operator-dropped disruptions and produces
+ * `pm_proposals` rows. It never writes to the execution board.
+ *
+ * The system prompt is kept in `pm-soul.md` so it's readable and editable
+ * without touching code. We read it at module init and bake it into the
+ * exported constant — migrations call `getPmSoulMd()` synchronously and
+ * the file lives next to this module.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+let _cache: string | null = null;
+
+/**
+ * Returns the PM agent's system prompt (soul_md) loaded from
+ * `pm-soul.md`. Cached after first read. If the file is missing
+ * (shouldn't happen in production — it's part of the source tree), we fall
+ * back to a stub so seeds still succeed and the operator can fix it later.
+ */
+export function getPmSoulMd(): string {
+  if (_cache) return _cache;
+  try {
+    // __dirname-equivalent for both bundled and unbundled callers. In
+    // dev/test the file resolves alongside this TS file; under
+    // `next build` the assets are co-located via the standalone bundler.
+    const filePath = path.join(__dirname, 'pm-soul.md');
+    _cache = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    _cache = PM_SOUL_FALLBACK;
+  }
+  return _cache!;
+}
+
+/**
+ * Hardcoded fallback — keeps seeds working even when the .md file isn't
+ * reachable from the bundle path (e.g. some Next.js packaging modes). This
+ * is intentionally a short summary rather than the full prompt; if the
+ * file ever becomes unreadable in production we want the operator to
+ * notice.
+ */
+const PM_SOUL_FALLBACK = `# PM Agent (fallback prompt)
+
+You are the workspace PM. Read the roadmap snapshot, analyze the
+operator's disruption, and call \`propose_changes\` with an impact
+summary plus a structured diff. Never edit the execution board directly.
+This is a stub fallback prompt; restore src/lib/agents/pm-soul.md to use
+the full version.`;
+
+export const PM_AGENT_NAME = 'PM';
+export const PM_AGENT_AVATAR = '📋';
+export const PM_AGENT_ROLE = 'pm';
+export const PM_AGENT_DESCRIPTION =
+  'Workspace project manager — maintains the roadmap, analyzes disruptions, proposes structured changes the operator approves.';

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -1,0 +1,421 @@
+/**
+ * PM dispatch path (Phase 5).
+ *
+ * Translates an operator-supplied disruption text into a `pm_proposals`
+ * row. Phase 5 ships the **synthesize fallback** — a deterministic parser
+ * that does naive regex extraction (dates, owner names, initiative refs)
+ * and produces a valid PmDiff[] from the snapshot.
+ *
+ * Why a fallback rather than an LLM call:
+ *
+ *   - MC has no Anthropic SDK wired today. Adding one is its own
+ *     project (auth, model selection, cost cap integration, eval).
+ *   - The lifecycle (disruption → proposal → accept → DB change) needs
+ *     to be exercised end-to-end before we layer in LLM polish. A
+ *     deterministic path is testable and cheap.
+ *   - The MCP `propose_changes` tool is ALSO available, so an out-of-band
+ *     PM session running through openclaw + sc-mission-control can
+ *     produce richer proposals; the synthesize path is the "operator
+ *     hits enter, gets something useful back instantly" floor.
+ *
+ * The contract: given a workspace snapshot and a free-text trigger,
+ * return a draft proposal whose changes only reference real ids in the
+ * snapshot. Hallucinated ids are a bug (tests cover this).
+ *
+ * Phase 6 may swap this implementation for an LLM-driven one — the
+ * caller surface (`synthesizeImpactAnalysis`) stays stable.
+ */
+
+import { getRoadmapSnapshot, type RoadmapSnapshot } from '@/lib/db/roadmap';
+import { previewDerivation } from '@/lib/roadmap/apply-derivation';
+import { queryAll, queryOne, run } from '@/lib/db';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  createProposal,
+  type PmDiff,
+  type PmProposal,
+  type PmProposalTriggerKind,
+} from '@/lib/db/pm-proposals';
+
+// ─── Public API ─────────────────────────────────────────────────────
+
+export interface DispatchPmInput {
+  workspace_id: string;
+  trigger_text: string;
+  trigger_kind?: PmProposalTriggerKind;
+  parent_proposal_id?: string | null;
+}
+
+export interface DispatchPmResult {
+  proposal: PmProposal;
+  used_synthesize_fallback: true;
+}
+
+/**
+ * Top-level dispatch entry. Today it always uses the synthesize fallback;
+ * Phase 6 may add a route to an LLM. Persists the proposal as a side
+ * effect and posts a chat message on the PM agent's chat thread referencing
+ * the proposal_id (so the /pm UI's card renderer fires).
+ */
+export function dispatchPm(input: DispatchPmInput): DispatchPmResult {
+  const snapshot = getRoadmapSnapshot({ workspace_id: input.workspace_id });
+  const synth = synthesizeImpactAnalysis(snapshot, input.trigger_text);
+
+  const proposal = createProposal({
+    workspace_id: input.workspace_id,
+    trigger_text: input.trigger_text,
+    trigger_kind: input.trigger_kind ?? 'manual',
+    impact_md: synth.impact_md,
+    proposed_changes: synth.changes,
+    parent_proposal_id: input.parent_proposal_id ?? null,
+  });
+
+  // Best-effort: post the impact summary into the PM agent's chat with
+  // a metadata.proposal_id so the /pm UI renders it as a card. Fails
+  // silently (the proposal still exists; the chat is a UX nicety).
+  try {
+    postPmChatMessage({
+      workspace_id: input.workspace_id,
+      content: synth.impact_md,
+      proposal_id: proposal.id,
+      role: 'assistant',
+    });
+    // Also echo the operator's trigger as a 'user' message so the chat
+    // shows the conversation. Safe to add here because this dispatch is
+    // currently the only entry point — when Phase 6 adds a real chat
+    // input pipe we'll move this to that route.
+    postPmChatMessage({
+      workspace_id: input.workspace_id,
+      content: input.trigger_text,
+      role: 'user',
+    });
+  } catch (err) {
+    console.warn('[pm-dispatch] chat insert failed:', (err as Error).message);
+  }
+
+  return { proposal, used_synthesize_fallback: true };
+}
+
+// ─── Synthesize fallback ────────────────────────────────────────────
+
+export interface SynthesizeResult {
+  impact_md: string;
+  changes: PmDiff[];
+  /** Diagnostics for tests / debug logs. */
+  parsed: {
+    owner_matches: Array<{ token: string; agent_id: string; agent_name: string }>;
+    initiative_matches: Array<{ token: string; initiative_id: string; title: string }>;
+    date_windows: Array<{ start: string; end: string; raw: string }>;
+    explicit_dates: string[];
+  };
+}
+
+/**
+ * Deterministic parser. Extracts:
+ *
+ *   - Owner names → matched against snapshot owner_agent rows + workspace
+ *     agents (so "Sarah out next week" finds Sarah even when she doesn't
+ *     own anything yet).
+ *   - Date windows: "next week", "this week", "Apr 25 – May 2", or
+ *     ISO ranges. Falls back to "today + 7 days" when an owner is
+ *     mentioned without a window.
+ *   - Initiative references: title substring match against snapshot
+ *     initiatives, longest-match-first to avoid "feature" matching when
+ *     "big feature" is meant.
+ *   - Action verbs: "delay", "slip", "block", "cancel", "out", "delayed".
+ *
+ * Maps these into PmDiff[]:
+ *
+ *   - Owner mentioned + window → `add_availability` for that owner.
+ *   - Initiative mentioned + delay/slip + new date → `shift_initiative_target`.
+ *   - Initiative mentioned + block/at-risk → `set_initiative_status`.
+ *
+ * If nothing parses, returns an empty changes array and an impact_md that
+ * tells the operator the PM didn't understand. (Better honest empty than
+ * a false-positive proposal.)
+ */
+export function synthesizeImpactAnalysis(
+  snapshot: RoadmapSnapshot,
+  triggerText: string,
+): SynthesizeResult {
+  const text = triggerText.trim();
+  const lower = text.toLowerCase();
+  const today = new Date();
+
+  // 1. Build agent lookup. We pull every agent in the workspace, not
+  //    just initiative owners — operators talk about teammates by name.
+  const agents = queryAll<{ id: string; name: string }>(
+    `SELECT id, name FROM agents WHERE workspace_id = ? AND is_active = 1`,
+    [snapshot.workspace_id],
+  );
+
+  const ownerMatches: SynthesizeResult['parsed']['owner_matches'] = [];
+  for (const a of agents) {
+    if (!a.name) continue;
+    // Match whole-word, case-insensitive. First name OR full name.
+    const firstName = a.name.split(/\s+/)[0];
+    const re = new RegExp(`\\b(${escapeRe(a.name)}|${escapeRe(firstName)})\\b`, 'i');
+    const m = text.match(re);
+    if (m) {
+      ownerMatches.push({ token: m[1], agent_id: a.id, agent_name: a.name });
+    }
+  }
+
+  // 2. Initiative title matches (longest-first).
+  const initiativeMatches: SynthesizeResult['parsed']['initiative_matches'] = [];
+  const sortedByLen = [...snapshot.initiatives].sort((a, b) => b.title.length - a.title.length);
+  const consumed: Array<[number, number]> = []; // ranges already claimed
+  for (const i of sortedByLen) {
+    if (i.title.length < 4) continue; // too noisy
+    const re = new RegExp(`\\b${escapeRe(i.title)}\\b`, 'i');
+    const m = lower.match(re);
+    if (!m || m.index == null) continue;
+    const start = m.index;
+    const end = start + m[0].length;
+    if (consumed.some(([s, e]) => !(end <= s || start >= e))) continue;
+    consumed.push([start, end]);
+    initiativeMatches.push({ token: m[0], initiative_id: i.id, title: i.title });
+  }
+
+  // 3. Date windows. Order of attempts: explicit ISO ranges → month-day
+  //    ranges → "next week" / "this week" / "X days".
+  const dateWindows: SynthesizeResult['parsed']['date_windows'] = [];
+  const explicitDates: string[] = [];
+
+  // ISO range "YYYY-MM-DD to YYYY-MM-DD" / "YYYY-MM-DD - YYYY-MM-DD"
+  const isoRangeRe = /(\d{4}-\d{2}-\d{2})\s*(?:[-–—to]+|until)\s*(\d{4}-\d{2}-\d{2})/gi;
+  for (const m of text.matchAll(isoRangeRe)) {
+    dateWindows.push({ start: m[1], end: m[2], raw: m[0] });
+  }
+  // Single ISO date — captured if no range already covers it.
+  const isoSingleRe = /\b(\d{4}-\d{2}-\d{2})\b/g;
+  for (const m of text.matchAll(isoSingleRe)) {
+    if (!dateWindows.some(w => w.raw.includes(m[1]))) explicitDates.push(m[1]);
+  }
+
+  // "next week" / "this week" / "next N days"
+  if (dateWindows.length === 0) {
+    if (/\bnext week\b/i.test(text)) {
+      const start = nextWeekStart(today);
+      const end = addDays(start, 6);
+      dateWindows.push({ start: iso(start), end: iso(end), raw: 'next week' });
+    } else if (/\bthis week\b/i.test(text)) {
+      const start = thisWeekStart(today);
+      const end = addDays(start, 6);
+      dateWindows.push({ start: iso(start), end: iso(end), raw: 'this week' });
+    } else {
+      const ndays = text.match(/\b(\d{1,3})\s*(?:days?|d)\b/i);
+      if (ndays) {
+        const days = parseInt(ndays[1], 10);
+        const start = today;
+        const end = addDays(start, days - 1);
+        dateWindows.push({ start: iso(start), end: iso(end), raw: ndays[0] });
+      }
+    }
+  }
+
+  // 4. Action verbs to dispatch on.
+  const verbs = {
+    out: /\b(out|away|off|unavailable|sick|vacation|pto|ooo)\b/i.test(lower),
+    delay: /\b(delay|delayed|slip|slipping|push(ed)? back|shift(ed)?)\b/i.test(lower),
+    block: /\bblock(ed|ing)?\b/i.test(lower),
+    risk: /\b(at[- ]?risk|risk(y)?)\b/i.test(lower),
+  };
+
+  // 5. Build changes.
+  const changes: PmDiff[] = [];
+  const summaryBullets: string[] = [];
+
+  // 5a. Availability rows for each owner mention with a window. If no
+  //     window was extracted but the verb "out" is present, default to
+  //     a 7-day window starting today.
+  if (ownerMatches.length > 0 && (verbs.out || dateWindows.length > 0)) {
+    const window = dateWindows[0] ?? {
+      start: iso(today),
+      end: iso(addDays(today, 6)),
+      raw: 'today+7d',
+    };
+    for (const om of ownerMatches) {
+      changes.push({
+        kind: 'add_availability',
+        agent_id: om.agent_id,
+        start: window.start,
+        end: window.end,
+        reason: text.length > 200 ? text.slice(0, 200) + '…' : text,
+      });
+      summaryBullets.push(
+        `Adds availability: ${om.agent_name} unavailable ${window.start} – ${window.end}`,
+      );
+    }
+  }
+
+  // 5b. Initiative shifts. Pick the latest explicit date as the new
+  //     target_end if one was supplied; otherwise we don't shift, we
+  //     just flag at_risk.
+  for (const im of initiativeMatches) {
+    if (verbs.delay && explicitDates.length > 0) {
+      const newEnd = explicitDates.sort()[explicitDates.length - 1];
+      changes.push({
+        kind: 'shift_initiative_target',
+        initiative_id: im.initiative_id,
+        target_end: newEnd,
+        reason: text.length > 200 ? text.slice(0, 200) + '…' : text,
+      });
+      summaryBullets.push(`"${im.title}" target_end → ${newEnd}`);
+    } else if (verbs.block) {
+      changes.push({
+        kind: 'set_initiative_status',
+        initiative_id: im.initiative_id,
+        status: 'blocked',
+      });
+      summaryBullets.push(`"${im.title}" → blocked`);
+    } else if (verbs.risk || (verbs.delay && ownerMatches.length > 0)) {
+      changes.push({
+        kind: 'set_initiative_status',
+        initiative_id: im.initiative_id,
+        status: 'at_risk',
+      });
+      summaryBullets.push(`"${im.title}" → at_risk`);
+    }
+  }
+
+  // 5c. If owners were mentioned out-of-office and there are NO
+  //     explicit initiative refs, flag every initiative they own as
+  //     at_risk so the operator can still see schedule impact.
+  if (
+    initiativeMatches.length === 0 &&
+    ownerMatches.length > 0 &&
+    (verbs.out || verbs.delay) &&
+    changes.length > 0 // we already added availability
+  ) {
+    const owned = new Set(ownerMatches.map(o => o.agent_id));
+    for (const i of snapshot.initiatives) {
+      if (i.owner_agent_id && owned.has(i.owner_agent_id) && i.status !== 'done' && i.status !== 'cancelled') {
+        changes.push({
+          kind: 'set_initiative_status',
+          initiative_id: i.id,
+          status: 'at_risk',
+        });
+        summaryBullets.push(`"${i.title}" → at_risk (owner unavailable)`);
+        if (summaryBullets.length >= 8) break; // cap output
+      }
+    }
+  }
+
+  // 6. Run a what-if derivation using the staged availability so the
+  //    impact summary can mention slipped milestones too. We only
+  //    consult the result; the changes are unchanged.
+  const availabilityOverrides = changes
+    .filter((c): c is Extract<PmDiff, { kind: 'add_availability' }> => c.kind === 'add_availability')
+    .map(c => ({
+      agent_id: c.agent_id,
+      unavailable_start: c.start,
+      unavailable_end: c.end,
+      reason: c.reason ?? null,
+    }));
+
+  let preview: ReturnType<typeof previewDerivation> | null = null;
+  try {
+    preview = previewDerivation(snapshot, { availabilityOverrides });
+  } catch (err) {
+    console.warn('[synthesize] previewDerivation failed:', (err as Error).message);
+  }
+
+  if (preview && preview.diffs.length > 0) {
+    const headline = preview.diffs[0];
+    summaryBullets.unshift(
+      `Schedule shift: "${headline.title}" derived_end ${headline.before.derived_end ?? '∅'} → ${headline.after.derived_end ?? '∅'} (and ${preview.diffs.length - 1} other${preview.diffs.length - 1 === 1 ? '' : 's'})`,
+    );
+  }
+
+  // 7. Compose impact_md.
+  const headline =
+    changes.length === 0
+      ? 'No structured changes inferred — disruption acknowledged'
+      : `Disruption parsed: ${changes.length} proposed change${changes.length === 1 ? '' : 's'}`;
+
+  const impactLines: string[] = [`### ${headline}`];
+  if (summaryBullets.length > 0) {
+    impactLines.push('');
+    for (const b of summaryBullets.slice(0, 8)) {
+      impactLines.push(`- ${b}`);
+    }
+  } else {
+    impactLines.push(
+      '',
+      '_The synthesize fallback could not extract specific owners, dates, or initiative references. Refine your request with explicit names and dates._',
+    );
+  }
+
+  return {
+    impact_md: impactLines.join('\n'),
+    changes,
+    parsed: {
+      owner_matches: ownerMatches,
+      initiative_matches: initiativeMatches,
+      date_windows: dateWindows,
+      explicit_dates: explicitDates,
+    },
+  };
+}
+
+// ─── PM chat helper ─────────────────────────────────────────────────
+
+interface PostPmChatMessage {
+  workspace_id: string;
+  content: string;
+  role: 'user' | 'assistant';
+  proposal_id?: string;
+}
+
+/**
+ * Insert one row into agent_chat_messages on the workspace's PM agent.
+ * The /pm UI polls + SSE-listens for these. Throws when the PM agent
+ * doesn't exist (caller is responsible for ensuring the migration ran).
+ */
+export function postPmChatMessage(input: PostPmChatMessage): void {
+  const pm = queryOne<{ id: string }>(
+    `SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm' LIMIT 1`,
+    [input.workspace_id],
+  );
+  if (!pm) {
+    throw new Error(
+      `No PM agent for workspace ${input.workspace_id} — migration 045 should have seeded one`,
+    );
+  }
+  const metadata = input.proposal_id
+    ? JSON.stringify({ proposal_id: input.proposal_id })
+    : null;
+  run(
+    `INSERT INTO agent_chat_messages (id, agent_id, role, content, status, metadata)
+     VALUES (?, ?, ?, ?, 'delivered', ?)`,
+    [uuidv4(), pm.id, input.role, input.content, metadata],
+  );
+}
+
+// ─── Date utils ─────────────────────────────────────────────────────
+
+function iso(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function addDays(d: Date, n: number): Date {
+  const r = new Date(d);
+  r.setUTCDate(r.getUTCDate() + n);
+  return r;
+}
+
+function thisWeekStart(d: Date): Date {
+  // Monday of the current week (UTC).
+  const day = d.getUTCDay();
+  const offset = day === 0 ? -6 : 1 - day;
+  return addDays(d, offset);
+}
+
+function nextWeekStart(d: Date): Date {
+  return addDays(thisWeekStart(d), 7);
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/lib/agents/pm-e2e.test.ts
+++ b/src/lib/agents/pm-e2e.test.ts
@@ -1,0 +1,167 @@
+/**
+ * End-to-end PM lifecycle test (Phase 5).
+ *
+ * Mirrors the API-level flow from the spec (§9.2) without spinning up
+ * Next.js: workspace + tree + PM agent, dispatch a disruption, verify
+ * draft proposal, accept it, verify diff applied + event emitted.
+ *
+ * The real /api/pm/proposals route does the same thing through HTTP;
+ * tests that bind a port are flaky in CI. The route handlers are thin
+ * wrappers over the same helpers exercised here.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+import { createInitiative } from '@/lib/db/initiatives';
+import { acceptProposal, getProposal, listProposals } from '@/lib/db/pm-proposals';
+import { dispatchPm } from './pm-dispatch';
+import { ensurePmAgent } from '@/lib/bootstrap-agents';
+import { createProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+test('PM lifecycle: dispatch → draft → accept → diff applied + event emitted', () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+
+  // Seed a "Sarah" agent + an initiative she owns + a milestone child.
+  const sarahId = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, created_at, updated_at)
+     VALUES (?, 'Sarah', 'worker', ?, 1, datetime('now'), datetime('now'))`,
+    [sarahId, ws],
+  );
+
+  const milestone = createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Customer demo',
+    target_end: '2026-05-30',
+    owner_agent_id: sarahId,
+  });
+  const epic = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Build big feature',
+    parent_initiative_id: milestone.id,
+    owner_agent_id: sarahId,
+    estimated_effort_hours: 24,
+  });
+
+  // 1. Operator drops a disruption.
+  const dispatch = dispatchPm({
+    workspace_id: ws,
+    trigger_text: 'Sarah out 2026-05-01 to 2026-05-08',
+  });
+  const proposalId = dispatch.proposal.id;
+  assert.equal(dispatch.proposal.status, 'draft');
+
+  // 2. Verify the proposal is listable in the workspace.
+  const drafts = listProposals({ workspace_id: ws, status: 'draft' });
+  assert.ok(drafts.find(p => p.id === proposalId));
+
+  // 3. Verify each change references real ids in this workspace.
+  const realInitiativeIds = new Set([milestone.id, epic.id]);
+  for (const change of dispatch.proposal.proposed_changes) {
+    if ('initiative_id' in change && change.initiative_id) {
+      assert.ok(
+        realInitiativeIds.has(change.initiative_id),
+        `hallucinated initiative id: ${change.initiative_id}`,
+      );
+    }
+    if (change.kind === 'add_availability') {
+      assert.equal(change.agent_id, sarahId);
+    }
+  }
+
+  // 4. Accept the proposal.
+  const eventBefore = queryAll(
+    `SELECT id FROM events WHERE type = 'pm_proposal_accepted'`,
+  ).length;
+  const accept = acceptProposal(proposalId, /* applied_by_agent_id */ null);
+  assert.equal(accept.idempotent_noop, false);
+  assert.equal(accept.proposal.status, 'accepted');
+  assert.ok(accept.proposal.applied_at);
+
+  // 5. Verify side effects:
+  //    - availability row inserted
+  //    - any set_initiative_status / shift_initiative_target diffs landed
+  //    - one new event row emitted
+  const availRows = queryAll<{ id: string }>(
+    `SELECT id FROM owner_availability WHERE agent_id = ? AND unavailable_start = ?`,
+    [sarahId, '2026-05-01'],
+  );
+  assert.equal(availRows.length, 1);
+
+  const eventAfter = queryAll(
+    `SELECT id FROM events WHERE type = 'pm_proposal_accepted'`,
+  ).length;
+  assert.equal(eventAfter, eventBefore + 1);
+
+  // 6. Idempotent re-accept is a no-op.
+  const r2 = acceptProposal(proposalId);
+  assert.equal(r2.idempotent_noop, true);
+  // Event count must NOT increase.
+  const eventFinal = queryAll(
+    `SELECT id FROM events WHERE type = 'pm_proposal_accepted'`,
+  ).length;
+  assert.equal(eventFinal, eventAfter);
+});
+
+test('PM lifecycle: PM is seeded once per workspace and ensurePmAgent is idempotent', () => {
+  const ws = freshWorkspace();
+  const first = ensurePmAgent(ws);
+  assert.equal(first.created, true);
+
+  const second = ensurePmAgent(ws);
+  assert.equal(second.created, false);
+  assert.equal(second.id, first.id);
+
+  const pms = queryAll<{ id: string }>(
+    `SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm'`,
+    [ws],
+  );
+  assert.equal(pms.length, 1);
+});
+
+test('PM lifecycle: refused diffs (done/cancelled status) never reach the DB', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+
+  // Direct API call — simulates an LLM trying to slip a forbidden diff
+  // through propose_changes. Validation must reject before any write.
+  let threw = false;
+  try {
+    createProposal({
+      workspace_id: ws,
+      trigger_text: 'sneaky',
+      impact_md: '.',
+      proposed_changes: [
+        // Forbidden status from the PM. The diff is well-formed JSON
+        // but the validator rejects 'done'/'cancelled'.
+        { kind: 'set_initiative_status', initiative_id: init.id, status: 'done' as never },
+      ],
+    });
+  } catch (err) {
+    threw = err instanceof PmProposalValidationError;
+  }
+  assert.equal(threw, true);
+
+  // Initiative status untouched, no proposal row written.
+  const fresh = queryOne<{ status: string }>(
+    'SELECT status FROM initiatives WHERE id = ?',
+    [init.id],
+  );
+  assert.equal(fresh?.status, 'planned');
+  const all = listProposals({ workspace_id: ws });
+  assert.equal(all.length, 0);
+});

--- a/src/lib/agents/pm-soul.md
+++ b/src/lib/agents/pm-soul.md
@@ -1,0 +1,90 @@
+# PM Agent — Project Manager
+
+You are the project manager for this workspace's roadmap. You maintain the
+schedule, flag drift, and translate operator-supplied disruptions into
+structured, reversible proposals.
+
+## Identity
+
+- **Role:** PM (planning layer). Distinct from the master orchestrator
+  (execution) and the coordinator (task decomposition).
+- **Persona:** Concise, structured, opinion-forward. Quantify impact
+  (days, percentages, status changes). Flag tradeoffs without wallowing
+  in caveats.
+
+## Scope
+
+You read:
+
+- The roadmap snapshot (`get_roadmap_snapshot`) — initiatives,
+  dependencies, owner availability, derived schedule.
+- Initiative history (`get_initiative_history`) for audit context.
+- Velocity data (`get_velocity_data`) for re-estimation.
+- Past proposals (`list_proposals`).
+
+You propose changes via the `propose_changes` MCP tool. That tool writes a
+`pm_proposals` row in `draft` status. The operator reviews and accepts /
+rejects / refines.
+
+## What you NEVER do
+
+- **Never** promote ideas → initiatives, stories → tasks, drafts → inbox.
+  All promotion is operator-driven.
+- **Never** dispatch tasks or change `tasks.status` for active tasks
+  (anything beyond `draft`/`inbox`).
+- **Never** write `derived_*` fields directly — those come from the nightly
+  derivation engine.
+- **Never** call any of the general write tools (`create_initiative`,
+  `update_initiative`, etc.) on your own initiative. The single exception is
+  `add_owner_availability` when the operator explicitly stated an
+  availability fact in their disruption (e.g. "Sarah is out next week" —
+  staging that availability before computing impact is part of your
+  workflow).
+
+## Workflow when an operator drops a disruption
+
+1. Read the disruption text. Extract: owners mentioned, dates / windows,
+   initiatives referenced, action verbs.
+2. Pull `get_roadmap_snapshot` for the workspace.
+3. If the operator stated a hard availability fact, you may stage it via
+   `add_owner_availability`. (This is a fact the operator told you, not a
+   speculative change.)
+4. Use `preview_derivation` with any what-if overrides to estimate the new
+   schedule WITHOUT writing.
+5. Compare derived dates before vs. after. Identify slipped milestones,
+   newly-at-risk initiatives, dependency cascades.
+6. Compose `impact_md`: a concise markdown summary, ≤ 8 bullets. Lead with
+   the headline (e.g. "Launch milestone slips 5d"). Each bullet quantifies
+   one effect.
+7. Compose `changes`: a JSON array of typed diffs (see below). Reference
+   real `initiative_id`s from the snapshot — never hallucinate ids.
+8. Call `propose_changes`. The tool returns a `proposal_id`.
+
+## Output discipline
+
+When the operator messages you, respond with a brief markdown summary
+followed immediately by the `propose_changes` tool call. Do **not** ask
+permission to call the tool — the operator approves at the proposal level
+(Accept / Reject / Refine).
+
+## Diff kinds (proposed_changes JSON)
+
+Each diff is one of:
+
+- `{ "kind": "shift_initiative_target", "initiative_id": "...", "target_start"?: "YYYY-MM-DD", "target_end"?: "YYYY-MM-DD", "reason": "..." }`
+- `{ "kind": "add_availability", "agent_id": "...", "start": "YYYY-MM-DD", "end": "YYYY-MM-DD", "reason": "..." }`
+- `{ "kind": "set_initiative_status", "initiative_id": "...", "status": "planned|in_progress|at_risk|blocked" }` — `done` and `cancelled` are off-limits.
+- `{ "kind": "add_dependency", "initiative_id": "...", "depends_on_initiative_id": "...", "note"?: "..." }`
+- `{ "kind": "remove_dependency", "dependency_id": "..." }`
+- `{ "kind": "reorder_initiatives", "parent_id": "...", "child_ids_in_order": ["..."] }`
+- `{ "kind": "update_status_check", "initiative_id": "...", "status_check_md": "..." }`
+
+Apply is all-or-nothing in v1. Keep diffs minimal — propose only what the
+operator asked about plus any cascading status flips that follow logically.
+
+## Refining
+
+If the operator asks to refine ("don't slip the launch milestone, defer
+analytics instead"), you'll get a `parent_proposal_id` and an
+`additional_constraint`. Re-derive with the new constraint, write a fresh
+proposal that supersedes the parent.

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -1,0 +1,156 @@
+/**
+ * PM agent (synthesize) + dispatch tests (Phase 5).
+ *
+ * Coverage:
+ *   - Empty triggers don't throw and produce a "no changes" proposal.
+ *   - Owner-out-of-office text → add_availability with the right window.
+ *   - Generated changes only reference real ids in the snapshot.
+ *   - dispatchPm posts a chat message with metadata.proposal_id and
+ *     persists a draft proposal.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+import { createInitiative } from '@/lib/db/initiatives';
+import { getRoadmapSnapshot } from '@/lib/db/roadmap';
+import { synthesizeImpactAnalysis, dispatchPm } from './pm-dispatch';
+import { ensurePmAgent } from '@/lib/bootstrap-agents';
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function seedNamedAgent(workspace: string, name: string): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, created_at, updated_at)
+     VALUES (?, ?, 'worker', ?, 1, datetime('now'), datetime('now'))`,
+    [id, name, workspace],
+  );
+  return id;
+}
+
+// ─── Synthesize ────────────────────────────────────────────────────
+
+test('synthesizeImpactAnalysis: empty trigger yields no changes', () => {
+  const ws = freshWorkspace();
+  const snap = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizeImpactAnalysis(snap, '');
+  assert.equal(result.changes.length, 0);
+  assert.match(result.impact_md, /could not extract|No structured changes/);
+});
+
+test('synthesizeImpactAnalysis: "Sarah out next week" → add_availability for Sarah', () => {
+  const ws = freshWorkspace();
+  const sarahId = seedNamedAgent(ws, 'Sarah');
+  const snap = getRoadmapSnapshot({ workspace_id: ws });
+
+  const result = synthesizeImpactAnalysis(snap, 'Sarah out next week');
+  const avail = result.changes.find(c => c.kind === 'add_availability');
+  assert.ok(avail, 'expected an add_availability diff');
+  assert.equal(avail!.kind, 'add_availability');
+  if (avail.kind === 'add_availability') {
+    assert.equal(avail.agent_id, sarahId);
+    // 7-day window inferred from "next week".
+    assert.ok(avail.start && avail.end);
+    assert.ok(avail.end > avail.start);
+  }
+});
+
+test('synthesizeImpactAnalysis: never references unknown initiative_ids', () => {
+  const ws = freshWorkspace();
+  const initA = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Build big feature' });
+  const snap = getRoadmapSnapshot({ workspace_id: ws });
+
+  const result = synthesizeImpactAnalysis(snap, 'Build big feature is delayed');
+  // Every initiative_id reference must be in the snapshot.
+  const allIds = new Set(snap.initiatives.map(i => i.id));
+  for (const c of result.changes) {
+    if ('initiative_id' in c && c.initiative_id) {
+      assert.ok(allIds.has(c.initiative_id), `hallucinated id: ${c.initiative_id}`);
+    }
+  }
+  // The epic should appear in the parsed initiative matches.
+  assert.ok(result.parsed.initiative_matches.some(m => m.initiative_id === initA.id));
+});
+
+test('synthesizeImpactAnalysis: ISO date range parsed into a date_window', () => {
+  const ws = freshWorkspace();
+  seedNamedAgent(ws, 'Sarah');
+  const snap = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizeImpactAnalysis(snap, 'Sarah out 2026-05-01 to 2026-05-05');
+  const window = result.parsed.date_windows[0];
+  assert.ok(window);
+  assert.equal(window.start, '2026-05-01');
+  assert.equal(window.end, '2026-05-05');
+});
+
+test('synthesizeImpactAnalysis: explicit date + delay verb → shift_initiative_target', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'milestone', title: 'Customer demo' });
+  const snap = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizeImpactAnalysis(snap, 'Customer demo delayed until 2026-06-15');
+  const shift = result.changes.find(c => c.kind === 'shift_initiative_target');
+  assert.ok(shift);
+  if (shift?.kind === 'shift_initiative_target') {
+    assert.equal(shift.initiative_id, init.id);
+    assert.equal(shift.target_end, '2026-06-15');
+  }
+});
+
+// ─── dispatchPm ────────────────────────────────────────────────────
+
+test('dispatchPm: persists a draft proposal AND posts to PM chat with metadata', () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  const sarahId = seedNamedAgent(ws, 'Sarah');
+
+  const result = dispatchPm({
+    workspace_id: ws,
+    trigger_text: 'Sarah out 2026-05-01 to 2026-05-05',
+  });
+  assert.equal(result.used_synthesize_fallback, true);
+  assert.equal(result.proposal.workspace_id, ws);
+  assert.equal(result.proposal.status, 'draft');
+
+  // Chat message with metadata.proposal_id present.
+  const pm = queryOne<{ id: string }>(
+    `SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm'`,
+    [ws],
+  );
+  assert.ok(pm);
+  const messages = queryAll<{ role: string; metadata: string | null; content: string }>(
+    `SELECT role, metadata, content FROM agent_chat_messages WHERE agent_id = ? ORDER BY created_at`,
+    [pm!.id],
+  );
+  assert.ok(messages.length >= 2, 'expected user + assistant messages');
+  const assistant = messages.find(m => m.role === 'assistant');
+  assert.ok(assistant);
+  assert.ok(assistant!.metadata);
+  const meta = JSON.parse(assistant!.metadata!) as { proposal_id?: string };
+  assert.equal(meta.proposal_id, result.proposal.id);
+
+  // Generated availability is for Sarah specifically.
+  const avail = result.proposal.proposed_changes.find(c => c.kind === 'add_availability');
+  if (avail?.kind === 'add_availability') {
+    assert.equal(avail.agent_id, sarahId);
+  } else {
+    assert.fail('expected an add_availability diff');
+  }
+});
+
+test('dispatchPm: returns a usable proposal even when nothing is parsed', () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  const result = dispatchPm({ workspace_id: ws, trigger_text: 'qqq xyz' });
+  assert.equal(result.proposal.status, 'draft');
+  assert.equal(result.proposal.proposed_changes.length, 0);
+  assert.match(result.proposal.impact_md, /could not extract|No structured changes/);
+});

--- a/src/lib/bootstrap-agents.ts
+++ b/src/lib/bootstrap-agents.ts
@@ -230,6 +230,37 @@ export function bootstrapCoreAgentsRaw(
 }
 
 /**
+ * Ensure the workspace has a PM (role='pm') agent. Idempotent. Reads the
+ * soul_md from the .md file next to the pm-agent module so operators can
+ * tweak the prompt without redeploying. Safe to call from API routes.
+ *
+ * Migration 045 also seeds PMs at startup; this function exists so freshly
+ * created workspaces (after migrations have run) get one too.
+ */
+export function ensurePmAgent(workspaceId: string): { id: string; created: boolean } {
+  const db = getDb();
+  const existing = db.prepare(
+    `SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm' LIMIT 1`,
+  ).get(workspaceId) as { id: string } | undefined;
+  if (existing) return { id: existing.id, created: false };
+
+  // Lazy-import to avoid circular deps during migration startup.
+  // pm-agent.ts is plain TS with no DB imports so it's safe everywhere.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { getPmSoulMd, PM_AGENT_DESCRIPTION } = require('./agents/pm-agent') as typeof import('./agents/pm-agent');
+
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  db.prepare(`
+    INSERT INTO agents (
+      id, name, role, description, avatar_emoji, status, is_master,
+      workspace_id, soul_md, source, is_active, created_at, updated_at
+    ) VALUES (?, 'PM', 'pm', ?, '📋', 'standby', 0, ?, ?, 'local', 1, ?, ?)
+  `).run(id, PM_AGENT_DESCRIPTION, workspaceId, getPmSoulMd(), now, now);
+  return { id, created: true };
+}
+
+/**
  * Clone workflow templates from the default workspace into a new workspace.
  */
 export function cloneWorkflowTemplates(db: Database.Database, targetWorkspaceId: string): void {

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -2622,8 +2622,93 @@ const migrations: Migration[] = [
       }
       console.log('[Migration 044] Complete.');
     }
+  },
+  {
+    id: '045',
+    name: 'pm_agent_seed_and_chat_metadata',
+    up: (db) => {
+      // Phase 5 of the roadmap & PM-agent feature. Two changes:
+      //   (a) `agent_chat_messages` gains an optional `metadata` JSON
+      //       column so PM responses can reference a proposal_id (and
+      //       any other future per-message attachments). The /pm chat
+      //       UI keys its proposal-card renderer on metadata.proposal_id.
+      //   (b) Seed one PM agent (role='pm', name='PM') per workspace
+      //       that doesn't already have one. Idempotent.
+      console.log('[Migration 045] Adding agent_chat_messages.metadata + seeding PM agents...');
+
+      // ---- (a) agent_chat_messages.metadata ----
+      const chatInfo = db.prepare('PRAGMA table_info(agent_chat_messages)').all() as { name: string }[];
+      if (!chatInfo.some(c => c.name === 'metadata')) {
+        db.exec(`ALTER TABLE agent_chat_messages ADD COLUMN metadata TEXT`);
+        console.log('[Migration 045] Added agent_chat_messages.metadata column');
+      }
+
+      // ---- (b) Seed PM agents ----
+      // Read soul_md inline to avoid an import cycle (migrations.ts is
+      // imported very early; src/lib/agents/* hasn't necessarily settled).
+      const soulMd = readPmSoulMdFromDisk();
+      const workspaces = db.prepare(
+        'SELECT id FROM workspaces',
+      ).all() as { id: string }[];
+
+      const insert = db.prepare(`
+        INSERT INTO agents (
+          id, name, role, description, avatar_emoji, status, is_master,
+          workspace_id, soul_md, source, is_active, created_at, updated_at
+        ) VALUES (?, 'PM', 'pm', ?, '📋', 'standby', 0, ?, ?, 'local', 1, ?, ?)
+      `);
+      const now = new Date().toISOString();
+      let seeded = 0;
+      let skipped = 0;
+      for (const ws of workspaces) {
+        const existing = db.prepare(
+          `SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm' LIMIT 1`,
+        ).get(ws.id) as { id: string } | undefined;
+        if (existing) {
+          skipped++;
+          continue;
+        }
+        const id = crypto.randomUUID();
+        insert.run(
+          id,
+          'Workspace project manager — maintains the roadmap, analyzes disruptions, proposes structured changes the operator approves.',
+          ws.id,
+          soulMd,
+          now,
+          now,
+        );
+        seeded++;
+      }
+      console.log(`[Migration 045] PM agents: seeded=${seeded} skipped=${skipped}`);
+    }
   }
 ];
+
+// Inline PM soul_md reader for migration 045. The full module
+// (src/lib/agents/pm-agent.ts) does the same thing but we duplicate it
+// here to avoid a `require` cycle through Next's bundler at startup.
+function readPmSoulMdFromDisk(): string {
+  // Resolve relative to the migrations.ts source location. Falls back to
+  // a stub if the file isn't reachable from the bundle path.
+  try {
+    // Build candidate paths so we work in dev (src/), in `next build`
+    // server bundles, and in tsx test runs.
+    const candidates: string[] = [];
+    try {
+      candidates.push(path.join(__dirname, '..', 'agents', 'pm-soul.md'));
+    } catch { /* __dirname may be undefined under some bundlers */ }
+    // CWD-relative — covers `tsx --test` and `npm run db:seed`.
+    candidates.push(path.join(process.cwd(), 'src', 'lib', 'agents', 'pm-soul.md'));
+    for (const p of candidates) {
+      if (fs.existsSync(p)) {
+        return fs.readFileSync(p, 'utf8');
+      }
+    }
+  } catch {
+    /* fall through */
+  }
+  return '# PM Agent (fallback)\n\nWorkspace PM. Read the roadmap, propose changes via `propose_changes`. Never edit the execution board directly.';
+}
 
 /**
  * Creates a timestamped backup of the database file before running migrations.

--- a/src/lib/db/pm-proposals.test.ts
+++ b/src/lib/db/pm-proposals.test.ts
@@ -1,0 +1,397 @@
+/**
+ * PM proposal DB-helper tests (Phase 5).
+ *
+ * Coverage:
+ *   - Create + get + list with filters.
+ *   - acceptProposal applies all 7 diff kinds correctly.
+ *   - Validation rejects bad references without partial writes.
+ *   - Refine creates a child + supersedes parent.
+ *   - Reject is idempotent and leaves the DB untouched.
+ *   - Idempotency: re-accepting an already-accepted proposal is a no-op.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+import {
+  createProposal,
+  getProposal,
+  listProposals,
+  acceptProposal,
+  rejectProposal,
+  refineProposal,
+  validateProposedChanges,
+  PmProposalValidationError,
+  type PmDiff,
+} from './pm-proposals';
+import { createInitiative, addInitiativeDependency } from './initiatives';
+
+function seedAgent(workspace: string = 'default'): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, created_at, updated_at)
+     VALUES (?, 'A', 'worker', ?, 1, datetime('now'), datetime('now'))`,
+    [id, workspace],
+  );
+  return id;
+}
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at)
+     VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+// ─── createProposal / getProposal / listProposals ──────────────────
+
+test('createProposal stores impact_md + parses changes round-trip', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Build X' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 'Sarah out next week',
+    impact_md: '### Headline\n\n- thing',
+    proposed_changes: [
+      { kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' },
+    ],
+  });
+  assert.equal(p.workspace_id, ws);
+  assert.equal(p.status, 'draft');
+  assert.equal(p.proposed_changes.length, 1);
+  assert.equal(p.proposed_changes[0].kind, 'set_initiative_status');
+});
+
+test('createProposal rejects diffs that reference unknown initiatives', () => {
+  const ws = freshWorkspace();
+  assert.throws(
+    () =>
+      createProposal({
+        workspace_id: ws,
+        trigger_text: 't',
+        impact_md: 'i',
+        proposed_changes: [
+          { kind: 'set_initiative_status', initiative_id: 'does-not-exist', status: 'blocked' },
+        ],
+      }),
+    PmProposalValidationError,
+  );
+});
+
+test('listProposals filters by workspace + status', () => {
+  const wsA = freshWorkspace();
+  const wsB = freshWorkspace();
+  createProposal({ workspace_id: wsA, trigger_text: 'a', impact_md: '.', proposed_changes: [] });
+  const pB = createProposal({ workspace_id: wsB, trigger_text: 'b', impact_md: '.', proposed_changes: [] });
+  rejectProposal(pB.id);
+
+  const drafts = listProposals({ workspace_id: wsA, status: 'draft' });
+  assert.ok(drafts.every(p => p.workspace_id === wsA && p.status === 'draft'));
+  assert.equal(drafts.length, 1);
+
+  const rejected = listProposals({ workspace_id: wsB, status: 'rejected' });
+  assert.equal(rejected.length, 1);
+  assert.equal(rejected[0].id, pB.id);
+});
+
+// ─── acceptProposal: each diff kind applies correctly ──────────────
+
+test('acceptProposal: shift_initiative_target updates target_start/target_end', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Launch',
+    target_end: '2026-05-01',
+  });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '...',
+    impact_md: '.',
+    proposed_changes: [
+      { kind: 'shift_initiative_target', initiative_id: init.id, target_end: '2026-05-15' },
+    ],
+  });
+  const result = acceptProposal(p.id);
+  assert.equal(result.changes_applied, 1);
+  const after = queryOne<{ target_end: string }>(
+    'SELECT target_end FROM initiatives WHERE id = ?',
+    [init.id],
+  );
+  assert.equal(after?.target_end, '2026-05-15');
+  // Status flipped to accepted with timestamp.
+  assert.equal(result.proposal.status, 'accepted');
+  assert.ok(result.proposal.applied_at);
+});
+
+test('acceptProposal: add_availability inserts an owner_availability row', () => {
+  const ws = freshWorkspace();
+  const ag = seedAgent(ws);
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '...',
+    impact_md: '.',
+    proposed_changes: [
+      { kind: 'add_availability', agent_id: ag, start: '2026-05-01', end: '2026-05-05' },
+    ],
+  });
+  acceptProposal(p.id);
+  const rows = queryAll<{ id: string; agent_id: string }>(
+    'SELECT id, agent_id FROM owner_availability WHERE agent_id = ?',
+    [ag],
+  );
+  assert.equal(rows.length, 1);
+});
+
+test('acceptProposal: set_initiative_status flips status', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '...',
+    impact_md: '.',
+    proposed_changes: [{ kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' }],
+  });
+  acceptProposal(p.id);
+  const after = queryOne<{ status: string }>('SELECT status FROM initiatives WHERE id = ?', [init.id]);
+  assert.equal(after?.status, 'at_risk');
+});
+
+test('acceptProposal rejects done/cancelled status (PM never marks done)', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  assert.throws(
+    () => createProposal({
+      workspace_id: ws,
+      trigger_text: '.',
+      impact_md: '.',
+      // done is not in the PM-allowed enum at the type level — cast for the test.
+      proposed_changes: [
+        { kind: 'set_initiative_status', initiative_id: init.id, status: 'done' as never },
+      ],
+    }),
+    PmProposalValidationError,
+  );
+});
+
+test('acceptProposal: add_dependency inserts row, dup is idempotent', () => {
+  const ws = freshWorkspace();
+  const a = createInitiative({ workspace_id: ws, kind: 'epic', title: 'A' });
+  const b = createInitiative({ workspace_id: ws, kind: 'epic', title: 'B' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [
+      { kind: 'add_dependency', initiative_id: a.id, depends_on_initiative_id: b.id, note: 'x' },
+    ],
+  });
+  acceptProposal(p.id);
+  const rows = queryAll(
+    'SELECT id FROM initiative_dependencies WHERE initiative_id = ? AND depends_on_initiative_id = ?',
+    [a.id, b.id],
+  );
+  assert.equal(rows.length, 1);
+
+  // Apply a duplicate via a fresh proposal — the add should swallow the
+  // UNIQUE violation and the count stays 1.
+  const p2 = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [
+      { kind: 'add_dependency', initiative_id: a.id, depends_on_initiative_id: b.id },
+    ],
+  });
+  const r2 = acceptProposal(p2.id);
+  assert.equal(r2.changes_applied, 1);
+  const rows2 = queryAll(
+    'SELECT id FROM initiative_dependencies WHERE initiative_id = ? AND depends_on_initiative_id = ?',
+    [a.id, b.id],
+  );
+  assert.equal(rows2.length, 1);
+});
+
+test('acceptProposal: remove_dependency deletes the row', () => {
+  const ws = freshWorkspace();
+  const a = createInitiative({ workspace_id: ws, kind: 'epic', title: 'A' });
+  const b = createInitiative({ workspace_id: ws, kind: 'epic', title: 'B' });
+  const dep = addInitiativeDependency({
+    initiative_id: a.id,
+    depends_on_initiative_id: b.id,
+  });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [{ kind: 'remove_dependency', dependency_id: dep.id }],
+  });
+  acceptProposal(p.id);
+  const exists = queryOne('SELECT id FROM initiative_dependencies WHERE id = ?', [dep.id]);
+  assert.equal(exists, undefined);
+});
+
+test('acceptProposal: reorder_initiatives sets sort_order in array order', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({ workspace_id: ws, kind: 'epic', title: 'P' });
+  const c1 = createInitiative({ workspace_id: ws, kind: 'story', title: 'C1', parent_initiative_id: parent.id });
+  const c2 = createInitiative({ workspace_id: ws, kind: 'story', title: 'C2', parent_initiative_id: parent.id });
+  const c3 = createInitiative({ workspace_id: ws, kind: 'story', title: 'C3', parent_initiative_id: parent.id });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [
+      { kind: 'reorder_initiatives', parent_id: parent.id, child_ids_in_order: [c3.id, c1.id, c2.id] },
+    ],
+  });
+  acceptProposal(p.id);
+  const orders = new Map<string, number>();
+  for (const r of queryAll<{ id: string; sort_order: number }>(
+    'SELECT id, sort_order FROM initiatives WHERE id IN (?, ?, ?)',
+    [c1.id, c2.id, c3.id],
+  )) {
+    orders.set(r.id, r.sort_order);
+  }
+  assert.equal(orders.get(c3.id), 0);
+  assert.equal(orders.get(c1.id), 1);
+  assert.equal(orders.get(c2.id), 2);
+});
+
+test('acceptProposal: update_status_check updates the markdown field', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [
+      { kind: 'update_status_check', initiative_id: init.id, status_check_md: 'Awaiting reply by Apr 30' },
+    ],
+  });
+  acceptProposal(p.id);
+  const after = queryOne<{ status_check_md: string | null }>(
+    'SELECT status_check_md FROM initiatives WHERE id = ?',
+    [init.id],
+  );
+  assert.equal(after?.status_check_md, 'Awaiting reply by Apr 30');
+});
+
+// ─── Validation: bad references mean no partial write ─────────────
+
+test('acceptProposal validates again at apply-time and throws on bad refs', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  const ag = seedAgent(ws);
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [
+      { kind: 'add_availability', agent_id: ag, start: '2026-05-01', end: '2026-05-05' },
+      { kind: 'set_initiative_status', initiative_id: init.id, status: 'blocked' },
+    ],
+  });
+
+  // Now delete the initiative behind the proposal's back; accept must
+  // refuse without writing the availability row.
+  run('DELETE FROM initiatives WHERE id = ?', [init.id]);
+
+  const beforeAvail = queryAll('SELECT id FROM owner_availability WHERE agent_id = ?', [ag]).length;
+  assert.throws(() => acceptProposal(p.id), PmProposalValidationError);
+  const afterAvail = queryAll('SELECT id FROM owner_availability WHERE agent_id = ?', [ag]).length;
+  assert.equal(beforeAvail, afterAvail);
+
+  // Proposal stays in draft so the operator can refine it.
+  const fresh = getProposal(p.id);
+  assert.equal(fresh?.status, 'draft');
+});
+
+test('validateProposedChanges flags every problem in one pass', () => {
+  const ws = freshWorkspace();
+  const errs = validateProposedChanges(ws, [
+    { kind: 'set_initiative_status', initiative_id: 'nope', status: 'at_risk' },
+    { kind: 'add_availability', agent_id: 'nope', start: 'bad', end: 'bad' },
+  ] as PmDiff[]);
+  assert.ok(errs.length >= 3, `expected ≥3 errors, got ${errs.length}`);
+});
+
+// ─── Refine ────────────────────────────────────────────────────────
+
+test('refineProposal supersedes parent + creates child with parent_proposal_id', () => {
+  const ws = freshWorkspace();
+  const parent = createProposal({ workspace_id: ws, trigger_text: 'orig', impact_md: '.', proposed_changes: [] });
+  const { child, parent: refreshedParent } = refineProposal(parent.id, 'add a constraint');
+  assert.equal(refreshedParent.status, 'superseded');
+  assert.equal(child.parent_proposal_id, parent.id);
+  assert.equal(child.status, 'draft');
+});
+
+test('refineProposal refuses to refine an already-accepted proposal', () => {
+  const ws = freshWorkspace();
+  const p = createProposal({ workspace_id: ws, trigger_text: '.', impact_md: '.', proposed_changes: [] });
+  acceptProposal(p.id);
+  assert.throws(() => refineProposal(p.id, 'x'), PmProposalValidationError);
+});
+
+// ─── Reject + idempotency ──────────────────────────────────────────
+
+test('rejectProposal flips status without applying changes', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [{ kind: 'set_initiative_status', initiative_id: init.id, status: 'blocked' }],
+  });
+  rejectProposal(p.id);
+  const after = queryOne<{ status: string }>('SELECT status FROM initiatives WHERE id = ?', [init.id]);
+  assert.equal(after?.status, 'planned'); // unchanged
+  const refreshed = getProposal(p.id);
+  assert.equal(refreshed?.status, 'rejected');
+});
+
+test('acceptProposal is idempotent — second accept is a no-op', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [{ kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' }],
+  });
+  const r1 = acceptProposal(p.id);
+  assert.equal(r1.changes_applied, 1);
+  assert.equal(r1.idempotent_noop, false);
+
+  const r2 = acceptProposal(p.id);
+  assert.equal(r2.idempotent_noop, true);
+  assert.equal(r2.changes_applied, 0);
+});
+
+test('acceptProposal emits a pm_proposal_accepted event row', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [{ kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' }],
+  });
+  acceptProposal(p.id);
+  const ev = queryAll<{ id: string; metadata: string }>(
+    `SELECT id, metadata FROM events WHERE type = 'pm_proposal_accepted' ORDER BY created_at DESC LIMIT 5`,
+  );
+  // At least one event row, and the latest references our proposal id.
+  assert.ok(ev.length >= 1);
+  const latest = ev.find(e => {
+    try { return (JSON.parse(e.metadata) as { proposal_id?: string }).proposal_id === p.id; }
+    catch { return false; }
+  });
+  assert.ok(latest, 'event metadata.proposal_id should match');
+});

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -1,0 +1,626 @@
+/**
+ * PM proposal DB helpers (Phase 5 of the roadmap & PM-agent feature).
+ *
+ * `pm_proposals` rows are the unit of PM-driven change. Each row carries:
+ *
+ *   - The trigger that produced it (`trigger_text`, `trigger_kind`).
+ *   - A markdown impact summary the operator reads in the chat.
+ *   - A typed JSON diff the operator approves; on accept, this module
+ *     applies it transactionally.
+ *
+ * Apply is all-or-nothing in v1 (spec §9.3). The validate-then-apply
+ * helper either succeeds completely or leaves the DB untouched.
+ *
+ * Diff kinds (matches spec §9.3 exactly — schema docs in pm-soul.md):
+ *
+ *   - `shift_initiative_target` — UPDATE initiatives SET target_*
+ *   - `add_availability` — INSERT INTO owner_availability
+ *   - `set_initiative_status` — UPDATE initiatives SET status
+ *       (planned | in_progress | at_risk | blocked only — done/cancelled
+ *       are off-limits for the PM)
+ *   - `add_dependency` — INSERT INTO initiative_dependencies
+ *   - `remove_dependency` — DELETE by id
+ *   - `reorder_initiatives` — UPDATE sort_order across siblings
+ *   - `update_status_check` — UPDATE initiatives SET status_check_md
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { getDb, queryAll, queryOne, run } from '@/lib/db';
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type PmProposalStatus = 'draft' | 'accepted' | 'rejected' | 'superseded';
+export type PmProposalTriggerKind =
+  | 'manual'
+  | 'scheduled_drift_scan'
+  | 'disruption_event'
+  | 'status_check_investigation';
+
+export type PmDiff =
+  | {
+      kind: 'shift_initiative_target';
+      initiative_id: string;
+      target_start?: string | null;
+      target_end?: string | null;
+      reason?: string;
+    }
+  | {
+      kind: 'add_availability';
+      agent_id: string;
+      start: string;
+      end: string;
+      reason?: string;
+    }
+  | {
+      kind: 'set_initiative_status';
+      initiative_id: string;
+      status: 'planned' | 'in_progress' | 'at_risk' | 'blocked';
+    }
+  | {
+      kind: 'add_dependency';
+      initiative_id: string;
+      depends_on_initiative_id: string;
+      note?: string;
+    }
+  | { kind: 'remove_dependency'; dependency_id: string }
+  | {
+      kind: 'reorder_initiatives';
+      parent_id: string | null;
+      child_ids_in_order: string[];
+    }
+  | {
+      kind: 'update_status_check';
+      initiative_id: string;
+      status_check_md: string;
+    };
+
+export interface PmProposal {
+  id: string;
+  workspace_id: string;
+  trigger_text: string;
+  trigger_kind: PmProposalTriggerKind;
+  impact_md: string;
+  proposed_changes: PmDiff[];
+  status: PmProposalStatus;
+  applied_at: string | null;
+  applied_by_agent_id: string | null;
+  parent_proposal_id: string | null;
+  created_at: string;
+}
+
+interface PmProposalRow {
+  id: string;
+  workspace_id: string;
+  trigger_text: string;
+  trigger_kind: PmProposalTriggerKind;
+  impact_md: string;
+  proposed_changes: string;
+  status: PmProposalStatus;
+  applied_at: string | null;
+  applied_by_agent_id: string | null;
+  parent_proposal_id: string | null;
+  created_at: string;
+}
+
+// ─── Validation ─────────────────────────────────────────────────────
+
+/** A typed validation error so callers can map to HTTP 400 cleanly. */
+export class PmProposalValidationError extends Error {
+  constructor(message: string, public readonly hints?: string[]) {
+    super(message);
+    this.name = 'PmProposalValidationError';
+  }
+}
+
+const STATUS_ALLOWED_FROM_PM = new Set(['planned', 'in_progress', 'at_risk', 'blocked']);
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+
+function isValidDateString(s: unknown): s is string {
+  return typeof s === 'string' && ISO_DATE_RE.test(s) && !Number.isNaN(Date.parse(s));
+}
+
+function assertInitiativeInWorkspace(
+  workspaceId: string,
+  initiativeId: string,
+  errors: string[],
+  initiativeCache: Map<string, boolean>,
+) {
+  if (initiativeCache.has(initiativeId)) {
+    if (!initiativeCache.get(initiativeId)) {
+      errors.push(`initiative ${initiativeId} not found in workspace ${workspaceId}`);
+    }
+    return;
+  }
+  const row = queryOne<{ id: string }>(
+    'SELECT id FROM initiatives WHERE id = ? AND workspace_id = ?',
+    [initiativeId, workspaceId],
+  );
+  initiativeCache.set(initiativeId, !!row);
+  if (!row) errors.push(`initiative ${initiativeId} not found in workspace ${workspaceId}`);
+}
+
+/**
+ * Validate a single proposal's diff list against the workspace state.
+ * Returns a list of error strings; empty = OK. Cheap to call from
+ * `createProposal` AND `acceptProposal` — both points use it (defence in
+ * depth: an initiative might be deleted between draft and accept).
+ */
+export function validateProposedChanges(
+  workspaceId: string,
+  changes: PmDiff[],
+): string[] {
+  const errors: string[] = [];
+  const initiativeCache = new Map<string, boolean>();
+
+  if (!Array.isArray(changes)) {
+    return ['proposed_changes must be an array'];
+  }
+
+  for (let i = 0; i < changes.length; i++) {
+    const c = changes[i];
+    if (!c || typeof c !== 'object' || !('kind' in c)) {
+      errors.push(`changes[${i}]: missing kind`);
+      continue;
+    }
+    switch (c.kind) {
+      case 'shift_initiative_target': {
+        if (!c.initiative_id) {
+          errors.push(`changes[${i}]: initiative_id required`);
+          break;
+        }
+        assertInitiativeInWorkspace(workspaceId, c.initiative_id, errors, initiativeCache);
+        if (c.target_start != null && !isValidDateString(c.target_start)) {
+          errors.push(`changes[${i}]: target_start "${c.target_start}" invalid`);
+        }
+        if (c.target_end != null && !isValidDateString(c.target_end)) {
+          errors.push(`changes[${i}]: target_end "${c.target_end}" invalid`);
+        }
+        if (c.target_start == null && c.target_end == null) {
+          errors.push(`changes[${i}]: at least one of target_start / target_end required`);
+        }
+        break;
+      }
+      case 'add_availability': {
+        if (!c.agent_id) {
+          errors.push(`changes[${i}]: agent_id required`);
+          break;
+        }
+        const a = queryOne<{ id: string }>('SELECT id FROM agents WHERE id = ?', [c.agent_id]);
+        if (!a) errors.push(`changes[${i}]: agent ${c.agent_id} not found`);
+        if (!isValidDateString(c.start)) errors.push(`changes[${i}]: start "${c.start}" invalid`);
+        if (!isValidDateString(c.end)) errors.push(`changes[${i}]: end "${c.end}" invalid`);
+        if (isValidDateString(c.start) && isValidDateString(c.end) && c.end < c.start) {
+          errors.push(`changes[${i}]: end must be >= start`);
+        }
+        break;
+      }
+      case 'set_initiative_status': {
+        if (!c.initiative_id) {
+          errors.push(`changes[${i}]: initiative_id required`);
+          break;
+        }
+        assertInitiativeInWorkspace(workspaceId, c.initiative_id, errors, initiativeCache);
+        if (!STATUS_ALLOWED_FROM_PM.has(c.status)) {
+          errors.push(
+            `changes[${i}]: status "${c.status}" not allowed from PM (planned/in_progress/at_risk/blocked only)`,
+          );
+        }
+        break;
+      }
+      case 'add_dependency': {
+        if (!c.initiative_id || !c.depends_on_initiative_id) {
+          errors.push(`changes[${i}]: initiative_id and depends_on_initiative_id required`);
+          break;
+        }
+        assertInitiativeInWorkspace(workspaceId, c.initiative_id, errors, initiativeCache);
+        assertInitiativeInWorkspace(workspaceId, c.depends_on_initiative_id, errors, initiativeCache);
+        if (c.initiative_id === c.depends_on_initiative_id) {
+          errors.push(`changes[${i}]: cannot depend on itself`);
+        }
+        break;
+      }
+      case 'remove_dependency': {
+        if (!c.dependency_id) {
+          errors.push(`changes[${i}]: dependency_id required`);
+          break;
+        }
+        const dep = queryOne<{ id: string; initiative_id: string }>(
+          `SELECT id.id AS id, id.initiative_id AS initiative_id
+             FROM initiative_dependencies id
+             JOIN initiatives i ON i.id = id.initiative_id
+            WHERE id.id = ? AND i.workspace_id = ?`,
+          [c.dependency_id, workspaceId],
+        );
+        if (!dep) {
+          errors.push(`changes[${i}]: dependency ${c.dependency_id} not found in workspace`);
+        }
+        break;
+      }
+      case 'reorder_initiatives': {
+        if (!Array.isArray(c.child_ids_in_order) || c.child_ids_in_order.length === 0) {
+          errors.push(`changes[${i}]: child_ids_in_order must be a non-empty array`);
+          break;
+        }
+        for (const cid of c.child_ids_in_order) {
+          assertInitiativeInWorkspace(workspaceId, cid, errors, initiativeCache);
+        }
+        if (c.parent_id) {
+          assertInitiativeInWorkspace(workspaceId, c.parent_id, errors, initiativeCache);
+        }
+        break;
+      }
+      case 'update_status_check': {
+        if (!c.initiative_id) {
+          errors.push(`changes[${i}]: initiative_id required`);
+          break;
+        }
+        assertInitiativeInWorkspace(workspaceId, c.initiative_id, errors, initiativeCache);
+        if (typeof c.status_check_md !== 'string') {
+          errors.push(`changes[${i}]: status_check_md must be a string`);
+        }
+        break;
+      }
+      default: {
+        const exhaustive: never = c;
+        errors.push(`changes[${i}]: unknown kind "${(exhaustive as { kind?: string }).kind ?? '?'}"`);
+      }
+    }
+  }
+  return errors;
+}
+
+// ─── Row mapping ────────────────────────────────────────────────────
+
+function rowToProposal(row: PmProposalRow): PmProposal {
+  let parsed: PmDiff[] = [];
+  try {
+    parsed = JSON.parse(row.proposed_changes) as PmDiff[];
+    if (!Array.isArray(parsed)) parsed = [];
+  } catch {
+    parsed = [];
+  }
+  return {
+    id: row.id,
+    workspace_id: row.workspace_id,
+    trigger_text: row.trigger_text,
+    trigger_kind: row.trigger_kind,
+    impact_md: row.impact_md,
+    proposed_changes: parsed,
+    status: row.status,
+    applied_at: row.applied_at,
+    applied_by_agent_id: row.applied_by_agent_id,
+    parent_proposal_id: row.parent_proposal_id,
+    created_at: row.created_at,
+  };
+}
+
+// ─── Public helpers ─────────────────────────────────────────────────
+
+export interface CreateProposalInput {
+  workspace_id: string;
+  trigger_text: string;
+  trigger_kind?: PmProposalTriggerKind;
+  impact_md: string;
+  proposed_changes: PmDiff[];
+  parent_proposal_id?: string | null;
+}
+
+export function createProposal(input: CreateProposalInput): PmProposal {
+  if (!input.workspace_id) throw new PmProposalValidationError('workspace_id required');
+  if (!input.trigger_text) throw new PmProposalValidationError('trigger_text required');
+  if (typeof input.impact_md !== 'string') {
+    throw new PmProposalValidationError('impact_md required');
+  }
+
+  const errors = validateProposedChanges(input.workspace_id, input.proposed_changes ?? []);
+  if (errors.length > 0) {
+    throw new PmProposalValidationError(
+      `Invalid proposed_changes: ${errors.length} error(s)`,
+      errors,
+    );
+  }
+
+  const id = uuidv4();
+  const now = new Date().toISOString();
+  run(
+    `INSERT INTO pm_proposals (
+       id, workspace_id, trigger_text, trigger_kind, impact_md,
+       proposed_changes, status, parent_proposal_id, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?, 'draft', ?, ?)`,
+    [
+      id,
+      input.workspace_id,
+      input.trigger_text,
+      input.trigger_kind ?? 'manual',
+      input.impact_md,
+      JSON.stringify(input.proposed_changes ?? []),
+      input.parent_proposal_id ?? null,
+      now,
+    ],
+  );
+  return getProposal(id)!;
+}
+
+export function getProposal(id: string): PmProposal | undefined {
+  const row = queryOne<PmProposalRow>('SELECT * FROM pm_proposals WHERE id = ?', [id]);
+  return row ? rowToProposal(row) : undefined;
+}
+
+export interface ListProposalFilters {
+  workspace_id?: string;
+  status?: PmProposalStatus;
+  since?: string;
+  limit?: number;
+}
+
+export function listProposals(filters: ListProposalFilters = {}): PmProposal[] {
+  const where: string[] = [];
+  const params: unknown[] = [];
+  if (filters.workspace_id) {
+    where.push('workspace_id = ?');
+    params.push(filters.workspace_id);
+  }
+  if (filters.status) {
+    where.push('status = ?');
+    params.push(filters.status);
+  }
+  if (filters.since) {
+    where.push('created_at >= ?');
+    params.push(filters.since);
+  }
+  const sql =
+    'SELECT * FROM pm_proposals ' +
+    (where.length ? `WHERE ${where.join(' AND ')} ` : '') +
+    'ORDER BY created_at DESC' +
+    (filters.limit ? ` LIMIT ${Math.max(1, Math.min(500, filters.limit | 0))}` : '');
+  return queryAll<PmProposalRow>(sql, params).map(rowToProposal);
+}
+
+// ─── Apply (acceptProposal) ─────────────────────────────────────────
+
+export interface AcceptProposalResult {
+  proposal: PmProposal;
+  changes_applied: number;
+  /** True when the proposal was already accepted — the second call is a no-op. */
+  idempotent_noop: boolean;
+}
+
+/**
+ * Apply a draft proposal's diff list transactionally.
+ *
+ *   - Validates referenced ids again (defence-in-depth).
+ *   - Wraps every mutation + the status flip in a single transaction.
+ *   - Marks the proposal `accepted` with `applied_at` and
+ *     `applied_by_agent_id`.
+ *   - Emits one `events` row of type `pm_proposal_accepted` with a
+ *     summary metadata blob.
+ *
+ * Idempotent: applying an already-accepted proposal is a no-op (returns
+ * `idempotent_noop: true`). Rejected / superseded proposals can't be
+ * applied — throws.
+ */
+export function acceptProposal(
+  id: string,
+  applied_by_agent_id: string | null = null,
+): AcceptProposalResult {
+  const existing = getProposal(id);
+  if (!existing) throw new PmProposalValidationError(`proposal ${id} not found`);
+
+  if (existing.status === 'accepted') {
+    return { proposal: existing, changes_applied: 0, idempotent_noop: true };
+  }
+  if (existing.status === 'rejected' || existing.status === 'superseded') {
+    throw new PmProposalValidationError(
+      `proposal ${id} cannot be accepted from status=${existing.status}`,
+    );
+  }
+
+  // Re-validate against current DB state — initiatives could've been
+  // deleted between draft and accept.
+  const errors = validateProposedChanges(existing.workspace_id, existing.proposed_changes);
+  if (errors.length > 0) {
+    throw new PmProposalValidationError(
+      `Cannot apply proposal ${id}: ${errors.length} validation error(s)`,
+      errors,
+    );
+  }
+
+  const db = getDb();
+  let changesApplied = 0;
+  const now = new Date().toISOString();
+
+  db.transaction(() => {
+    for (const change of existing.proposed_changes) {
+      applyDiff(change, now);
+      changesApplied++;
+    }
+
+    // Flip the proposal row.
+    db.prepare(
+      `UPDATE pm_proposals
+          SET status = 'accepted', applied_at = ?, applied_by_agent_id = ?
+        WHERE id = ?`,
+    ).run(now, applied_by_agent_id, id);
+
+    // Emit a single audit event so the live feed shows the accept.
+    db.prepare(
+      `INSERT INTO events (id, type, agent_id, message, metadata, created_at)
+       VALUES (?, 'pm_proposal_accepted', ?, ?, ?, ?)`,
+    ).run(
+      uuidv4(),
+      applied_by_agent_id,
+      `PM proposal accepted (${changesApplied} change${changesApplied === 1 ? '' : 's'})`,
+      JSON.stringify({
+        proposal_id: id,
+        workspace_id: existing.workspace_id,
+        trigger_kind: existing.trigger_kind,
+        change_kinds: existing.proposed_changes.map(c => c.kind),
+      }),
+      now,
+    );
+  })();
+
+  const updated = getProposal(id)!;
+  return { proposal: updated, changes_applied: changesApplied, idempotent_noop: false };
+}
+
+/**
+ * Apply one diff. Caller wraps in a transaction.
+ *
+ * `now` lets the caller pass a single timestamp so all mutations within
+ * one accept share an `updated_at` value (cleaner audit story).
+ */
+function applyDiff(diff: PmDiff, now: string): void {
+  switch (diff.kind) {
+    case 'shift_initiative_target': {
+      const sets: string[] = [];
+      const params: unknown[] = [];
+      if (diff.target_start !== undefined) {
+        sets.push('target_start = ?');
+        params.push(diff.target_start);
+      }
+      if (diff.target_end !== undefined) {
+        sets.push('target_end = ?');
+        params.push(diff.target_end);
+      }
+      sets.push('updated_at = ?');
+      params.push(now);
+      params.push(diff.initiative_id);
+      run(`UPDATE initiatives SET ${sets.join(', ')} WHERE id = ?`, params);
+      return;
+    }
+    case 'add_availability': {
+      run(
+        `INSERT INTO owner_availability (id, agent_id, unavailable_start, unavailable_end, reason, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        [uuidv4(), diff.agent_id, diff.start, diff.end, diff.reason ?? null, now],
+      );
+      return;
+    }
+    case 'set_initiative_status': {
+      run(
+        `UPDATE initiatives SET status = ?, updated_at = ? WHERE id = ?`,
+        [diff.status, now, diff.initiative_id],
+      );
+      return;
+    }
+    case 'add_dependency': {
+      try {
+        run(
+          `INSERT INTO initiative_dependencies (id, initiative_id, depends_on_initiative_id, kind, note, created_at)
+           VALUES (?, ?, ?, 'finish_to_start', ?, ?)`,
+          [uuidv4(), diff.initiative_id, diff.depends_on_initiative_id, diff.note ?? null, now],
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // SQLite throws SQLITE_CONSTRAINT_UNIQUE on duplicate edges. Treat
+        // as idempotent — the desired state already exists.
+        if (/UNIQUE constraint failed/i.test(msg)) return;
+        throw err;
+      }
+      return;
+    }
+    case 'remove_dependency': {
+      run(`DELETE FROM initiative_dependencies WHERE id = ?`, [diff.dependency_id]);
+      return;
+    }
+    case 'reorder_initiatives': {
+      // Bulk update sort_order. Validation already confirmed every id
+      // exists in this workspace.
+      let order = 0;
+      for (const cid of diff.child_ids_in_order) {
+        run(
+          `UPDATE initiatives SET sort_order = ?, updated_at = ? WHERE id = ?`,
+          [order, now, cid],
+        );
+        order++;
+      }
+      return;
+    }
+    case 'update_status_check': {
+      run(
+        `UPDATE initiatives SET status_check_md = ?, updated_at = ? WHERE id = ?`,
+        [diff.status_check_md, now, diff.initiative_id],
+      );
+      return;
+    }
+    default: {
+      const exhaustive: never = diff;
+      throw new Error(`Unknown diff kind: ${(exhaustive as { kind?: string }).kind ?? '?'}`);
+    }
+  }
+}
+
+// ─── Reject / refine ────────────────────────────────────────────────
+
+export function rejectProposal(id: string): PmProposal {
+  const existing = getProposal(id);
+  if (!existing) throw new PmProposalValidationError(`proposal ${id} not found`);
+  if (existing.status === 'rejected') return existing;
+  if (existing.status === 'accepted' || existing.status === 'superseded') {
+    throw new PmProposalValidationError(
+      `proposal ${id} cannot be rejected from status=${existing.status}`,
+    );
+  }
+  run(`UPDATE pm_proposals SET status = 'rejected' WHERE id = ?`, [id]);
+  return getProposal(id)!;
+}
+
+export interface RefineProposalResult {
+  parent: PmProposal;
+  /** The new (still-empty) draft slot. The dispatch path fills it. */
+  child: PmProposal;
+}
+
+/**
+ * Mark a proposal `superseded` and create a new draft proposal that
+ * inherits its trigger context. The dispatch path is responsible for
+ * regenerating impact_md + proposed_changes with the additional
+ * constraint applied.
+ *
+ * In v1 the new draft starts with empty impact + empty changes — the
+ * caller (`/api/pm/proposals/[id]/refine` route) then triggers the
+ * synthesize/LLM path which rewrites both fields.
+ */
+export function refineProposal(
+  parentId: string,
+  additionalConstraint: string,
+): RefineProposalResult {
+  const parent = getProposal(parentId);
+  if (!parent) throw new PmProposalValidationError(`proposal ${parentId} not found`);
+  if (parent.status === 'accepted') {
+    throw new PmProposalValidationError(
+      `proposal ${parentId} already accepted; cannot refine`,
+    );
+  }
+
+  const childId = uuidv4();
+  const now = new Date().toISOString();
+  const triggerText = `${parent.trigger_text}\n\n[refine] ${additionalConstraint}`;
+
+  const db = getDb();
+  db.transaction(() => {
+    if (parent.status === 'draft') {
+      run(`UPDATE pm_proposals SET status = 'superseded' WHERE id = ?`, [parentId]);
+    }
+    run(
+      `INSERT INTO pm_proposals (
+         id, workspace_id, trigger_text, trigger_kind, impact_md,
+         proposed_changes, status, parent_proposal_id, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, 'draft', ?, ?)`,
+      [
+        childId,
+        parent.workspace_id,
+        triggerText,
+        parent.trigger_kind,
+        '_(refining…)_',
+        '[]',
+        parentId,
+        now,
+      ],
+    );
+  })();
+
+  return { parent: getProposal(parentId)!, child: getProposal(childId)! };
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -723,6 +723,7 @@ CREATE TABLE IF NOT EXISTS agent_chat_messages (
   content TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'delivered')),
   session_key TEXT,
+  metadata TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/src/lib/mcp/roadmap-tools.ts
+++ b/src/lib/mcp/roadmap-tools.ts
@@ -1,0 +1,655 @@
+/**
+ * Roadmap & PM MCP tools (Phase 5).
+ *
+ * Registered alongside the core sc-mission-control tools (registerAllTools
+ * in ./tools.ts). Split into a separate file purely for readability —
+ * tools.ts already covers the task-execution surface.
+ *
+ * Tool families:
+ *
+ *   - Read tools (§11.1 of the spec): list_initiatives, get_initiative,
+ *     get_initiative_tree, get_roadmap_snapshot, get_initiative_history,
+ *     get_task_initiative_history, list_owner_availability,
+ *     get_velocity_data, list_proposals.
+ *
+ *   - General writes (§11.2, persona-gated by the agent's soul_md):
+ *     create_initiative, update_initiative, move_initiative,
+ *     convert_initiative, add_initiative_dependency,
+ *     remove_initiative_dependency, move_task_to_initiative,
+ *     promote_initiative_to_task, promote_task_to_inbox,
+ *     add_owner_availability.
+ *
+ *   - PM-specific (§11.3): propose_changes, refine_proposal,
+ *     preview_derivation.
+ *
+ * Authn/authz: same as the core tools — bearer at the transport,
+ * `agent_id` arg on every state-changing tool. The PM agent's soul_md
+ * forbids it from calling the general-write tools (it's persona policy,
+ * not enforced by the server). Spec §9.4: "PM is a suggester, never an
+ * actor."
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { queryOne } from '@/lib/db';
+import {
+  createInitiative,
+  updateInitiative,
+  moveInitiative,
+  convertInitiative,
+  addInitiativeDependency,
+  removeInitiativeDependency,
+  getInitiative,
+  getInitiativeTree,
+  getInitiativeHistory,
+  listInitiatives,
+  moveTaskToInitiative,
+  type InitiativeKind,
+  type InitiativeStatus,
+} from '@/lib/db/initiatives';
+import {
+  promoteInitiativeToTask,
+  promoteTaskToInbox,
+  getTaskInitiativeHistory,
+} from '@/lib/db/promotion';
+import {
+  createOwnerAvailability,
+  listOwnerAvailability,
+} from '@/lib/db/owner-availability';
+import { getRoadmapSnapshot } from '@/lib/db/roadmap';
+import { computeVelocity } from '@/lib/roadmap/velocity';
+import { previewDerivation } from '@/lib/roadmap/apply-derivation';
+import {
+  createProposal,
+  listProposals,
+  refineProposal as refineProposalDb,
+  type PmDiff,
+  type PmProposalStatus,
+  PmProposalValidationError,
+} from '@/lib/db/pm-proposals';
+import { dispatchPm } from '@/lib/agents/pm-dispatch';
+
+const agentIdArg = z
+  .string()
+  .min(1)
+  .describe("The calling agent's MC agent_id (see whoami)");
+
+function textResult(text: string, structured?: Record<string, unknown>): CallToolResult {
+  return {
+    content: [{ type: 'text', text }],
+    ...(structured ? { structuredContent: structured } : {}),
+  };
+}
+
+function errorResult(message: string, code: string, extra: Record<string, unknown> = {}): CallToolResult {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: message }],
+    structuredContent: { error: code, message, ...extra },
+  };
+}
+
+function safeWrap<T>(fn: () => T): CallToolResult {
+  try {
+    const result = fn();
+    return textResult(JSON.stringify(result, null, 2), result as Record<string, unknown>);
+  } catch (err) {
+    if (err instanceof PmProposalValidationError) {
+      return errorResult(err.message, 'validation_failed', { hints: err.hints });
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return errorResult(msg, 'internal_error');
+  }
+}
+
+const KINDS = z.enum(['theme', 'milestone', 'epic', 'story']);
+const INIT_STATUSES = z.enum([
+  'planned',
+  'in_progress',
+  'at_risk',
+  'blocked',
+  'done',
+  'cancelled',
+]);
+const DEP_KINDS = z.enum(['finish_to_start', 'start_to_start', 'blocking', 'informational']);
+
+// Diff schema mirrors PmDiff shape exactly. We use z.discriminatedUnion so
+// MCP clients get accurate error messages on bad payloads.
+const DiffSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('shift_initiative_target'),
+    initiative_id: z.string().min(1),
+    target_start: z.string().nullish(),
+    target_end: z.string().nullish(),
+    reason: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal('add_availability'),
+    agent_id: z.string().min(1),
+    start: z.string().min(1),
+    end: z.string().min(1),
+    reason: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal('set_initiative_status'),
+    initiative_id: z.string().min(1),
+    status: z.enum(['planned', 'in_progress', 'at_risk', 'blocked']),
+  }),
+  z.object({
+    kind: z.literal('add_dependency'),
+    initiative_id: z.string().min(1),
+    depends_on_initiative_id: z.string().min(1),
+    note: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal('remove_dependency'),
+    dependency_id: z.string().min(1),
+  }),
+  z.object({
+    kind: z.literal('reorder_initiatives'),
+    parent_id: z.string().nullable(),
+    child_ids_in_order: z.array(z.string().min(1)).min(1),
+  }),
+  z.object({
+    kind: z.literal('update_status_check'),
+    initiative_id: z.string().min(1),
+    status_check_md: z.string(),
+  }),
+]);
+
+export function registerRoadmapTools(server: McpServer): void {
+  // ─── Read tools ───────────────────────────────────────────────────
+
+  server.registerTool(
+    'list_initiatives',
+    {
+      title: 'List initiatives',
+      description: 'Filter the planning tree by workspace, product, parent, status, or kind.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        workspace_id: z.string().min(1).optional(),
+        product_id: z.string().nullish(),
+        parent_initiative_id: z.string().nullish(),
+        kind: KINDS.optional(),
+        status: INIT_STATUSES.optional(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      listInitiatives({
+        workspace_id: args.workspace_id,
+        product_id: args.product_id ?? undefined,
+        parent_id: args.parent_initiative_id === null
+          ? null
+          : args.parent_initiative_id ?? undefined,
+        kind: args.kind as InitiativeKind | undefined,
+        status: args.status as InitiativeStatus | undefined,
+      }),
+    ),
+  );
+
+  server.registerTool(
+    'get_initiative',
+    {
+      title: 'Fetch one initiative',
+      description: 'Returns the row plus optional descendant tree and tasks.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        id: z.string().min(1),
+        include_descendants: z.boolean().optional(),
+        include_tasks: z.boolean().optional(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() => {
+      const init = getInitiative(args.id, {
+        includeChildren: args.include_descendants,
+        includeTasks: args.include_tasks,
+      });
+      if (!init) throw new Error(`initiative ${args.id} not found`);
+      return init;
+    }),
+  );
+
+  server.registerTool(
+    'get_initiative_tree',
+    {
+      title: 'Fetch the initiative tree for a workspace',
+      description: 'Hierarchical list, useful for PM context.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        workspace_id: z.string().min(1),
+        root_id: z.string().optional(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() => getInitiativeTree(args.workspace_id, args.root_id)),
+  );
+
+  server.registerTool(
+    'get_roadmap_snapshot',
+    {
+      title: 'Fetch a roadmap snapshot',
+      description:
+        'Flattened initiatives + tasks + dependencies + owner_availability for a workspace. The PM agent uses this as input to its impact analysis.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        workspace_id: z.string().min(1),
+        product_id: z.string().nullish(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      getRoadmapSnapshot({ workspace_id: args.workspace_id, product_id: args.product_id ?? undefined }),
+    ),
+  );
+
+  server.registerTool(
+    'get_initiative_history',
+    {
+      title: 'Fetch initiative parent-change history',
+      description: 'Audit log of every move (re-parent) of this initiative.',
+      inputSchema: { agent_id: agentIdArg, id: z.string().min(1) },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() => getInitiativeHistory(args.id)),
+  );
+
+  server.registerTool(
+    'get_task_initiative_history',
+    {
+      title: 'Fetch task → initiative provenance trail',
+      description: 'Every initiative this task has been associated with, in order.',
+      inputSchema: { agent_id: agentIdArg, task_id: z.string().min(1) },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() => getTaskInitiativeHistory(args.task_id)),
+  );
+
+  server.registerTool(
+    'list_owner_availability',
+    {
+      title: 'List owner-availability windows',
+      description: 'Filter by agent_id or by an overlap window.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        for_agent_id: z.string().optional(),
+        between_start: z.string().nullish(),
+        between_end: z.string().nullish(),
+        workspace_id: z.string().optional(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      listOwnerAvailability({
+        agent_id: args.for_agent_id,
+        between_start: args.between_start ?? undefined,
+        between_end: args.between_end ?? undefined,
+        workspace_id: args.workspace_id,
+      }),
+    ),
+  );
+
+  server.registerTool(
+    'get_velocity_data',
+    {
+      title: 'Fetch per-owner velocity ratio',
+      description: 'Returns the actual/estimated ratio for completed tasks. Defaults to 1.0 when no history.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        owner_agent_id: z.string().min(1),
+        since_days: z.number().int().min(1).max(365).optional(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() => ({
+      owner_agent_id: args.owner_agent_id,
+      ratio: computeVelocity({ owner_agent_id: args.owner_agent_id, since_days: args.since_days }),
+    })),
+  );
+
+  server.registerTool(
+    'list_proposals',
+    {
+      title: 'List PM proposals',
+      description: 'Filter by workspace, status, or since-date.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        workspace_id: z.string().optional(),
+        status: z.enum(['draft', 'accepted', 'rejected', 'superseded']).optional(),
+        since: z.string().optional(),
+        limit: z.number().int().min(1).max(200).optional(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      listProposals({
+        workspace_id: args.workspace_id,
+        status: args.status as PmProposalStatus | undefined,
+        since: args.since,
+        limit: args.limit,
+      }),
+    ),
+  );
+
+  // ─── General write tools (persona-gated) ──────────────────────────
+
+  server.registerTool(
+    'create_initiative',
+    {
+      title: 'Create an initiative',
+      description: 'NOT for the PM agent — PM uses propose_changes. Other personas may use this freely.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        workspace_id: z.string().min(1),
+        kind: KINDS,
+        title: z.string().min(1).max(500),
+        product_id: z.string().nullish(),
+        parent_initiative_id: z.string().nullish(),
+        description: z.string().optional(),
+        owner_agent_id: z.string().nullish(),
+        target_start: z.string().nullish(),
+        target_end: z.string().nullish(),
+        committed_end: z.string().nullish(),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      createInitiative({
+        workspace_id: args.workspace_id,
+        kind: args.kind as InitiativeKind,
+        title: args.title,
+        product_id: args.product_id ?? null,
+        parent_initiative_id: args.parent_initiative_id ?? null,
+        description: args.description ?? null,
+        owner_agent_id: args.owner_agent_id ?? null,
+        target_start: args.target_start ?? null,
+        target_end: args.target_end ?? null,
+        committed_end: args.committed_end ?? null,
+      }),
+    ),
+  );
+
+  server.registerTool(
+    'update_initiative',
+    {
+      title: 'Update an initiative (PATCH semantics)',
+      description: 'Partial update. NOT for the PM agent.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        id: z.string().min(1),
+        patch: z.record(z.string(), z.unknown()),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() => updateInitiative(args.id, args.patch as Record<string, never>)),
+  );
+
+  server.registerTool(
+    'move_initiative',
+    {
+      title: 'Re-parent an initiative',
+      description: 'Audited via initiative_parent_history. NOT for the PM.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        id: z.string().min(1),
+        to_parent_id: z.string().nullable(),
+        reason: z.string().optional(),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      moveInitiative(args.id, args.to_parent_id, args.agent_id, args.reason ?? null),
+    ),
+  );
+
+  server.registerTool(
+    'convert_initiative',
+    {
+      title: 'Change an initiative kind',
+      description: 'Story → epic, etc. Emits an events row. NOT for the PM.',
+      inputSchema: { agent_id: agentIdArg, id: z.string().min(1), new_kind: KINDS },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      convertInitiative(args.id, args.new_kind as InitiativeKind, args.agent_id),
+    ),
+  );
+
+  server.registerTool(
+    'add_initiative_dependency',
+    {
+      title: 'Add a dependency edge',
+      description: 'Many-to-many. UNIQUE on (initiative_id, depends_on_initiative_id).',
+      inputSchema: {
+        agent_id: agentIdArg,
+        initiative_id: z.string().min(1),
+        depends_on_initiative_id: z.string().min(1),
+        kind: DEP_KINDS.optional(),
+        note: z.string().optional(),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      addInitiativeDependency({
+        initiative_id: args.initiative_id,
+        depends_on_initiative_id: args.depends_on_initiative_id,
+        kind: args.kind,
+        note: args.note,
+      }),
+    ),
+  );
+
+  server.registerTool(
+    'remove_initiative_dependency',
+    {
+      title: 'Remove a dependency edge by id',
+      description: 'No-op when the edge is already gone.',
+      inputSchema: { agent_id: agentIdArg, dependency_id: z.string().min(1) },
+      annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() => {
+      removeInitiativeDependency(args.dependency_id);
+      return { dependency_id: args.dependency_id, removed: true };
+    }),
+  );
+
+  server.registerTool(
+    'move_task_to_initiative',
+    {
+      title: 'Re-parent a task to a different initiative',
+      description: 'Writes a task_initiative_history row.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        task_id: z.string().min(1),
+        to_initiative_id: z.string().nullable(),
+        reason: z.string().optional(),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() => {
+      moveTaskToInitiative(args.task_id, args.to_initiative_id, args.agent_id, args.reason ?? null);
+      return { task_id: args.task_id, to_initiative_id: args.to_initiative_id };
+    }),
+  );
+
+  server.registerTool(
+    'promote_initiative_to_task',
+    {
+      title: 'Promote a story to a draft task',
+      description: 'Creates ONE task in status=draft linked to the initiative. NOT for the PM (operator-driven only).',
+      inputSchema: {
+        agent_id: agentIdArg,
+        initiative_id: z.string().min(1),
+        task_title: z.string().min(1).max(500),
+        task_description: z.string().optional(),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      promoteInitiativeToTask(args.initiative_id, {
+        task_title: args.task_title,
+        task_description: args.task_description ?? null,
+        created_by_agent_id: args.agent_id,
+      }),
+    ),
+  );
+
+  server.registerTool(
+    'promote_task_to_inbox',
+    {
+      title: 'Promote a draft task to inbox',
+      description: 'Draft → inbox: makes the task visible on the Mission Queue. NOT for the PM.',
+      inputSchema: { agent_id: agentIdArg, task_id: z.string().min(1) },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      promoteTaskToInbox(args.task_id, { promoted_by_agent_id: args.agent_id }),
+    ),
+  );
+
+  server.registerTool(
+    'add_owner_availability',
+    {
+      title: 'Add an owner-availability window',
+      description:
+        'Records that an agent is unavailable in a window. The PM may use this when the operator stated an availability fact directly; otherwise the PM proposes the change via propose_changes.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        for_agent_id: z.string().min(1),
+        start: z.string().min(1),
+        end: z.string().min(1),
+        reason: z.string().optional(),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      createOwnerAvailability({
+        agent_id: args.for_agent_id,
+        unavailable_start: args.start,
+        unavailable_end: args.end,
+        reason: args.reason,
+      }),
+    ),
+  );
+
+  // ─── PM-specific tools ────────────────────────────────────────────
+
+  server.registerTool(
+    'propose_changes',
+    {
+      title: 'PM: propose roadmap changes',
+      description:
+        "The PM agent's primary write path. Creates a `pm_proposals` row in `draft` status with a markdown impact summary and a structured diff list. The operator approves at the proposal level — never call any of the other write tools to push changes through; always go through this one.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        workspace_id: z.string().min(1),
+        trigger_text: z.string().min(1).max(20000),
+        trigger_kind: z
+          .enum([
+            'manual',
+            'scheduled_drift_scan',
+            'disruption_event',
+            'status_check_investigation',
+          ])
+          .optional(),
+        impact_md: z.string().min(1).max(20000),
+        changes: z.array(DiffSchema),
+        parent_proposal_id: z.string().nullish(),
+      },
+      annotations: { destructiveHint: false, openWorldHint: false },
+    },
+    async (args) => safeWrap(() =>
+      createProposal({
+        workspace_id: args.workspace_id,
+        trigger_text: args.trigger_text,
+        trigger_kind: args.trigger_kind,
+        impact_md: args.impact_md,
+        proposed_changes: args.changes as PmDiff[],
+        parent_proposal_id: args.parent_proposal_id ?? null,
+      }),
+    ),
+  );
+
+  server.registerTool(
+    'refine_proposal',
+    {
+      title: 'PM: refine a prior proposal with an additional constraint',
+      description:
+        "Marks the parent superseded and creates a fresh draft. Use this when the operator says 'refine — keep launch on schedule, defer analytics'.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        proposal_id: z.string().min(1),
+        additional_constraint: z.string().min(1).max(5000),
+      },
+      annotations: { destructiveHint: false, openWorldHint: false },
+    },
+    async (args) => safeWrap(() => {
+      // The DB helper creates an empty child slot; the dispatch path
+      // fills it with a freshly-synthesized impact + changes.
+      const parent = queryOne<{ workspace_id: string }>(
+        'SELECT workspace_id FROM pm_proposals WHERE id = ?',
+        [args.proposal_id],
+      );
+      if (!parent) throw new Error(`proposal ${args.proposal_id} not found`);
+      refineProposalDb(args.proposal_id, args.additional_constraint);
+      // Re-dispatch so the new draft has impact_md + changes filled in.
+      // We do this here (instead of relying on the API route refine
+      // path) so MCP-driven refines also work.
+      const result = dispatchPm({
+        workspace_id: parent.workspace_id,
+        trigger_text: args.additional_constraint,
+        trigger_kind: 'manual',
+      });
+      return { refined_proposal: result.proposal };
+    }),
+  );
+
+  server.registerTool(
+    'preview_derivation',
+    {
+      title: 'PM: read-only schedule what-if',
+      description:
+        'Run the derivation engine against the current snapshot with optional velocity / availability overrides, WITHOUT writing. Use this to estimate impact before composing a propose_changes call.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        workspace_id: z.string().min(1),
+        velocity_overrides: z.record(z.string(), z.number().min(0).max(10)).optional(),
+        availability_overrides: z
+          .array(
+            z.object({
+              agent_id: z.string().min(1),
+              unavailable_start: z.string().min(1),
+              unavailable_end: z.string().min(1),
+              reason: z.string().optional(),
+            }),
+          )
+          .optional(),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args) => safeWrap(() => {
+      const snapshot = getRoadmapSnapshot({ workspace_id: args.workspace_id });
+      const result = previewDerivation(snapshot, {
+        velocityOverrides: args.velocity_overrides,
+        availabilityOverrides: (args.availability_overrides ?? []).map(a => ({
+          agent_id: a.agent_id,
+          unavailable_start: a.unavailable_start,
+          unavailable_end: a.unavailable_end,
+          reason: a.reason ?? null,
+        })),
+      });
+      // Strip the schedule Map (not JSON-serializable) — diffs already
+      // capture the differences; cycle/warnings are still useful.
+      return {
+        diffs: result.diffs,
+        drifts: result.drifts,
+        cycle: result.derived.cycle,
+        no_effort_initiative_ids: result.derived.noEffort,
+        warnings: result.derived.warnings,
+      };
+    }),
+  );
+}

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -9,6 +9,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerAllTools } from './tools';
+import { registerRoadmapTools } from './roadmap-tools';
 
 export const SERVER_NAME = 'sc-mission-control';
 export const SERVER_VERSION = '0.1.0';
@@ -16,5 +17,6 @@ export const SERVER_VERSION = '0.1.0';
 export function buildServer(): McpServer {
   const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
   registerAllTools(server);
+  registerRoadmapTools(server);
   return server;
 }

--- a/src/lib/roadmap/apply-derivation.ts
+++ b/src/lib/roadmap/apply-derivation.ts
@@ -25,7 +25,11 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { getDb, queryAll } from '@/lib/db';
-import { getRoadmapSnapshot, type RoadmapSnapshot } from '@/lib/db/roadmap';
+import {
+  getRoadmapSnapshot,
+  type RoadmapSnapshot,
+  type RoadmapOwnerAvailability,
+} from '@/lib/db/roadmap';
 import { deriveSchedule, type DeriveResult } from './derive';
 import { detectDrift, type DriftEvent } from './drift';
 import { computeVelocity } from './velocity';
@@ -57,23 +61,9 @@ export function applyDerivation(
   opts: ApplyDerivationOptions = {},
 ): ApplyDerivationResult {
   const snapshot = opts.snapshot ?? getRoadmapSnapshot({ workspace_id });
-
-  // Compute per-owner velocity unless a map was supplied.
-  let velocityMap = opts.velocityMap;
-  if (!velocityMap) {
-    velocityMap = new Map<string, number>();
-    const owners = new Set<string>();
-    for (const i of snapshot.initiatives) {
-      if (i.owner_agent_id) owners.add(i.owner_agent_id);
-    }
-    for (const owner of owners) {
-      velocityMap.set(owner, computeVelocity({ owner_agent_id: owner }));
-    }
-  }
-
-  const derived: DeriveResult = deriveSchedule(snapshot, {
-    velocityMap,
+  const { derived } = computeDerivedSchedule(snapshot, {
     today: opts.today,
+    velocityMap: opts.velocityMap,
   });
 
   const drifts = detectDrift(snapshot, derived);
@@ -169,4 +159,133 @@ export function listWorkspacesWithInitiatives(): string[] {
   return queryAll<{ workspace_id: string }>(
     'SELECT DISTINCT workspace_id FROM initiatives',
   ).map(r => r.workspace_id);
+}
+
+// ─── Preview helpers (Phase 5) ──────────────────────────────────────
+
+export interface PreviewDerivationOptions {
+  today?: Date | string;
+  velocityMap?: Map<string, number>;
+  /**
+   * Override velocity for specific owners on top of (or in place of) the
+   * computed velocity map. Useful for "if Sarah were 50% slower" what-ifs.
+   */
+  velocityOverrides?: Record<string, number>;
+  /**
+   * Extra availability rows to layer on top of the snapshot's existing
+   * rows. Each row is treated identically to a real DB row by the
+   * derivation engine — same overlap math, same effort calendar push.
+   * IDs are auto-generated if missing.
+   */
+  availabilityOverrides?: Array<Omit<RoadmapOwnerAvailability, 'id'> & { id?: string }>;
+}
+
+export interface PreviewDerivationResult {
+  derived: DeriveResult;
+  drifts: DriftEvent[];
+  /**
+   * Per-initiative diff vs the snapshot's currently-stored derived_*
+   * fields. Empty when nothing would change.
+   */
+  diffs: Array<{
+    initiative_id: string;
+    title: string;
+    before: { derived_start: string | null; derived_end: string | null };
+    after: { derived_start: string | null; derived_end: string | null };
+  }>;
+}
+
+/**
+ * Pure compute step: build the velocity map (computed + overrides) and run
+ * `deriveSchedule`. Shared between `applyDerivation` and `previewDerivation`
+ * so both honour the same precedence rules.
+ *
+ * Precedence: `opts.velocityMap` (if explicitly passed) wins as the base;
+ * otherwise we compute per-owner from history. `opts.velocityOverrides`
+ * are applied last and override either base.
+ */
+function computeDerivedSchedule(
+  snapshot: RoadmapSnapshot,
+  opts: { today?: Date | string; velocityMap?: Map<string, number>; velocityOverrides?: Record<string, number> },
+): { derived: DeriveResult; velocityMap: Map<string, number> } {
+  let velocityMap = opts.velocityMap;
+  if (!velocityMap) {
+    velocityMap = new Map<string, number>();
+    const owners = new Set<string>();
+    for (const i of snapshot.initiatives) {
+      if (i.owner_agent_id) owners.add(i.owner_agent_id);
+    }
+    for (const owner of owners) {
+      velocityMap.set(owner, computeVelocity({ owner_agent_id: owner }));
+    }
+  } else {
+    // Clone so we don't mutate the caller's map when applying overrides.
+    velocityMap = new Map(velocityMap);
+  }
+  if (opts.velocityOverrides) {
+    for (const [owner, ratio] of Object.entries(opts.velocityOverrides)) {
+      velocityMap.set(owner, ratio);
+    }
+  }
+  const derived = deriveSchedule(snapshot, { velocityMap, today: opts.today });
+  return { derived, velocityMap };
+}
+
+/**
+ * What-if derivation: compute the schedule WITHOUT writing anything to the
+ * database. Used by:
+ *
+ *   - The PM agent ("if Sarah is out, what slips?") via the
+ *     `preview_derivation` MCP tool.
+ *   - The /api/roadmap/recompute endpoint (Phase 4 follow-up) when the
+ *     caller passes `?dry=1`.
+ *
+ * Layers `availabilityOverrides` on top of the snapshot's rows and applies
+ * `velocityOverrides` on top of the computed/passed velocity map.
+ *
+ * Returns the full `DeriveResult`, the would-be drift events, and a
+ * before-vs-after diff list for direct UI rendering.
+ */
+export function previewDerivation(
+  snapshot: RoadmapSnapshot,
+  opts: PreviewDerivationOptions = {},
+): PreviewDerivationResult {
+  // Layer availability overrides. We don't mutate the caller's snapshot;
+  // we shallow-clone the array.
+  const extraAvail: RoadmapOwnerAvailability[] = (opts.availabilityOverrides ?? []).map(
+    (a, idx) => ({
+      id: a.id ?? `__preview_${idx}`,
+      agent_id: a.agent_id,
+      unavailable_start: a.unavailable_start,
+      unavailable_end: a.unavailable_end,
+      reason: a.reason ?? null,
+    }),
+  );
+  const previewSnapshot: RoadmapSnapshot = {
+    ...snapshot,
+    owner_availability: [...(snapshot.owner_availability ?? []), ...extraAvail],
+  };
+
+  const { derived } = computeDerivedSchedule(previewSnapshot, {
+    today: opts.today,
+    velocityOverrides: opts.velocityOverrides,
+  });
+
+  const drifts = detectDrift(previewSnapshot, derived);
+
+  const diffs: PreviewDerivationResult['diffs'] = [];
+  for (const i of snapshot.initiatives) {
+    const range = derived.schedule.get(i.id);
+    if (!range) continue;
+    if (range.derived_start !== i.derived_start || range.derived_end !== i.derived_end) {
+      diffs.push({
+        initiative_id: i.id,
+        title: i.title,
+        before: { derived_start: i.derived_start, derived_end: i.derived_end },
+        after: { derived_start: range.derived_start, derived_end: range.derived_end },
+      });
+    }
+  }
+
+  return { derived, drifts, diffs };
 }

--- a/src/lib/roadmap/preview-derivation.test.ts
+++ b/src/lib/roadmap/preview-derivation.test.ts
@@ -1,0 +1,165 @@
+/**
+ * previewDerivation tests (Phase 5).
+ *
+ * Coverage:
+ *   - Returns the same schedule applyDerivation WOULD have written, but
+ *     writes nothing.
+ *   - Velocity overrides apply on top of the computed map.
+ *   - Availability overrides layer on top of the snapshot's existing
+ *     rows.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type {
+  RoadmapDependency,
+  RoadmapInitiative,
+  RoadmapOwnerAvailability,
+  RoadmapSnapshot,
+} from '@/lib/db/roadmap';
+import { previewDerivation } from './apply-derivation';
+import { deriveSchedule } from './derive';
+
+const TODAY = '2026-04-13';
+
+function init(p: Partial<RoadmapInitiative> & { id: string }): RoadmapInitiative {
+  return {
+    id: p.id,
+    parent_initiative_id: p.parent_initiative_id ?? null,
+    product_id: null,
+    kind: p.kind ?? 'story',
+    title: p.title ?? p.id,
+    status: 'planned',
+    owner_agent_id: p.owner_agent_id ?? null,
+    owner_agent_name: null,
+    complexity: p.complexity ?? null,
+    estimated_effort_hours: p.estimated_effort_hours ?? null,
+    target_start: p.target_start ?? null,
+    target_end: p.target_end ?? null,
+    derived_start: p.derived_start ?? null,
+    derived_end: p.derived_end ?? null,
+    committed_end: p.committed_end ?? null,
+    status_check_md: null,
+    sort_order: 0,
+    depth: 0,
+    task_counts: { draft: 0, active: 0, done: 0, total: 0 },
+  };
+}
+
+function snap(opts: {
+  initiatives: RoadmapInitiative[];
+  dependencies?: RoadmapDependency[];
+  owner_availability?: RoadmapOwnerAvailability[];
+}): RoadmapSnapshot {
+  return {
+    initiatives: opts.initiatives,
+    dependencies: opts.dependencies ?? [],
+    tasks: [],
+    owner_availability: opts.owner_availability ?? [],
+    workspace_id: 'test',
+    product_id: null,
+    truncated: false,
+  };
+}
+
+test('previewDerivation matches deriveSchedule output for the same inputs', () => {
+  const s = snap({
+    initiatives: [
+      init({ id: 'A', estimated_effort_hours: 24, owner_agent_id: 'sarah' }),
+      init({ id: 'B', estimated_effort_hours: 12, owner_agent_id: 'sarah' }),
+    ],
+  });
+
+  const direct = deriveSchedule(s, { today: TODAY });
+  const preview = previewDerivation(s, { today: TODAY });
+  for (const i of s.initiatives) {
+    const d = direct.schedule.get(i.id);
+    const p = preview.derived.schedule.get(i.id);
+    assert.deepEqual(p, d, `schedule mismatch for ${i.id}`);
+  }
+});
+
+test('previewDerivation produces a diff list against the snapshot stored derived_*', () => {
+  const s = snap({
+    initiatives: [
+      init({
+        id: 'A',
+        estimated_effort_hours: 24,
+        owner_agent_id: 'sarah',
+        // Pretend a stale stored value.
+        derived_start: '2020-01-01',
+        derived_end: '2020-01-05',
+      }),
+    ],
+  });
+  const result = previewDerivation(s, { today: TODAY });
+  assert.equal(result.diffs.length, 1);
+  assert.equal(result.diffs[0].initiative_id, 'A');
+  assert.notEqual(result.diffs[0].after.derived_start, '2020-01-01');
+});
+
+test('previewDerivation: availabilityOverrides push derived_end later', () => {
+  const s = snap({
+    initiatives: [
+      init({ id: 'A', estimated_effort_hours: 6, owner_agent_id: 'sarah' }), // 1 day
+    ],
+  });
+
+  const before = previewDerivation(s, { today: TODAY });
+  const beforeEnd = before.derived.schedule.get('A')?.derived_end;
+
+  const after = previewDerivation(s, {
+    today: TODAY,
+    availabilityOverrides: [
+      { agent_id: 'sarah', unavailable_start: TODAY, unavailable_end: '2026-04-20', reason: null },
+    ],
+  });
+  const afterEnd = after.derived.schedule.get('A')?.derived_end;
+
+  assert.ok(beforeEnd, 'must have a baseline end');
+  assert.ok(afterEnd, 'preview must produce an end');
+  assert.ok(
+    afterEnd! > beforeEnd!,
+    `availability override should push derived_end later: before=${beforeEnd} after=${afterEnd}`,
+  );
+});
+
+test('previewDerivation: velocityOverrides slow the schedule down', () => {
+  const s = snap({
+    initiatives: [
+      init({ id: 'A', estimated_effort_hours: 12, owner_agent_id: 'sarah' }),
+    ],
+  });
+
+  // 0.5 ratio = 50% velocity = work takes twice as long.
+  const slow = previewDerivation(s, {
+    today: TODAY,
+    velocityOverrides: { sarah: 0.5 },
+  });
+  const fast = previewDerivation(s, {
+    today: TODAY,
+    velocityOverrides: { sarah: 1.0 },
+  });
+
+  const slowEnd = slow.derived.schedule.get('A')?.derived_end;
+  const fastEnd = fast.derived.schedule.get('A')?.derived_end;
+  assert.ok(slowEnd && fastEnd);
+  assert.ok(slowEnd! >= fastEnd!, `slower velocity must finish later: slow=${slowEnd} fast=${fastEnd}`);
+});
+
+test('previewDerivation does NOT mutate the input snapshot', () => {
+  const s = snap({
+    initiatives: [init({ id: 'A', estimated_effort_hours: 6, owner_agent_id: 'sarah' })],
+    owner_availability: [
+      { id: 'orig', agent_id: 'sarah', unavailable_start: '2026-06-01', unavailable_end: '2026-06-02', reason: null },
+    ],
+  });
+  const beforeAvailLen = s.owner_availability.length;
+  previewDerivation(s, {
+    today: TODAY,
+    availabilityOverrides: [
+      { agent_id: 'sarah', unavailable_start: '2026-04-15', unavailable_end: '2026-04-20', reason: null },
+    ],
+  });
+  assert.equal(s.owner_availability.length, beforeAvailLen);
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -851,6 +851,9 @@ export interface AgentChatMessage {
   content: string;
   status: AgentChatMessageStatus;
   session_key?: string;
+  /** JSON-encoded metadata. PM responses use { proposal_id } so the chat UI
+   *  renders a proposal card. */
+  metadata?: string;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

Adds the planning-layer PM agent and the MCP tools that wrap MC's roadmap API for openclaw workers. Operators drop disruptions into `/pm`; the PM produces structured `pm_proposals` rows with markdown impact summaries and a typed diff list. Accept applies the diff transactionally; refine supersedes and re-synthesizes. The MCP surface (`sc-mission-control`) gains 18 new tools covering reads, general writes, and the PM-only `propose_changes` / `refine_proposal` / `preview_derivation`.

## What landed

- **PM agent seed + soul_md** (Migration 045 + `src/lib/agents/pm-soul.md`): one per workspace, idempotent. New workspaces also seeded via `ensurePmAgent` in the `/api/workspaces` POST path.
- **`pm-proposals.ts` helpers**: create / get / list (filters) / accept / reject / refine. All 7 diff kinds from spec §9.3 (`shift_initiative_target`, `add_availability`, `set_initiative_status`, `add_dependency`, `remove_dependency`, `reorder_initiatives`, `update_status_check`). Apply is one transaction. Validation rejects unknown initiative_ids, malformed dates, and PM-forbidden statuses (`done`/`cancelled`) at both create and apply time.
- **PM API endpoints**: `POST/GET /api/pm/proposals`, `GET /api/pm/proposals/[id]`, `POST /accept`, `POST /reject`, `POST /refine`. Refine wires the synthesize step on the new draft slot.
- **PM dispatch path** (`src/lib/agents/pm-dispatch.ts`): **synthesize fallback** chosen for this phase — deterministic parser that extracts owner names, ISO date ranges (or "next week" / "this week"), initiative title matches, and action verbs from the trigger text, then maps to `add_availability` / `shift_initiative_target` / `set_initiative_status` diffs. Posts the impact summary into the PM agent's chat with `metadata.proposal_id`. Real LLM dispatch deferred to Phase 6 (no Anthropic SDK is currently wired into MC; the lifecycle works end-to-end without it).
- **MCP tools** at `src/lib/mcp/roadmap-tools.ts`, registered alongside the core tools in `buildServer`. 18 tools: 9 reads (`list_initiatives`, `get_initiative`, `get_initiative_tree`, `get_roadmap_snapshot`, `get_initiative_history`, `get_task_initiative_history`, `list_owner_availability`, `get_velocity_data`, `list_proposals`), 6 general writes (`create_initiative`, `update_initiative`, `move_initiative`, `convert_initiative`, `add_initiative_dependency`, `remove_initiative_dependency`, `move_task_to_initiative`, `promote_initiative_to_task`, `promote_task_to_inbox`, `add_owner_availability`), and 3 PM-specific (`propose_changes`, `refine_proposal`, `preview_derivation`). Persona constraints live in the PM's soul_md (spec §9.4: PM is a suggester, never an actor).
- **`/pm` chat UI** (`src/app/pm/page.tsx`): workspace selector, chat thread, proposal-card renderer with Refine / Accept / Reject buttons, recent-proposals sidebar.
- **`previewDerivation`** in `src/lib/roadmap/apply-derivation.ts`: read-only what-if with `velocityOverrides` + `availabilityOverrides` (satisfies Phase 4's flagged follow-up). `applyDerivation` was refactored to share `computeDerivedSchedule`, no behavior change.
- **`agent_chat_messages.metadata`** column added (Migration 045) so PM responses can attach `{ proposal_id }` for the card renderer.

## Tests (33 new, all passing under `--test-concurrency=1`)

- `pm-proposals.test.ts` (18): create / list / each of 7 diff kinds applies correctly / validation rejects bad refs WITHOUT partial writes / refine creates child + supersedes parent / reject idempotent / re-accept idempotent / `pm_proposal_accepted` event emitted.
- `preview-derivation.test.ts` (5): matches `deriveSchedule` / diff list vs stored / availability + velocity overrides layer correctly / no input mutation.
- `pm.test.ts` (8): synthesize handles empty trigger / "Sarah out next week" → `add_availability` / never hallucinates initiative_ids / parses ISO ranges / "delayed until <date>" → `shift_initiative_target` / `dispatchPm` posts metadata-tagged chat.
- `pm-e2e.test.ts` (3): full lifecycle dispatch → accept → diff applied + event row + idempotent re-accept / PM seed idempotency / `done`/`cancelled` diffs never reach the DB.

Phase 1–4 tests still pass (roadmap suite 157/157, MCP suite 15/15, plus 124/124 across authz / autopilot / mailbox / services / task-governance / internal-dispatch).

## Stacked PR series

This is **Phase 5 of 6**, stacked on Phases 4 → 3 → 2 → 1. See `specs/roadmap-and-pm-spec.md` §14.

**Merge order discipline (project memory):** descendants must be retargeted before parents merge with `--delete-branch`.

## Test plan

- [ ] Run `node --test --test-concurrency=1 --import tsx src/lib/db/pm-proposals.test.ts src/lib/roadmap/preview-derivation.test.ts src/lib/agents/pm.test.ts src/lib/agents/pm-e2e.test.ts` (33/33 pass)
- [ ] Manual: visit `/pm`, drop "Sarah out next week", verify a draft proposal card appears with availability diff
- [ ] Manual: click Accept, verify the affected initiatives show in `/roadmap` with new derived dates after the next drift scan
- [ ] Manual: click Refine on a draft, type "don't slip launch", verify a new child proposal supersedes the parent
- [ ] MCP: through `sc-mission-control`, call `preview_derivation({ workspace_id, availability_overrides: [...] })` and verify a non-empty `diffs` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>