### PR TITLE
Phase 6: PM agent (proactive) — standup + drift scan

### DIFF
--- a/specs/roadmap-and-pm-spec.md
+++ b/specs/roadmap-and-pm-spec.md
@@ -675,6 +675,29 @@ Each phase is a separate PR, demoable.
 
 **Done means:** without prompting, PM posts a daily card if anything's drifting.
 
+**Phase 6 implementation notes (post-merge):**
+
+- Standup synthesis lives in `src/lib/agents/pm-standup.ts` (`generateStandup`).
+  Deterministic — given the same snapshot + `today` anchor, the same diff list comes out.
+- Idempotency uses the `(YYYY-MM-DD)` stamp embedded in `trigger_text` (not
+  `created_at`) so a re-run with the same logical day correctly returns the
+  existing draft. The `force=true` flag bypasses this for "Run standup now".
+- Drift signals: milestone_at_risk, slippage (>3d), stale_blocked (≥3d idle),
+  stale_in_progress (≥7d idle), cycle_detected. Cycle members never receive
+  date-shift diffs.
+- Schedule seeding chosen: **Option A** — migration `046_seed_roadmap_drift_scan_schedules`
+  inserts a per-workspace cron (`0 9 * * 1-5` MT) on the workspace's oldest
+  active product. Workspaces without a product are skipped — operators can
+  trigger via `POST /api/pm/standup` instead.
+- Two new event types: `pm_standup_generated` (with proposal_id) and
+  `pm_standup_skipped` (silent runs). Both surface in `LiveFeed` with deep
+  links into `/pm?proposal=…` (standup) or `/roadmap` (drift scan).
+- `/pm` page additions: pinned-standup banner, "Run standup" toolbar
+  button, `?proposal=<id>` deep-link auto-scroll + highlight, trigger_kind
+  badge on every proposal card.
+- The PM still never auto-applies — every standup proposal is `draft`
+  awaiting operator accept.
+
 ---
 
 ## 15. Out of Scope (v1)

--- a/src/app/api/pm/standup/route.test.ts
+++ b/src/app/api/pm/standup/route.test.ts
@@ -1,0 +1,129 @@
+/**
+ * POST /api/pm/standup route test (Phase 6).
+ *
+ * Calls the route handler directly with a constructed NextRequest. Avoids
+ * spinning up Next.js — the route is a thin wrapper over generateStandup,
+ * so unit-testing the wrapper itself is enough.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { run } from '@/lib/db';
+import { ensurePmAgent } from '@/lib/bootstrap-agents';
+import { createInitiative } from '@/lib/db/initiatives';
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  ensurePmAgent(id);
+  return id;
+}
+
+function postJson(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/pm/standup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+test('POST /api/pm/standup: missing workspace_id → 400', async () => {
+  const res = await POST(postJson({}));
+  assert.equal(res.status, 400);
+  const data = await res.json();
+  assert.ok(data.error);
+});
+
+test('POST /api/pm/standup: no drift → returns skipped: true', async () => {
+  const ws = freshWorkspace();
+  // Healthy workspace — pre-emptive milestone with no slip.
+  createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Future milestone',
+    committed_end: '2027-12-31',
+  });
+
+  const res = await POST(postJson({ workspace_id: ws, derive_first: false }));
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.equal(data.skipped, true);
+  assert.equal(data.proposal, null);
+  assert.equal(data.reason, 'no_drift');
+});
+
+test('POST /api/pm/standup: drift present → 201 with proposal', async () => {
+  const ws = freshWorkspace();
+  const owner = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, created_at, updated_at)
+     VALUES (?, 'Owen', 'worker', ?, 1, datetime('now'), datetime('now'))`,
+    [owner, ws],
+  );
+  const m = createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Past commit',
+    committed_end: '2024-01-01',
+    owner_agent_id: owner,
+  });
+  createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Heavy work',
+    parent_initiative_id: m.id,
+    owner_agent_id: owner,
+    estimated_effort_hours: 100,
+    target_start: '2024-01-01',
+  });
+
+  const res = await POST(postJson({ workspace_id: ws, derive_first: false }));
+  assert.equal(res.status, 201);
+  const data = await res.json();
+  assert.ok(data.proposal);
+  assert.equal(data.proposal.status, 'draft');
+  assert.equal(data.proposal.trigger_kind, 'scheduled_drift_scan');
+  assert.ok(data.drift_count > 0);
+});
+
+test('POST /api/pm/standup: force=true bypasses idempotency', async () => {
+  const ws = freshWorkspace();
+  const owner = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, created_at, updated_at)
+     VALUES (?, 'P', 'worker', ?, 1, datetime('now'), datetime('now'))`,
+    [owner, ws],
+  );
+  const m = createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Past commit',
+    committed_end: '2024-01-01',
+    owner_agent_id: owner,
+  });
+  createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Heavy work',
+    parent_initiative_id: m.id,
+    owner_agent_id: owner,
+    estimated_effort_hours: 100,
+    target_start: '2024-01-01',
+  });
+
+  const r1 = await (await POST(postJson({ workspace_id: ws, derive_first: false }))).json();
+  // Second WITHOUT force should return the same proposal (already_today).
+  const r2 = await (await POST(postJson({ workspace_id: ws, derive_first: false }))).json();
+  assert.equal(r2.skipped, true);
+  assert.equal(r2.reason, 'already_today');
+  // Third WITH force creates a new one.
+  const r3 = await (await POST(postJson({ workspace_id: ws, derive_first: false, force: true }))).json();
+  assert.ok(r3.proposal);
+  assert.notEqual(r3.proposal.id, r1.proposal.id);
+});

--- a/src/app/api/pm/standup/route.ts
+++ b/src/app/api/pm/standup/route.ts
@@ -1,0 +1,100 @@
+/**
+ * POST /api/pm/standup
+ *
+ *   body { workspace_id, force?: boolean }
+ *
+ * Manually triggers the proactive PM standup synthesizer (Phase 6).
+ *
+ * Behaviour mirrors the schedule path:
+ *   - 200 with `{ proposal, used_synthesize_fallback: true }` when a new
+ *     draft proposal was created.
+ *   - 200 with `{ proposal: null, skipped: true, reason: 'no_drift' | 'already_today' }`
+ *     when nothing was created.
+ *
+ * `force=true` bypasses the once-per-day idempotency check, which is the
+ * "Run standup now" UI button's behaviour — the operator explicitly asked.
+ *
+ * Use cases:
+ *   - Operator clicks "Run standup now" in /pm.
+ *   - Demos / scripts that want the standup card on demand.
+ *   - Recovery from a missed cron tick.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { generateStandup } from '@/lib/agents/pm-standup';
+import { applyDerivation } from '@/lib/roadmap/apply-derivation';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  workspace_id: z.string().min(1),
+  force: z.boolean().optional(),
+  /**
+   * When true, also run `applyDerivation` first so derived_* columns reflect
+   * the latest velocity / availability data. Defaults to true — the manual
+   * caller almost always wants the freshest possible read. Tests pass false
+   * to skip the derivation pass.
+   */
+  derive_first: z.boolean().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  try {
+    if (parsed.data.derive_first !== false) {
+      try {
+        applyDerivation(parsed.data.workspace_id);
+      } catch (err) {
+        // Don't fail the standup just because derivation hit a snag — the
+        // standup synthesizer also recomputes a preview internally and
+        // will degrade gracefully.
+        console.warn(
+          '[POST /api/pm/standup] applyDerivation failed (continuing):',
+          (err as Error).message,
+        );
+      }
+    }
+    const result = generateStandup({
+      workspace_id: parsed.data.workspace_id,
+      force: parsed.data.force,
+    });
+    // generateStandup returns a proposal AND a non-null skipped_reason when
+    // the lookup hits an existing draft (already_today). Treat that as
+    // "skipped" from the route's perspective so the operator's UI can tell
+    // the difference between "I just made you a card" vs "already done".
+    if (result.proposal && result.skipped_reason == null) {
+      return NextResponse.json(
+        {
+          proposal: result.proposal,
+          used_synthesize_fallback: true,
+          drift_count: result.drift_count,
+        },
+        { status: 201 },
+      );
+    }
+    return NextResponse.json({
+      proposal: result.proposal,
+      skipped: true,
+      reason: result.skipped_reason,
+      drift_count: result.drift_count,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to generate standup';
+    console.error('Failed to generate PM standup:', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/pm/page.tsx
+++ b/src/app/pm/page.tsx
@@ -13,7 +13,8 @@
 
 import { useEffect, useState, useCallback, useMemo, useRef, Suspense } from 'react';
 import Link from 'next/link';
-import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox } from 'lucide-react';
+import { useSearchParams } from 'next/navigation';
+import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox, Sunrise, Pin } from 'lucide-react';
 
 interface Workspace {
   id: string;
@@ -77,6 +78,25 @@ const STATUS_BADGE: Record<PmProposal['status'], string> = {
   superseded: 'bg-zinc-500/20 text-zinc-300',
 };
 
+// Trigger-kind badge palette. Distinct colors so the operator can tell at a
+// glance whether a card was operator-initiated (manual), scheduled (drift),
+// or a disruption response.
+const TRIGGER_BADGE: Record<string, { label: string; cls: string }> = {
+  manual: { label: 'manual', cls: 'bg-blue-500/15 text-blue-300 border-blue-500/30' },
+  scheduled_drift_scan: {
+    label: 'scheduled',
+    cls: 'bg-violet-500/15 text-violet-300 border-violet-500/30',
+  },
+  disruption_event: {
+    label: 'disruption',
+    cls: 'bg-orange-500/15 text-orange-300 border-orange-500/30',
+  },
+  status_check_investigation: {
+    label: 'status check',
+    cls: 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30',
+  },
+};
+
 export default function PmChatPage() {
   // useSearchParams() requires a Suspense boundary during static prerender
   // (Next 16). The actual page contents live in PmChatPageInner below.
@@ -99,7 +119,17 @@ function PmChatPageInner() {
   const [error, setError] = useState<string | null>(null);
   const [refining, setRefining] = useState<string | null>(null);
   const [refineText, setRefineText] = useState('');
+  const [runningStandup, setRunningStandup] = useState(false);
+  const [standupBanner, setStandupBanner] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const cardRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+
+  // Phase 6: support `?proposal=<id>` deep-links — scroll to and highlight
+  // the matching proposal card on load. Cleared after first successful
+  // scroll so subsequent re-renders don't keep re-scrolling.
+  const searchParams = useSearchParams();
+  const focusProposalId = searchParams?.get('proposal') ?? null;
+  const [highlightedProposalId, setHighlightedProposalId] = useState<string | null>(null);
 
   // Load workspace list once.
   useEffect(() => {
@@ -267,10 +297,71 @@ function PmChatPageInner() {
     }
   };
 
+  const handleRunStandup = useCallback(async () => {
+    if (runningStandup) return;
+    setRunningStandup(true);
+    setStandupBanner(null);
+    setError(null);
+    try {
+      const res = await fetch('/api/pm/standup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ workspace_id: workspaceId, force: true }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? 'Standup failed');
+      if (data.proposal) {
+        setStandupBanner(
+          `Standup posted — ${data.drift_count ?? 0} drift signal${data.drift_count === 1 ? '' : 's'}.`,
+        );
+      } else {
+        setStandupBanner(
+          `Standup ran — nothing to surface (${data.reason ?? 'no_drift'}).`,
+        );
+      }
+      await loadMessages();
+      await loadRecent();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setRunningStandup(false);
+    }
+  }, [runningStandup, workspaceId, loadMessages, loadRecent]);
+
+  // Deep-link scroll: once the proposal card is rendered, scroll it into
+  // view and apply a transient highlight class. We watch `proposals` so the
+  // effect waits for the underlying fetches in `loadMessages` to populate.
+  useEffect(() => {
+    if (!focusProposalId) return;
+    if (!proposals[focusProposalId]) return;
+    const el = cardRefs.current.get(focusProposalId);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      setHighlightedProposalId(focusProposalId);
+      // Auto-dim the highlight after 4s.
+      const timer = setTimeout(() => setHighlightedProposalId(null), 4000);
+      return () => clearTimeout(timer);
+    }
+  }, [focusProposalId, proposals]);
+
   const proposalCount = useMemo(() => {
     const draft = recentProposals.filter(p => p.status === 'draft').length;
     return { draft, total: recentProposals.length };
   }, [recentProposals]);
+
+  // Latest still-draft standup proposal for the current workspace, if any.
+  // Used to render the pinned banner at the top of the chat thread.
+  const pinnedStandup = useMemo<PmProposal | null>(() => {
+    const standups = recentProposals.filter(
+      p =>
+        p.workspace_id === workspaceId &&
+        p.status === 'draft' &&
+        p.trigger_kind === 'scheduled_drift_scan',
+    );
+    if (standups.length === 0) return null;
+    // Newest first.
+    return standups.sort((a, b) => b.created_at.localeCompare(a.created_at))[0];
+  }, [recentProposals, workspaceId]);
 
   return (
     <div className="flex flex-col h-screen bg-mc-bg text-mc-text">
@@ -292,6 +383,16 @@ function PmChatPageInner() {
         <div className="ml-auto text-xs text-mc-text-secondary">
           {proposalCount.draft} draft · {proposalCount.total} total
         </div>
+        <button
+          type="button"
+          onClick={handleRunStandup}
+          disabled={!pmAgent || runningStandup}
+          title="Run today's PM standup now (proactive drift scan)"
+          className="flex items-center gap-1.5 text-xs px-2.5 py-1 border border-mc-border rounded-sm hover:bg-mc-bg/50 disabled:opacity-50"
+        >
+          {runningStandup ? <Loader className="w-3 h-3 animate-spin" /> : <Sunrise className="w-3 h-3" />}
+          Run standup
+        </button>
         <Link href="/roadmap" className="text-xs text-mc-accent hover:underline">
           View roadmap →
         </Link>
@@ -305,6 +406,28 @@ function PmChatPageInner() {
               <AlertTriangle className="w-4 h-4" /> {error}
             </div>
           )}
+          {standupBanner && (
+            <div className="m-3 px-3 py-2 bg-violet-500/10 border border-violet-500/30 text-violet-200 text-sm rounded-sm flex items-center gap-2">
+              <Sunrise className="w-4 h-4" /> {standupBanner}
+              <button
+                type="button"
+                onClick={() => setStandupBanner(null)}
+                className="ml-auto text-violet-300/70 hover:text-violet-200"
+                aria-label="Dismiss"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </div>
+          )}
+          {pinnedStandup && (
+            <PinnedStandupCard
+              proposal={pinnedStandup}
+              onAccept={onAccept}
+              onReject={onReject}
+              setRef={(el) => cardRefs.current.set(pinnedStandup.id, el)}
+              highlighted={highlightedProposalId === pinnedStandup.id}
+            />
+          )}
           <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-3">
             {messages.length === 0 && pmAgent && (
               <div className="text-center py-12 text-mc-text-secondary">
@@ -316,21 +439,32 @@ function PmChatPageInner() {
               </div>
             )}
 
-            {messages.map(m => (
-              <ChatMessageRow
-                key={m.id}
-                message={m}
-                proposal={parseProposalId(m) ? proposals[parseProposalId(m)!] : undefined}
-                onAccept={onAccept}
-                onReject={onReject}
-                refining={refining}
-                refineText={refineText}
-                onRefineStart={(id) => { setRefining(id); setRefineText(''); }}
-                onRefineCancel={() => { setRefining(null); setRefineText(''); }}
-                onRefineSubmit={onRefineSubmit}
-                onRefineTextChange={setRefineText}
-              />
-            ))}
+            {messages.map(m => {
+              const pid = parseProposalId(m);
+              const proposal = pid ? proposals[pid] : undefined;
+              // Suppress duplicate render of the pinned standup card here —
+              // it's already rendered above the thread.
+              if (proposal && pinnedStandup && proposal.id === pinnedStandup.id) {
+                return null;
+              }
+              return (
+                <ChatMessageRow
+                  key={m.id}
+                  message={m}
+                  proposal={proposal}
+                  onAccept={onAccept}
+                  onReject={onReject}
+                  refining={refining}
+                  refineText={refineText}
+                  onRefineStart={(id) => { setRefining(id); setRefineText(''); }}
+                  onRefineCancel={() => { setRefining(null); setRefineText(''); }}
+                  onRefineSubmit={onRefineSubmit}
+                  onRefineTextChange={setRefineText}
+                  setCardRef={(id, el) => cardRefs.current.set(id, el)}
+                  highlighted={proposal ? highlightedProposalId === proposal.id : false}
+                />
+              );
+            })}
           </div>
 
           <div className="border-t border-mc-border p-3 space-y-2 shrink-0">
@@ -422,6 +556,10 @@ interface ChatMessageRowProps {
   onRefineCancel: () => void;
   onRefineSubmit: (id: string) => void;
   onRefineTextChange: (s: string) => void;
+  /** Phase 6: register the card's DOM element so the page can scroll to it. */
+  setCardRef?: (id: string, el: HTMLDivElement | null) => void;
+  /** Phase 6: visual highlight after a deep-link scroll. */
+  highlighted?: boolean;
 }
 
 function ChatMessageRow({
@@ -435,6 +573,8 @@ function ChatMessageRow({
   onRefineCancel,
   onRefineSubmit,
   onRefineTextChange,
+  setCardRef,
+  highlighted,
 }: ChatMessageRowProps) {
   const isUser = message.role === 'user';
 
@@ -457,13 +597,25 @@ function ChatMessageRow({
   }
 
   // Proposal card
+  const trigger = TRIGGER_BADGE[proposal.trigger_kind] ?? TRIGGER_BADGE.manual;
   return (
     <div className="mr-12">
-      <div className="border border-amber-500/40 bg-amber-500/5 rounded-md overflow-hidden">
+      <div
+        ref={(el) => setCardRef?.(proposal.id, el)}
+        className={`border border-amber-500/40 bg-amber-500/5 rounded-md overflow-hidden transition-shadow ${
+          highlighted ? 'ring-2 ring-mc-accent shadow-lg shadow-mc-accent/20' : ''
+        }`}
+      >
         <div className="px-3 py-2 bg-amber-500/10 border-b border-amber-500/30 flex items-center gap-2">
           <AlertTriangle className="w-4 h-4 text-amber-300" />
           <span className="text-sm font-semibold text-amber-200">
             Proposal — {proposal.proposed_changes.length} change{proposal.proposed_changes.length === 1 ? '' : 's'}
+          </span>
+          <span
+            className={`px-1.5 py-0.5 text-[10px] rounded-sm border uppercase tracking-wide ${trigger.cls}`}
+            title={`trigger_kind: ${proposal.trigger_kind}`}
+          >
+            {trigger.label}
           </span>
           <span className={`ml-auto px-2 py-0.5 text-xs rounded-sm ${STATUS_BADGE[proposal.status]}`}>
             {proposal.status}
@@ -567,4 +719,92 @@ function summarizeDiff(c: PmDiff): string {
 function shortId(id: string | null | undefined): string {
   if (!id) return '∅';
   return id.slice(0, 8);
+}
+
+interface PinnedStandupCardProps {
+  proposal: PmProposal;
+  onAccept: (id: string) => void;
+  onReject: (id: string) => void;
+  setRef: (el: HTMLDivElement | null) => void;
+  highlighted: boolean;
+}
+
+/**
+ * Pinned banner above the chat thread for the current workspace's most-
+ * recent draft standup. Visually distinct from the inline proposal cards
+ * (violet accent + pin icon) so the operator can tell at a glance "this is
+ * today's PM-initiated card, not something I asked for".
+ *
+ * Renders accept/reject inline. Clicking the title scrolls into view (no
+ * change of route) — refining is intentionally NOT exposed here; the
+ * operator can refine via the inline card lower in the thread, or accept
+ * the standup as-is. Keeps the banner uncluttered.
+ */
+function PinnedStandupCard({
+  proposal,
+  onAccept,
+  onReject,
+  setRef,
+  highlighted,
+}: PinnedStandupCardProps) {
+  const created = new Date(
+    proposal.created_at.endsWith('Z') ? proposal.created_at : proposal.created_at + 'Z',
+  ).toLocaleString();
+  return (
+    <div
+      ref={setRef}
+      className={`m-3 border-l-4 border-violet-500 bg-violet-500/10 rounded-sm overflow-hidden transition-shadow ${
+        highlighted ? 'ring-2 ring-mc-accent shadow-lg shadow-mc-accent/20' : ''
+      }`}
+    >
+      <div className="px-3 py-2 flex items-center gap-2 border-b border-violet-500/30">
+        <Pin className="w-4 h-4 text-violet-300" />
+        <span className="text-sm font-semibold text-violet-200">
+          Latest standup — {proposal.proposed_changes.length} change
+          {proposal.proposed_changes.length === 1 ? '' : 's'}
+        </span>
+        <span
+          className="px-1.5 py-0.5 text-[10px] rounded-sm border bg-violet-500/15 text-violet-300 border-violet-500/30 uppercase tracking-wide"
+          title="trigger_kind: scheduled_drift_scan"
+        >
+          scheduled
+        </span>
+        <span className="ml-auto text-[11px] text-mc-text-secondary/80">{created}</span>
+      </div>
+      <div className="p-3 text-sm whitespace-pre-wrap">{proposal.impact_md}</div>
+      {proposal.proposed_changes.length > 0 && (
+        <div className="px-3 pb-3 space-y-1 text-xs text-mc-text-secondary">
+          {proposal.proposed_changes.slice(0, 6).map((c, idx) => (
+            <div key={idx} className="font-mono">
+              · {summarizeDiff(c)}
+            </div>
+          ))}
+          {proposal.proposed_changes.length > 6 && (
+            <div className="font-mono">
+              …and {proposal.proposed_changes.length - 6} more
+            </div>
+          )}
+        </div>
+      )}
+      <div className="px-3 py-2 border-t border-violet-500/30 bg-violet-500/5 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onAccept(proposal.id)}
+          className="text-xs px-2 py-1 bg-emerald-500/20 border border-emerald-500/40 text-emerald-200 rounded-sm hover:bg-emerald-500/30 flex items-center gap-1"
+        >
+          <Check className="w-3 h-3" /> Accept
+        </button>
+        <button
+          type="button"
+          onClick={() => onReject(proposal.id)}
+          className="text-xs px-2 py-1 bg-red-500/20 border border-red-500/40 text-red-200 rounded-sm hover:bg-red-500/30 flex items-center gap-1"
+        >
+          <X className="w-3 h-3" /> Reject
+        </button>
+        <span className="ml-auto text-[10px] text-mc-text-secondary/80">
+          See thread below to refine.
+        </span>
+      </div>
+    </div>
+  );
 }

--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { ChevronUp, ChevronDown, Clock, PanelRightClose, PanelRightOpen } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import type { Event } from '@/lib/types';
@@ -143,6 +144,15 @@ function EventItem({ event }: { event: Event }) {
         return '📦';
       case 'task_unarchived':
         return '📤';
+      // Phase 4 / 6: roadmap + PM-agent events.
+      case 'roadmap_drift_scan':
+        return '📐';
+      case 'pm_standup_generated':
+        return '🌅';
+      case 'pm_standup_skipped':
+        return '🤐';
+      case 'pm_proposal_accepted':
+        return '📋';
       default:
         return '📌';
     }
@@ -151,22 +161,96 @@ function EventItem({ event }: { event: Event }) {
   const isTaskEvent = ['task_created', 'task_assigned', 'task_completed'].includes(event.type);
   const isHighlight = event.type === 'task_created' || event.type === 'task_completed';
 
-  return (
-    <div
-      className={`p-2 rounded border-l-2 animate-slide-in ${
-        isHighlight ? 'bg-mc-bg-tertiary border-mc-accent-pink' : 'bg-transparent border-transparent hover:bg-mc-bg-tertiary'
-      }`}
-    >
-      <div className="flex items-start gap-2">
-        <span className="text-sm">{getEventIcon(event.type)}</span>
-        <div className="flex-1 min-w-0">
-          <p className={`text-sm ${isTaskEvent ? 'text-mc-accent-pink' : 'text-mc-text'}`}>{event.message}</p>
-          <div className="flex items-center gap-1 mt-1 text-xs text-mc-text-secondary">
-            <Clock className="w-3 h-3" />
-            {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
-          </div>
+  // Phase 6: deep-link the planning-layer events. Drift scans link to the
+  // roadmap; standup events link to the proposal in /pm. Skipped runs are
+  // informational only — no link.
+  const planningLink = computePlanningLink(event);
+  const inner = (
+    <div className="flex items-start gap-2">
+      <span className="text-sm">{getEventIcon(event.type)}</span>
+      <div className="flex-1 min-w-0">
+        <p className={`text-sm ${isTaskEvent ? 'text-mc-accent-pink' : 'text-mc-text'}`}>
+          {summarizePlanningEvent(event) ?? event.message}
+        </p>
+        <div className="flex items-center gap-1 mt-1 text-xs text-mc-text-secondary">
+          <Clock className="w-3 h-3" />
+          {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
         </div>
       </div>
     </div>
   );
+
+  const wrapperClass = `p-2 rounded border-l-2 animate-slide-in ${
+    isHighlight ? 'bg-mc-bg-tertiary border-mc-accent-pink' : 'bg-transparent border-transparent hover:bg-mc-bg-tertiary'
+  }`;
+
+  if (planningLink) {
+    return (
+      <Link href={planningLink} className={`block ${wrapperClass} hover:underline`}>
+        {inner}
+      </Link>
+    );
+  }
+  return <div className={wrapperClass}>{inner}</div>;
+}
+
+interface PlanningEventMetadata {
+  workspace_id?: string;
+  initiatives_updated?: number;
+  status_flips?: number;
+  drifts?: unknown[];
+  drift_count?: number;
+  proposal_id?: string;
+  date?: string;
+  change_kinds?: string[];
+}
+
+function parseMeta(event: Event): PlanningEventMetadata {
+  if (!event.metadata) return {};
+  try {
+    return JSON.parse(event.metadata) as PlanningEventMetadata;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Where clicking a planning-layer event should take the operator. Roadmap
+ * for drift scans, /pm with a proposal deep-link for standups.
+ */
+function computePlanningLink(event: Event): string | null {
+  const meta = parseMeta(event);
+  if (event.type === 'roadmap_drift_scan') {
+    const ws = meta.workspace_id ? `?workspace=${encodeURIComponent(meta.workspace_id)}` : '';
+    return `/roadmap${ws}`;
+  }
+  if (event.type === 'pm_standup_generated' && meta.proposal_id) {
+    return `/pm?proposal=${encodeURIComponent(meta.proposal_id)}`;
+  }
+  if (event.type === 'pm_proposal_accepted' && meta.proposal_id) {
+    return `/pm?proposal=${encodeURIComponent(meta.proposal_id)}`;
+  }
+  return null;
+}
+
+/**
+ * Override the bare DB message with a more useful summary string when the
+ * metadata gives us extra signal. Returns null to fall back to event.message.
+ */
+function summarizePlanningEvent(event: Event): string | null {
+  if (event.type === 'roadmap_drift_scan') {
+    const meta = parseMeta(event);
+    const updated = meta.initiatives_updated ?? 0;
+    const drifts = Array.isArray(meta.drifts) ? meta.drifts.length : meta.drift_count ?? 0;
+    return `Roadmap recomputed — ${updated} initiative${updated === 1 ? '' : 's'} updated, ${drifts} drift${drifts === 1 ? '' : 's'} detected`;
+  }
+  if (event.type === 'pm_standup_generated') {
+    const meta = parseMeta(event);
+    const kinds = meta.change_kinds?.length ?? 0;
+    return `PM standup posted: ${kinds} change${kinds === 1 ? '' : 's'} proposed`;
+  }
+  if (event.type === 'pm_standup_skipped') {
+    return 'PM standup ran — nothing drifting today';
+  }
+  return null;
 }

--- a/src/lib/agents/pm-standup.test.ts
+++ b/src/lib/agents/pm-standup.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Proactive PM standup tests (Phase 6).
+ *
+ * Coverage:
+ *   1. No drift → returns null, emits pm_standup_skipped, no proposal.
+ *   2. Milestone slipping → proposal with set_initiative_status + shift_initiative_target.
+ *   3. Cycle detected → flagged in impact_md without shift diffs for cycle members.
+ *   4. Stale in-progress task → update_status_check suggestion.
+ *   5. Idempotent within 24h → second call returns the existing proposal.
+ *   6. End-to-end via schedule trigger → applyDerivation runs, then standup runs.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run, getDb } from '@/lib/db';
+import { createInitiative, addInitiativeDependency } from '@/lib/db/initiatives';
+import { listProposals } from '@/lib/db/pm-proposals';
+import { ensurePmAgent } from '@/lib/bootstrap-agents';
+import { generateStandup } from './pm-standup';
+import { applyDerivation } from '@/lib/roadmap/apply-derivation';
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  ensurePmAgent(id);
+  return id;
+}
+
+function seedAgent(workspace: string, name: string): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, created_at, updated_at)
+     VALUES (?, ?, 'worker', ?, 1, datetime('now'), datetime('now'))`,
+    [id, name, workspace],
+  );
+  return id;
+}
+
+// ─── Test 1: no drift → skipped event, no proposal ─────────────────
+
+test('generateStandup: no drift → returns null + emits pm_standup_skipped', () => {
+  const ws = freshWorkspace();
+  // Healthy workspace: a milestone with committed_end well in the future,
+  // no slipping initiatives, no blocked items.
+  createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Q3 launch',
+    committed_end: '2027-01-01',
+    target_end: '2027-01-01',
+  });
+
+  const before = queryAll(
+    `SELECT id FROM events WHERE type IN ('pm_standup_generated','pm_standup_skipped')`,
+  ).length;
+
+  const result = generateStandup({ workspace_id: ws, today: '2026-04-24' });
+  assert.equal(result.proposal, null);
+  assert.equal(result.skipped_reason, 'no_drift');
+
+  const after = queryAll<{ id: string; type: string }>(
+    `SELECT id, type FROM events WHERE type IN ('pm_standup_generated','pm_standup_skipped') ORDER BY created_at DESC`,
+  );
+  assert.equal(after.length - before, 1);
+  assert.equal(after[0].type, 'pm_standup_skipped');
+
+  // No proposal created.
+  const props = listProposals({ workspace_id: ws });
+  assert.equal(props.length, 0);
+});
+
+// ─── Test 2: milestone slipping → proposal with shift + at_risk ────
+
+test('generateStandup: milestone slipping past committed_end → proposal created', () => {
+  const ws = freshWorkspace();
+  const owner = seedAgent(ws, 'Sarah');
+
+  // Milestone committed_end is in the past — it's already late.
+  const milestone = createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Customer demo',
+    committed_end: '2026-04-10',
+    target_end: '2026-04-10',
+    owner_agent_id: owner,
+  });
+  // Epic under it with explicit effort — drives derived_end past committed_end.
+  createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Build big feature',
+    parent_initiative_id: milestone.id,
+    owner_agent_id: owner,
+    estimated_effort_hours: 200,
+    target_start: '2026-04-15',
+  });
+
+  const result = generateStandup({ workspace_id: ws, today: '2026-04-24' });
+  assert.ok(result.proposal, 'expected a proposal');
+  const p = result.proposal!;
+  assert.equal(p.trigger_kind, 'scheduled_drift_scan');
+  assert.equal(p.status, 'draft');
+  assert.match(p.trigger_text, /Daily roadmap standup/);
+
+  // The diff list should include set_initiative_status=at_risk on the
+  // milestone and a shift_initiative_target on the same.
+  const setStatuses = p.proposed_changes.filter(
+    c => c.kind === 'set_initiative_status' && c.initiative_id === milestone.id,
+  );
+  assert.equal(setStatuses.length, 1);
+  assert.equal((setStatuses[0] as { status: string }).status, 'at_risk');
+
+  const shifts = p.proposed_changes.filter(
+    c => c.kind === 'shift_initiative_target' && c.initiative_id === milestone.id,
+  );
+  assert.equal(shifts.length, 1);
+
+  // Event row was emitted.
+  const ev = queryAll<{ id: string }>(
+    `SELECT id FROM events WHERE type = 'pm_standup_generated'`,
+  );
+  assert.ok(ev.length >= 1);
+});
+
+// ─── Test 3: cycle detected → flagged in md, no shifts for members ─
+
+test('generateStandup: cycle detected → flagged in impact_md without shift diffs for members', () => {
+  const ws = freshWorkspace();
+  const owner = seedAgent(ws, 'Alex');
+
+  const a = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Alpha',
+    owner_agent_id: owner,
+    estimated_effort_hours: 8,
+    target_end: '2026-04-30',
+  });
+  const b = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Bravo',
+    owner_agent_id: owner,
+    estimated_effort_hours: 8,
+    target_end: '2026-04-30',
+  });
+  // A→B and B→A is a cycle.
+  addInitiativeDependency({ initiative_id: a.id, depends_on_initiative_id: b.id });
+  addInitiativeDependency({ initiative_id: b.id, depends_on_initiative_id: a.id });
+
+  const result = generateStandup({ workspace_id: ws, today: '2026-04-24' });
+  // A cycle counts as drift, so a proposal IS created (impact_md flags it).
+  assert.ok(result.proposal, 'cycle should still produce a proposal');
+  const p = result.proposal!;
+
+  // impact_md mentions the cycle.
+  assert.match(p.impact_md, /cycle/i);
+
+  // No shift_initiative_target diffs reference the cycle members (engine
+  // makes their derived_* NULL inside the cycle).
+  for (const c of p.proposed_changes) {
+    if (c.kind === 'shift_initiative_target') {
+      assert.notEqual(c.initiative_id, a.id);
+      assert.notEqual(c.initiative_id, b.id);
+    }
+  }
+});
+
+// ─── Test 4: stale in-progress task → update_status_check ──────────
+
+test('generateStandup: stale in-progress initiative → update_status_check suggestion', () => {
+  const ws = freshWorkspace();
+  const owner = seedAgent(ws, 'Dana');
+
+  // 14 days ago — past the STALE_TASK_DAYS=7 threshold.
+  const fourteenDaysAgo = new Date(Date.UTC(2026, 3, 10)).toISOString(); // 2026-04-10
+  const initiativeId = uuidv4();
+  run(
+    `INSERT INTO initiatives (id, workspace_id, kind, title, status, owner_agent_id, created_at, updated_at)
+     VALUES (?, ?, 'epic', 'Stuck thing', 'in_progress', ?, ?, ?)`,
+    [initiativeId, ws, owner, fourteenDaysAgo, fourteenDaysAgo],
+  );
+  // A task on it whose updated_at is the same old timestamp.
+  const taskId = uuidv4();
+  run(
+    `INSERT INTO tasks (id, title, status, workspace_id, initiative_id, created_at, updated_at)
+     VALUES (?, 'Implement x', 'in_progress', ?, ?, ?, ?)`,
+    [taskId, ws, initiativeId, fourteenDaysAgo, fourteenDaysAgo],
+  );
+
+  const result = generateStandup({ workspace_id: ws, today: '2026-04-24' });
+  assert.ok(result.proposal, 'expected a proposal');
+  const p = result.proposal!;
+
+  const checkDiffs = p.proposed_changes.filter(
+    c => c.kind === 'update_status_check' && c.initiative_id === initiativeId,
+  );
+  assert.equal(checkDiffs.length, 1, 'expected one update_status_check diff');
+  assert.match(
+    (checkDiffs[0] as { status_check_md: string }).status_check_md,
+    /no task activity in \d+d/,
+  );
+});
+
+// ─── Test 5: idempotency within 24h ────────────────────────────────
+
+test('generateStandup: idempotent within UTC day — second call returns existing draft', () => {
+  const ws = freshWorkspace();
+  const owner = seedAgent(ws, 'Eli');
+  const milestone = createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Demo',
+    committed_end: '2026-04-10',
+    owner_agent_id: owner,
+  });
+  createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Heavy lift',
+    parent_initiative_id: milestone.id,
+    owner_agent_id: owner,
+    estimated_effort_hours: 200,
+    target_start: '2026-04-15',
+  });
+
+  const first = generateStandup({ workspace_id: ws, today: '2026-04-24' });
+  assert.ok(first.proposal);
+
+  const second = generateStandup({ workspace_id: ws, today: '2026-04-24' });
+  assert.ok(second.proposal);
+  assert.equal(second.proposal!.id, first.proposal!.id, 'should return the same proposal');
+  assert.equal(second.skipped_reason, 'already_today');
+
+  // Only one draft proposal exists for this workspace.
+  const drafts = listProposals({ workspace_id: ws, status: 'draft' });
+  assert.equal(drafts.length, 1);
+
+  // force=true bypasses the idempotency guard — useful for the manual
+  // "Run standup now" button.
+  const forced = generateStandup({
+    workspace_id: ws,
+    today: '2026-04-24',
+    force: true,
+  });
+  assert.ok(forced.proposal);
+  assert.notEqual(forced.proposal!.id, first.proposal!.id);
+});
+
+// ─── Test 6: schedule handler runs derive then standup ─────────────
+
+test('generateStandup: end-to-end via schedule handler — applyDerivation + generateStandup', async () => {
+  const ws = freshWorkspace();
+  const owner = seedAgent(ws, 'Finn');
+
+  // Slipping milestone — derived_end will exceed committed_end.
+  const milestone = createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Schedule-handler demo',
+    committed_end: '2026-04-12',
+    owner_agent_id: owner,
+  });
+  createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Big lift',
+    parent_initiative_id: milestone.id,
+    owner_agent_id: owner,
+    estimated_effort_hours: 100,
+    target_start: '2026-04-15',
+  });
+
+  // Mirror what scheduling.ts does for the roadmap_drift_scan branch:
+  // (1) applyDerivation, (2) generateStandup.
+  const apply = applyDerivation(ws, { today: '2026-04-24' });
+  assert.ok(apply.drifts.length > 0, 'derivation should detect drift');
+
+  const before = queryAll<{ id: string }>(
+    `SELECT id FROM events WHERE type = 'pm_standup_generated'`,
+  ).length;
+
+  const standup = generateStandup({ workspace_id: ws, today: '2026-04-24' });
+  assert.ok(standup.proposal, 'standup should produce a proposal');
+
+  const after = queryAll<{ id: string }>(
+    `SELECT id FROM events WHERE type = 'pm_standup_generated'`,
+  ).length;
+  assert.equal(after - before, 1);
+
+  // The proposal references the real milestone id.
+  const refsMilestone = standup.proposal!.proposed_changes.some(
+    c => 'initiative_id' in c && c.initiative_id === milestone.id,
+  );
+  assert.ok(refsMilestone, 'standup should reference the slipping milestone');
+
+  // Suppress unused — we only care that the queryOne import resolves.
+  void queryOne;
+  void getDb;
+});

--- a/src/lib/agents/pm-standup.ts
+++ b/src/lib/agents/pm-standup.ts
@@ -1,0 +1,634 @@
+/**
+ * Proactive PM standup synthesizer (Phase 6 of the roadmap & PM-agent feature).
+ *
+ * Phase 5 wired the PM's *reactive* path (operator drops a disruption →
+ * `dispatchPm` → proposal). Phase 6 adds the *proactive* path: a scheduled
+ * scan that posts a "morning standup" proposal whenever the roadmap is
+ * drifting in ways the operator should look at.
+ *
+ * Drift sources we surface (per spec §14, with thresholds documented inline):
+ *
+ *   1. Milestones with `derived_end > committed_end` — we propose
+ *      `set_initiative_status='at_risk'` (only when not already at_risk),
+ *      and a `shift_initiative_target` if the gap is wide enough that the
+ *      operator likely wants to move the target.
+ *   2. Initiatives with `derived_end > target_end + SLIPPAGE_THRESHOLD_DAYS`
+ *      (3 days) — same treatment.
+ *   3. Blocked initiatives that haven't moved (no recent updated_at change)
+ *      — `update_status_check` suggesting the operator chase the blocker.
+ *   4. Cycles in the dependency graph — surfaced in `impact_md` only;
+ *      we don't generate shift diffs because the dates are NULL inside
+ *      a cycle (engine breaks them).
+ *   5. Stale in-progress tasks — initiatives with `status='in_progress'`
+ *      whose tasks haven't been updated in N days. `update_status_check`
+ *      suggesting a quick check-in.
+ *
+ * Determinism: given the same DB state and `today` anchor, this synthesizer
+ * produces the same proposed_changes in the same order. That makes the
+ * tests tractable and lets the operator compare Tuesday's proposal against
+ * Monday's to see what shifted overnight.
+ *
+ * Idempotency: we refuse to create a second standup proposal in the same
+ * UTC day for the same workspace — see `findExistingStandupToday`. Phase 4
+ * already debounces derived_* writes; this is the matching debounce on the
+ * proposal layer so a re-run of `checkAndRunDueSchedules` doesn't post
+ * duplicate cards.
+ *
+ * No-drift behaviour: when nothing crosses any threshold we DO NOT create a
+ * proposal — we instead emit one `events` row with `type='pm_standup_skipped'`
+ * so the operator can see the PM ran but had nothing to say. Quiet PM is
+ * better than spammy PM (the operator's chat shouldn't fill up with empty
+ * cards every morning).
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { getDb, queryAll, queryOne } from '@/lib/db';
+import {
+  getRoadmapSnapshot,
+  type RoadmapSnapshot,
+  type RoadmapInitiative,
+} from '@/lib/db/roadmap';
+import { previewDerivation } from '@/lib/roadmap/apply-derivation';
+import { SLIPPAGE_THRESHOLD_DAYS } from '@/lib/roadmap/drift';
+import { daysBetween } from '@/lib/roadmap/date-math';
+import {
+  createProposal,
+  getProposal,
+  type PmDiff,
+  type PmProposal,
+} from '@/lib/db/pm-proposals';
+import { postPmChatMessage } from './pm-dispatch';
+
+/**
+ * Minimum gap (days) before we propose moving a target_end. Below this, we
+ * only flip status to at_risk — the operator can absorb a couple-day slip
+ * without re-publishing a target.
+ */
+const TARGET_SHIFT_THRESHOLD_DAYS = 5;
+
+/**
+ * Number of days a `status='in_progress'` initiative's tasks must have been
+ * idle (no `updated_at` change) before we flag it as stale work.
+ */
+const STALE_TASK_DAYS = 7;
+
+/**
+ * Number of days a `status='blocked'` initiative must have sat untouched
+ * before we suggest the operator chase the blocker.
+ */
+const STALE_BLOCKED_DAYS = 3;
+
+export interface GenerateStandupInput {
+  workspace_id: string;
+  /** Anchor — defaults to current time. Tests pass a fixed date. */
+  today?: Date | string;
+  /**
+   * When set, force-create the proposal even if one already exists today.
+   * Used by the manual `POST /api/pm/standup` endpoint when the operator
+   * explicitly clicks "Run standup now". The schedule path leaves this
+   * undefined to honour idempotency.
+   */
+  force?: boolean;
+}
+
+export interface GenerateStandupResult {
+  /** The new (or existing, if `force=false`) proposal — null when skipped. */
+  proposal: PmProposal | null;
+  /** Reason returned to the caller when no proposal was created. */
+  skipped_reason:
+    | null
+    | 'no_drift'
+    | 'already_today';
+  /** Number of drift signals detected (whether or not a proposal was made). */
+  drift_count: number;
+}
+
+/**
+ * Generate today's standup proposal for `workspace_id`.
+ *
+ * Returns `proposal: null` and a non-null `skipped_reason` when nothing was
+ * created. The caller (schedule handler / manual route) can show the
+ * operator why.
+ */
+export function generateStandup(input: GenerateStandupInput): GenerateStandupResult {
+  const today = normalizeToday(input.today);
+  const todayIso = isoDate(today);
+
+  // 1. Idempotency check (unless force=true). We use the events table — the
+  //    most recent pm_standup_generated event for this workspace within
+  //    the same UTC day is the signal. Cheap and self-cleaning.
+  if (!input.force) {
+    const existing = findExistingStandupToday(input.workspace_id, todayIso);
+    if (existing) {
+      return {
+        proposal: existing,
+        skipped_reason: 'already_today',
+        drift_count: 0,
+      };
+    }
+  }
+
+  // 2. Pull a fresh snapshot. Phase 4's drift-scan handler runs
+  //    `applyDerivation` BEFORE this — so derived_* fields are current.
+  //    We then run `previewDerivation` (without overrides) to recompute
+  //    the schedule from scratch and detect drift events the same way the
+  //    drift-scan does, so the standup is robust even when called outside
+  //    the scheduled flow.
+  const snapshot = getRoadmapSnapshot({ workspace_id: input.workspace_id });
+  const preview = previewDerivation(snapshot, { today });
+
+  // 3. Detect drift signals using the snapshot + preview. Each signal
+  //    becomes zero-or-more PmDiff entries plus a bullet line.
+  const detection = detectStandupSignals(snapshot, preview, today);
+
+  // 4. No drift → emit skipped event, return null.
+  if (detection.signals.length === 0) {
+    emitEvent({
+      type: 'pm_standup_skipped',
+      workspace_id: input.workspace_id,
+      message: 'PM standup: no drift detected — quiet morning',
+      metadata: {
+        workspace_id: input.workspace_id,
+        date: todayIso,
+        initiatives_scanned: snapshot.initiatives.length,
+      },
+    });
+    return { proposal: null, skipped_reason: 'no_drift', drift_count: 0 };
+  }
+
+  // 5. Build the proposal.
+  const triggerText = `Daily roadmap standup — automated drift scan (${todayIso})`;
+  const impactMd = composeImpactMd(detection, todayIso);
+
+  const proposal = createProposal({
+    workspace_id: input.workspace_id,
+    trigger_text: triggerText,
+    trigger_kind: 'scheduled_drift_scan',
+    impact_md: impactMd,
+    proposed_changes: detection.changes,
+  });
+
+  // 6. Best-effort: post into the PM chat thread so the operator sees the
+  //    new card immediately. Same mechanism as Phase 5's reactive path.
+  try {
+    postPmChatMessage({
+      workspace_id: input.workspace_id,
+      content: impactMd,
+      proposal_id: proposal.id,
+      role: 'assistant',
+    });
+  } catch (err) {
+    console.warn('[pm-standup] chat insert failed:', (err as Error).message);
+  }
+
+  // 7. Emit the generated event so the live feed shows the standup landed.
+  emitEvent({
+    type: 'pm_standup_generated',
+    workspace_id: input.workspace_id,
+    message: `PM standup posted: ${detection.changes.length} change${detection.changes.length === 1 ? '' : 's'} proposed`,
+    metadata: {
+      workspace_id: input.workspace_id,
+      proposal_id: proposal.id,
+      date: todayIso,
+      drift_count: detection.signals.length,
+      change_kinds: detection.changes.map(c => c.kind),
+    },
+  });
+
+  return {
+    proposal,
+    skipped_reason: null,
+    drift_count: detection.signals.length,
+  };
+}
+
+// ─── Detection ──────────────────────────────────────────────────────
+
+interface StandupDetection {
+  signals: StandupSignal[];
+  changes: PmDiff[];
+  bullets: string[];
+  /** Cycle membership pulled out so impact_md can flag it specifically. */
+  cycle_initiative_ids: string[];
+}
+
+type StandupSignal =
+  | {
+      kind: 'milestone_at_risk';
+      initiative: RoadmapInitiative;
+      derived_end: string;
+      committed_end: string;
+      days_over: number;
+    }
+  | {
+      kind: 'slippage';
+      initiative: RoadmapInitiative;
+      derived_end: string;
+      target_end: string;
+      days_over: number;
+    }
+  | {
+      kind: 'stale_blocked';
+      initiative: RoadmapInitiative;
+      days_idle: number;
+    }
+  | {
+      kind: 'stale_in_progress';
+      initiative: RoadmapInitiative;
+      days_idle: number;
+      task_count: number;
+    }
+  | {
+      kind: 'cycle_detected';
+      initiative_ids: string[];
+    };
+
+/**
+ * Pure-ish signal detection. Reads:
+ *   - snapshot (initiatives, dependencies, tasks)
+ *   - preview (the just-recomputed schedule + drifts)
+ *
+ * Hits the DB once for stale-task data (initiative_id → max(task.updated_at)).
+ * Returns ordered signals + matching diffs + bullets — order is stable (sort
+ * by initiative.id within each category) so two runs against the same
+ * snapshot produce identical proposals.
+ */
+function detectStandupSignals(
+  snapshot: RoadmapSnapshot,
+  preview: ReturnType<typeof previewDerivation>,
+  today: Date,
+): StandupDetection {
+  const signals: StandupSignal[] = [];
+  const changes: PmDiff[] = [];
+  const bullets: string[] = [];
+  const initiativesById = new Map<string, RoadmapInitiative>();
+  for (const i of snapshot.initiatives) initiativesById.set(i.id, i);
+
+  // Track which initiatives are inside a cycle so we don't propose date
+  // shifts for them (their derived_* are NULL).
+  const cycleSet = new Set<string>(preview.derived.cycle);
+
+  // 1. milestone_at_risk + slippage from preview.drifts.
+  // Sort drift events deterministically (by initiative_id then kind).
+  const sortedDrifts = [...preview.drifts].sort((a, b) => {
+    const aKey = `${'initiative_id' in a ? a.initiative_id : ''}__${a.kind}`;
+    const bKey = `${'initiative_id' in b ? b.initiative_id : ''}__${b.kind}`;
+    return aKey.localeCompare(bKey);
+  });
+
+  for (const drift of sortedDrifts) {
+    if (drift.kind === 'milestone_at_risk') {
+      const init = initiativesById.get(drift.initiative_id);
+      if (!init) continue;
+      signals.push({
+        kind: 'milestone_at_risk',
+        initiative: init,
+        derived_end: drift.derived_end,
+        committed_end: drift.committed_end,
+        days_over: drift.days_over,
+      });
+      // Flip to at_risk only when not already at_risk/blocked/cancelled/done.
+      if (init.status === 'planned' || init.status === 'in_progress') {
+        changes.push({
+          kind: 'set_initiative_status',
+          initiative_id: init.id,
+          status: 'at_risk',
+        });
+      }
+      // Suggest moving the committed_end via target_end shift only when the
+      // gap is large enough that the operator likely wants to re-publish.
+      // We don't touch committed_end directly (PM diff vocabulary doesn't
+      // include it — operator decides whether to re-commit).
+      if (drift.days_over >= TARGET_SHIFT_THRESHOLD_DAYS) {
+        changes.push({
+          kind: 'shift_initiative_target',
+          initiative_id: init.id,
+          target_end: drift.derived_end,
+          reason: `Milestone at risk: derived_end ${drift.derived_end} exceeds committed_end ${drift.committed_end} by ${drift.days_over}d`,
+        });
+      }
+      bullets.push(
+        `⚠ Milestone "${init.title}" at risk — derived ${drift.derived_end} vs committed ${drift.committed_end} (+${drift.days_over}d)`,
+      );
+      continue;
+    }
+    if (drift.kind === 'slippage') {
+      const init = initiativesById.get(drift.initiative_id);
+      if (!init) continue;
+      // Threshold check is already inside detectDrift (SLIPPAGE_THRESHOLD_DAYS).
+      signals.push({
+        kind: 'slippage',
+        initiative: init,
+        derived_end: drift.derived_end,
+        target_end: drift.target_end,
+        days_over: drift.days_over,
+      });
+      if (init.status === 'planned' || init.status === 'in_progress') {
+        changes.push({
+          kind: 'set_initiative_status',
+          initiative_id: init.id,
+          status: 'at_risk',
+        });
+      }
+      if (drift.days_over >= TARGET_SHIFT_THRESHOLD_DAYS) {
+        changes.push({
+          kind: 'shift_initiative_target',
+          initiative_id: init.id,
+          target_end: drift.derived_end,
+          reason: `Slippage: derived_end ${drift.derived_end} exceeds target_end ${drift.target_end} by ${drift.days_over}d`,
+        });
+      }
+      bullets.push(
+        `↗ "${init.title}" slipping — derived ${drift.derived_end} vs target ${drift.target_end} (+${drift.days_over}d)`,
+      );
+      continue;
+    }
+    if (drift.kind === 'cycle_detected') {
+      signals.push({ kind: 'cycle_detected', initiative_ids: [...drift.initiative_ids] });
+      const titles = drift.initiative_ids
+        .map(id => initiativesById.get(id)?.title ?? id)
+        .slice(0, 5);
+      bullets.push(`⊗ Dependency cycle detected: ${titles.join(' → ')}`);
+      // Intentionally NO set_initiative_status / shift diffs for cycle
+      // members — derivation engine sets their dates to NULL inside the
+      // cycle and the operator's first job is to break the cycle, not
+      // shift dates.
+      continue;
+    }
+    // 'no_effort_signal' is too noisy for a standup (every back-of-the-
+    // -envelope idea would fire). Phase 4 already surfaces them in the
+    // drift event metadata; we pass.
+  }
+
+  // 2. Stale blocked initiatives — `status='blocked'` and updated_at > N days.
+  const stale = findStaleInitiatives(snapshot, today);
+
+  for (const row of stale.blocked) {
+    const init = initiativesById.get(row.initiative_id);
+    if (!init) continue;
+    signals.push({
+      kind: 'stale_blocked',
+      initiative: init,
+      days_idle: row.days_idle,
+    });
+    const note = `[standup] Blocked ${row.days_idle}d — chase the blocker or unblock manually.`;
+    changes.push({
+      kind: 'update_status_check',
+      initiative_id: init.id,
+      status_check_md: appendStatusCheck(init.status_check_md, note),
+    });
+    bullets.push(`⏸ "${init.title}" blocked ${row.days_idle}d — needs a check-in`);
+  }
+
+  // 3. Stale in-progress initiatives — owner not pushing, no task updates.
+  for (const row of stale.in_progress) {
+    if (cycleSet.has(row.initiative_id)) continue;
+    const init = initiativesById.get(row.initiative_id);
+    if (!init) continue;
+    signals.push({
+      kind: 'stale_in_progress',
+      initiative: init,
+      days_idle: row.days_idle,
+      task_count: row.task_count,
+    });
+    const note = `[standup] In-progress but no task activity in ${row.days_idle}d. Check on PR review status / pings.`;
+    changes.push({
+      kind: 'update_status_check',
+      initiative_id: init.id,
+      status_check_md: appendStatusCheck(init.status_check_md, note),
+    });
+    bullets.push(
+      `🟡 "${init.title}" in-progress — no task updates in ${row.days_idle}d`,
+    );
+  }
+
+  // Dedupe set_initiative_status diffs (a single initiative can match
+  // both milestone_at_risk and slippage if the operator set both
+  // committed_end and target_end). Keep the first; same with
+  // shift_initiative_target.
+  const dedupedChanges = dedupeChanges(changes);
+
+  return {
+    signals,
+    changes: dedupedChanges,
+    bullets,
+    cycle_initiative_ids: [...cycleSet],
+  };
+}
+
+interface StaleRow {
+  initiative_id: string;
+  days_idle: number;
+  task_count: number;
+}
+
+interface StaleResult {
+  blocked: StaleRow[];
+  in_progress: StaleRow[];
+}
+
+/**
+ * Find initiatives whose tasks haven't been touched recently. We compute
+ * `days_idle` from the most recent of:
+ *   - the initiative's own `updated_at`
+ *   - the max `updated_at` across that initiative's tasks (any status)
+ *
+ * For initiatives with no tasks, we fall back to the initiative's
+ * `updated_at`. Returns rows in initiative_id order for determinism.
+ */
+function findStaleInitiatives(
+  snapshot: RoadmapSnapshot,
+  today: Date,
+): StaleResult {
+  const blocked: StaleRow[] = [];
+  const in_progress: StaleRow[] = [];
+
+  // Pull (initiative_id, max(task.updated_at), count) once per workspace.
+  // Cheap — workspaces are small. Group by initiative_id.
+  const taskActivity = queryAll<{
+    initiative_id: string;
+    max_updated_at: string | null;
+    task_count: number;
+  }>(
+    `SELECT initiative_id,
+            MAX(updated_at) AS max_updated_at,
+            COUNT(*) AS task_count
+       FROM tasks
+      WHERE workspace_id = ? AND initiative_id IS NOT NULL
+      GROUP BY initiative_id`,
+    [snapshot.workspace_id],
+  );
+  const activityById = new Map<string, { max: string | null; count: number }>();
+  for (const a of taskActivity) {
+    activityById.set(a.initiative_id, { max: a.max_updated_at, count: a.task_count });
+  }
+
+  // Pull initiative.updated_at for the workspace's initiatives (the snapshot
+  // doesn't include it). One query — keyed by id.
+  const initRows = queryAll<{ id: string; updated_at: string | null }>(
+    'SELECT id, updated_at FROM initiatives WHERE workspace_id = ?',
+    [snapshot.workspace_id],
+  );
+  const initUpdatedAt = new Map<string, string | null>();
+  for (const r of initRows) initUpdatedAt.set(r.id, r.updated_at);
+
+  // Sort by id for determinism.
+  const sorted = [...snapshot.initiatives].sort((a, b) => a.id.localeCompare(b.id));
+  for (const init of sorted) {
+    if (init.status !== 'blocked' && init.status !== 'in_progress') continue;
+    const activity = activityById.get(init.id);
+    const lastTouched =
+      activity?.max ?? initUpdatedAt.get(init.id) ?? null;
+    if (!lastTouched) continue;
+    const idle = daysBetween(lastTouched.slice(0, 10), isoDate(today));
+    if (!isFinite(idle) || idle <= 0) continue;
+    if (init.status === 'blocked' && idle >= STALE_BLOCKED_DAYS) {
+      blocked.push({
+        initiative_id: init.id,
+        days_idle: idle,
+        task_count: activity?.count ?? 0,
+      });
+    }
+    if (init.status === 'in_progress' && idle >= STALE_TASK_DAYS) {
+      in_progress.push({
+        initiative_id: init.id,
+        days_idle: idle,
+        task_count: activity?.count ?? 0,
+      });
+    }
+  }
+  return { blocked, in_progress };
+}
+
+/**
+ * Append a status-check note as a new line, preserving any existing text.
+ * Truncates to keep the column readable (5KB hard cap).
+ */
+function appendStatusCheck(existing: string | null, note: string): string {
+  const head = (existing ?? '').trim();
+  const combined = head ? `${head}\n\n${note}` : note;
+  return combined.length > 5000 ? combined.slice(0, 5000) : combined;
+}
+
+/**
+ * Dedupe set_initiative_status / shift_initiative_target / update_status_check
+ * by initiative_id (keep first), and dedupe add_dependency by edge. Other
+ * kinds pass through unchanged.
+ */
+function dedupeChanges(changes: PmDiff[]): PmDiff[] {
+  const seen = new Set<string>();
+  const out: PmDiff[] = [];
+  for (const c of changes) {
+    let key: string | null = null;
+    if (c.kind === 'set_initiative_status') key = `set:${c.initiative_id}`;
+    else if (c.kind === 'shift_initiative_target') key = `shift:${c.initiative_id}`;
+    else if (c.kind === 'update_status_check') key = `chk:${c.initiative_id}`;
+    else if (c.kind === 'add_dependency')
+      key = `dep:${c.initiative_id}->${c.depends_on_initiative_id}`;
+    if (key) {
+      if (seen.has(key)) continue;
+      seen.add(key);
+    }
+    out.push(c);
+  }
+  return out;
+}
+
+// ─── Impact_md composition ──────────────────────────────────────────
+
+function composeImpactMd(
+  detection: StandupDetection,
+  todayIso: string,
+): string {
+  const headline =
+    detection.changes.length === 0
+      ? `### Daily standup — ${todayIso}: drift detected, no actionable changes`
+      : `### Daily standup — ${todayIso}: ${detection.changes.length} change${detection.changes.length === 1 ? '' : 's'} proposed`;
+
+  const lines: string[] = [headline, ''];
+  if (detection.cycle_initiative_ids.length > 0) {
+    lines.push(
+      `**Dependency cycle present** — ${detection.cycle_initiative_ids.length} initiatives. ` +
+        `Date diffs are skipped for these; break the cycle first.`,
+      '',
+    );
+  }
+  for (const b of detection.bullets.slice(0, 12)) {
+    lines.push(`- ${b}`);
+  }
+  if (detection.bullets.length > 12) {
+    lines.push(`- _…and ${detection.bullets.length - 12} more_`);
+  }
+  return lines.join('\n');
+}
+
+// ─── Idempotency lookup ─────────────────────────────────────────────
+
+/**
+ * Returns the most recent `pm_standup_generated` proposal for this workspace
+ * created today (UTC), if any. Used by the schedule path to avoid duplicate
+ * cards if the cron fires twice.
+ *
+ * We match on the date *embedded in the trigger_text* (e.g.
+ * "Daily roadmap standup — automated drift scan (2026-04-24)") rather than
+ * on `created_at`. This way the "logical day" the standup was generated for
+ * is what counts — not when the row happened to be inserted. Tests can pass
+ * a fixed `today` and re-running with the same `today` is correctly
+ * idempotent even when wall-clock has advanced.
+ */
+function findExistingStandupToday(
+  workspaceId: string,
+  todayIso: string,
+): PmProposal | null {
+  const stamp = `(${todayIso})`;
+  const row = queryOne<{ id: string }>(
+    `SELECT id FROM pm_proposals
+      WHERE workspace_id = ?
+        AND trigger_kind = 'scheduled_drift_scan'
+        AND status = 'draft'
+        AND trigger_text LIKE ?
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [workspaceId, `%${stamp}%`],
+  );
+  if (!row) return null;
+  return getProposal(row.id) ?? null;
+}
+
+// ─── Event emission ─────────────────────────────────────────────────
+
+interface EmitEventInput {
+  type: 'pm_standup_generated' | 'pm_standup_skipped';
+  workspace_id: string;
+  message: string;
+  metadata: Record<string, unknown>;
+}
+
+function emitEvent(input: EmitEventInput): void {
+  const db = getDb();
+  db.prepare(
+    `INSERT INTO events (id, type, message, metadata, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(
+    uuidv4(),
+    input.type,
+    input.message,
+    JSON.stringify(input.metadata),
+    new Date().toISOString(),
+  );
+}
+
+// ─── Date utils ─────────────────────────────────────────────────────
+
+function normalizeToday(today: Date | string | undefined): Date {
+  if (today instanceof Date) return today;
+  if (typeof today === 'string') {
+    const d = new Date(today);
+    if (!isNaN(d.getTime())) return d;
+  }
+  return new Date();
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}

--- a/src/lib/autopilot/scheduling.ts
+++ b/src/lib/autopilot/scheduling.ts
@@ -167,7 +167,33 @@ export async function checkAndRunDueSchedules(): Promise<void> {
             console.warn(`[Schedule] roadmap_drift_scan ${schedule.id} has no resolvable workspace`);
             break;
           }
+          // Phase 4: derive first (writes derived_*).
           applyDerivation(workspaceId);
+          // Phase 6: synthesize the morning standup proposal AFTER
+          // derivation, so the standup reads the fresh schedule. The
+          // standup generator is idempotent within a UTC day — re-runs
+          // of this handler produce no extra cards.
+          try {
+            const { generateStandup } = await import('@/lib/agents/pm-standup');
+            const result = generateStandup({ workspace_id: workspaceId });
+            if (result.proposal) {
+              console.log(
+                `[Schedule] PM standup posted (${result.drift_count} drift signals) for workspace=${workspaceId}`,
+              );
+            } else {
+              console.log(
+                `[Schedule] PM standup skipped (${result.skipped_reason}) for workspace=${workspaceId}`,
+              );
+            }
+          } catch (err) {
+            // Standup generation must NEVER break Phase 4's idempotency
+            // contract — if the standup throws, the derivation has
+            // already committed and the operator sees the drift event.
+            console.error(
+              `[Schedule] PM standup generation failed for ${workspaceId}:`,
+              (err as Error).message,
+            );
+          }
           break;
         }
         default:

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -2681,7 +2681,103 @@ const migrations: Migration[] = [
       }
       console.log(`[Migration 045] PM agents: seeded=${seeded} skipped=${skipped}`);
     }
-  }
+  },
+  {
+    id: '046',
+    name: 'seed_roadmap_drift_scan_schedules',
+    up: (db) => {
+      // Phase 6 of the roadmap & PM-agent feature. Auto-enable the daily
+      // roadmap drift scan + PM standup for every workspace that already has
+      // (a) at least one initiative and (b) at least one active product.
+      //
+      // Schedule shape:
+      //   schedule_type = 'roadmap_drift_scan'
+      //   cron = '0 9 * * 1-5'   (9am MT weekdays — matches spec §9.2)
+      //   product_id = the workspace's oldest active product (or first product
+      //     if none active). Phase 4's handler resolves workspace_id from
+      //     this product, so any product within the right workspace works.
+      //   config = JSON {"workspace_id":"<id>"} — explicit, future-proof in
+      //     case the operator moves products between workspaces.
+      //
+      // Idempotent: skips workspaces that already have a roadmap_drift_scan
+      // schedule (matched on schedule_type alone, not on product_id, so
+      // re-running this migration after schedule cleanup never duplicates).
+      console.log('[Migration 046] Seeding roadmap_drift_scan schedules per workspace...');
+
+      const workspaces = db
+        .prepare(
+          `SELECT DISTINCT w.id AS workspace_id
+             FROM workspaces w
+             JOIN initiatives i ON i.workspace_id = w.id`,
+        )
+        .all() as { workspace_id: string }[];
+
+      const insert = db.prepare(`
+        INSERT INTO product_schedules (
+          id, product_id, schedule_type, cron_expression, timezone,
+          enabled, config, created_at, updated_at
+        ) VALUES (?, ?, 'roadmap_drift_scan', '0 9 * * 1-5', 'America/Denver', 1, ?, ?, ?)
+      `);
+      const now = new Date().toISOString();
+      let seeded = 0;
+      let skippedExisting = 0;
+      let skippedNoProduct = 0;
+
+      for (const ws of workspaces) {
+        // Already has a roadmap_drift_scan schedule for any product in this
+        // workspace? skip.
+        const existing = db
+          .prepare(
+            `SELECT ps.id FROM product_schedules ps
+               JOIN products p ON p.id = ps.product_id
+              WHERE p.workspace_id = ? AND ps.schedule_type = 'roadmap_drift_scan'
+              LIMIT 1`,
+          )
+          .get(ws.workspace_id) as { id: string } | undefined;
+        if (existing) {
+          skippedExisting++;
+          continue;
+        }
+
+        // Pick the oldest active product (most likely the workspace's
+        // canonical "main" product). Falls back to the oldest product
+        // regardless of status. Workspaces with no product at all are
+        // skipped — the operator will need to create one or call the
+        // manual `/api/pm/standup` endpoint instead.
+        const product =
+          (db
+            .prepare(
+              `SELECT id FROM products
+                WHERE workspace_id = ? AND status = 'active'
+                ORDER BY created_at LIMIT 1`,
+            )
+            .get(ws.workspace_id) as { id: string } | undefined) ??
+          (db
+            .prepare(
+              `SELECT id FROM products WHERE workspace_id = ?
+                ORDER BY created_at LIMIT 1`,
+            )
+            .get(ws.workspace_id) as { id: string } | undefined);
+
+        if (!product) {
+          skippedNoProduct++;
+          continue;
+        }
+
+        insert.run(
+          crypto.randomUUID(),
+          product.id,
+          JSON.stringify({ workspace_id: ws.workspace_id }),
+          now,
+          now,
+        );
+        seeded++;
+      }
+      console.log(
+        `[Migration 046] roadmap_drift_scan schedules: seeded=${seeded}, skipped_existing=${skippedExisting}, skipped_no_product=${skippedNoProduct}`,
+      );
+    },
+  },
 ];
 
 // Inline PM soul_md reader for migration 045. The full module

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,7 +28,12 @@ export type EventType =
   | 'message_sent'
   | 'agent_status_changed'
   | 'agent_joined'
-  | 'system';
+  | 'system'
+  // Roadmap & PM-agent events (Phases 4 + 6).
+  | 'roadmap_drift_scan'
+  | 'pm_proposal_accepted'
+  | 'pm_standup_generated'
+  | 'pm_standup_skipped';
 
 export type AgentSource = 'local' | 'gateway';
 


### PR DESCRIPTION
## Summary
Wires the proactive PM path. The scheduled `roadmap_drift_scan` cron now invokes a deterministic standup synthesizer that detects drift (slipping milestones, stale work, blocked initiatives, dependency cycles) and posts a draft `pm_proposals` row the operator can refine, accept, or reject. Quiet PM is preserved: when nothing's drifting, the run emits a `pm_standup_skipped` event instead of an empty card. Phase 5's reactive flow is unchanged — Phase 6 reuses `synthesizeImpactAnalysis`, `createProposal`, and the proposal-card chat surface.

## What landed
- **Standup synthesizer** (`src/lib/agents/pm-standup.ts`) — `generateStandup({workspace_id, today?, force?})`. Pulls a fresh snapshot, runs `previewDerivation`, and walks drift events. Detects milestone_at_risk + slippage + cycle + stale_blocked (≥3d) + stale_in_progress (≥7d). Emits `set_initiative_status='at_risk'` (only when not already at_risk), `shift_initiative_target` when gap ≥5d, and `update_status_check` for stale work. Cycle members get NO date diffs. Deterministic order: drift events sorted by `(initiative_id, kind)`.
- **Schedule wiring** (`src/lib/autopilot/scheduling.ts`) — the `roadmap_drift_scan` branch now runs `applyDerivation` then `generateStandup`. Standup failures are isolated; they don't break Phase 4's idempotency contract.
- **Manual trigger endpoint** (`POST /api/pm/standup`) — body `{workspace_id, force?, derive_first?}`. Returns 201 with the proposal, or 200 with `{skipped: true, reason: 'no_drift'|'already_today'}`.
- **Idempotency** — same UTC day = same proposal. Implemented via the `(YYYY-MM-DD)` stamp embedded in `trigger_text` (not `created_at`) so tests with a fixed `today` parameter are correctly idempotent. `force=true` bypasses.
- **Live feed integration** (`src/components/LiveFeed.tsx`) — renders `roadmap_drift_scan` (→ `/roadmap`), `pm_standup_generated` (→ `/pm?proposal=<id>`), `pm_standup_skipped` (no link), `pm_proposal_accepted` (→ `/pm?proposal=<id>`). New `EventType` union members in `src/lib/types.ts`.
- **PM page enhancements** (`src/app/pm/page.tsx`) — pinned violet "Latest standup" banner at top of chat thread when a draft scheduled_drift_scan proposal exists for the current workspace; "Run standup" toolbar button calls `/api/pm/standup` with `force=true`; `?proposal=<id>` deep-link scrolls to and highlights the matching card; trigger_kind badge (`manual` / `scheduled` / `disruption` / `status check`) on every proposal card.
- **Schedule seeding (Option A)** — Migration 046 seeds a `0 9 * * 1-5` MT cron per workspace on the workspace's oldest active product (falls back to oldest regardless of status). Workspaces without a product are skipped — operator can call `/api/pm/standup` manually.
- **Tests** — 10 new (6 standup helper + 4 API route): no-drift skip, milestone slipping, cycle, stale in-progress, idempotency, end-to-end via schedule-handler simulation. All Phase 1–5 tests still pass when run individually.

## Live feed component status
Found and integrated `src/components/LiveFeed.tsx` (the existing live feed consumed by `useMissionControl().events`). New event types render with deep-links and emoji icons; older event types unchanged.

## Schedule seeding choice
Picked **Option A** (per-workspace migration) for v1 simplicity: zero UI, deterministic, runs at db migrate time. Tradeoff: adds product-coupling (the schedule needs a product_id; we use the workspace's oldest active product). A future Option B (workspace-settings toggle) is a clean follow-up and the manual `POST /api/pm/standup` endpoint already covers the "I want to run it now" gap.

## Spec edits
Added a "Phase 6 implementation notes" subsection to `specs/roadmap-and-pm-spec.md` §14 documenting:
- Idempotency strategy (trigger_text stamp, not `created_at`).
- Drift signal taxonomy + thresholds.
- Schedule seeding choice (Option A) + per-workspace product fallback.
- Two new event types and their deep-link targets.

## Stacked PR series
This is **Phase 6 of 6**, the final phase, stacked on Phases 5→4→3→2→1. See `specs/roadmap-and-pm-spec.md` §14.

**Merge order discipline (project memory):** when a parent merges with --delete-branch, retarget descendants to the new base BEFORE merging the parent. Recommended order to merge the whole stack:
1. Retarget #44 → main, merge #43 with --delete-branch
2. Retarget #45 → main, merge #44 with --delete-branch
3. Retarget #46 → main, merge #45 with --delete-branch
4. Retarget #48 → main, merge #46 with --delete-branch
5. Retarget THIS PR → main, merge #48 with --delete-branch
6. Merge THIS PR with --delete-branch

## Test plan
- [ ] Migration 046 runs cleanly on a current production DB snapshot.
- [ ] Existing task pipeline / Mission Queue unaffected.
- [ ] `tsx --test src/lib/agents/pm-standup.test.ts` and `src/app/api/pm/standup/route.test.ts` both pass.
- [ ] On a workspace with a slipping milestone, run `POST /api/pm/standup` and confirm a draft proposal appears in `/pm` with the violet pinned banner + a `scheduled` trigger_kind badge. Click the corresponding `pm_standup_generated` row in the live feed and verify it deep-links + highlights the matching card.
- [ ] Re-run `POST /api/pm/standup` (no force) and confirm `{skipped: true, reason: 'already_today'}`.
- [ ] Re-run with `force=true` and confirm a NEW proposal id is returned.
- [ ] On a healthy workspace, run the standup and confirm no proposal + a `pm_standup_skipped` event in the feed.
- [ ] Accept a standup proposal and verify the diff applied + `pm_proposal_accepted` event emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>