### PR TITLE
Polish B: Guided planning + PM-driven decomposition

### DIFF
--- a/specs/roadmap-and-pm-spec.md
+++ b/specs/roadmap-and-pm-spec.md
@@ -464,7 +464,19 @@ Apply is a single transaction. v1 is all-or-nothing accept; partial accept (per-
 - **Never** edits `tasks.status` for active tasks (anything beyond `draft`/`inbox`).
 - **Never** writes `derived_*` outside the nightly scan.
 
-The PM is a *suggester*, not an actor on the execution board.
+The PM is a *suggester*, not an actor on the execution board. **Note for `plan_initiative` (§9.5):** plan-initiative proposals are explicitly advisory — `acceptProposal` is a no-op for that trigger_kind. The operator applies the suggestions client-side by populating the new-initiative form. The proposal exists only for audit + the refine chain. (Decompose proposals, by contrast, DO mutate state on accept.)
+
+### 9.5 Guided modes (Polish B)
+
+In addition to the reactive disruption flow, the PM has two operator-driven guided modes. Both reuse the proposal lifecycle (draft → refine* → accept/reject) and the same MCP tools, but specialize the synthesizer:
+
+**Plan an initiative draft** — `trigger_kind='plan_initiative'`. Operator drafts an initiative (title + rough description) and asks the PM for a refined description, suggested complexity, suggested target window, and candidate dependencies surfaced from existing workspace initiatives by keyword overlap. Output is a single advisory proposal: `acceptProposal` is a no-op for this trigger_kind, and `proposed_changes` stays empty. The structured suggestions are returned in the API response and embedded in `impact_md` as an HTML-comment JSON sidecar so the refine endpoint can return them too. The operator applies the suggestions by populating the create-initiative form before clicking Save.
+
+**Decompose an existing epic/milestone** — `trigger_kind='decompose_initiative'`. Operator picks an existing epic or milestone (story-kind initiatives are not decomposable). The PM proposes 3-7 child initiatives (story-kind by default; epic allowed; theme/milestone forbidden as `child_kind`). Each child carries a brief description, a complexity estimate, a `sort_order`, and optional `depends_on_initiative_ids`. Sibling pre-wiring uses placeholder ids (`$0`, `$1`, …) that resolve to the freshly-inserted real ids during the second pass of `acceptProposal`. On accept: children are inserted under the parent in a single transaction with matching `initiative_parent_history` rows (`reason='created via PM decompose proposal #<id>'`).
+
+**New diff kind** — `create_child_initiative`. Only emitted from `decompose_initiative` proposals. Validation rejects `child_kind='theme'` or `'milestone'`.
+
+UI surface: a "Plan with PM" button next to Save in the initiative edit drawer; a "Decompose with PM" entry in the `⋮` action menu (epic/milestone rows) and a button on `/initiatives/[id]` for the same kinds. Both flows use the existing refine endpoint.
 
 ---
 

--- a/src/app/(app)/initiatives/[id]/page.tsx
+++ b/src/app/(app)/initiatives/[id]/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useCallback, use } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, ChevronRight, Plus, Send, History, Link2 } from 'lucide-react';
+import { ArrowLeft, ChevronRight, Plus, Send, History, Link2, Sparkles } from 'lucide-react';
+import DecomposeWithPmModal from '@/components/DecomposeWithPmModal';
 
 type Kind = 'theme' | 'milestone' | 'epic' | 'story';
 type Status = 'planned' | 'in_progress' | 'at_risk' | 'blocked' | 'done' | 'cancelled';
@@ -108,6 +109,7 @@ export default function InitiativeDetailPage({
   const [error, setError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [showPromoteModal, setShowPromoteModal] = useState(false);
+  const [showDecomposeModal, setShowDecomposeModal] = useState(false);
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -229,6 +231,15 @@ export default function InitiativeDetailPage({
                 kind={initiative.kind}
                 onClick={() => setShowPromoteModal(true)}
               />
+              {(initiative.kind === 'epic' || initiative.kind === 'milestone') && (
+                <button
+                  onClick={() => setShowDecomposeModal(true)}
+                  className="inline-flex items-center gap-2 px-3 py-2 rounded-lg text-sm border border-mc-accent/40 text-mc-accent hover:bg-mc-accent/10"
+                  title="Ask the PM to propose 3-7 child initiatives"
+                >
+                  <Sparkles className="w-4 h-4" /> Decompose with PM
+                </button>
+              )}
             </div>
           </div>
 
@@ -374,6 +385,21 @@ export default function InitiativeDetailPage({
           onClose={() => setShowPromoteModal(false)}
           onSaved={() => {
             setShowPromoteModal(false);
+            refresh();
+          }}
+        />
+      )}
+      {showDecomposeModal && (
+        <DecomposeWithPmModal
+          initiative={{
+            id: initiative.id,
+            title: initiative.title,
+            kind: initiative.kind,
+            workspace_id: initiative.workspace_id,
+          }}
+          onClose={() => setShowDecomposeModal(false)}
+          onAccepted={() => {
+            setShowDecomposeModal(false);
             refresh();
           }}
         />

--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -14,9 +14,13 @@ import {
   History,
   Send,
   CornerUpLeft,
+  Sparkles,
+  Network,
 } from 'lucide-react';
 import Drawer from '@/components/Drawer';
 import ActionMenu, { ActionMenuItem } from '@/components/ActionMenu';
+import PlanWithPmPanel, { type PlanInitiativeSuggestions } from '@/components/PlanWithPmPanel';
+import DecomposeWithPmModal from '@/components/DecomposeWithPmModal';
 
 // Local types (kept separate from src/lib/types.ts so Phase 1 doesn't touch
 // the central type module — Phase 2 can promote these once the broader API
@@ -96,6 +100,7 @@ export default function InitiativesPage() {
   const [promoting, setPromoting] = useState<Initiative | null>(null);
   const [historyFor, setHistoryFor] = useState<Initiative | null>(null);
   const [addingDepFor, setAddingDepFor] = useState<Initiative | null>(null);
+  const [decomposing, setDecomposing] = useState<Initiative | null>(null);
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -205,6 +210,7 @@ export default function InitiativesPage() {
                 onShowHistory={setHistoryFor}
                 onAddDependency={setAddingDepFor}
                 onDetach={detach}
+                onDecompose={setDecomposing}
                 onDelete={async (init) => {
                   if (!confirm(`Delete "${init.title}"?`)) return;
                   const res = await fetch(`/api/initiatives/${init.id}`, { method: 'DELETE' });
@@ -289,6 +295,16 @@ export default function InitiativesPage() {
           }}
         />
       )}
+      {decomposing && (
+        <DecomposeWithPmModal
+          initiative={decomposing}
+          onClose={() => setDecomposing(null)}
+          onAccepted={() => {
+            setDecomposing(null);
+            refresh();
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -321,6 +337,7 @@ function InitiativeRow({
   onShowHistory,
   onAddDependency,
   onDetach,
+  onDecompose,
   onDelete,
 }: {
   node: TreeNode;
@@ -336,12 +353,14 @@ function InitiativeRow({
   onAddDependency: (init: Initiative) => void;
   onDetach: (init: Initiative) => void;
   onDelete: (init: Initiative) => void;
+  onDecompose: (init: Initiative) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const counts = taskCounts[node.id];
   const isStory = node.kind === 'story';
   const isContainer = node.kind !== 'story';
   const hasParent = !!node.parent_initiative_id;
+  const isDecomposable = node.kind === 'epic' || node.kind === 'milestone';
 
   // The carat for expand/collapse stays as its own affordance per the spec.
   // High-frequency actions ("Promote to task" for stories, "Add child" for
@@ -349,6 +368,15 @@ function InitiativeRow({
   // overflow menu.
   const menuItems: ActionMenuItem[] = [
     { label: 'Edit', icon: <Pencil className="w-3.5 h-3.5" />, onClick: () => onEdit(node) },
+    ...(isDecomposable
+      ? [
+          {
+            label: 'Decompose with PM',
+            icon: <Network className="w-3.5 h-3.5" />,
+            onClick: () => onDecompose(node),
+          },
+        ]
+      : []),
     { label: 'Move', icon: <MoveRight className="w-3.5 h-3.5" />, onClick: () => onMove(node) },
     { label: 'Convert kind', icon: <Shuffle className="w-3.5 h-3.5" />, onClick: () => onConvert(node) },
     { label: 'Add dependency', icon: <Link2 className="w-3.5 h-3.5" />, onClick: () => onAddDependency(node) },
@@ -458,6 +486,7 @@ function InitiativeRow({
           onShowHistory={onShowHistory}
           onAddDependency={onAddDependency}
           onDetach={onDetach}
+          onDecompose={onDecompose}
           onDelete={onDelete}
         />
       ))}
@@ -811,6 +840,18 @@ function EditDrawer({
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
+  const [planOpen, setPlanOpen] = useState(false);
+  // The plan panel needs a stable draft snapshot — re-running the plan
+  // on every keystroke would spam the synthesizer. We snapshot the form
+  // state at the moment the operator clicks "Plan with PM".
+  const [planDraft, setPlanDraft] = useState<{
+    title: string;
+    description: string;
+    complexity?: 'S' | 'M' | 'L' | 'XL';
+    target_start?: string | null;
+    target_end?: string | null;
+    parent_initiative_id?: string | null;
+  } | null>(null);
 
   // Reset form state when a new initiative is opened.
   useEffect(() => {
@@ -827,6 +868,8 @@ function EditDrawer({
     setOwnerAgentId('');
     setLoaded(false);
     setErr(null);
+    setPlanOpen(false);
+    setPlanDraft(null);
   }, [initiative]);
 
   // Pull the full record so we have the optional fields not in the list view.
@@ -926,6 +969,27 @@ function EditDrawer({
       footer={
         <div className="flex justify-end gap-2">
           {err && <div className="text-red-400 text-sm mr-auto self-center">{err}</div>}
+          <button
+            onClick={() => {
+              if (!title) return;
+              // Snapshot the current draft. The panel re-fetches on open
+              // so re-clicking after edits triggers a fresh plan.
+              setPlanDraft({
+                title,
+                description,
+                complexity: complexity || undefined,
+                target_start: targetStart || null,
+                target_end: targetEnd || null,
+                parent_initiative_id: initiative?.parent_initiative_id ?? null,
+              });
+              setPlanOpen(true);
+            }}
+            disabled={!title}
+            className="px-3 py-2 rounded border border-mc-accent/50 text-mc-accent text-sm inline-flex items-center gap-1 disabled:opacity-50"
+            title="Ask the PM agent to suggest description / complexity / window / dependencies"
+          >
+            <Sparkles className="w-3.5 h-3.5" /> Plan with PM
+          </button>
           <button
             onClick={onClose}
             className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm"
@@ -1077,6 +1141,25 @@ function EditDrawer({
             />
           </label>
         </FormSection>
+
+        {planOpen && planDraft && initiative && (
+          <PlanWithPmPanel
+            open={planOpen}
+            workspaceId={initiative.workspace_id}
+            draft={planDraft}
+            onClose={() => setPlanOpen(false)}
+            onApply={(s: PlanInitiativeSuggestions) => {
+              // Populate the form fields with the PM's recommendations.
+              // The operator can still tweak before Save.
+              if (s.refined_description) setDescription(s.refined_description);
+              if (s.complexity) setComplexity(s.complexity);
+              if (s.target_start) setTargetStart(s.target_start);
+              if (s.target_end) setTargetEnd(s.target_end);
+              if (s.status_check_md) setStatusCheck(s.status_check_md);
+              setPlanOpen(false);
+            }}
+          />
+        )}
       </form>
     </Drawer>
   );

--- a/src/app/api/pm/decompose-initiative/route.test.ts
+++ b/src/app/api/pm/decompose-initiative/route.test.ts
@@ -1,0 +1,114 @@
+/**
+ * POST /api/pm/decompose-initiative route test (Polish B).
+ *
+ * Verifies the wrapper requires initiative_id, only accepts epic/milestone
+ * parents, returns a draft proposal, and that accepting that proposal
+ * actually creates the children with audit rows.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { POST as acceptPOST } from '../proposals/[id]/accept/route';
+import { run } from '@/lib/db';
+import { ensurePmAgent } from '@/lib/bootstrap-agents';
+import { createInitiative } from '@/lib/db/initiatives';
+import { queryAll } from '@/lib/db';
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  ensurePmAgent(id);
+  return id;
+}
+
+function postJson(path: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+test('POST /api/pm/decompose-initiative: missing initiative_id → 400', async () => {
+  const res = await POST(postJson('/api/pm/decompose-initiative', {}));
+  assert.equal(res.status, 400);
+});
+
+test('POST /api/pm/decompose-initiative: rejects story-kind parent', async () => {
+  const ws = freshWorkspace();
+  const story = createInitiative({ workspace_id: ws, kind: 'story', title: 'A story' });
+  const res = await POST(
+    postJson('/api/pm/decompose-initiative', { initiative_id: story.id }),
+  );
+  assert.equal(res.status, 400);
+});
+
+test('POST /api/pm/decompose-initiative: returns draft proposal for an epic', async () => {
+  const ws = freshWorkspace();
+  const epic = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Build something',
+  });
+
+  const res = await POST(
+    postJson('/api/pm/decompose-initiative', { initiative_id: epic.id }),
+  );
+  assert.equal(res.status, 201);
+  const data = await res.json();
+  assert.ok(data.proposal);
+  assert.equal(data.proposal.trigger_kind, 'decompose_initiative');
+  assert.equal(data.proposal.status, 'draft');
+  assert.ok(Array.isArray(data.proposal.proposed_changes));
+  assert.ok(data.proposal.proposed_changes.length >= 3);
+  for (const c of data.proposal.proposed_changes) {
+    assert.equal(c.kind, 'create_child_initiative');
+    assert.equal(c.parent_initiative_id, epic.id);
+  }
+});
+
+test('POST /api/pm/decompose-initiative + accept: children are created', async () => {
+  const ws = freshWorkspace();
+  const epic = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Build feature X',
+  });
+
+  const decRes = await POST(
+    postJson('/api/pm/decompose-initiative', { initiative_id: epic.id }),
+  );
+  const decData = await decRes.json();
+  const proposalId = decData.proposal.id;
+
+  const acceptRes = await acceptPOST(
+    postJson(`/api/pm/proposals/${proposalId}/accept`, {}),
+    { params: Promise.resolve({ id: proposalId }) },
+  );
+  assert.equal(acceptRes.status, 200);
+  const acceptData = await acceptRes.json();
+  assert.ok(acceptData.changes_applied >= 3);
+
+  // Children inserted.
+  const children = queryAll<{ id: string; title: string }>(
+    `SELECT id, title FROM initiatives WHERE parent_initiative_id = ?`,
+    [epic.id],
+  );
+  assert.ok(children.length >= 3);
+
+  // Audit rows present.
+  for (const c of children) {
+    const audit = queryAll<{ to_parent_id: string }>(
+      `SELECT to_parent_id FROM initiative_parent_history WHERE initiative_id = ?`,
+      [c.id],
+    );
+    assert.equal(audit.length, 1);
+    assert.equal(audit[0].to_parent_id, epic.id);
+  }
+});

--- a/src/app/api/pm/decompose-initiative/route.ts
+++ b/src/app/api/pm/decompose-initiative/route.ts
@@ -1,0 +1,107 @@
+/**
+ * POST /api/pm/decompose-initiative
+ *
+ * Polish B (decompose flow). Operator picks an existing epic/milestone;
+ * the PM proposes 3-7 child initiatives. Returns a draft proposal with
+ * trigger_kind='decompose_initiative' and proposed_changes containing
+ * one `create_child_initiative` diff per proposed child.
+ *
+ * On accept the children are inserted in a single transaction with
+ * matching `initiative_parent_history` rows and any pre-wired sibling
+ * dep edges (placeholder ids `$N` resolved post-insert).
+ *
+ * Body:
+ *   { initiative_id, hint? }
+ *
+ * Response:
+ *   { proposal }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getInitiative } from '@/lib/db/initiatives';
+import { synthesizeDecompose } from '@/lib/agents/pm-agent';
+import { createProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { postPmChatMessage } from '@/lib/agents/pm-dispatch';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  initiative_id: z.string().min(1),
+  hint: z.string().max(2000).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Body required' }, { status: 400 });
+  }
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const parent = getInitiative(parsed.data.initiative_id);
+    if (!parent) {
+      return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
+    }
+    if (parent.kind !== 'epic' && parent.kind !== 'milestone') {
+      return NextResponse.json(
+        {
+          error: `Decompose only supported for epic/milestone parents (got "${parent.kind}")`,
+        },
+        { status: 400 },
+      );
+    }
+
+    const synth = synthesizeDecompose(parent, parsed.data.hint);
+
+    // Embed the original hint in trigger_text so refine() can re-run with
+    // the same context.
+    const triggerText = JSON.stringify({
+      mode: 'decompose_initiative',
+      initiative_id: parent.id,
+      parent_title: parent.title,
+      hint: parsed.data.hint ?? null,
+    });
+
+    const proposal = createProposal({
+      workspace_id: parent.workspace_id,
+      trigger_text: triggerText,
+      trigger_kind: 'decompose_initiative',
+      impact_md: synth.impact_md,
+      proposed_changes: synth.changes,
+    });
+
+    try {
+      postPmChatMessage({
+        workspace_id: parent.workspace_id,
+        role: 'user',
+        content: `Decompose: "${parent.title}"` + (parsed.data.hint ? ` (hint: ${parsed.data.hint})` : ''),
+      });
+      postPmChatMessage({
+        workspace_id: parent.workspace_id,
+        role: 'assistant',
+        content: synth.impact_md,
+        proposal_id: proposal.id,
+      });
+    } catch (err) {
+      console.warn('[pm-decompose] chat insert failed:', (err as Error).message);
+    }
+
+    return NextResponse.json({ proposal }, { status: 201 });
+  } catch (err) {
+    if (err instanceof PmProposalValidationError) {
+      return NextResponse.json({ error: err.message, hints: err.hints }, { status: 400 });
+    }
+    const msg = err instanceof Error ? err.message : 'Failed to decompose initiative';
+    console.error('Failed to decompose initiative:', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/pm/plan-initiative/route.test.ts
+++ b/src/app/api/pm/plan-initiative/route.test.ts
@@ -1,0 +1,98 @@
+/**
+ * POST /api/pm/plan-initiative route test (Polish B).
+ *
+ * Verifies the wrapper accepts a draft, persists an advisory proposal,
+ * and returns the structured suggestions. Refinement chain is exercised
+ * separately because that route is the existing /refine endpoint.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { POST as refinePOST } from '../proposals/[id]/refine/route';
+import { run } from '@/lib/db';
+import { ensurePmAgent } from '@/lib/bootstrap-agents';
+import { getProposal } from '@/lib/db/pm-proposals';
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  ensurePmAgent(id);
+  return id;
+}
+
+function postJson(path: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+test('POST /api/pm/plan-initiative: missing workspace_id → 400', async () => {
+  const res = await POST(postJson('/api/pm/plan-initiative', { draft: { title: 'x' } }));
+  assert.equal(res.status, 400);
+});
+
+test('POST /api/pm/plan-initiative: missing title → 400', async () => {
+  const ws = freshWorkspace();
+  const res = await POST(postJson('/api/pm/plan-initiative', { workspace_id: ws, draft: {} }));
+  assert.equal(res.status, 400);
+});
+
+test('POST /api/pm/plan-initiative: returns proposal_id + suggestions', async () => {
+  const ws = freshWorkspace();
+  const res = await POST(
+    postJson('/api/pm/plan-initiative', {
+      workspace_id: ws,
+      draft: { title: 'Add invoicing', description: 'A new invoicing flow' },
+    }),
+  );
+  assert.equal(res.status, 201);
+  const data = await res.json();
+  assert.ok(data.proposal_id);
+  assert.ok(data.proposal);
+  assert.equal(data.proposal.trigger_kind, 'plan_initiative');
+  assert.equal(data.proposal.status, 'draft');
+  assert.ok(data.suggestions);
+  assert.ok(['S', 'M', 'L', 'XL'].includes(data.suggestions.complexity));
+  assert.ok(data.suggestions.target_end);
+
+  // Proposal is recorded in DB.
+  const stored = getProposal(data.proposal_id);
+  assert.ok(stored);
+  assert.equal(stored!.trigger_kind, 'plan_initiative');
+});
+
+test('POST /api/pm/plan-initiative + refine: refine returns a child proposal with parent_proposal_id set', async () => {
+  const ws = freshWorkspace();
+  const planRes = await POST(
+    postJson('/api/pm/plan-initiative', {
+      workspace_id: ws,
+      draft: { title: 'Add invoicing' },
+    }),
+  );
+  const planData = await planRes.json();
+  const parentId = planData.proposal_id;
+
+  // Now refine via the existing endpoint.
+  const refineReq = new NextRequest(
+    `http://localhost/api/pm/proposals/${parentId}/refine`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ additional_constraint: 'force complexity to L' }),
+    },
+  );
+  const refineRes = await refinePOST(refineReq, { params: Promise.resolve({ id: parentId }) });
+  assert.equal(refineRes.status, 201);
+  const refineData = await refineRes.json();
+  assert.ok(refineData.proposal);
+  assert.equal(refineData.proposal.parent_proposal_id, parentId);
+  assert.equal(refineData.proposal.trigger_kind, 'plan_initiative');
+});

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -1,0 +1,120 @@
+/**
+ * POST /api/pm/plan-initiative
+ *
+ * Polish B (guided planning). The operator drafts an initiative (title +
+ * rough description) and asks the PM to fill in the planning fields. We
+ * synthesize suggestions deterministically (no LLM dep — see
+ * synthesizePlanInitiative for v1 heuristics) and store an advisory
+ * `pm_proposals` row with trigger_kind='plan_initiative'.
+ *
+ * Advisory means: accepting the proposal does NOT mutate state. The
+ * operator applies the suggestions client-side by populating the form
+ * fields. The proposal exists for audit + the refine chain only.
+ *
+ * Body:
+ *   {
+ *     workspace_id,
+ *     draft: { title, description?, kind?, complexity?,
+ *              parent_initiative_id?, target_start?, target_end? }
+ *   }
+ *
+ * Response:
+ *   { proposal_id, suggestions: { ... } }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getRoadmapSnapshot } from '@/lib/db/roadmap';
+import { synthesizePlanInitiative } from '@/lib/agents/pm-agent';
+import { createProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { postPmChatMessage } from '@/lib/agents/pm-dispatch';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  workspace_id: z.string().min(1),
+  draft: z.object({
+    title: z.string().min(1).max(500),
+    description: z.string().max(20000).optional().nullable(),
+    kind: z.enum(['theme', 'milestone', 'epic', 'story']).optional(),
+    complexity: z.enum(['S', 'M', 'L', 'XL']).optional().nullable(),
+    parent_initiative_id: z.string().optional().nullable(),
+    target_start: z.string().optional().nullable(),
+    target_end: z.string().optional().nullable(),
+  }),
+});
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Body required' }, { status: 400 });
+  }
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const snapshot = getRoadmapSnapshot({ workspace_id: parsed.data.workspace_id });
+    const synth = synthesizePlanInitiative(snapshot, parsed.data.draft);
+
+    // Persist the suggestions inside trigger_text so refine() can
+    // re-synthesize from the same draft without losing the planning
+    // context.
+    const triggerText = JSON.stringify({
+      mode: 'plan_initiative',
+      draft: parsed.data.draft,
+    });
+
+    // Stash the suggestions in proposed_changes as a synthetic single-diff
+    // payload via update_status_check on a sentinel that we never apply
+    // (advisory accept short-circuits). We use a JSON sidecar block in
+    // impact_md instead so client can read suggestions without parsing
+    // diffs. proposed_changes stays an empty array = nothing to apply.
+    const proposal = createProposal({
+      workspace_id: parsed.data.workspace_id,
+      trigger_text: triggerText,
+      trigger_kind: 'plan_initiative',
+      impact_md: synth.impact_md,
+      proposed_changes: synth.changes,
+    });
+
+    // Best-effort chat echo for audit visibility in /pm.
+    try {
+      postPmChatMessage({
+        workspace_id: parsed.data.workspace_id,
+        role: 'user',
+        content: `Plan with PM: "${parsed.data.draft.title}"`,
+      });
+      postPmChatMessage({
+        workspace_id: parsed.data.workspace_id,
+        role: 'assistant',
+        content: synth.impact_md,
+        proposal_id: proposal.id,
+      });
+    } catch (err) {
+      console.warn('[pm-plan] chat insert failed:', (err as Error).message);
+    }
+
+    return NextResponse.json(
+      {
+        proposal_id: proposal.id,
+        proposal,
+        suggestions: synth.suggestions,
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    if (err instanceof PmProposalValidationError) {
+      return NextResponse.json({ error: err.message, hints: err.hints }, { status: 400 });
+    }
+    const msg = err instanceof Error ? err.message : 'Failed to plan initiative';
+    console.error('Failed to plan initiative:', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/pm/proposals/[id]/diffs/route.ts
+++ b/src/app/api/pm/proposals/[id]/diffs/route.ts
@@ -1,0 +1,86 @@
+/**
+ * PUT /api/pm/proposals/[id]/diffs
+ *
+ * Polish B helper. Replaces the proposed_changes array on a draft
+ * proposal — used by the Decompose-with-PM modal so the operator can
+ * edit the PM's proposed children before accepting.
+ *
+ * Only allowed when the proposal is still in `draft` status. Re-runs
+ * validation against the workspace before persisting so we never let
+ * a tampered diff pass.
+ *
+ * Body:
+ *   { proposed_changes: PmDiff[] }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  getProposal,
+  validateProposedChanges,
+  PmProposalValidationError,
+  type PmDiff,
+} from '@/lib/db/pm-proposals';
+import { run } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  proposed_changes: z.array(z.unknown()),
+});
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Body required' }, { status: 400 });
+  }
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const existing = getProposal(id);
+    if (!existing) {
+      return NextResponse.json({ error: 'Proposal not found' }, { status: 404 });
+    }
+    if (existing.status !== 'draft') {
+      return NextResponse.json(
+        { error: `Cannot edit diffs on status=${existing.status}` },
+        { status: 400 },
+      );
+    }
+
+    const changes = parsed.data.proposed_changes as PmDiff[];
+    const errors = validateProposedChanges(existing.workspace_id, changes);
+    if (errors.length > 0) {
+      throw new PmProposalValidationError(
+        `Invalid proposed_changes: ${errors.length} error(s)`,
+        errors,
+      );
+    }
+
+    run(`UPDATE pm_proposals SET proposed_changes = ? WHERE id = ?`, [
+      JSON.stringify(changes),
+      id,
+    ]);
+    return NextResponse.json({ proposal: getProposal(id) });
+  } catch (err) {
+    if (err instanceof PmProposalValidationError) {
+      return NextResponse.json({ error: err.message, hints: err.hints }, { status: 400 });
+    }
+    const msg = err instanceof Error ? err.message : 'Failed to update diffs';
+    console.error('Failed to update proposal diffs:', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -13,6 +13,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getProposal, refineProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
 import { dispatchPm } from '@/lib/agents/pm-dispatch';
+import { synthesizePlanInitiative, synthesizeDecompose } from '@/lib/agents/pm-agent';
+import { getRoadmapSnapshot } from '@/lib/db/roadmap';
+import { getInitiative } from '@/lib/db/initiatives';
 
 export const dynamic = 'force-dynamic';
 
@@ -22,6 +25,22 @@ const Body = z.object({
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+/**
+ * Plan/decompose proposals stash structured context as JSON in
+ * trigger_text. Older trigger_text is free-text — we return null and the
+ * caller falls back gracefully.
+ */
+function parseTriggerContext(triggerText: string): Record<string, unknown> | null {
+  try {
+    const trimmed = triggerText.trim();
+    if (!trimmed.startsWith('{')) return null;
+    const parsed = JSON.parse(trimmed.split('\n\n[refine]')[0]);
+    return typeof parsed === 'object' && parsed != null ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
 }
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
@@ -44,40 +63,70 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     // refineProposal creates the (empty) draft slot and supersedes the
-    // parent; we then re-dispatch with the combined trigger so the slot
-    // is filled with the new impact + diffs. We do this in two steps so
-    // the supersede + new-id pair is visible even if dispatch fails.
+    // parent. We then route the re-synthesis to the right backend based
+    // on the parent's trigger_kind:
+    //   - plan_initiative / decompose_initiative → call the matching
+    //     synthesizer directly with the parent's structured context
+    //     (parsed out of trigger_text).
+    //   - everything else → fall back to dispatchPm (the disruption-
+    //     analysis synthesizer).
     const { child } = refineProposal(id, parsed.data.additional_constraint);
 
-    // Re-dispatch using the parent's full trigger + the additional
-    // constraint as a free-text bolt-on. We then patch the child row
-    // with the new impact + changes by deleting/recreating — simplest
-    // reliable path that doesn't require an "update_proposal" helper.
-    // Call dispatchPm separately (without parent_proposal_id) so it
-    // returns a freshly-synthesized result we copy onto `child`.
-    const synthesized = dispatchPm({
-      workspace_id: parent.workspace_id,
-      trigger_text: child.trigger_text,
-      trigger_kind: parent.trigger_kind,
-      // We do NOT pass parent_proposal_id here — that would create a
-      // SECOND child. The freshly-synthesized proposal exists; we
-      // delete it and update our pre-allocated slot below.
-    });
+    let newImpactMd: string;
+    let newChanges: unknown[];
 
-    // Move the synthesized impact + changes onto our pre-allocated child
-    // row, then delete the side-effect row created by dispatchPm.
-    // Rationale: refineProposal already produced the supersede chain we
-    // want — we're only borrowing dispatchPm's synthesizer.
+    if (parent.trigger_kind === 'plan_initiative') {
+      // Re-run synthesizePlanInitiative with the operator's draft + the
+      // additional constraint folded into the description.
+      const ctx = parseTriggerContext(parent.trigger_text);
+      const draft = (ctx?.draft as Record<string, unknown> | undefined) ?? { title: 'Untitled' };
+      const refinedDraft = {
+        ...draft,
+        description:
+          (draft.description ? `${draft.description as string}\n\n` : '') +
+          `Refine: ${parsed.data.additional_constraint}`,
+      } as Parameters<typeof synthesizePlanInitiative>[1];
+      const snapshot = getRoadmapSnapshot({ workspace_id: parent.workspace_id });
+      const synth = synthesizePlanInitiative(snapshot, refinedDraft);
+      newImpactMd = synth.impact_md;
+      newChanges = synth.changes;
+    } else if (parent.trigger_kind === 'decompose_initiative') {
+      const ctx = parseTriggerContext(parent.trigger_text);
+      const initiativeId = ctx?.initiative_id as string | undefined;
+      const init = initiativeId ? getInitiative(initiativeId) : undefined;
+      if (!init) {
+        return NextResponse.json(
+          { error: 'Original parent initiative no longer exists; cannot refine' },
+          { status: 400 },
+        );
+      }
+      const combinedHint =
+        ((ctx?.hint as string | null) ?? '') +
+        (ctx?.hint ? '\n' : '') +
+        `Refine: ${parsed.data.additional_constraint}`;
+      const synth = synthesizeDecompose(init, combinedHint.trim());
+      newImpactMd = synth.impact_md;
+      newChanges = synth.changes;
+    } else {
+      // Default disruption-analysis path. We borrow dispatchPm's
+      // synthesizer and patch the result onto the pre-allocated child
+      // row, then delete the side-effect row dispatchPm created.
+      const synthesized = dispatchPm({
+        workspace_id: parent.workspace_id,
+        trigger_text: child.trigger_text,
+        trigger_kind: parent.trigger_kind,
+      });
+      newImpactMd = synthesized.proposal.impact_md;
+      newChanges = synthesized.proposal.proposed_changes;
+      const { run } = await import('@/lib/db');
+      run(`DELETE FROM pm_proposals WHERE id = ?`, [synthesized.proposal.id]);
+    }
+
     const { run } = await import('@/lib/db');
     run(
       `UPDATE pm_proposals SET impact_md = ?, proposed_changes = ? WHERE id = ?`,
-      [
-        synthesized.proposal.impact_md,
-        JSON.stringify(synthesized.proposal.proposed_changes),
-        child.id,
-      ],
+      [newImpactMd, JSON.stringify(newChanges), child.id],
     );
-    run(`DELETE FROM pm_proposals WHERE id = ?`, [synthesized.proposal.id]);
 
     const refreshed = getProposal(child.id)!;
     return NextResponse.json({ proposal: refreshed }, { status: 201 });

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -1,0 +1,411 @@
+'use client';
+
+/**
+ * Decompose-with-PM modal.
+ *
+ * Polish B (PM-driven decomposition). The operator picks an existing
+ * epic or milestone; the PM proposes 3-7 child initiatives. The
+ * operator reviews — reorder, edit, remove, add — then Accept inserts
+ * them transactionally with audit rows.
+ *
+ * Flow:
+ *   1. POST /api/pm/decompose-initiative → draft proposal + create_child_initiative diffs.
+ *   2. The operator edits the diffs locally (drag-reorder via arrow buttons,
+ *      title/description inline edits, +/- rows).
+ *   3. On Accept: PATCH the proposal's proposed_changes via a fresh POST
+ *      to a new "edit" endpoint? No — simpler: we create the proposal,
+ *      then if the operator changed anything we update via a small
+ *      helper route. v1 keeps it simple by always re-creating the
+ *      proposal on accept with the operator-edited diffs.
+ *
+ * v1 implementation: the modal calls accept directly with the original
+ * proposal. If the operator edited the diffs, we PATCH the proposal's
+ * proposed_changes via a small "apply edits" path: we delete the original
+ * draft proposal and create a fresh one with the edited diffs, then
+ * accept that. This keeps audit clean (one accepted proposal per
+ * decompose run) and doesn't require a new mutate-proposal endpoint.
+ *
+ * Refine: posting to /api/pm/proposals/[id]/refine produces a fresh
+ * superseded chain — the modal swaps in the new proposal's diffs.
+ */
+
+import { useState, useEffect } from 'react';
+import { Sparkles, Send, RefreshCw, Plus, Trash2, ArrowUp, ArrowDown, X } from 'lucide-react';
+
+interface InitiativeLite {
+  id: string;
+  title: string;
+  kind: string;
+  workspace_id: string;
+}
+
+interface ChildDiff {
+  kind: 'create_child_initiative';
+  parent_initiative_id: string;
+  title: string;
+  description?: string | null;
+  child_kind: 'epic' | 'story';
+  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+  estimated_effort_hours?: number | null;
+  sort_order?: number;
+  depends_on_initiative_ids?: string[];
+}
+
+interface ProposalRow {
+  id: string;
+  trigger_text: string;
+  trigger_kind: string;
+  impact_md: string;
+  proposed_changes: ChildDiff[];
+  status: string;
+}
+
+export default function DecomposeWithPmModal({
+  initiative,
+  onClose,
+  onAccepted,
+}: {
+  initiative: InitiativeLite;
+  onClose: () => void;
+  onAccepted: () => void;
+}) {
+  const [proposalId, setProposalId] = useState<string | null>(null);
+  const [impactMd, setImpactMd] = useState<string>('');
+  const [children, setChildren] = useState<ChildDiff[]>([]);
+  const [hint, setHint] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [refining, setRefining] = useState(false);
+  const [refineText, setRefineText] = useState('');
+  const [accepting, setAccepting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setErr(null);
+      try {
+        const res = await fetch('/api/pm/decompose-initiative', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ initiative_id: initiative.id }),
+        });
+        const body = await res.json();
+        if (!res.ok) throw new Error(body.error || `Decompose failed (${res.status})`);
+        if (cancelled) return;
+        const proposal = body.proposal as ProposalRow;
+        setProposalId(proposal.id);
+        setImpactMd(proposal.impact_md);
+        setChildren(proposal.proposed_changes);
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : 'Decompose failed');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [initiative.id]);
+
+  // Esc to close.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const refine = async () => {
+    if (!proposalId || !refineText.trim()) return;
+    setRefining(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/pm/proposals/${proposalId}/refine`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ additional_constraint: refineText.trim() }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || `Refine failed (${res.status})`);
+      const proposal = body.proposal as ProposalRow;
+      setProposalId(proposal.id);
+      setImpactMd(proposal.impact_md);
+      setChildren(proposal.proposed_changes);
+      setRefineText('');
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Refine failed');
+    } finally {
+      setRefining(false);
+    }
+  };
+
+  const accept = async () => {
+    if (!proposalId) return;
+    if (children.length === 0) {
+      setErr('Add at least one child or close the modal.');
+      return;
+    }
+    setAccepting(true);
+    setErr(null);
+    try {
+      // The operator may have edited diffs locally; persist those
+      // edits onto the proposal row before accepting. We use a small
+      // PATCH-style route that updates proposed_changes in place when
+      // the proposal is still draft.
+      const persist = await fetch(`/api/pm/proposals/${proposalId}/diffs`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ proposed_changes: normalizedChildren(children) }),
+      });
+      if (!persist.ok) {
+        const body = await persist.json().catch(() => ({}));
+        throw new Error(body.error || `Could not persist edits (${persist.status})`);
+      }
+      const res = await fetch(`/api/pm/proposals/${proposalId}/accept`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || `Accept failed (${res.status})`);
+      onAccepted();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Accept failed');
+    } finally {
+      setAccepting(false);
+    }
+  };
+
+  const move = (i: number, dir: -1 | 1) => {
+    const j = i + dir;
+    if (j < 0 || j >= children.length) return;
+    const next = [...children];
+    [next[i], next[j]] = [next[j], next[i]];
+    setChildren(next);
+  };
+
+  const updateChild = (i: number, patch: Partial<ChildDiff>) => {
+    setChildren(prev => prev.map((c, idx) => (idx === i ? { ...c, ...patch } : c)));
+  };
+
+  const removeChild = (i: number) => {
+    setChildren(prev => prev.filter((_, idx) => idx !== i));
+  };
+
+  const addChild = () => {
+    setChildren(prev => [
+      ...prev,
+      {
+        kind: 'create_child_initiative',
+        parent_initiative_id: initiative.id,
+        title: 'New child',
+        description: null,
+        child_kind: 'story',
+        complexity: 'M',
+      },
+    ]);
+  };
+
+  // Strip the embedded JSON comment from the markdown for human display.
+  const displayMd = impactMd.replace(/<!--pm-plan-suggestions[\s\S]*?-->/g, '').trim();
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Decompose initiative with PM"
+    >
+      <div
+        className="bg-mc-bg-secondary border border-mc-border rounded-lg w-full max-w-3xl max-h-[90vh] flex flex-col text-mc-text"
+        onClick={e => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between px-5 py-3 border-b border-mc-border">
+          <div className="flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-mc-accent" />
+            <h2 className="text-lg font-semibold">Decompose &ldquo;{initiative.title}&rdquo;</h2>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            title="Close (Esc)"
+            className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          {err && (
+            <div className="p-3 rounded bg-red-500/10 border border-red-500/30 text-red-300 text-sm">
+              {err}
+            </div>
+          )}
+
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-mc-text-secondary">
+              <RefreshCw className="w-4 h-4 animate-spin" /> Asking PM to decompose…
+            </div>
+          ) : (
+            <>
+              {displayMd && (
+                <div className="text-xs text-mc-text-secondary whitespace-pre-wrap rounded border border-mc-border bg-mc-bg p-3">
+                  {displayMd}
+                </div>
+              )}
+
+              <div>
+                <div className="flex items-center gap-2 mb-2">
+                  <h3 className="text-sm font-medium text-mc-text">
+                    Proposed children ({children.length})
+                  </h3>
+                  <button
+                    onClick={addChild}
+                    className="ml-auto inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-mc-border text-mc-text-secondary hover:text-mc-text hover:border-mc-accent/40"
+                  >
+                    <Plus className="w-3 h-3" /> Add child
+                  </button>
+                </div>
+
+                {children.length === 0 ? (
+                  <p className="text-sm text-mc-text-secondary">No children proposed. Add one manually above or refine below.</p>
+                ) : (
+                  <ul className="space-y-2">
+                    {children.map((c, i) => (
+                      <li
+                        key={i}
+                        className="rounded border border-mc-border bg-mc-bg p-3 space-y-2"
+                      >
+                        <div className="flex items-center gap-2">
+                          <div className="flex flex-col gap-1">
+                            <button
+                              onClick={() => move(i, -1)}
+                              disabled={i === 0}
+                              aria-label="Move up"
+                              className="p-1 rounded hover:bg-mc-bg-secondary text-mc-text-secondary disabled:opacity-30"
+                            >
+                              <ArrowUp className="w-3 h-3" />
+                            </button>
+                            <button
+                              onClick={() => move(i, 1)}
+                              disabled={i === children.length - 1}
+                              aria-label="Move down"
+                              className="p-1 rounded hover:bg-mc-bg-secondary text-mc-text-secondary disabled:opacity-30"
+                            >
+                              <ArrowDown className="w-3 h-3" />
+                            </button>
+                          </div>
+                          <select
+                            value={c.child_kind}
+                            onChange={e => updateChild(i, { child_kind: e.target.value as 'epic' | 'story' })}
+                            className="px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border text-xs"
+                            aria-label="Child kind"
+                          >
+                            <option value="story">story</option>
+                            <option value="epic">epic</option>
+                          </select>
+                          <input
+                            type="text"
+                            value={c.title}
+                            onChange={e => updateChild(i, { title: e.target.value })}
+                            className="flex-1 px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border text-sm"
+                            aria-label={`Title for child ${i + 1}`}
+                          />
+                          <select
+                            value={c.complexity ?? ''}
+                            onChange={e => updateChild(i, { complexity: (e.target.value || null) as ChildDiff['complexity'] })}
+                            className="px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border text-xs"
+                            aria-label="Complexity"
+                          >
+                            <option value="">—</option>
+                            <option value="S">S</option>
+                            <option value="M">M</option>
+                            <option value="L">L</option>
+                            <option value="XL">XL</option>
+                          </select>
+                          <button
+                            onClick={() => removeChild(i)}
+                            aria-label={`Remove child ${i + 1}`}
+                            className="p-1 rounded hover:bg-red-500/20 text-mc-text-secondary hover:text-red-400"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        </div>
+                        <textarea
+                          value={c.description ?? ''}
+                          onChange={e => updateChild(i, { description: e.target.value })}
+                          placeholder="Description (optional)"
+                          className="w-full px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border text-xs h-12"
+                          aria-label={`Description for child ${i + 1}`}
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <label className="block">
+                  <span className="text-xs text-mc-text-secondary">
+                    Refine (e.g., &ldquo;skip the marketing step&rdquo;, &ldquo;add a security review child&rdquo;)
+                  </span>
+                  <div className="mt-1 flex items-center gap-2">
+                    <input
+                      type="text"
+                      value={refineText}
+                      onChange={e => setRefineText(e.target.value)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault();
+                          refine();
+                        }
+                      }}
+                      className="flex-1 px-2 py-1.5 rounded bg-mc-bg border border-mc-border text-xs"
+                      placeholder="What should change?"
+                      disabled={refining}
+                    />
+                    <button
+                      onClick={refine}
+                      disabled={refining || !refineText.trim()}
+                      className="inline-flex items-center gap-1 px-2 py-1.5 rounded bg-mc-bg border border-mc-border text-xs text-mc-text disabled:opacity-50"
+                    >
+                      <Send className="w-3 h-3" />
+                      {refining ? 'Refining…' : 'Send'}
+                    </button>
+                  </div>
+                </label>
+              </div>
+            </>
+          )}
+        </div>
+
+        <footer className="border-t border-mc-border px-5 py-3 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={accept}
+            disabled={accepting || loading || children.length === 0 || !proposalId}
+            className="px-3 py-2 rounded bg-mc-accent text-white text-sm disabled:opacity-50"
+          >
+            {accepting ? 'Creating…' : `Accept (${children.length} children)`}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+/** Re-stamp sort_order to the operator's current display order. */
+function normalizedChildren(children: ChildDiff[]): ChildDiff[] {
+  return children.map((c, i) => ({ ...c, sort_order: i }));
+}

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -1,0 +1,305 @@
+'use client';
+
+/**
+ * Plan-with-PM side panel.
+ *
+ * Polish B (guided planning). Operator hands a draft (title + optional
+ * description and pre-set fields) to the PM agent and receives a
+ * structured suggestion: refined description, complexity, target window,
+ * candidate dependencies, status_check_md scaffolding.
+ *
+ * The panel:
+ *   - POSTs to /api/pm/plan-initiative (creates an advisory pm_proposals
+ *     row; accept is a no-op for plan_initiative trigger_kind).
+ *   - Lets the operator refine via /api/pm/proposals/[id]/refine
+ *     (chained re-synthesis with a free-text additional constraint).
+ *   - On "Apply suggestions", calls back to the host with the parsed
+ *     suggestions so the host can populate its form fields.
+ *
+ * The panel does NOT mutate any initiative directly. It is rendered
+ * inline inside an existing Drawer, NOT as a separate dialog — keyboard
+ * focus stays inside the parent drawer.
+ */
+
+import { useState, useEffect, useRef } from 'react';
+import { Sparkles, Send, X, RefreshCw } from 'lucide-react';
+
+export interface PlanInitiativeDraft {
+  title: string;
+  description?: string | null;
+  kind?: 'theme' | 'milestone' | 'epic' | 'story';
+  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+  parent_initiative_id?: string | null;
+  target_start?: string | null;
+  target_end?: string | null;
+}
+
+export interface PlanInitiativeSuggestions {
+  refined_description: string;
+  complexity: 'S' | 'M' | 'L' | 'XL';
+  target_start: string | null;
+  target_end: string;
+  dependencies: Array<{
+    depends_on_initiative_id: string;
+    kind: 'finish_to_start' | 'informational';
+    note: string;
+  }>;
+  status_check_md: string;
+  owner_agent_id: string | null;
+}
+
+/**
+ * Extract the structured suggestions JSON from a proposal's impact_md
+ * (we embed it in an HTML comment so the markdown stays human-readable
+ * but the client can pull suggestions out of any /refine response).
+ */
+function parseSuggestionsFromImpactMd(md: string): PlanInitiativeSuggestions | null {
+  // [\s\S] matches anything including newlines (the `s` flag is ES2018+
+  // and the project's tsconfig predates that — works on a wider range).
+  const m = md.match(/<!--pm-plan-suggestions\s+([\s\S]*?)\s*-->/);
+  if (!m) return null;
+  try {
+    return JSON.parse(m[1]) as PlanInitiativeSuggestions;
+  } catch {
+    return null;
+  }
+}
+
+interface KnownInitiative {
+  id: string;
+  title: string;
+}
+
+export default function PlanWithPmPanel({
+  open,
+  workspaceId,
+  draft,
+  knownInitiatives,
+  onClose,
+  onApply,
+}: {
+  open: boolean;
+  workspaceId: string;
+  draft: PlanInitiativeDraft;
+  knownInitiatives?: KnownInitiative[];
+  onClose: () => void;
+  /** Operator clicked Apply — receive the suggestions to populate the form. */
+  onApply: (suggestions: PlanInitiativeSuggestions) => void;
+}) {
+  const [proposalId, setProposalId] = useState<string | null>(null);
+  const [impactMd, setImpactMd] = useState<string>('');
+  const [suggestions, setSuggestions] = useState<PlanInitiativeSuggestions | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [refining, setRefining] = useState(false);
+  const [refineText, setRefineText] = useState('');
+  const [err, setErr] = useState<string | null>(null);
+  const submittedRef = useRef(false);
+
+  // Kick off the initial plan request when the panel opens.
+  useEffect(() => {
+    if (!open) {
+      // Reset on close so the next open re-runs.
+      setProposalId(null);
+      setImpactMd('');
+      setSuggestions(null);
+      setErr(null);
+      setRefineText('');
+      submittedRef.current = false;
+      return;
+    }
+    if (submittedRef.current) return;
+    submittedRef.current = true;
+
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setErr(null);
+      try {
+        const res = await fetch('/api/pm/plan-initiative', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            workspace_id: workspaceId,
+            draft,
+          }),
+        });
+        const body = await res.json();
+        if (!res.ok) throw new Error(body.error || `Plan failed (${res.status})`);
+        if (cancelled) return;
+        setProposalId(body.proposal_id);
+        setImpactMd(body.proposal?.impact_md ?? '');
+        setSuggestions(body.suggestions ?? null);
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : 'Plan failed');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, workspaceId, draft]);
+
+  const refine = async () => {
+    if (!proposalId || !refineText.trim()) return;
+    setRefining(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/pm/proposals/${proposalId}/refine`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ additional_constraint: refineText.trim() }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || `Refine failed (${res.status})`);
+      const newProposal = body.proposal;
+      setProposalId(newProposal.id);
+      setImpactMd(newProposal.impact_md);
+      const parsed = parseSuggestionsFromImpactMd(newProposal.impact_md);
+      if (parsed) setSuggestions(parsed);
+      setRefineText('');
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Refine failed');
+    } finally {
+      setRefining(false);
+    }
+  };
+
+  const apply = () => {
+    if (suggestions) onApply(suggestions);
+  };
+
+  if (!open) return null;
+
+  const titleFor = (id: string) =>
+    knownInitiatives?.find(i => i.id === id)?.title ?? id;
+
+  // Strip the embedded JSON comment from the markdown for human display.
+  const displayMd = impactMd.replace(/<!--pm-plan-suggestions[\s\S]*?-->/g, '').trim();
+
+  return (
+    <aside
+      className="border border-mc-accent/30 rounded-lg bg-mc-bg p-4 mt-4"
+      role="region"
+      aria-label="Plan with PM suggestions"
+    >
+      <header className="flex items-center gap-2 mb-3">
+        <Sparkles className="w-4 h-4 text-mc-accent" />
+        <h3 className="font-semibold text-mc-text text-sm">PM suggestions</h3>
+        <button
+          onClick={onClose}
+          aria-label="Close suggestions panel"
+          className="ml-auto p-1 rounded hover:bg-mc-bg-secondary text-mc-text-secondary hover:text-mc-text"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </header>
+
+      <div className="rounded border border-mc-border bg-mc-bg-secondary p-3 mb-3 text-xs">
+        <div className="text-mc-text-secondary uppercase tracking-wide text-[10px] mb-1">Your draft</div>
+        <div className="text-mc-text">
+          <strong>{draft.title}</strong>
+          {draft.description ? <p className="text-mc-text-secondary mt-1 whitespace-pre-wrap">{draft.description}</p> : null}
+        </div>
+      </div>
+
+      {err && (
+        <div className="p-2 rounded bg-red-500/10 border border-red-500/30 text-red-300 text-xs mb-3">
+          {err}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-mc-text-secondary">
+          <RefreshCw className="w-4 h-4 animate-spin" /> Thinking…
+        </div>
+      ) : suggestions ? (
+        <>
+          <div className="rounded border border-mc-border bg-mc-bg-secondary p-3 mb-3 text-xs space-y-2">
+            <div>
+              <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">Refined description</div>
+              <pre className="text-mc-text whitespace-pre-wrap font-sans text-xs mt-1">{suggestions.refined_description}</pre>
+            </div>
+            <div className="grid grid-cols-3 gap-3">
+              <div>
+                <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">Complexity</div>
+                <div className="text-mc-text font-medium">{suggestions.complexity}</div>
+              </div>
+              <div>
+                <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">Target start</div>
+                <div className="text-mc-text font-medium">{suggestions.target_start ?? '—'}</div>
+              </div>
+              <div>
+                <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">Target end</div>
+                <div className="text-mc-text font-medium">{suggestions.target_end}</div>
+              </div>
+            </div>
+            {suggestions.dependencies.length > 0 && (
+              <div>
+                <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">Possible dependencies</div>
+                <ul className="text-mc-text mt-1 space-y-1">
+                  {suggestions.dependencies.map(d => (
+                    <li key={d.depends_on_initiative_id}>
+                      <span className="font-medium">{titleFor(d.depends_on_initiative_id)}</span>{' '}
+                      <span className="text-mc-text-secondary italic">— {d.note}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+
+          <div className="text-[11px] text-mc-text-secondary mb-3 whitespace-pre-wrap">
+            {displayMd}
+          </div>
+
+          <div className="space-y-2 mb-3">
+            <label className="block">
+              <span className="text-xs text-mc-text-secondary">Refine (e.g., "make it L not M, drop the marketing dep")</span>
+              <div className="mt-1 flex items-center gap-2">
+                <input
+                  type="text"
+                  value={refineText}
+                  onChange={e => setRefineText(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault();
+                      refine();
+                    }
+                  }}
+                  className="flex-1 px-2 py-1.5 rounded bg-mc-bg-secondary border border-mc-border text-xs"
+                  placeholder="What should change?"
+                  disabled={refining}
+                />
+                <button
+                  onClick={refine}
+                  disabled={refining || !refineText.trim()}
+                  className="inline-flex items-center gap-1 px-2 py-1.5 rounded bg-mc-bg-secondary border border-mc-border text-xs text-mc-text disabled:opacity-50"
+                >
+                  <Send className="w-3 h-3" /> Send
+                </button>
+              </div>
+            </label>
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={onClose}
+              className="px-3 py-1.5 rounded border border-mc-border text-mc-text-secondary text-xs"
+            >
+              Save without applying
+            </button>
+            <button
+              onClick={apply}
+              className="px-3 py-1.5 rounded bg-mc-accent text-white text-xs"
+            >
+              Apply suggestions
+            </button>
+          </div>
+        </>
+      ) : (
+        <p className="text-sm text-mc-text-secondary">No suggestions yet.</p>
+      )}
+    </aside>
+  );
+}

--- a/src/lib/agents/pm-agent.ts
+++ b/src/lib/agents/pm-agent.ts
@@ -14,6 +14,9 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import type { Initiative } from '@/lib/db/initiatives';
+import type { PmDiff } from '@/lib/db/pm-proposals';
+import type { RoadmapSnapshot } from '@/lib/db/roadmap';
 
 let _cache: string | null = null;
 
@@ -57,3 +60,340 @@ export const PM_AGENT_AVATAR = '📋';
 export const PM_AGENT_ROLE = 'pm';
 export const PM_AGENT_DESCRIPTION =
   'Workspace project manager — maintains the roadmap, analyzes disruptions, proposes structured changes the operator approves.';
+
+// ─── Polish B: Guided synthesizers ──────────────────────────────────
+//
+// Two new synthesize seams matching the LLM-swap-in pattern of
+// `synthesizeImpactAnalysis` (pm-dispatch.ts). v1 is deterministic so
+// the proposal lifecycle is testable without an LLM dependency. v2 will
+// route through an LLM using the same input/output shape.
+
+export interface PlanInitiativeDraft {
+  title: string;
+  description?: string | null;
+  kind?: 'theme' | 'milestone' | 'epic' | 'story';
+  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+  parent_initiative_id?: string | null;
+  target_start?: string | null;
+  target_end?: string | null;
+}
+
+export interface PlanInitiativeSuggestions {
+  refined_description: string;
+  complexity: 'S' | 'M' | 'L' | 'XL';
+  target_start: string | null;
+  target_end: string;
+  dependencies: Array<{
+    depends_on_initiative_id: string;
+    kind: 'finish_to_start' | 'informational';
+    note: string;
+  }>;
+  status_check_md: string;
+  owner_agent_id: string | null;
+}
+
+export interface SynthesizePlanResult {
+  impact_md: string;
+  suggestions: PlanInitiativeSuggestions;
+  /** Stored on the proposal as `proposed_changes` for audit. The
+   *  acceptProposal handler treats plan_initiative as advisory and never
+   *  applies these — they exist as a snapshot of what the PM suggested. */
+  changes: PmDiff[];
+}
+
+/**
+ * Plan a draft initiative — produce a refined description + suggested
+ * scaffolding the operator can apply to the form.
+ *
+ * v1 heuristics (DETERMINISTIC):
+ *   - description: capitalize first letter, trim, append a "Goals" bullet
+ *     stub if the input is too short to read as goals.
+ *   - complexity: respect the operator's choice; otherwise infer from
+ *     description word count + keywords:
+ *       contains "platform"/"rebuild"/"migrate" → XL
+ *       contains "redesign"/"refactor"/"system" → L
+ *       contains "tweak"/"copy"/"text"/"fix"   → S
+ *       0-30 words → S, 31-100 → M, 101-300 → L, 300+ → XL
+ *   - target_start: today (or operator's value).
+ *   - target_end: target_start + complexity-derived offset:
+ *       S=7d, M=14d, L=28d, XL=56d.
+ *   - dependencies: scan workspace initiatives for noun overlap with the
+ *     draft title. We split on whitespace, drop stopwords, dedupe, and
+ *     emit informational dep suggestions (operator confirms which become
+ *     finish_to_start). Capped at 3 to avoid noise.
+ *   - status_check_md: scaffolded with three operator-fillable bullets
+ *     (Linked PR / Waiting on / Demo plan).
+ *   - owner_agent_id: null (v1 doesn't suggest owners — the agent picker
+ *     is the operator's call).
+ *
+ * The LLM swap-in seam is this whole function: replace the body with a
+ * model call that returns the same `SynthesizePlanResult` shape.
+ *
+ * `velocityOverrides`/`availabilityOverrides` are accepted for parity with
+ * `synthesizeImpactAnalysis` but unused in v1.
+ */
+export function synthesizePlanInitiative(
+  snapshot: RoadmapSnapshot,
+  draft: PlanInitiativeDraft,
+  _opts: {
+    velocityOverrides?: unknown;
+    availabilityOverrides?: unknown;
+  } = {},
+): SynthesizePlanResult {
+  const title = draft.title.trim();
+  const rawDesc = (draft.description ?? '').trim();
+  const wordCount = rawDesc ? rawDesc.split(/\s+/).filter(Boolean).length : 0;
+
+  // ─── Refined description ─────────────────────────────────────────
+  let refined: string;
+  if (rawDesc.length === 0) {
+    // Stub — give the operator a starting structure.
+    refined =
+      `${capitalizeFirst(title)}.\n\n` +
+      `**Goals**\n- (define the primary user value here)\n\n` +
+      `**Out of scope**\n- (call out what this is NOT)\n\n` +
+      `**Success criteria**\n- (one measurable outcome)`;
+  } else {
+    refined = capitalizeFirst(rawDesc);
+  }
+
+  // ─── Complexity heuristic ────────────────────────────────────────
+  const lowerCorpus = `${title} ${rawDesc}`.toLowerCase();
+  let complexity: 'S' | 'M' | 'L' | 'XL';
+  if (draft.complexity) {
+    complexity = draft.complexity;
+  } else if (/\b(platform|rebuild|migrate|migration|overhaul)\b/.test(lowerCorpus)) {
+    complexity = 'XL';
+  } else if (/\b(redesign|refactor|system|architecture|integrate)\b/.test(lowerCorpus)) {
+    complexity = 'L';
+  } else if (/\b(tweak|copy|text|fix|typo|polish)\b/.test(lowerCorpus)) {
+    complexity = 'S';
+  } else if (wordCount <= 30) complexity = 'S';
+  else if (wordCount <= 100) complexity = 'M';
+  else if (wordCount <= 300) complexity = 'L';
+  else complexity = 'XL';
+
+  // ─── Target window ───────────────────────────────────────────────
+  const offsetDays: Record<typeof complexity, number> = { S: 7, M: 14, L: 28, XL: 56 };
+  const today = new Date();
+  const start = draft.target_start ?? isoDate(today);
+  const startDate = new Date(start + 'T00:00:00Z');
+  const end = isoDate(addDays(startDate, offsetDays[complexity]));
+
+  // ─── Dependency suggestions (keyword overlap) ────────────────────
+  const dependencies: PlanInitiativeSuggestions['dependencies'] = [];
+  const titleNouns = extractNouns(title);
+  if (titleNouns.length > 0) {
+    const seen = new Set<string>();
+    for (const i of snapshot.initiatives) {
+      if (i.id === draft.parent_initiative_id) continue;
+      if (i.status === 'done' || i.status === 'cancelled') continue;
+      const otherNouns = extractNouns(i.title);
+      const overlap = titleNouns.filter(n => otherNouns.includes(n));
+      if (overlap.length === 0) continue;
+      if (seen.has(i.id)) continue;
+      seen.add(i.id);
+      dependencies.push({
+        depends_on_initiative_id: i.id,
+        kind: 'informational',
+        note: `Title shares "${overlap.join(', ')}" — confirm if this is a real dependency.`,
+      });
+      if (dependencies.length >= 3) break;
+    }
+  }
+
+  // ─── Status check scaffolding ────────────────────────────────────
+  const statusCheckMd =
+    `### Status check\n` +
+    `- **Linked PR / branch:** _(none yet)_\n` +
+    `- **Waiting on:** _(nothing)_\n` +
+    `- **Demo plan:** _(TBD)_`;
+
+  const suggestions: PlanInitiativeSuggestions = {
+    refined_description: refined,
+    complexity,
+    target_start: start,
+    target_end: end,
+    dependencies,
+    status_check_md: statusCheckMd,
+    owner_agent_id: null,
+  };
+
+  // ─── Compose impact_md (audit-friendly summary) ──────────────────
+  const lines: string[] = [
+    `### PM plan suggestion`,
+    ``,
+    `- **Title:** ${title}`,
+    `- **Suggested complexity:** ${complexity}` +
+      (draft.complexity ? ' (operator-set)' : ' (inferred)'),
+    `- **Suggested window:** ${start} → ${end}`,
+  ];
+  if (dependencies.length > 0) {
+    lines.push(`- **Possible dependencies (${dependencies.length}):**`);
+    for (const d of dependencies) {
+      const t = snapshot.initiatives.find(i => i.id === d.depends_on_initiative_id)?.title ?? d.depends_on_initiative_id;
+      lines.push(`  - "${t}" — ${d.note}`);
+    }
+  } else {
+    lines.push(`- **Dependencies:** none inferred`);
+  }
+  lines.push(
+    ``,
+    `_Advisory only — accept to record the suggestion; apply the form fields client-side._`,
+  );
+
+  // Embed the structured suggestions inside an HTML comment so the
+  // client can parse them out of any /api/pm/proposals/[id]/refine
+  // response (which returns only the proposal row). Markdown renderers
+  // ignore HTML comments, so this is invisible to humans.
+  lines.push('', `<!--pm-plan-suggestions ${JSON.stringify(suggestions)} -->`);
+
+  // No DB-applied changes for plan_initiative — proposed_changes stays
+  // empty so the advisory short-circuit in acceptProposal has nothing
+  // to apply. The audit lives in trigger_text + impact_md.
+  const changes: PmDiff[] = [];
+
+  return { impact_md: lines.join('\n'), suggestions, changes };
+}
+
+export interface SynthesizeDecomposeResult {
+  impact_md: string;
+  changes: PmDiff[];
+}
+
+/**
+ * Decompose an existing epic/milestone into 3-7 child initiatives.
+ *
+ * v1 templates (DETERMINISTIC):
+ *   - Title starts with "Build"/"Feature"/"Implement" →
+ *       [Design X, Implement core X, Wire X to UI, Test X end-to-end, Document X]
+ *   - Title starts with "Launch" or kind=milestone →
+ *       [Finalize scope for X, Engineering for X, Marketing for X, QA for X, Go-live for X]
+ *   - Otherwise → [Discovery for X, Implementation for X, Verification for X]
+ *
+ * Children are stories by default. The first child has no deps, each
+ * subsequent child depends on its predecessor (pre-wired chain) so the
+ * decomposed work has a sensible default ordering. Operators can edit
+ * before accepting.
+ *
+ * `hint` is appended to the description of every child as context.
+ *
+ * The LLM swap-in seam is this whole function — same pattern as
+ * `synthesizePlanInitiative`. v2 reads the parent's description + dep
+ * graph and produces richer breakdowns.
+ */
+export function synthesizeDecompose(
+  parent: Initiative,
+  hint?: string,
+  _opts: {
+    velocityOverrides?: unknown;
+    availabilityOverrides?: unknown;
+  } = {},
+): SynthesizeDecomposeResult {
+  const x = parent.title;
+  const lowerTitle = parent.title.toLowerCase();
+  const isLaunch = lowerTitle.startsWith('launch') || parent.kind === 'milestone';
+  const isBuild = /^(build|feature|implement|create|add)\b/i.test(parent.title);
+
+  let titles: string[];
+  if (isBuild) {
+    titles = [
+      `Design ${x}`,
+      `Implement core ${x}`,
+      `Wire ${x} to UI`,
+      `Test ${x} end-to-end`,
+      `Document ${x}`,
+    ];
+  } else if (isLaunch) {
+    titles = [
+      `Finalize scope for ${x}`,
+      `Engineering for ${x}`,
+      `Marketing for ${x}`,
+      `QA for ${x}`,
+      `Go-live for ${x}`,
+    ];
+  } else {
+    titles = [
+      `Discovery for ${x}`,
+      `Implementation for ${x}`,
+      `Verification for ${x}`,
+    ];
+  }
+
+  const baseDesc = parent.description?.trim() ?? '';
+  const hintBlock = hint ? `\n\n_Operator hint: ${hint.trim()}_` : '';
+
+  const changes: PmDiff[] = [];
+  for (let i = 0; i < titles.length; i++) {
+    const t = titles[i];
+    // Pre-wire each child to depend on the prior sibling — the operator
+    // can prune. We use placeholder ids `$0`, `$1`, … which resolve to
+    // real ids at apply time inside acceptProposal.
+    const deps = i === 0 ? [] : [`$${i - 1}`];
+    changes.push({
+      kind: 'create_child_initiative',
+      parent_initiative_id: parent.id,
+      title: t,
+      description:
+        `${t} for parent initiative "${x}".` +
+        (baseDesc ? `\n\nParent context:\n${baseDesc}` : '') +
+        hintBlock,
+      child_kind: 'story',
+      complexity: 'M',
+      sort_order: i,
+      depends_on_initiative_ids: deps,
+    });
+  }
+
+  const lines: string[] = [
+    `### PM decomposition for "${x}"`,
+    ``,
+    `Proposed ${changes.length} children (${isLaunch ? 'launch template' : isBuild ? 'build template' : 'generic template'}):`,
+    ``,
+  ];
+  for (const c of changes) {
+    if (c.kind === 'create_child_initiative') {
+      lines.push(`- ${c.title}`);
+    }
+  }
+  if (hint) {
+    lines.push(``, `_Operator hint applied: "${hint.trim()}"._`);
+  }
+  lines.push(
+    ``,
+    `Apply to insert these as children. You can edit titles or remove rows before accepting.`,
+  );
+
+  return { impact_md: lines.join('\n'), changes };
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function capitalizeFirst(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function addDays(d: Date, n: number): Date {
+  const r = new Date(d);
+  r.setUTCDate(r.getUTCDate() + n);
+  return r;
+}
+
+const STOPWORDS = new Set([
+  'a','an','the','and','or','but','of','to','in','on','for','with','at','by',
+  'from','up','as','is','it','be','do','we','our','i','my','this','that',
+  'plan','build','add','create','launch','new','setup','make','feature',
+]);
+
+function extractNouns(s: string): string[] {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length >= 4 && !STOPWORDS.has(w));
+}

--- a/src/lib/agents/pm-decompose.test.ts
+++ b/src/lib/agents/pm-decompose.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Decompose-with-PM tests (Polish B).
+ *
+ * Covers:
+ *   - synthesizeDecompose produces 3-5 children with valid kinds.
+ *   - acceptProposal applies create_child_initiative diffs:
+ *       * children inserted with right parent
+ *       * initiative_parent_history rows appended
+ *       * sibling placeholder ($N) deps resolved to real ids
+ *   - Validation rejects theme/milestone as child_kind.
+ *   - plan_initiative trigger_kind makes acceptProposal a no-op.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+import { createInitiative } from '@/lib/db/initiatives';
+import { synthesizeDecompose, synthesizePlanInitiative } from './pm-agent';
+import {
+  createProposal,
+  acceptProposal,
+  PmProposalValidationError,
+} from '@/lib/db/pm-proposals';
+import { getRoadmapSnapshot } from '@/lib/db/roadmap';
+
+function freshWorkspace(): string {
+  const id = `ws-decompose-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+// ─── Synthesizer ─────────────────────────────────────────────────────
+
+test('synthesizeDecompose: build-style parent → 3-7 children, all story kind', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Build invoicing module',
+    description: 'A new invoicing flow with PDF export',
+  });
+
+  const result = synthesizeDecompose(parent);
+  assert.ok(result.changes.length >= 3 && result.changes.length <= 7);
+  for (const c of result.changes) {
+    assert.equal(c.kind, 'create_child_initiative');
+    if (c.kind === 'create_child_initiative') {
+      assert.ok(['epic', 'story'].includes(c.child_kind));
+      assert.equal(c.parent_initiative_id, parent.id);
+    }
+  }
+});
+
+test('synthesizeDecompose: launch milestone → launch template', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Launch v2',
+    description: 'Public launch',
+  });
+
+  const result = synthesizeDecompose(parent);
+  // Launch template includes "Marketing" as one of the children.
+  const titles = result.changes
+    .filter(c => c.kind === 'create_child_initiative')
+    .map(c => (c.kind === 'create_child_initiative' ? c.title : ''));
+  assert.ok(titles.some(t => /marketing/i.test(t)));
+  assert.ok(titles.some(t => /go-live/i.test(t)));
+});
+
+test('synthesizeDecompose: generic parent → 3 children', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Customer success initiative',
+  });
+
+  const result = synthesizeDecompose(parent);
+  assert.equal(result.changes.length, 3);
+});
+
+test('synthesizeDecompose: hint is folded into child descriptions', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Build feature X',
+  });
+
+  const result = synthesizeDecompose(parent, 'focus on backend first');
+  for (const c of result.changes) {
+    if (c.kind === 'create_child_initiative') {
+      assert.match(c.description ?? '', /focus on backend first/);
+    }
+  }
+});
+
+// ─── Apply via acceptProposal ────────────────────────────────────────
+
+test('acceptProposal: create_child_initiative inserts children with audit + dep chain', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Build user notifications',
+  });
+
+  const synth = synthesizeDecompose(parent);
+  const proposal = createProposal({
+    workspace_id: ws,
+    trigger_text: JSON.stringify({ mode: 'decompose_initiative', initiative_id: parent.id }),
+    trigger_kind: 'decompose_initiative',
+    impact_md: synth.impact_md,
+    proposed_changes: synth.changes,
+  });
+
+  const result = acceptProposal(proposal.id);
+  assert.equal(result.idempotent_noop, false);
+  assert.ok(result.changes_applied >= 3);
+
+  // Children created under parent.
+  const created = queryAll<{ id: string; title: string; kind: string }>(
+    `SELECT id, title, kind FROM initiatives WHERE parent_initiative_id = ? ORDER BY sort_order`,
+    [parent.id],
+  );
+  assert.ok(created.length >= 3, 'expected children to be created');
+  for (const child of created) {
+    // Exactly one parent_history row per new child.
+    const rows = queryAll<{ to_parent_id: string; reason: string }>(
+      `SELECT to_parent_id, reason FROM initiative_parent_history WHERE initiative_id = ?`,
+      [child.id],
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].to_parent_id, parent.id);
+    assert.match(rows[0].reason, /PM decompose/);
+  }
+
+  // Dep chain: child[1] depends on child[0], etc. (the synthesizer
+  // pre-wires `$0`, `$1`, … placeholders).
+  for (let i = 1; i < created.length; i++) {
+    const deps = queryAll<{ depends_on_initiative_id: string }>(
+      `SELECT depends_on_initiative_id FROM initiative_dependencies WHERE initiative_id = ?`,
+      [created[i].id],
+    );
+    assert.ok(deps.length >= 1, `child[${i}] should have at least one dep`);
+    assert.equal(deps[0].depends_on_initiative_id, created[i - 1].id);
+  }
+});
+
+test('acceptProposal: rejects create_child_initiative with theme/milestone child_kind', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Parent' });
+
+  assert.throws(
+    () =>
+      createProposal({
+        workspace_id: ws,
+        trigger_text: 'test',
+        trigger_kind: 'decompose_initiative',
+        impact_md: 'x',
+        proposed_changes: [
+          {
+            // @ts-expect-error testing the validation path
+            kind: 'create_child_initiative',
+            parent_initiative_id: parent.id,
+            title: 'Bad theme child',
+            child_kind: 'theme',
+          },
+        ],
+      }),
+    PmProposalValidationError,
+  );
+});
+
+test('acceptProposal: plan_initiative is a no-op (advisory)', () => {
+  const ws = freshWorkspace();
+  const snapshot = getRoadmapSnapshot({ workspace_id: ws });
+  const synth = synthesizePlanInitiative(snapshot, { title: 'Hello' });
+
+  const proposal = createProposal({
+    workspace_id: ws,
+    trigger_text: JSON.stringify({ mode: 'plan_initiative', draft: { title: 'Hello' } }),
+    trigger_kind: 'plan_initiative',
+    impact_md: synth.impact_md,
+    proposed_changes: synth.changes,
+  });
+
+  const before = queryOne<{ n: number }>('SELECT COUNT(*) as n FROM initiatives WHERE workspace_id = ?', [ws]);
+  const result = acceptProposal(proposal.id);
+  const after = queryOne<{ n: number }>('SELECT COUNT(*) as n FROM initiatives WHERE workspace_id = ?', [ws]);
+
+  assert.equal(result.idempotent_noop, false);
+  // No rows applied — the array was empty AND the trigger_kind short-circuits.
+  assert.equal(result.proposal.status, 'accepted');
+  assert.equal(before!.n, after!.n);
+});

--- a/src/lib/agents/pm-plan.test.ts
+++ b/src/lib/agents/pm-plan.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Plan-with-PM synthesizer tests (Polish B).
+ *
+ * Covers the deterministic v1 of `synthesizePlanInitiative`:
+ *   - Returns a SynthesizePlanResult with the right shape.
+ *   - Suggests a target_end when the draft has no dates.
+ *   - Heuristics are stable for fixed inputs.
+ *   - Description-keyword complexity inference works.
+ *   - Overlap-based dependency suggestion picks workspace siblings.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import { createInitiative } from '@/lib/db/initiatives';
+import { getRoadmapSnapshot } from '@/lib/db/roadmap';
+import { synthesizePlanInitiative } from './pm-agent';
+
+function freshWorkspace(): string {
+  const id = `ws-plan-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+test('synthesizePlanInitiative: returns valid shape with title-only draft', () => {
+  const ws = freshWorkspace();
+  const snapshot = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizePlanInitiative(snapshot, { title: 'Build invoicing' });
+
+  assert.equal(typeof result.impact_md, 'string');
+  assert.ok(result.impact_md.length > 0);
+  assert.ok(result.suggestions);
+  assert.ok(result.suggestions.refined_description.length > 0);
+  assert.ok(['S', 'M', 'L', 'XL'].includes(result.suggestions.complexity));
+  assert.ok(result.suggestions.target_end);
+  assert.ok(Array.isArray(result.suggestions.dependencies));
+  assert.ok(result.suggestions.status_check_md.includes('Status check'));
+  // Plan-initiative is advisory — proposed_changes stays empty.
+  assert.equal(result.changes.length, 0);
+});
+
+test('synthesizePlanInitiative: suggests target_end when draft has no dates', () => {
+  const ws = freshWorkspace();
+  const snapshot = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizePlanInitiative(snapshot, { title: 'Add login' });
+  assert.ok(result.suggestions.target_end);
+  // target_start defaults to today (when not provided).
+  assert.ok(result.suggestions.target_start);
+  assert.ok(result.suggestions.target_end > result.suggestions.target_start!);
+});
+
+test('synthesizePlanInitiative: heuristic — "platform rebuild" → XL', () => {
+  const ws = freshWorkspace();
+  const snapshot = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizePlanInitiative(snapshot, {
+    title: 'Platform rebuild',
+    description: 'Migrate the legacy system to a new platform',
+  });
+  assert.equal(result.suggestions.complexity, 'XL');
+});
+
+test('synthesizePlanInitiative: heuristic — "fix typo" → S', () => {
+  const ws = freshWorkspace();
+  const snapshot = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizePlanInitiative(snapshot, {
+    title: 'Fix typo on homepage',
+    description: 'Change copy on the welcome banner',
+  });
+  assert.equal(result.suggestions.complexity, 'S');
+});
+
+test('synthesizePlanInitiative: respects operator-set complexity', () => {
+  const ws = freshWorkspace();
+  const snapshot = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizePlanInitiative(snapshot, {
+    title: 'Platform rebuild',
+    description: 'Migrate the legacy system',
+    complexity: 'M',
+  });
+  // Should NOT override the operator's choice.
+  assert.equal(result.suggestions.complexity, 'M');
+});
+
+test('synthesizePlanInitiative: deterministic for same input', () => {
+  const ws = freshWorkspace();
+  const snapshot = getRoadmapSnapshot({ workspace_id: ws });
+  const draft = {
+    title: 'Add invoicing module',
+    description: 'A new invoicing system',
+    target_start: '2026-05-01',
+  };
+  const a = synthesizePlanInitiative(snapshot, draft);
+  const b = synthesizePlanInitiative(snapshot, draft);
+  assert.equal(a.suggestions.complexity, b.suggestions.complexity);
+  assert.equal(a.suggestions.target_end, b.suggestions.target_end);
+  assert.equal(a.suggestions.refined_description, b.suggestions.refined_description);
+});
+
+test('synthesizePlanInitiative: noun-overlap picks workspace siblings as candidate deps', () => {
+  const ws = freshWorkspace();
+  // A sibling that shares "invoicing" with the draft title.
+  const sibling = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Invoicing data model',
+  });
+  // A sibling that shares no nouns.
+  createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Marketing automation',
+  });
+
+  const snapshot = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizePlanInitiative(snapshot, {
+    title: 'Build invoicing UI',
+  });
+
+  const dep = result.suggestions.dependencies.find(
+    d => d.depends_on_initiative_id === sibling.id,
+  );
+  assert.ok(dep, 'expected the invoicing-related sibling to be a candidate dep');
+  assert.equal(dep!.kind, 'informational');
+});
+
+test('synthesizePlanInitiative: target_end uses operator-supplied target_start', () => {
+  const ws = freshWorkspace();
+  const snapshot = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizePlanInitiative(snapshot, {
+    title: 'New page',
+    target_start: '2026-06-01',
+    complexity: 'M',
+  });
+  assert.equal(result.suggestions.target_start, '2026-06-01');
+  // M = 14d offset → 2026-06-15.
+  assert.equal(result.suggestions.target_end, '2026-06-15');
+});

--- a/src/lib/agents/pm-soul.md
+++ b/src/lib/agents/pm-soul.md
@@ -78,6 +78,7 @@ Each diff is one of:
 - `{ "kind": "remove_dependency", "dependency_id": "..." }`
 - `{ "kind": "reorder_initiatives", "parent_id": "...", "child_ids_in_order": ["..."] }`
 - `{ "kind": "update_status_check", "initiative_id": "...", "status_check_md": "..." }`
+- `{ "kind": "create_child_initiative", "parent_initiative_id": "...", "title": "...", "child_kind": "epic|story", "complexity": "S|M|L|XL", "depends_on_initiative_ids": ["..."] }` — only emitted from a `decompose_initiative` proposal.
 
 Apply is all-or-nothing in v1. Keep diffs minimal — propose only what the
 operator asked about plus any cascading status flips that follow logically.
@@ -88,3 +89,51 @@ If the operator asks to refine ("don't slip the launch milestone, defer
 analytics instead"), you'll get a `parent_proposal_id` and an
 `additional_constraint`. Re-derive with the new constraint, write a fresh
 proposal that supersedes the parent.
+
+## Guided modes (Polish B)
+
+Beyond the reactive disruption flow, the PM has two operator-driven
+guided modes:
+
+### Plan an initiative draft (`trigger_kind=plan_initiative`)
+
+When asked to PLAN an initiative draft, you receive a partial draft
+(title + rough description, optional kind/complexity/window). Produce:
+
+- A refined description (clean prose; goals + out-of-scope + success
+  criteria when the draft is sparse).
+- A suggested complexity (S/M/L/XL) inferred from the description's
+  length and keyword shape (rebuild/migration → XL; redesign/refactor → L;
+  tweak/copy → S; otherwise word count buckets).
+- A suggested target window (today + complexity-derived offset).
+- Candidate dependencies among existing workspace initiatives, surfaced
+  by keyword overlap and capped at three. Mark them `informational` —
+  the operator promotes to `finish_to_start` if real.
+- A status_check_md scaffold (Linked PR / Waiting on / Demo plan).
+
+**Critically:** plan_initiative is **purely advisory**. The proposal is
+recorded for audit and refinement, but `acceptProposal` is a no-op for
+this trigger_kind — the operator applies the suggestions client-side by
+populating the new-initiative form. This is intentional: the form is
+the source of truth for create-time fields; the PM is the suggester,
+not the actor, even at the planning layer.
+
+### Decompose an existing epic/milestone (`trigger_kind=decompose_initiative`)
+
+When asked to DECOMPOSE an epic or milestone, propose 3-7 child
+initiatives that together cover the parent's scope. Each child:
+
+- Title is task-shaped ("Design X", "Engineering for X", etc.).
+- `child_kind` is `epic` or `story` only — themes/milestones are
+  operator-driven and never proposed via this path.
+- Includes a brief description that quotes the parent's title and any
+  operator hint.
+- Carries a complexity estimate (default M).
+- May pre-wire `depends_on_initiative_ids` against sibling placeholder
+  ids (`$0`, `$1`, …) so the chain has sensible default ordering. The
+  operator can prune.
+
+Output as a `decompose_initiative` proposal whose `proposed_changes` is
+an array of `create_child_initiative` diffs. On accept the children
+are inserted under the parent in a single transaction with matching
+`initiative_parent_history` rows; sibling deps are resolved post-insert.

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -2778,6 +2778,77 @@ const migrations: Migration[] = [
       );
     },
   },
+  {
+    id: '047',
+    name: 'pm_proposals_trigger_kind_guided_modes',
+    up: (db) => {
+      // Polish B (guided planning) — extend pm_proposals.trigger_kind CHECK
+      // to include 'plan_initiative' and 'decompose_initiative' so the new
+      // advisory and decomposition flows can write rows. SQLite can't ALTER
+      // a CHECK in place, so we patch the stored CREATE TABLE text via
+      // writable_schema (same surgical technique as migrations 036/037/043).
+      console.log('[Migration 047] Extending pm_proposals.trigger_kind with plan_initiative + decompose_initiative...');
+
+      const row = db.prepare(
+        `SELECT sql FROM sqlite_master WHERE type='table' AND name='pm_proposals'`,
+      ).get() as { sql: string } | undefined;
+      if (!row) {
+        console.log('[Migration 047] pm_proposals table absent; skipping.');
+        return;
+      }
+      if (row.sql.includes("'plan_initiative'") && row.sql.includes("'decompose_initiative'")) {
+        console.log('[Migration 047] Already extended; skipping.');
+        return;
+      }
+
+      // Match the exact CHECK clause shape from migration 043 first; fall
+      // back to a permissive regex if the stored shape differs.
+      const oldCheck = `trigger_kind TEXT NOT NULL DEFAULT 'manual'
+            CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation'))`;
+      const newCheck = `trigger_kind TEXT NOT NULL DEFAULT 'manual'
+            CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation','plan_initiative','decompose_initiative'))`;
+
+      let patched: string;
+      if (row.sql.includes(oldCheck)) {
+        patched = row.sql.replace(oldCheck, newCheck);
+      } else {
+        // Permissive fallback — match any whitespace shape and append our
+        // two new values to the IN(...) list.
+        const re = /(trigger_kind\s+TEXT\s+NOT\s+NULL\s+DEFAULT\s+'manual'\s*\n?\s*CHECK\s*\(\s*trigger_kind\s+IN\s*\()([^)]+)(\))/i;
+        const m = row.sql.match(re);
+        if (!m) {
+          console.warn('[Migration 047] trigger_kind CHECK shape unrecognized; current schema:\n' + row.sql);
+          throw new Error('[Migration 047] Unable to locate trigger_kind CHECK clause — refusing to patch');
+        }
+        const inList = m[2].trim();
+        const newInList = `${inList}, 'plan_initiative', 'decompose_initiative'`;
+        patched = row.sql.replace(re, `$1${newInList}$3`);
+      }
+
+      const escaped = patched.replace(/'/g, "''");
+      db.unsafeMode(true);
+      try {
+        db.pragma('writable_schema = ON');
+        db.exec(
+          `UPDATE sqlite_master SET sql = '${escaped}' WHERE type='table' AND name='pm_proposals'`,
+        );
+        db.pragma('writable_schema = OFF');
+
+        const integrity = db.prepare('PRAGMA integrity_check').all() as { integrity_check: string }[];
+        // "Page X: never used" is a benign leaked-space warning from prior
+        // VACUUM-less writes (matches migration 043's filter).
+        const isBenign = (msg: string) =>
+          msg === 'ok' || /^Page \d+: never used$/.test(msg);
+        const realErrors = integrity.filter(r => !isBenign(r.integrity_check));
+        if (realErrors.length > 0) {
+          throw new Error('[Migration 047] integrity_check failed after writable_schema patch: ' + JSON.stringify(realErrors));
+        }
+      } finally {
+        db.unsafeMode(false);
+      }
+      console.log('[Migration 047] Complete.');
+    },
+  },
 ];
 
 // Inline PM soul_md reader for migration 045. The full module

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -34,7 +34,9 @@ export type PmProposalTriggerKind =
   | 'manual'
   | 'scheduled_drift_scan'
   | 'disruption_event'
-  | 'status_check_investigation';
+  | 'status_check_investigation'
+  | 'plan_initiative'
+  | 'decompose_initiative';
 
 export type PmDiff =
   | {
@@ -72,6 +74,25 @@ export type PmDiff =
       kind: 'update_status_check';
       initiative_id: string;
       status_check_md: string;
+    }
+  | {
+      // Polish B (decompose flow). On accept, the decompose handler inserts
+      // one initiative row under `parent_initiative_id`. `depends_on_initiative_ids`
+      // can carry placeholder ids (`$0`, `$1`, …) that point to other
+      // siblings created in the SAME accept call (resolved post-insert) or
+      // real ids for existing initiatives. `child_kind` is constrained to
+      // {epic, story} — themes/milestones are operator-driven only.
+      kind: 'create_child_initiative';
+      parent_initiative_id: string;
+      title: string;
+      description?: string | null;
+      child_kind: 'epic' | 'story';
+      complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+      estimated_effort_hours?: number | null;
+      sort_order?: number;
+      depends_on_initiative_ids?: string[];
+      /** Optional placeholder id for cross-sibling dep resolution. */
+      placeholder_id?: string;
     };
 
 export interface PmProposal {
@@ -261,6 +282,39 @@ export function validateProposedChanges(
         }
         break;
       }
+      case 'create_child_initiative': {
+        if (!c.parent_initiative_id) {
+          errors.push(`changes[${i}]: parent_initiative_id required`);
+          break;
+        }
+        assertInitiativeInWorkspace(workspaceId, c.parent_initiative_id, errors, initiativeCache);
+        if (!c.title || typeof c.title !== 'string') {
+          errors.push(`changes[${i}]: title required`);
+        }
+        // Hard-coded allowlist for child_kind — themes/milestones are
+        // operator-driven and never proposed by the PM.
+        if (c.child_kind !== 'epic' && c.child_kind !== 'story') {
+          errors.push(
+            `changes[${i}]: child_kind must be 'epic' or 'story' (got '${c.child_kind}')`,
+          );
+        }
+        if (c.complexity != null && !['S', 'M', 'L', 'XL'].includes(c.complexity)) {
+          errors.push(`changes[${i}]: complexity must be one of S/M/L/XL`);
+        }
+        if (Array.isArray(c.depends_on_initiative_ids)) {
+          for (const ref of c.depends_on_initiative_ids) {
+            // Placeholder ids ($0, $1, …) are resolved at apply time so we
+            // skip the workspace check here. Real ids must already exist.
+            if (typeof ref !== 'string') {
+              errors.push(`changes[${i}]: depends_on_initiative_ids must be strings`);
+              continue;
+            }
+            if (ref.startsWith('$')) continue;
+            assertInitiativeInWorkspace(workspaceId, ref, errors, initiativeCache);
+          }
+        }
+        break;
+      }
       default: {
         const exhaustive: never = c;
         errors.push(`changes[${i}]: unknown kind "${(exhaustive as { kind?: string }).kind ?? '?'}"`);
@@ -430,10 +484,66 @@ export function acceptProposal(
   let changesApplied = 0;
   const now = new Date().toISOString();
 
+  // plan_initiative is advisory: no DB writes other than flipping the
+  // proposal row to 'accepted'. The operator applies the suggestions
+  // client-side by populating the create-initiative form. Keeps the
+  // refine + audit chain intact without touching real state.
+  const isAdvisory = existing.trigger_kind === 'plan_initiative';
+
   db.transaction(() => {
-    for (const change of existing.proposed_changes) {
-      applyDiff(change, now);
-      changesApplied++;
+    if (!isAdvisory) {
+      // Build placeholder→real id map for cross-sibling dep resolution
+      // (used by create_child_initiative diffs in decompose flows).
+      const placeholderMap = new Map<string, string>();
+      // First pass: insert children, populate the map.
+      for (let idx = 0; idx < existing.proposed_changes.length; idx++) {
+        const change = existing.proposed_changes[idx];
+        if (change.kind === 'create_child_initiative') {
+          const newId = applyCreateChildInitiative(
+            existing.workspace_id,
+            change,
+            now,
+            applied_by_agent_id,
+            id,
+          );
+          // Two index forms accepted: explicit `placeholder_id` field or
+          // ordinal `$N` based on diff position.
+          placeholderMap.set(`$${idx}`, newId);
+          if (change.placeholder_id) {
+            placeholderMap.set(change.placeholder_id, newId);
+          }
+          changesApplied++;
+        }
+      }
+      // Second pass: dep edges + remaining diffs.
+      for (let idx = 0; idx < existing.proposed_changes.length; idx++) {
+        const change = existing.proposed_changes[idx];
+        if (change.kind === 'create_child_initiative') {
+          // Resolve dep placeholders against the freshly-built map and
+          // create dependency edges.
+          const childId = placeholderMap.get(`$${idx}`);
+          if (childId && Array.isArray(change.depends_on_initiative_ids)) {
+            for (const rawRef of change.depends_on_initiative_ids) {
+              const realRef = rawRef.startsWith('$')
+                ? placeholderMap.get(rawRef)
+                : rawRef;
+              if (!realRef) {
+                throw new PmProposalValidationError(
+                  `create_child_initiative: unresolved placeholder dep "${rawRef}"`,
+                );
+              }
+              run(
+                `INSERT INTO initiative_dependencies (id, initiative_id, depends_on_initiative_id, kind, note, created_at)
+                 VALUES (?, ?, ?, 'finish_to_start', ?, ?)`,
+                [uuidv4(), childId, realRef, null, now],
+              );
+            }
+          }
+          continue;
+        }
+        applyDiff(change, now);
+        changesApplied++;
+      }
     }
 
     // Flip the proposal row.
@@ -545,11 +655,68 @@ function applyDiff(diff: PmDiff, now: string): void {
       );
       return;
     }
+    case 'create_child_initiative': {
+      // Handled out-of-band in acceptProposal so cross-sibling dep
+      // placeholders can resolve in a second pass. Reaching this branch
+      // is a programming error.
+      throw new Error('create_child_initiative must be applied via applyCreateChildInitiative');
+    }
     default: {
       const exhaustive: never = diff;
       throw new Error(`Unknown diff kind: ${(exhaustive as { kind?: string }).kind ?? '?'}`);
     }
   }
+}
+
+/**
+ * Apply one `create_child_initiative` diff. Inserts the initiative row,
+ * appends an `initiative_parent_history` audit row, and returns the new
+ * id so the caller can wire dep placeholders post-hoc.
+ *
+ * Caller wraps in a transaction — same pattern as `applyDiff`.
+ */
+function applyCreateChildInitiative(
+  workspace_id: string,
+  diff: Extract<PmDiff, { kind: 'create_child_initiative' }>,
+  now: string,
+  applied_by_agent_id: string | null,
+  proposal_id: string,
+): string {
+  const childId = uuidv4();
+  run(
+    `INSERT INTO initiatives (
+       id, workspace_id, parent_initiative_id, kind, title, description,
+       status, complexity, estimated_effort_hours, sort_order,
+       created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, 'planned', ?, ?, ?, ?, ?)`,
+    [
+      childId,
+      workspace_id,
+      diff.parent_initiative_id,
+      diff.child_kind,
+      diff.title,
+      diff.description ?? null,
+      diff.complexity ?? null,
+      diff.estimated_effort_hours ?? null,
+      diff.sort_order ?? 0,
+      now,
+      now,
+    ],
+  );
+  run(
+    `INSERT INTO initiative_parent_history (
+       id, initiative_id, from_parent_id, to_parent_id, moved_by_agent_id, reason, created_at
+     ) VALUES (?, ?, NULL, ?, ?, ?, ?)`,
+    [
+      uuidv4(),
+      childId,
+      diff.parent_initiative_id,
+      applied_by_agent_id,
+      `created via PM decompose proposal #${proposal_id}`,
+      now,
+    ],
+  );
+  return childId;
 }
 
 // ─── Reject / refine ────────────────────────────────────────────────

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -912,7 +912,7 @@ CREATE TABLE IF NOT EXISTS pm_proposals (
   workspace_id TEXT NOT NULL REFERENCES workspaces(id),
   trigger_text TEXT NOT NULL,
   trigger_kind TEXT NOT NULL DEFAULT 'manual'
-    CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation')),
+    CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation','plan_initiative','decompose_initiative')),
   impact_md TEXT NOT NULL,
   proposed_changes TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'draft'


### PR DESCRIPTION
## Summary
Connects the initiative form to the PM agent so operators can:
1. Iterate with the PM on a draft initiative (title + rough description) → get refined description, suggested dates, complexity, deps. Apply to populate the form, then Save.
2. Right-click an epic/milestone → PM proposes 3-7 child initiatives. Review, edit, accept → children created with audit rows.

Both flows reuse the existing pm_proposals lifecycle (refine + accept). New advisory trigger kind for plan; new \`create_child_initiative\` diff kind for decompose.

## What landed
- **Migration 047** — extends \`pm_proposals.trigger_kind\` CHECK to include \`plan_initiative\` and \`decompose_initiative\` (writable_schema patch with the same orphan-page-tolerant integrity check as migration 043).
- **Synthesizers** (\`src/lib/agents/pm-agent.ts\`):
  - \`synthesizePlanInitiative\` — deterministic v1: complexity heuristic from keywords + word count, target_end from complexity-derived offset (S=7d, M=14d, L=28d, XL=56d), candidate deps from noun overlap (cap 3), status_check_md scaffolding. LLM swap-in seam documented.
  - \`synthesizeDecompose\` — deterministic v1: build/launch/generic templates produce 3-5 children, pre-wired sibling deps via \`$0\`/\`$1\` placeholders.
- **API routes**:
  - \`POST /api/pm/plan-initiative\` — advisory proposal; suggestions returned in body and embedded in \`impact_md\` as an HTML-comment JSON sidecar so refine() can return them.
  - \`POST /api/pm/decompose-initiative\` — draft proposal with \`create_child_initiative\` diffs; rejects story-kind parents.
  - \`PUT /api/pm/proposals/[id]/diffs\` — lets the decompose modal persist operator edits before accepting (required because the PM proposes, the operator edits, then we apply).
  - Refine route extended to dispatch on \`trigger_kind\` (plan / decompose / disruption) to the right synthesizer.
- **acceptProposal**:
  - \`plan_initiative\` short-circuits as a no-op (advisory only).
  - \`create_child_initiative\` runs in two passes inside the transaction: insert children, then resolve \`\$N\` placeholder deps and create \`initiative_dependencies\` edges. Each child gets an \`initiative_parent_history\` row.
  - Validation rejects \`child_kind ∈ {theme, milestone}\`.
- **UI**:
  - "Plan with PM" button next to Save in the EditDrawer; opens \`PlanWithPmPanel\` inline (suggestions card + refine input + Apply / Save without applying). Disabled until title is non-empty.
  - "Decompose with PM" entry in the \`⋮\` menu (epic/milestone only) and a button on \`/initiatives/[id]\` for those kinds. \`DecomposeWithPmModal\` shows the proposed children as a checklist with reorder, inline edit, remove, add, and refine.
- **Persona** (\`pm-soul.md\`) — new "Guided modes" section; \`create_child_initiative\` added to the diff-kinds list.
- **Spec** — §9.4 amended; §9.5 "Guided modes (Polish B)" added.
- **Tests** — 23 new (8 plan synthesizer, 7 decompose synthesizer/accept, 4 plan-initiative API, 4 decompose API). Full suite: 320 pass / 0 fail under \`tsx --test --test-concurrency=1\`.

## Design decisions worth flagging
- **plan_initiative is advisory.** \`acceptProposal\` short-circuits on this trigger_kind. The operator applies suggestions client-side via the form. Rationale: the create-initiative form is the source of truth for create-time fields; making the PM mutate state directly would split that ownership. The proposal still exists for audit and supports the refine chain.
- **\`create_child_initiative\` does mutate state.** Decomposing an existing initiative is a different flow — the parent already exists, the PM is producing children. Accept inserts them transactionally with audit rows.
- **Suggestions sidecar in impact_md.** \`PlanWithPmPanel\` needs to read structured suggestions out of any \`/refine\` response (which only returns the proposal row, not synthesizer output). I embed the JSON in an HTML comment that markdown ignores. Alternative: a dedicated suggestions column on \`pm_proposals\` — but that bloats the schema for a single trigger_kind.
- **PUT /diffs route.** Decompose lets the operator edit the proposed children before accepting. v1 persists those edits via a small in-place update on \`proposed_changes\` (only allowed in \`draft\` status, with full re-validation). Less invasive than a per-diff PATCH endpoint.

## Test plan
- [ ] Drawer "Plan with PM" produces suggestions, refine loops, Apply populates form
- [ ] Decompose modal lists proposed children, reorder/edit/remove works, Accept creates them with history rows
- [ ] PM never auto-promotes; plan_initiative is advisory only
- [ ] Existing reactive PM + drift scan + standup unaffected
- [ ] yarn build green; full test suite passes (320/320 with --test-concurrency=1)

## Notes on test infra
The npm test script (post #47) still has DB race conditions when run with default \`tsx --test\` (parallel mode). With \`--test-concurrency=1\` (the flag the prompt specifies) all 320 pass cleanly. Recommend either updating the npm script to add the flag or accepting the parallel-run flakiness as a known issue — every existing test file was already written assuming sequential DB access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>