### PR TITLE
schema: add ON DELETE CASCADE / SET NULL across FK graph + guardrail test

### DIFF
--- a/specs/cascade-rules.md
+++ b/specs/cascade-rules.md
@@ -1,0 +1,144 @@
+# Schema FK Cascade Rules
+
+**Last touched:** migration 048 (`fk_cascade_safety`)
+**Guardrail test:** `src/lib/db/schema-cascade.test.ts`
+
+Mission Control's data model has a small set of "top-level" entities — workspaces, tasks, agents, initiatives, products, ideas — and a long tail of auxiliary tables that reference them. When a top-level row is deleted, every FK pointing at it must declare what happens to the dependent row.
+
+This page is the source of truth for those decisions. The guardrail test enforces that no FK to a guarded parent is left as a plain reference — every FK gets either `ON DELETE CASCADE` or `ON DELETE SET NULL`.
+
+## Decision rule
+
+- **`ON DELETE CASCADE`** when the dependent row is meaningless without its parent. e.g. `task_deliverables` without a `task` is garbage; `convoy_subtasks` without a `convoy` is garbage; `agent_health` without an `agent` is garbage.
+- **`ON DELETE SET NULL`** when the dependent row should survive but lose context. Audit-trail rows (`events`, `task_initiative_history`, `initiative_parent_history`), durable user-facing artifacts (`ideas`, `knowledge_entries`, `content_inventory`, `product_skills`), and rows that just happen to mention the parent for context (`tasks.assigned_agent_id`, `tasks.initiative_id`) all SET NULL.
+
+## Cascade matrix (top-level entities)
+
+### `workspaces`
+
+Everything below cascades. Deleting a workspace empties it and removes the workspace row itself.
+
+| Child table | Column | Rule |
+|---|---|---|
+| `agents` | `workspace_id` | CASCADE |
+| `tasks` | `workspace_id` | CASCADE |
+| `workflow_templates` | `workspace_id` | CASCADE |
+| `knowledge_entries` | `workspace_id` | CASCADE |
+| `rollcall_sessions` | `workspace_id` | CASCADE |
+| `products` | `workspace_id` | CASCADE |
+| `cost_events` | `workspace_id` | CASCADE |
+| `cost_caps` | `workspace_id` | CASCADE |
+| `initiatives` | `workspace_id` | CASCADE |
+| `pm_proposals` | `workspace_id` | CASCADE |
+
+### `tasks`
+
+| Child table | Column | Rule | Notes |
+|---|---|---|---|
+| `planning_questions` | `task_id` | CASCADE | |
+| `planning_specs` | `task_id` | CASCADE | |
+| `task_roles` | `task_id` | CASCADE | |
+| `task_activities` | `task_id` | CASCADE | |
+| `task_deliverables` | `task_id` | CASCADE | |
+| `work_checkpoints` | `task_id` | CASCADE | |
+| `task_notes` | `task_id` | CASCADE | |
+| `user_task_reads` | `task_id` | CASCADE | |
+| `task_initiative_history` | `task_id` | CASCADE | |
+| `workspace_ports` | `task_id` | CASCADE | |
+| `workspace_merges` | `task_id` | CASCADE | |
+| `convoys` | `parent_task_id` | CASCADE | |
+| `convoy_subtasks` | `task_id` | CASCADE | |
+| `openclaw_sessions` | `task_id` | CASCADE | session is bound to task lifetime |
+| `skill_reports` | `task_id` | CASCADE | report is part of the task that produced it |
+| `conversations` | `task_id` | SET NULL | chat history survives |
+| `events` | `task_id` | SET NULL | audit trail survives |
+| `agent_health` | `task_id` | SET NULL | last-observed health survives end-of-task |
+| `agent_mailbox` | `task_id` | SET NULL | mail outlives transient task scoping |
+| `knowledge_entries` | `task_id` | SET NULL | knowledge is durable |
+| `ideas` | `task_id` | SET NULL | idea outlives the build task |
+| `content_inventory` | `task_id` | SET NULL | content survives the task that produced it |
+| `product_skills` | `created_by_task_id` | SET NULL | skill is durable |
+| `cost_events` | `task_id` | SET NULL | billing rows survive |
+
+### `agents`
+
+| Child table | Column | Rule | Notes |
+|---|---|---|---|
+| `task_roles` | `agent_id` | CASCADE | NOT NULL — role assignment requires an agent |
+| `work_checkpoints` | `agent_id` | CASCADE | NOT NULL |
+| `agent_health` | `agent_id` | CASCADE | |
+| `agent_chat_messages` | `agent_id` | CASCADE | |
+| `owner_availability` | `agent_id` | CASCADE | |
+| `openclaw_sessions` | `agent_id` | CASCADE | session is owned by agent |
+| `agent_mailbox` | `from_agent_id`, `to_agent_id` | CASCADE | NOT NULL — see "Tradeoffs" below |
+| `rollcall_sessions` | `initiator_agent_id` | CASCADE | NOT NULL |
+| `rollcall_entries` | `target_agent_id` | CASCADE | NOT NULL |
+| `conversation_participants` | `agent_id` | CASCADE | join row dies with member |
+| `tasks` | `assigned_agent_id`, `created_by_agent_id` | SET NULL | task survives agent loss |
+| `messages` | `sender_agent_id` | SET NULL | audit trail |
+| `events` | `agent_id` | SET NULL | audit trail |
+| `task_activities` | `agent_id` | SET NULL | activity log survives |
+| `knowledge_entries` | `created_by_agent_id` | SET NULL | knowledge is durable |
+| `research_cycles` | `agent_id` | SET NULL | cycle audit survives |
+| `cost_events` | `agent_id` | SET NULL | billing rows survive |
+| `operations_log` | `agent_id` | SET NULL | audit |
+| `product_skills` | `created_by_agent_id` | SET NULL | skill is durable |
+| `initiatives` | `owner_agent_id` | SET NULL | initiative survives owner change |
+| `initiative_parent_history` | `moved_by_agent_id` | SET NULL | audit |
+| `task_initiative_history` | `moved_by_agent_id` | SET NULL | audit |
+| `pm_proposals` | `applied_by_agent_id` | SET NULL | proposal survives |
+
+### `initiatives`
+
+`deleteInitiative` blocks deletion when descendants exist (see `initiatives.ts`), so most of these are belt-and-suspenders, not load-bearing.
+
+| Child table | Column | Rule |
+|---|---|---|
+| `initiative_dependencies` | `initiative_id`, `depends_on_initiative_id` | CASCADE |
+| `initiative_parent_history` | `initiative_id` | CASCADE |
+| `tasks` | `initiative_id` | SET NULL |
+| `ideas` | `initiative_id` | SET NULL |
+| `initiatives` | `parent_initiative_id` | SET NULL |
+| `initiative_parent_history` | `from_parent_id`, `to_parent_id` | SET NULL |
+| `task_initiative_history` | `from_initiative_id`, `to_initiative_id` | SET NULL |
+
+### `products`
+
+| Child table | Column | Rule |
+|---|---|---|
+| `research_cycles`, `ideation_cycles`, `autopilot_activity_log`, `ideas`, `idea_embeddings`, `idea_suppressions`, `swipe_history`, `preference_models`, `maybe_pool`, `product_feedback`, `product_schedules`, `operations_log`, `content_inventory`, `social_queue`, `seo_keywords`, `product_health_scores`, `product_program_variants`, `product_ab_tests`, `product_skills` | `product_id` | CASCADE |
+| `tasks` | `product_id` | SET NULL |
+| `cost_events` | `product_id` | SET NULL |
+| `cost_caps` | `product_id` | SET NULL (downgrade to workspace-scope) |
+| `initiatives` | `product_id` | SET NULL |
+
+### `ideas`
+
+| Child table | Column | Rule |
+|---|---|---|
+| `idea_embeddings`, `swipe_history`, `maybe_pool` | `idea_id` | CASCADE |
+| `idea_suppressions` | `similar_to_idea_id` | CASCADE |
+| `tasks` | `idea_id` | SET NULL |
+| `ideas` | `resurfaced_from` | SET NULL |
+| `product_feedback`, `content_inventory`, `social_queue` | `idea_id` | SET NULL |
+| `initiatives` | `source_idea_id` | SET NULL |
+
+## Tradeoffs worth flagging
+
+**`agent_mailbox.from_agent_id` / `to_agent_id` are CASCADE, not SET NULL.**
+The columns are NOT NULL by structural design (mail must have sender + recipient). To preserve mail across agent deletion we'd have to drop the NOT NULL constraint. We chose the simpler route: deleting an agent purges their inbox / outbox. If you later want mail to survive (e.g. for compliance auditing), drop NOT NULL on both columns and switch the FK action to SET NULL.
+
+**`rollcall_sessions.initiator_agent_id`, `rollcall_entries.target_agent_id` are CASCADE.**
+Same reasoning — NOT NULL columns, transient state, no compelling audit need.
+
+**`work_checkpoints.agent_id` is CASCADE.**
+NOT NULL. Checkpoint is meaningless without the agent that produced it; CASCADE matches the structural intent.
+
+## Guardrail
+
+`src/lib/db/schema-cascade.test.ts` parses the schema (compiled into a fresh in-memory DB) and asserts:
+
+1. Every FK to a guarded parent (workspaces, tasks, agents, initiatives, products, ideas, convoys, conversations, research_cycles, rollcall_sessions, workflow_templates, product_skills, product_program_variants, pm_proposals, agent_mailbox) carries `ON DELETE CASCADE` or `ON DELETE SET NULL` — never bare `NO ACTION`.
+2. Every `workspace_id` FK is `CASCADE` (workspace-scoped rows are never durable past workspace deletion).
+
+When you add a new table, the test will tell you exactly which FK is missing its delete rule. Update both `schema.ts` and `migrations.ts` (the next pending migration), then update this page if the new entity is itself a "top-level" parent.

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -2849,7 +2849,331 @@ const migrations: Migration[] = [
       console.log('[Migration 047] Complete.');
     },
   },
+  {
+    id: '048',
+    name: 'fk_cascade_safety',
+    up: (db) => {
+      // Hardening pass: most FKs in earlier migrations were declared without
+      // an ON DELETE rule, so deleting a parent row failed (FK on) or left
+      // orphans (FK off). PR #53's deleteWorkspaceCascade worked around
+      // that by manually walking ~20 dependent tables with FKs disabled.
+      //
+      // Now that nothing is in production yet, fix it properly: add the
+      // right ON DELETE rule to every FK that targets workspaces, tasks,
+      // agents, initiatives, products, ideas, conversations, convoys,
+      // research_cycles, workflow_templates, rollcall_sessions,
+      // product_skills, product_program_variants, or pm_proposals.
+      //
+      // Decision rule:
+      //   - CASCADE  if a row has no meaning without its parent
+      //              (e.g. task_deliverables without a task)
+      //   - SET NULL if the row should survive but lose context
+      //              (e.g. events.task_id — the event still happened,
+      //              just orphaned from the task that triggered it)
+      //
+      // SET NULL choices worth flagging (audit-trail / durability):
+      //   tasks.assigned_agent_id, tasks.created_by_agent_id,
+      //   tasks.product_id, tasks.idea_id, tasks.initiative_id,
+      //   tasks.workflow_template_id            — task survives parent loss
+      //   events.agent_id, events.task_id       — audit trail survives
+      //   conversations.task_id                 — chat history survives
+      //   messages.sender_agent_id              — message survives
+      //   knowledge_entries.task_id, .created_by_agent_id
+      //                                         — knowledge is durable
+      //   task_activities.agent_id              — activity log survives
+      //   agent_health.task_id                  — agent's last health row
+      //                                            persists across task end
+      //   research_cycles.agent_id              — cycle audit survives
+      //   ideas.task_id, .resurfaced_from, .variant_id, .initiative_id
+      //                                         — idea is durable
+      //   product_feedback.idea_id              — feedback survives idea
+      //   cost_events.product_id, .task_id, .cycle_id, .agent_id
+      //                                         — billing rows survive
+      //   cost_caps.product_id                  — cap downgrades to ws-level
+      //   operations_log.agent_id               — audit survives
+      //   content_inventory.idea_id, .task_id   — content is durable
+      //   social_queue.idea_id                  — post survives
+      //   product_skills.created_by_task_id, .created_by_agent_id,
+      //     .supersedes_skill_id                — skill is durable
+      //   initiatives.product_id, .parent_initiative_id, .owner_agent_id,
+      //     .source_idea_id                     — initiative survives
+      //   initiative_parent_history.{from,to}_parent_id, .moved_by_agent_id
+      //                                         — audit row survives
+      //   task_initiative_history.{from,to}_initiative_id, .moved_by_agent_id
+      //                                         — audit row survives
+      //   pm_proposals.applied_by_agent_id, .parent_proposal_id
+      //                                         — proposal record survives
+      //   product_ab_tests.winner_variant_id    — test record survives
+      //
+      // CASCADE choices on NOT NULL audit-shaped FKs (we lose the row when
+      // the agent is deleted, but the alternative would be relaxing
+      // NOT NULL — kept simple here):
+      //   agent_mailbox.from_agent_id, .to_agent_id
+      //   rollcall_sessions.initiator_agent_id
+      //   rollcall_entries.target_agent_id
+      //
+      // The patch is mechanical: for each table, fetch its CREATE TABLE
+      // text via sqlite_master, run a per-FK string replace to append
+      // " ON DELETE CASCADE" or " ON DELETE SET NULL" to the bare
+      // REFERENCES clause, write back via writable_schema. This preserves
+      // row data — no rebuild required. Idempotent: skips FKs already
+      // carrying the desired clause (substring guard).
+      console.log('[Migration 048] Adding ON DELETE rules across FK graph...');
+
+      // Per-table list of [oldRefClause, newRefClause] replacements.
+      // The "old" string is the bare `REFERENCES table(col)` chunk we
+      // expect to see in the stored CREATE TABLE text (no ON DELETE).
+      // The "new" string is the same chunk with the chosen rule appended.
+      // Replacements are anchor-loose enough to handle migration-created
+      // tables that may have slight whitespace drift from schema.ts.
+      type FkPatch = { col: string; old: string; nw: string };
+      const patches: Record<string, FkPatch[]> = {
+        agents: [
+          { col: 'workspace_id', old: 'REFERENCES workspaces(id)', nw: 'REFERENCES workspaces(id) ON DELETE CASCADE' },
+        ],
+        tasks: [
+          { col: 'assigned_agent_id',    old: 'REFERENCES agents(id)',             nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+          { col: 'created_by_agent_id',  old: 'REFERENCES agents(id)',             nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+          { col: 'workspace_id',         old: 'REFERENCES workspaces(id)',         nw: 'REFERENCES workspaces(id) ON DELETE CASCADE' },
+          { col: 'workflow_template_id', old: 'REFERENCES workflow_templates(id)', nw: 'REFERENCES workflow_templates(id) ON DELETE SET NULL' },
+          { col: 'product_id',           old: 'REFERENCES products(id)',           nw: 'REFERENCES products(id) ON DELETE SET NULL' },
+          { col: 'idea_id',              old: 'REFERENCES ideas(id)',              nw: 'REFERENCES ideas(id) ON DELETE SET NULL' },
+          { col: 'initiative_id',        old: 'REFERENCES initiatives(id)',        nw: 'REFERENCES initiatives(id) ON DELETE SET NULL' },
+        ],
+        workspace_ports: [
+          { col: 'task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE CASCADE' },
+        ],
+        workspace_merges: [
+          { col: 'task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE CASCADE' },
+        ],
+        conversations: [
+          { col: 'task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE SET NULL' },
+        ],
+        messages: [
+          { col: 'sender_agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+        ],
+        events: [
+          { col: 'agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+          { col: 'task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE SET NULL' },
+        ],
+        openclaw_sessions: [
+          { col: 'agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE CASCADE' },
+          { col: 'task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE CASCADE' },
+        ],
+        workflow_templates: [
+          { col: 'workspace_id', old: 'REFERENCES workspaces(id)', nw: 'REFERENCES workspaces(id) ON DELETE CASCADE' },
+        ],
+        task_roles: [
+          { col: 'agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE CASCADE' },
+        ],
+        knowledge_entries: [
+          { col: 'workspace_id', old: 'REFERENCES workspaces(id)', nw: 'REFERENCES workspaces(id) ON DELETE CASCADE' },
+          { col: 'task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE SET NULL' },
+          { col: 'created_by_agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+        ],
+        task_activities: [
+          { col: 'agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+        ],
+        agent_health: [
+          { col: 'task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE SET NULL' },
+        ],
+        work_checkpoints: [
+          { col: 'agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE CASCADE' },
+        ],
+        agent_mailbox: [
+          { col: 'from_agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE CASCADE' },
+          { col: 'to_agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE CASCADE' },
+        ],
+        rollcall_sessions: [
+          { col: 'workspace_id', old: 'REFERENCES workspaces(id)', nw: 'REFERENCES workspaces(id) ON DELETE CASCADE' },
+          { col: 'initiator_agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE CASCADE' },
+        ],
+        rollcall_entries: [
+          { col: 'target_agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE CASCADE' },
+        ],
+        products: [
+          { col: 'workspace_id', old: 'REFERENCES workspaces(id)', nw: 'REFERENCES workspaces(id) ON DELETE CASCADE' },
+        ],
+        research_cycles: [
+          { col: 'agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+        ],
+        ideation_cycles: [
+          { col: 'product_id', old: 'REFERENCES products(id)', nw: 'REFERENCES products(id) ON DELETE CASCADE' },
+          { col: 'research_cycle_id', old: 'REFERENCES research_cycles(id)', nw: 'REFERENCES research_cycles(id) ON DELETE SET NULL' },
+        ],
+        autopilot_activity_log: [
+          { col: 'product_id', old: 'REFERENCES products(id)', nw: 'REFERENCES products(id) ON DELETE CASCADE' },
+        ],
+        ideas: [
+          { col: 'cycle_id', old: 'REFERENCES research_cycles(id)', nw: 'REFERENCES research_cycles(id) ON DELETE SET NULL' },
+          { col: 'task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE SET NULL' },
+          { col: 'resurfaced_from', old: 'REFERENCES ideas(id)', nw: 'REFERENCES ideas(id) ON DELETE SET NULL' },
+          { col: 'variant_id', old: 'REFERENCES product_program_variants(id)', nw: 'REFERENCES product_program_variants(id) ON DELETE SET NULL' },
+          { col: 'initiative_id', old: 'REFERENCES initiatives(id)', nw: 'REFERENCES initiatives(id) ON DELETE SET NULL' },
+        ],
+        idea_suppressions: [
+          { col: 'similar_to_idea_id', old: 'REFERENCES ideas(id)', nw: 'REFERENCES ideas(id) ON DELETE CASCADE' },
+        ],
+        product_feedback: [
+          { col: 'idea_id', old: 'REFERENCES ideas(id)', nw: 'REFERENCES ideas(id) ON DELETE SET NULL' },
+        ],
+        cost_events: [
+          { col: 'product_id', old: 'REFERENCES products(id)', nw: 'REFERENCES products(id) ON DELETE SET NULL' },
+          { col: 'workspace_id', old: 'REFERENCES workspaces(id)', nw: 'REFERENCES workspaces(id) ON DELETE CASCADE' },
+          { col: 'task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE SET NULL' },
+          { col: 'cycle_id', old: 'REFERENCES research_cycles(id)', nw: 'REFERENCES research_cycles(id) ON DELETE SET NULL' },
+          { col: 'agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+        ],
+        cost_caps: [
+          { col: 'workspace_id', old: 'REFERENCES workspaces(id)', nw: 'REFERENCES workspaces(id) ON DELETE CASCADE' },
+          { col: 'product_id', old: 'REFERENCES products(id)', nw: 'REFERENCES products(id) ON DELETE SET NULL' },
+        ],
+        operations_log: [
+          { col: 'agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+        ],
+        content_inventory: [
+          { col: 'idea_id', old: 'REFERENCES ideas(id)', nw: 'REFERENCES ideas(id) ON DELETE SET NULL' },
+          { col: 'task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE SET NULL' },
+        ],
+        social_queue: [
+          { col: 'idea_id', old: 'REFERENCES ideas(id)', nw: 'REFERENCES ideas(id) ON DELETE SET NULL' },
+        ],
+        product_ab_tests: [
+          { col: 'variant_a_id', old: 'REFERENCES product_program_variants(id)', nw: 'REFERENCES product_program_variants(id) ON DELETE CASCADE' },
+          { col: 'variant_b_id', old: 'REFERENCES product_program_variants(id)', nw: 'REFERENCES product_program_variants(id) ON DELETE CASCADE' },
+          { col: 'winner_variant_id', old: 'REFERENCES product_program_variants(id)', nw: 'REFERENCES product_program_variants(id) ON DELETE SET NULL' },
+        ],
+        product_skills: [
+          { col: 'created_by_task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE SET NULL' },
+          { col: 'created_by_agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+          { col: 'supersedes_skill_id', old: 'REFERENCES product_skills(id)', nw: 'REFERENCES product_skills(id) ON DELETE SET NULL' },
+        ],
+        skill_reports: [
+          { col: 'task_id', old: 'REFERENCES tasks(id)', nw: 'REFERENCES tasks(id) ON DELETE CASCADE' },
+        ],
+        initiatives: [
+          { col: 'workspace_id', old: 'REFERENCES workspaces(id)', nw: 'REFERENCES workspaces(id) ON DELETE CASCADE' },
+          { col: 'product_id', old: 'REFERENCES products(id)', nw: 'REFERENCES products(id) ON DELETE SET NULL' },
+          { col: 'parent_initiative_id', old: 'REFERENCES initiatives(id)', nw: 'REFERENCES initiatives(id) ON DELETE SET NULL' },
+          { col: 'owner_agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+          { col: 'source_idea_id', old: 'REFERENCES ideas(id)', nw: 'REFERENCES ideas(id) ON DELETE SET NULL' },
+        ],
+        initiative_parent_history: [
+          { col: 'from_parent_id', old: 'REFERENCES initiatives(id)', nw: 'REFERENCES initiatives(id) ON DELETE SET NULL' },
+          { col: 'to_parent_id', old: 'REFERENCES initiatives(id)', nw: 'REFERENCES initiatives(id) ON DELETE SET NULL' },
+          { col: 'moved_by_agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+        ],
+        task_initiative_history: [
+          { col: 'from_initiative_id', old: 'REFERENCES initiatives(id)', nw: 'REFERENCES initiatives(id) ON DELETE SET NULL' },
+          { col: 'to_initiative_id', old: 'REFERENCES initiatives(id)', nw: 'REFERENCES initiatives(id) ON DELETE SET NULL' },
+          { col: 'moved_by_agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+        ],
+        pm_proposals: [
+          { col: 'workspace_id', old: 'REFERENCES workspaces(id)', nw: 'REFERENCES workspaces(id) ON DELETE CASCADE' },
+          { col: 'applied_by_agent_id', old: 'REFERENCES agents(id)', nw: 'REFERENCES agents(id) ON DELETE SET NULL' },
+          { col: 'parent_proposal_id', old: 'REFERENCES pm_proposals(id)', nw: 'REFERENCES pm_proposals(id) ON DELETE SET NULL' },
+        ],
+      };
+
+      const tablesPatched: string[] = [];
+
+      for (const [tableName, fkList] of Object.entries(patches)) {
+        const row = db.prepare(
+          `SELECT sql FROM sqlite_master WHERE type='table' AND name=?`,
+        ).get(tableName) as { sql: string } | undefined;
+
+        if (!row) {
+          console.log(`[Migration 048] table ${tableName} absent; skipping.`);
+          continue;
+        }
+
+        let sql = row.sql;
+        let mutated = false;
+
+        for (const fk of fkList) {
+          // Locate the FK by anchoring on the column name + the bare
+          // REFERENCES clause. We require the column name to appear in
+          // the same statement as the matching REFERENCES so we don't
+          // accidentally rewrite a sibling FK that targets the same
+          // table from a different column.
+          //
+          // SQLite stored CREATE TABLE preserves the original casing /
+          // whitespace from the CREATE call. We handle both single-line
+          // and the (rare) multi-line shape with a permissive regex.
+          //
+          // Pattern (anchored on column name):
+          //   <col_name> ... REFERENCES <table>(<col>)
+          // …and we replace the bare REFERENCES with the new clause.
+          const colRe = new RegExp(
+            `(\\b${fk.col}\\b[^,\\n]*?)` + escapeReg(fk.old) + `(?!\\s+ON\\s+DELETE)`,
+            'i',
+          );
+          const m = sql.match(colRe);
+          if (!m) {
+            // Either already patched (idempotent path), or column absent.
+            continue;
+          }
+          sql = sql.replace(colRe, `$1${fk.nw}`);
+          mutated = true;
+        }
+
+        if (!mutated) continue;
+
+        const escaped = sql.replace(/'/g, "''");
+        db.unsafeMode(true);
+        try {
+          db.pragma('writable_schema = ON');
+          db.exec(
+            `UPDATE sqlite_master SET sql = '${escaped}' WHERE type='table' AND name='${tableName}'`,
+          );
+          db.pragma('writable_schema = OFF');
+        } finally {
+          db.unsafeMode(false);
+        }
+        tablesPatched.push(tableName);
+      }
+
+      // After patching sqlite_master, force the schema parser to re-read
+      // so the new ON DELETE rules become active on this connection.
+      // Without this, FK actions remain whatever was cached at connect
+      // time — meaning DELETE on a parent still fails with the OLD
+      // (no-op) FK rule. Bumping schema_version is the standard SQLite
+      // trick: the next statement re-parses sqlite_master.
+      // (See https://www.sqlite.org/pragma.html#pragma_schema_version)
+      if (tablesPatched.length > 0) {
+        const cur = (db.pragma('schema_version', { simple: true }) as number) ?? 0;
+        db.unsafeMode(true);
+        try {
+          db.pragma(`schema_version = ${cur + 1}`);
+        } finally {
+          db.unsafeMode(false);
+        }
+      }
+
+      // Run a single integrity check across all tables once at the end.
+      // "Page X: never used" is a benign leaked-space warning — same
+      // filter migration 043 uses.
+      const integrity = db.prepare('PRAGMA integrity_check').all() as { integrity_check: string }[];
+      const isBenign = (msg: string) =>
+        msg === 'ok' || /^Page \d+: never used$/.test(msg);
+      const realErrors = integrity.filter(r => !isBenign(r.integrity_check));
+      if (realErrors.length > 0) {
+        throw new Error('[Migration 048] integrity_check failed after writable_schema patch: ' + JSON.stringify(realErrors));
+      }
+      const orphans = integrity.filter(r => /^Page \d+: never used$/.test(r.integrity_check));
+      if (orphans.length > 0) {
+        console.warn(`[Migration 048] ${orphans.length} orphan page(s) detected (benign — run VACUUM to reclaim): ` + JSON.stringify(orphans));
+      }
+
+      console.log(`[Migration 048] Complete. Patched ${tablesPatched.length} tables: ${tablesPatched.join(', ')}`);
+    },
+  },
 ];
+
+/** Escape a string for inclusion as a literal in a RegExp source. */
+function escapeReg(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 // Inline PM soul_md reader for migration 045. The full module
 // (src/lib/agents/pm-agent.ts) does the same thing but we duplicate it

--- a/src/lib/db/schema-cascade.test.ts
+++ b/src/lib/db/schema-cascade.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Schema FK cascade-coverage guardrail.
+ *
+ * Migration 048 hardened the FK graph by adding `ON DELETE CASCADE` /
+ * `ON DELETE SET NULL` to every reference targeting a top-level entity
+ * (workspaces, tasks, agents, initiatives, products, ideas, …). This
+ * test scans the live schema (a fresh in-memory DB compiled from
+ * `schema.ts`) and asserts that no FK to one of those parents has been
+ * left as a plain reference.
+ *
+ * Any future schema addition that forgets a delete rule will fail this
+ * test, forcing the author to make an intentional CASCADE-vs-SET-NULL
+ * choice.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { schema } from './schema';
+
+/**
+ * Parent tables whose FKs must always carry an explicit ON DELETE rule.
+ * Adding to this list tightens coverage; removing weakens it.
+ */
+const GUARDED_PARENTS = new Set([
+  'workspaces',
+  'tasks',
+  'agents',
+  'initiatives',
+  'products',
+  'ideas',
+  'convoys',
+  'conversations',
+  'research_cycles',
+  'rollcall_sessions',
+  'workflow_templates',
+  'product_skills',
+  'product_program_variants',
+  'pm_proposals',
+  'agent_mailbox',
+]);
+
+/**
+ * Per-(table, fromColumn) explicit choice. The test asserts the FK has
+ * the listed rule. If a child table truly needs a custom rule (e.g. NO
+ * ACTION because the parent is never deleted), encode it here so the
+ * intent is visible.
+ *
+ * Currently empty — the broad rule "must be CASCADE or SET NULL" is
+ * sufficient for every guarded parent. Reserved as an extension point.
+ */
+const EXPLICIT_RULES: Record<string, 'CASCADE' | 'SET NULL'> = {};
+
+interface FkRow {
+  id: number;
+  seq: number;
+  table: string;
+  from: string;
+  to: string;
+  on_update: string;
+  on_delete: string;
+  match: string;
+}
+
+function compileSchemaDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.exec(schema);
+  return db;
+}
+
+function listTables(db: Database.Database): string[] {
+  return (
+    db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
+      )
+      .all() as { name: string }[]
+  ).map(r => r.name);
+}
+
+function listForeignKeys(db: Database.Database, table: string): FkRow[] {
+  // Use raw exec to avoid double-quoting the table name. Table names in
+  // schema.ts are vetted source — no SQL injection surface here.
+  return db.prepare(`PRAGMA foreign_key_list("${table}")`).all() as FkRow[];
+}
+
+test('every FK to a guarded parent table has ON DELETE CASCADE or SET NULL', () => {
+  const db = compileSchemaDb();
+  const violations: string[] = [];
+
+  for (const table of listTables(db)) {
+    const fks = listForeignKeys(db, table);
+    for (const fk of fks) {
+      if (!GUARDED_PARENTS.has(fk.table)) continue;
+
+      const rule = (fk.on_delete || '').toUpperCase().trim();
+      const allowed = rule === 'CASCADE' || rule === 'SET NULL';
+      if (!allowed) {
+        violations.push(
+          `${table}.${fk.from} -> ${fk.table}(${fk.to}): ON DELETE is "${fk.on_delete}" (need CASCADE or SET NULL)`,
+        );
+        continue;
+      }
+
+      // Honour any per-FK explicit rule overrides.
+      const key = `${table}.${fk.from}`;
+      const explicit = EXPLICIT_RULES[key];
+      if (explicit && rule !== explicit) {
+        violations.push(
+          `${table}.${fk.from} -> ${fk.table}(${fk.to}): expected ON DELETE ${explicit} (per EXPLICIT_RULES), got ${rule}`,
+        );
+      }
+    }
+  }
+
+  db.close();
+
+  assert.equal(
+    violations.length,
+    0,
+    `Schema FK guardrail violations:\n  ` + violations.join('\n  '),
+  );
+});
+
+test('workspace_id columns cascade everywhere they appear', () => {
+  // Tightened sub-rule: every FK named workspace_id to workspaces(id)
+  // must be CASCADE (not SET NULL) — workspace-scoped rows are
+  // meaningless without their workspace.
+  const db = compileSchemaDb();
+  const violations: string[] = [];
+
+  for (const table of listTables(db)) {
+    for (const fk of listForeignKeys(db, table)) {
+      if (fk.table !== 'workspaces') continue;
+      if (fk.from !== 'workspace_id') continue;
+      const rule = (fk.on_delete || '').toUpperCase().trim();
+      if (rule !== 'CASCADE') {
+        violations.push(`${table}.${fk.from} -> workspaces(id): expected CASCADE, got "${fk.on_delete}"`);
+      }
+    }
+  }
+
+  db.close();
+
+  assert.equal(
+    violations.length,
+    0,
+    `workspace_id cascade violations:\n  ` + violations.join('\n  '),
+  );
+});

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS agents (
   avatar_emoji TEXT DEFAULT '🤖',
   status TEXT DEFAULT 'standby' CHECK (status IN ('standby', 'working', 'offline')),
   is_master INTEGER DEFAULT 0,
-  workspace_id TEXT DEFAULT 'default' REFERENCES workspaces(id),
+  workspace_id TEXT DEFAULT 'default' REFERENCES workspaces(id) ON DELETE CASCADE,
   soul_md TEXT,
   user_md TEXT,
   agents_md TEXT,
@@ -52,12 +52,12 @@ CREATE TABLE IF NOT EXISTS tasks (
   description TEXT,
   status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'draft', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done', 'cancelled', 'needs_user_input')),
   priority TEXT DEFAULT 'normal' CHECK (priority IN ('low', 'normal', 'high', 'urgent')),
-  assigned_agent_id TEXT REFERENCES agents(id),
-  created_by_agent_id TEXT REFERENCES agents(id),
-  workspace_id TEXT DEFAULT 'default' REFERENCES workspaces(id),
+  assigned_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  created_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  workspace_id TEXT DEFAULT 'default' REFERENCES workspaces(id) ON DELETE CASCADE,
   business_id TEXT DEFAULT 'default',
   due_date TEXT,
-  workflow_template_id TEXT REFERENCES workflow_templates(id),
+  workflow_template_id TEXT REFERENCES workflow_templates(id) ON DELETE SET NULL,
   planning_session_key TEXT,
   planning_messages TEXT,
   planning_complete INTEGER DEFAULT 0,
@@ -68,8 +68,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   images TEXT,
   convoy_id TEXT,
   is_subtask INTEGER DEFAULT 0,
-  product_id TEXT REFERENCES products(id),
-  idea_id TEXT REFERENCES ideas(id),
+  product_id TEXT REFERENCES products(id) ON DELETE SET NULL,
+  idea_id TEXT REFERENCES ideas(id) ON DELETE SET NULL,
   estimated_cost_usd REAL,
   actual_cost_usd REAL DEFAULT 0,
   repo_url TEXT,
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS tasks (
   is_archived INTEGER DEFAULT 0,
   archived_at TEXT,
   include_knowledge INTEGER DEFAULT 0,
-  initiative_id TEXT REFERENCES initiatives(id),
+  initiative_id TEXT REFERENCES initiatives(id) ON DELETE SET NULL,
   status_check_md TEXT,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
@@ -94,7 +94,7 @@ CREATE TABLE IF NOT EXISTS tasks (
 -- Workspace port allocations for parallel build isolation
 CREATE TABLE IF NOT EXISTS workspace_ports (
   id TEXT PRIMARY KEY,
-  task_id TEXT NOT NULL REFERENCES tasks(id),
+  task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
   port INTEGER NOT NULL UNIQUE,
   product_id TEXT,
   status TEXT NOT NULL DEFAULT 'active',
@@ -105,7 +105,7 @@ CREATE TABLE IF NOT EXISTS workspace_ports (
 -- Workspace merge history
 CREATE TABLE IF NOT EXISTS workspace_merges (
   id TEXT PRIMARY KEY,
-  task_id TEXT NOT NULL REFERENCES tasks(id),
+  task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
   workspace_path TEXT NOT NULL,
   strategy TEXT NOT NULL,
   base_commit TEXT,
@@ -147,7 +147,7 @@ CREATE TABLE IF NOT EXISTS conversations (
   id TEXT PRIMARY KEY,
   title TEXT,
   type TEXT DEFAULT 'direct' CHECK (type IN ('direct', 'group', 'task')),
-  task_id TEXT REFERENCES tasks(id),
+  task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -164,7 +164,7 @@ CREATE TABLE IF NOT EXISTS conversation_participants (
 CREATE TABLE IF NOT EXISTS messages (
   id TEXT PRIMARY KEY,
   conversation_id TEXT REFERENCES conversations(id) ON DELETE CASCADE,
-  sender_agent_id TEXT REFERENCES agents(id),
+  sender_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
   content TEXT NOT NULL,
   message_type TEXT DEFAULT 'text' CHECK (message_type IN ('text', 'system', 'task_update', 'file')),
   metadata TEXT,
@@ -175,8 +175,8 @@ CREATE TABLE IF NOT EXISTS messages (
 CREATE TABLE IF NOT EXISTS events (
   id TEXT PRIMARY KEY,
   type TEXT NOT NULL,
-  agent_id TEXT REFERENCES agents(id),
-  task_id TEXT REFERENCES tasks(id),
+  agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
   message TEXT NOT NULL,
   metadata TEXT,
   created_at TEXT DEFAULT (datetime('now'))
@@ -193,12 +193,12 @@ CREATE TABLE IF NOT EXISTS businesses (
 -- OpenClaw session mapping
 CREATE TABLE IF NOT EXISTS openclaw_sessions (
   id TEXT PRIMARY KEY,
-  agent_id TEXT REFERENCES agents(id),
+  agent_id TEXT REFERENCES agents(id) ON DELETE CASCADE,
   openclaw_session_id TEXT NOT NULL,
   channel TEXT,
   status TEXT DEFAULT 'active',
   session_type TEXT DEFAULT 'persistent',
-  task_id TEXT REFERENCES tasks(id),
+  task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
   ended_at TEXT,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
@@ -207,7 +207,7 @@ CREATE TABLE IF NOT EXISTS openclaw_sessions (
 -- Workflow templates (per-workspace workflow definitions)
 CREATE TABLE IF NOT EXISTS workflow_templates (
   id TEXT PRIMARY KEY,
-  workspace_id TEXT DEFAULT 'default' REFERENCES workspaces(id),
+  workspace_id TEXT DEFAULT 'default' REFERENCES workspaces(id) ON DELETE CASCADE,
   name TEXT NOT NULL,
   description TEXT,
   stages TEXT NOT NULL,
@@ -222,7 +222,7 @@ CREATE TABLE IF NOT EXISTS task_roles (
   id TEXT PRIMARY KEY,
   task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
   role TEXT NOT NULL,
-  agent_id TEXT NOT NULL REFERENCES agents(id),
+  agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
   created_at TEXT DEFAULT (datetime('now')),
   UNIQUE(task_id, role)
 );
@@ -230,14 +230,14 @@ CREATE TABLE IF NOT EXISTS task_roles (
 -- Knowledge entries (learner knowledge base)
 CREATE TABLE IF NOT EXISTS knowledge_entries (
   id TEXT PRIMARY KEY,
-  workspace_id TEXT DEFAULT 'default' REFERENCES workspaces(id),
-  task_id TEXT REFERENCES tasks(id),
+  workspace_id TEXT DEFAULT 'default' REFERENCES workspaces(id) ON DELETE CASCADE,
+  task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
   category TEXT NOT NULL,
   title TEXT NOT NULL,
   content TEXT NOT NULL,
   tags TEXT,
   confidence REAL DEFAULT 0.5,
-  created_by_agent_id TEXT REFERENCES agents(id),
+  created_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
   created_at TEXT DEFAULT (datetime('now'))
 );
 
@@ -245,7 +245,7 @@ CREATE TABLE IF NOT EXISTS knowledge_entries (
 CREATE TABLE IF NOT EXISTS task_activities (
   id TEXT PRIMARY KEY,
   task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
-  agent_id TEXT REFERENCES agents(id),
+  agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
   activity_type TEXT NOT NULL,
   message TEXT NOT NULL,
   metadata TEXT,
@@ -314,7 +314,7 @@ CREATE TABLE IF NOT EXISTS convoy_subtasks (
 CREATE TABLE IF NOT EXISTS agent_health (
   id TEXT PRIMARY KEY,
   agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
-  task_id TEXT REFERENCES tasks(id),
+  task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
   health_state TEXT DEFAULT 'idle' CHECK (health_state IN ('idle', 'working', 'stalled', 'stuck', 'zombie', 'offline')),
   last_activity_at TEXT,
   last_checkpoint_at TEXT,
@@ -328,7 +328,7 @@ CREATE TABLE IF NOT EXISTS agent_health (
 CREATE TABLE IF NOT EXISTS work_checkpoints (
   id TEXT PRIMARY KEY,
   task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
-  agent_id TEXT NOT NULL REFERENCES agents(id),
+  agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
   checkpoint_type TEXT DEFAULT 'auto' CHECK (checkpoint_type IN ('auto', 'manual', 'crash_recovery')),
   state_summary TEXT NOT NULL,
   files_snapshot TEXT,
@@ -343,8 +343,8 @@ CREATE TABLE IF NOT EXISTS agent_mailbox (
   id TEXT PRIMARY KEY,
   convoy_id TEXT REFERENCES convoys(id) ON DELETE CASCADE,
   task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
-  from_agent_id TEXT NOT NULL REFERENCES agents(id),
-  to_agent_id TEXT NOT NULL REFERENCES agents(id),
+  from_agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  to_agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
   subject TEXT,
   body TEXT NOT NULL,
   read_at TEXT,
@@ -359,8 +359,8 @@ CREATE INDEX IF NOT EXISTS idx_agent_mailbox_task ON agent_mailbox(task_id) WHER
 -- surface two distinct failure modes (couldn't deliver vs. agent silent).
 CREATE TABLE IF NOT EXISTS rollcall_sessions (
   id TEXT PRIMARY KEY,
-  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
-  initiator_agent_id TEXT NOT NULL REFERENCES agents(id),
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  initiator_agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
   mode TEXT NOT NULL CHECK (mode IN ('direct', 'coordinator')),
   timeout_seconds INTEGER NOT NULL DEFAULT 30,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -369,7 +369,7 @@ CREATE TABLE IF NOT EXISTS rollcall_sessions (
 CREATE TABLE IF NOT EXISTS rollcall_entries (
   id TEXT PRIMARY KEY,
   rollcall_id TEXT NOT NULL REFERENCES rollcall_sessions(id) ON DELETE CASCADE,
-  target_agent_id TEXT NOT NULL REFERENCES agents(id),
+  target_agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
   delivery_status TEXT NOT NULL DEFAULT 'pending' CHECK (delivery_status IN ('pending', 'sent', 'failed', 'skipped')),
   delivery_error TEXT,
   delivered_at TEXT,
@@ -384,7 +384,7 @@ CREATE INDEX IF NOT EXISTS idx_rollcall_entries_target ON rollcall_entries(targe
 -- Products table (Product Autopilot)
 CREATE TABLE IF NOT EXISTS products (
   id TEXT PRIMARY KEY,
-  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   name TEXT NOT NULL,
   description TEXT,
   repo_url TEXT,
@@ -412,7 +412,7 @@ CREATE TABLE IF NOT EXISTS research_cycles (
   ideas_generated INTEGER DEFAULT 0,
   cost_usd REAL DEFAULT 0,
   tokens_used INTEGER DEFAULT 0,
-  agent_id TEXT REFERENCES agents(id),
+  agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
   current_phase TEXT DEFAULT 'init',
   phase_data TEXT,
   session_key TEXT,
@@ -426,8 +426,8 @@ CREATE TABLE IF NOT EXISTS research_cycles (
 -- Ideation cycles: AI ideation runs per product
 CREATE TABLE IF NOT EXISTS ideation_cycles (
   id TEXT PRIMARY KEY,
-  product_id TEXT NOT NULL REFERENCES products(id),
-  research_cycle_id TEXT REFERENCES research_cycles(id),
+  product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  research_cycle_id TEXT REFERENCES research_cycles(id) ON DELETE SET NULL,
   status TEXT NOT NULL DEFAULT 'running' CHECK (status IN ('running', 'completed', 'failed', 'interrupted')),
   current_phase TEXT DEFAULT 'init',
   phase_data TEXT,
@@ -443,7 +443,7 @@ CREATE TABLE IF NOT EXISTS ideation_cycles (
 -- Autopilot activity log: real-time activity tracking
 CREATE TABLE IF NOT EXISTS autopilot_activity_log (
   id TEXT PRIMARY KEY,
-  product_id TEXT NOT NULL REFERENCES products(id),
+  product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
   cycle_id TEXT NOT NULL,
   cycle_type TEXT NOT NULL CHECK(cycle_type IN ('research', 'ideation')),
   event_type TEXT NOT NULL,
@@ -458,7 +458,7 @@ CREATE TABLE IF NOT EXISTS autopilot_activity_log (
 CREATE TABLE IF NOT EXISTS ideas (
   id TEXT PRIMARY KEY,
   product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
-  cycle_id TEXT REFERENCES research_cycles(id),
+  cycle_id TEXT REFERENCES research_cycles(id) ON DELETE SET NULL,
   title TEXT NOT NULL,
   description TEXT NOT NULL,
   category TEXT NOT NULL CHECK (category IN (
@@ -482,15 +482,15 @@ CREATE TABLE IF NOT EXISTS ideas (
     'pending', 'approved', 'rejected', 'maybe', 'building', 'built', 'shipped'
   )),
   swiped_at TEXT,
-  task_id TEXT REFERENCES tasks(id),
+  task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
   user_notes TEXT,
-  resurfaced_from TEXT REFERENCES ideas(id),
+  resurfaced_from TEXT REFERENCES ideas(id) ON DELETE SET NULL,
   resurfaced_reason TEXT,
   similarity_flag TEXT,
   auto_suppressed INTEGER DEFAULT 0,
   suppress_reason TEXT,
-  variant_id TEXT REFERENCES product_program_variants(id),
-  initiative_id TEXT REFERENCES initiatives(id),
+  variant_id TEXT REFERENCES product_program_variants(id) ON DELETE SET NULL,
+  initiative_id TEXT REFERENCES initiatives(id) ON DELETE SET NULL,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -512,7 +512,7 @@ CREATE TABLE IF NOT EXISTS idea_suppressions (
   product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
   suppressed_title TEXT NOT NULL,
   suppressed_description TEXT NOT NULL,
-  similar_to_idea_id TEXT NOT NULL REFERENCES ideas(id),
+  similar_to_idea_id TEXT NOT NULL REFERENCES ideas(id) ON DELETE CASCADE,
   similarity_score REAL NOT NULL,
   reason TEXT NOT NULL,
   ideation_cycle_id TEXT,
@@ -572,18 +572,18 @@ CREATE TABLE IF NOT EXISTS product_feedback (
   category TEXT,
   sentiment TEXT CHECK (sentiment IN ('positive', 'negative', 'neutral', 'mixed')),
   processed INTEGER DEFAULT 0,
-  idea_id TEXT REFERENCES ideas(id),
+  idea_id TEXT REFERENCES ideas(id) ON DELETE SET NULL,
   created_at TEXT DEFAULT (datetime('now'))
 );
 
 -- Cost events: granular cost tracking per operation
 CREATE TABLE IF NOT EXISTS cost_events (
   id TEXT PRIMARY KEY,
-  product_id TEXT REFERENCES products(id),
-  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
-  task_id TEXT REFERENCES tasks(id),
-  cycle_id TEXT REFERENCES research_cycles(id),
-  agent_id TEXT REFERENCES agents(id),
+  product_id TEXT REFERENCES products(id) ON DELETE SET NULL,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+  cycle_id TEXT REFERENCES research_cycles(id) ON DELETE SET NULL,
+  agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
   event_type TEXT NOT NULL CHECK (event_type IN (
     'agent_dispatch', 'research_cycle', 'ideation_cycle', 'build_task',
     'content_generation', 'seo_analysis', 'web_search', 'external_api'
@@ -600,8 +600,8 @@ CREATE TABLE IF NOT EXISTS cost_events (
 -- Cost caps: spending limits per workspace/product
 CREATE TABLE IF NOT EXISTS cost_caps (
   id TEXT PRIMARY KEY,
-  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
-  product_id TEXT REFERENCES products(id),
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  product_id TEXT REFERENCES products(id) ON DELETE SET NULL,
   cap_type TEXT NOT NULL CHECK (cap_type IN ('per_cycle', 'per_task', 'daily', 'monthly', 'per_product_monthly')),
   limit_usd REAL NOT NULL,
   current_spend_usd REAL DEFAULT 0,
@@ -644,7 +644,7 @@ CREATE TABLE IF NOT EXISTS operations_log (
   summary TEXT,
   details TEXT,
   cost_usd REAL DEFAULT 0,
-  agent_id TEXT REFERENCES agents(id),
+  agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
   created_at TEXT DEFAULT (datetime('now'))
 );
 
@@ -662,8 +662,8 @@ CREATE TABLE IF NOT EXISTS content_inventory (
   target_keywords TEXT,
   performance TEXT,
   last_refreshed_at TEXT,
-  idea_id TEXT REFERENCES ideas(id),
-  task_id TEXT REFERENCES tasks(id),
+  idea_id TEXT REFERENCES ideas(id) ON DELETE SET NULL,
+  task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -679,7 +679,7 @@ CREATE TABLE IF NOT EXISTS social_queue (
   status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected', 'posted', 'failed')),
   posted_at TEXT,
   performance TEXT,
-  idea_id TEXT REFERENCES ideas(id),
+  idea_id TEXT REFERENCES ideas(id) ON DELETE SET NULL,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -766,13 +766,13 @@ CREATE TABLE IF NOT EXISTS product_program_variants (
 CREATE TABLE IF NOT EXISTS product_ab_tests (
   id TEXT PRIMARY KEY,
   product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
-  variant_a_id TEXT NOT NULL REFERENCES product_program_variants(id),
-  variant_b_id TEXT NOT NULL REFERENCES product_program_variants(id),
+  variant_a_id TEXT NOT NULL REFERENCES product_program_variants(id) ON DELETE CASCADE,
+  variant_b_id TEXT NOT NULL REFERENCES product_program_variants(id) ON DELETE CASCADE,
   status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'concluded', 'cancelled')),
   split_mode TEXT NOT NULL DEFAULT 'concurrent' CHECK (split_mode IN ('concurrent', 'alternating')),
   min_swipes INTEGER NOT NULL DEFAULT 50,
   last_variant_used TEXT,
-  winner_variant_id TEXT REFERENCES product_program_variants(id),
+  winner_variant_id TEXT REFERENCES product_program_variants(id) ON DELETE SET NULL,
   created_at TEXT DEFAULT (datetime('now')),
   concluded_at TEXT
 );
@@ -791,9 +791,9 @@ CREATE TABLE IF NOT EXISTS product_skills (
   times_used INTEGER DEFAULT 0,
   times_succeeded INTEGER DEFAULT 0,
   last_used_at TEXT,
-  created_by_task_id TEXT REFERENCES tasks(id),
-  created_by_agent_id TEXT REFERENCES agents(id),
-  supersedes_skill_id TEXT REFERENCES product_skills(id),
+  created_by_task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+  created_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  supersedes_skill_id TEXT REFERENCES product_skills(id) ON DELETE SET NULL,
   status TEXT DEFAULT 'draft' CHECK (status IN ('active', 'deprecated', 'draft')),
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
@@ -803,7 +803,7 @@ CREATE TABLE IF NOT EXISTS product_skills (
 CREATE TABLE IF NOT EXISTS skill_reports (
   id TEXT PRIMARY KEY,
   skill_id TEXT NOT NULL REFERENCES product_skills(id) ON DELETE CASCADE,
-  task_id TEXT NOT NULL REFERENCES tasks(id),
+  task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
   used INTEGER NOT NULL DEFAULT 1,
   succeeded INTEGER NOT NULL DEFAULT 0,
   deviation TEXT,
@@ -839,15 +839,15 @@ CREATE TABLE IF NOT EXISTS debug_config (
 -- nullable so a backlog item can be a one-line title with no other detail.
 CREATE TABLE IF NOT EXISTS initiatives (
   id TEXT PRIMARY KEY,
-  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
-  product_id TEXT REFERENCES products(id),
-  parent_initiative_id TEXT REFERENCES initiatives(id),
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  product_id TEXT REFERENCES products(id) ON DELETE SET NULL,
+  parent_initiative_id TEXT REFERENCES initiatives(id) ON DELETE SET NULL,
   kind TEXT NOT NULL CHECK (kind IN ('theme','milestone','epic','story')),
   title TEXT NOT NULL,
   description TEXT,
   status TEXT NOT NULL DEFAULT 'planned'
     CHECK (status IN ('planned','in_progress','at_risk','blocked','done','cancelled')),
-  owner_agent_id TEXT REFERENCES agents(id),
+  owner_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
   estimated_effort_hours REAL,
   complexity TEXT CHECK (complexity IN ('S','M','L','XL')),
   target_start TEXT,
@@ -857,7 +857,7 @@ CREATE TABLE IF NOT EXISTS initiatives (
   committed_end TEXT,
   status_check_md TEXT,
   sort_order INTEGER DEFAULT 0,
-  source_idea_id TEXT REFERENCES ideas(id),
+  source_idea_id TEXT REFERENCES ideas(id) ON DELETE SET NULL,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -878,9 +878,9 @@ CREATE TABLE IF NOT EXISTS initiative_dependencies (
 CREATE TABLE IF NOT EXISTS initiative_parent_history (
   id TEXT PRIMARY KEY,
   initiative_id TEXT NOT NULL REFERENCES initiatives(id) ON DELETE CASCADE,
-  from_parent_id TEXT REFERENCES initiatives(id),
-  to_parent_id TEXT REFERENCES initiatives(id),
-  moved_by_agent_id TEXT REFERENCES agents(id),
+  from_parent_id TEXT REFERENCES initiatives(id) ON DELETE SET NULL,
+  to_parent_id TEXT REFERENCES initiatives(id) ON DELETE SET NULL,
+  moved_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
   reason TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -889,9 +889,9 @@ CREATE TABLE IF NOT EXISTS initiative_parent_history (
 CREATE TABLE IF NOT EXISTS task_initiative_history (
   id TEXT PRIMARY KEY,
   task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
-  from_initiative_id TEXT REFERENCES initiatives(id),
-  to_initiative_id TEXT REFERENCES initiatives(id),
-  moved_by_agent_id TEXT REFERENCES agents(id),
+  from_initiative_id TEXT REFERENCES initiatives(id) ON DELETE SET NULL,
+  to_initiative_id TEXT REFERENCES initiatives(id) ON DELETE SET NULL,
+  moved_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
   reason TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -909,7 +909,7 @@ CREATE TABLE IF NOT EXISTS owner_availability (
 -- PM proposal artifacts (Phase 5 will populate these).
 CREATE TABLE IF NOT EXISTS pm_proposals (
   id TEXT PRIMARY KEY,
-  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   trigger_text TEXT NOT NULL,
   trigger_kind TEXT NOT NULL DEFAULT 'manual'
     CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation','plan_initiative','decompose_initiative')),
@@ -918,8 +918,8 @@ CREATE TABLE IF NOT EXISTS pm_proposals (
   status TEXT NOT NULL DEFAULT 'draft'
     CHECK (status IN ('draft','accepted','rejected','superseded')),
   applied_at TEXT,
-  applied_by_agent_id TEXT REFERENCES agents(id),
-  parent_proposal_id TEXT REFERENCES pm_proposals(id),
+  applied_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  parent_proposal_id TEXT REFERENCES pm_proposals(id) ON DELETE SET NULL,
   created_at TEXT DEFAULT (datetime('now'))
 );
 

--- a/src/lib/db/workspaces.test.ts
+++ b/src/lib/db/workspaces.test.ts
@@ -118,13 +118,17 @@ test('deleteWorkspaceCascade cascades through task dependents (task_deliverables
   assert.equal(orphan, undefined);
 });
 
-test('deleteWorkspaceCascade cleans non-cascading task refs (events.task_id)', () => {
+test('deleteWorkspaceCascade preserves audit trail in events (SET NULL on task_id)', () => {
   const ws = seedWorkspace('NonCascading');
   const taskId = seedTask(ws.id);
 
-  // events.task_id is a plain reference (no ON DELETE CASCADE). If our
-  // helper doesn't snipe it, deleting tasks would either fail (FK on)
-  // or leave orphans (FK off, naive).
+  // events.task_id is `ON DELETE SET NULL` — the audit trail survives
+  // task deletion (the event still happened). Pre-cascade-safety this
+  // FK was a plain reference and the workspace helper had to manually
+  // delete events; under migration 048 the FK does the right thing.
+  // The point of this test is twofold:
+  //   1. Cascade succeeds without FK constraint errors (the ws is gone).
+  //   2. The event row survives with task_id nulled out.
   const eventId = uuidv4();
   run(
     `INSERT INTO events (id, type, task_id, message, created_at)
@@ -134,13 +138,22 @@ test('deleteWorkspaceCascade cleans non-cascading task refs (events.task_id)', (
 
   deleteWorkspaceCascade(ws.id);
 
-  // Workspace is gone — and re-enabling FKs at the end shouldn't have
-  // tripped on a stale event row.
+  // Workspace is gone, task is gone.
   const wsRow = queryOne<{ id: string }>('SELECT id FROM workspaces WHERE id = ?', [ws.id]);
   assert.equal(wsRow, undefined);
+  const taskRow = queryOne<{ id: string }>('SELECT id FROM tasks WHERE id = ?', [taskId]);
+  assert.equal(taskRow, undefined);
 
-  const evtRow = queryOne<{ id: string }>('SELECT id FROM events WHERE id = ?', [eventId]);
-  assert.equal(evtRow, undefined);
+  // Event row survives with task_id nulled.
+  const evtRow = queryOne<{ id: string; task_id: string | null }>(
+    'SELECT id, task_id FROM events WHERE id = ?',
+    [eventId],
+  );
+  assert.ok(evtRow, 'event row should survive task deletion (audit trail)');
+  assert.equal(evtRow.task_id, null);
+
+  // Cleanup the now-orphaned event so it doesn't leak into other tests.
+  run('DELETE FROM events WHERE id = ?', [eventId]);
 });
 
 test('deleteWorkspaceCascade refuses to delete the default workspace', () => {

--- a/src/lib/db/workspaces.ts
+++ b/src/lib/db/workspaces.ts
@@ -1,27 +1,35 @@
 /**
  * Workspace cascade-delete helper.
  *
- * Mission Control's schema doesn't put `ON DELETE CASCADE` on the FK from
- * workspace-scoped tables (tasks, agents, products, …) back to `workspaces`,
- * and it doesn't always cascade FROM tasks/agents into their dependent
- * tables either (e.g. `events.task_id` is a plain reference). Naively
- * issuing `DELETE FROM workspaces WHERE id = ?` would either fail with a
- * FK constraint, or silently leave orphan rows behind.
+ * As of migration 048, every FK that targets `workspaces`, `tasks`,
+ * `agents`, `initiatives`, `products`, `ideas`, etc. carries an explicit
+ * `ON DELETE CASCADE` or `ON DELETE SET NULL` rule (see
+ * `schema-cascade.test.ts` for the guardrail). Deleting a workspace
+ * triggers a transitive cascade through the FK graph that empties:
  *
- * `deleteWorkspaceCascade` walks the dependency graph in reverse and
- * deletes everything the workspace owns inside a single transaction. We
- * temporarily disable FK checks while doing it (1) so the order of
- * deletions doesn't have to be perfect across edge-case schemas seen in
- * the field, and (2) so cascades from earlier rows don't fight with
- * explicit deletes from later ones.
+ *   workspace → tasks → (planning_*, task_*, work_checkpoints,
+ *                        workspace_ports, workspace_merges,
+ *                        skill_reports, openclaw_sessions, …)
+ *   workspace → agents → (agent_health, agent_chat_messages,
+ *                         agent_mailbox, rollcall_sessions, …)
+ *   workspace → initiatives → (initiative_dependencies,
+ *                              initiative_parent_history,
+ *                              task_initiative_history)
+ *   workspace → products → (research_cycles, ideas, ideation_cycles,
+ *                           product_skills, content_inventory, …)
+ *   workspace → workflow_templates / knowledge_entries / pm_proposals /
+ *               cost_caps / cost_events / rollcall_sessions
  *
- * `getWorkspaceCascadeCounts` returns the row counts the operator will
- * see in the confirmation modal, so we can render an honest "this will
- * delete X tasks, Y agents, …" warning before actually destroying
- * anything.
+ * The helper here therefore collapses to a single `DELETE FROM workspaces`
+ * inside a transaction. We still snapshot the cascade counts up front so
+ * the caller can show "this will delete N tasks / M agents / …" in the UI
+ * confirm modal.
+ *
+ * `getWorkspaceCascadeCounts` walks the workspace-scoped tables to render
+ * the operator's confirmation modal — that's a read concern, decoupled
+ * from how the delete actually executes.
  */
 
-import type Database from 'better-sqlite3';
 import { getDb } from './index';
 
 export interface WorkspaceCascadeCounts {
@@ -36,84 +44,6 @@ export interface WorkspaceCascadeCounts {
   costCaps: number;
   rollcallSessions: number;
 }
-
-/** Tables scoped directly by workspace_id. Order matters for FK safety
- *  even with FKs disabled — we keep the same order in the deletion
- *  routine so it's easy to follow. */
-const WORKSPACE_SCOPED_TABLES = [
-  'pm_proposals',
-  'cost_caps',
-  'cost_events',
-  'rollcall_sessions',
-  'knowledge_entries',
-  'workflow_templates',
-  'products',
-  'initiatives',
-  'tasks',
-  'agents',
-] as const;
-
-/**
- * Tables whose rows reference a task via `task_id`. We delete any row
- * that points at one of the workspace's tasks BEFORE we delete the
- * tasks themselves, because the cascade-delete-with-FK-OFF strategy we
- * use means SQLite's ON DELETE CASCADE triggers don't fire — we have
- * to explicitly clean every dependent ourselves.
- *
- * Includes both ON DELETE CASCADE tables (where the cascade would
- * normally fire) and plain references.
- */
-const TASK_REF_TABLES = [
-  // Cascading children (would auto-delete if FKs were on; we list them
-  // anyway because we run with FKs off for atomicity).
-  'planning_questions',
-  'planning_specs',
-  'task_roles',
-  'task_activities',
-  'task_deliverables',
-  'work_checkpoints',
-  'task_notes',
-  'user_task_reads',
-  'task_initiative_history',
-  // Non-cascading task references.
-  'workspace_ports',
-  'workspace_merges',
-  'conversations',
-  'events',
-  'openclaw_sessions',
-  'messages',
-  'ideas',
-  'skill_reports',
-  'debug_events',
-] as const;
-
-/**
- * Tables whose rows reference an agent via `agent_id` (or similar).
- * Same rationale as TASK_REF_TABLES — we explicitly snipe all
- * referencing rows because cascades don't fire with FKs off.
- */
-const AGENT_REF_TABLES = [
-  // Cascade-on-delete dependents.
-  'agent_health',
-  'agent_chat_messages',
-  'owner_availability',
-  // Plain references.
-  'messages',
-  'events',
-  'openclaw_sessions',
-  'agent_mailbox',
-  'rollcall_entries',
-  'autopilot_activity_log',
-  'debug_events',
-  'task_initiative_history',
-  'initiative_parent_history',
-] as const;
-
-/**
- * Tables that reference convoys (id from convoys), which themselves
- * cascade off tasks. With FKs off, we need to clean these too.
- */
-const CONVOY_REF_TABLES = ['convoy_subtasks', 'agent_mailbox'] as const;
 
 /**
  * Counts rows the operator will lose when a given workspace is deleted.
@@ -169,147 +99,19 @@ export function deleteWorkspaceCascade(workspaceId: string): WorkspaceCascadeCou
 
   const counts = getWorkspaceCascadeCounts(workspaceId);
 
-  // We disable FKs for the duration of the transaction so the explicit
-  // deletes can run in any order without tripping pending references.
-  // SQLite restores the previous FK state on COMMIT/ROLLBACK boundary
-  // because pragmas live on the connection.
-  db.pragma('foreign_keys = OFF');
-  try {
-    const tx = db.transaction(() => {
-      // Pre-collect IDs we'll need to scrub from referencing tables.
-      const taskIds = (db
-        .prepare('SELECT id FROM tasks WHERE workspace_id = ?')
-        .all(workspaceId) as { id: string }[]).map(r => r.id);
-      const agentIds = (db
-        .prepare('SELECT id FROM agents WHERE workspace_id = ?')
-        .all(workspaceId) as { id: string }[]).map(r => r.id);
-      // Convoys live as parent_task_id → tasks; gather convoy ids so
-      // we can scrub their dependents too.
-      let convoyIds: string[] = [];
-      if (taskIds.length > 0) {
-        convoyIds = chunkInQuery(
-          db,
-          'SELECT id FROM convoys WHERE parent_task_id IN',
-          taskIds,
-        ).map(r => (r as { id: string }).id);
-      }
-
-      // 1. Scrub convoy dependents first (they FK into convoys.id).
-      if (convoyIds.length > 0) {
-        for (const table of CONVOY_REF_TABLES) {
-          deleteByColumnIn(db, table, 'convoy_id', convoyIds);
-        }
-      }
-      // Then drop the convoys themselves so nothing references them.
-      if (taskIds.length > 0) {
-        deleteByColumnIn(db, 'convoys', 'parent_task_id', taskIds);
-      }
-
-      // 2. Scrub all task references. Cascading rows are listed too —
-      // since we're running with FKs off, the schema's CASCADE triggers
-      // don't fire, so we have to delete them ourselves.
-      if (taskIds.length > 0) {
-        for (const table of TASK_REF_TABLES) {
-          deleteByColumnIn(db, table, 'task_id', taskIds);
-        }
-      }
-
-      // 3. Scrub all agent references.
-      if (agentIds.length > 0) {
-        for (const table of AGENT_REF_TABLES) {
-          deleteByColumnIn(db, table, 'agent_id', agentIds);
-        }
-        // Tables with non-`agent_id` agent columns:
-        deleteByColumnIn(db, 'agent_mailbox', 'from_agent_id', agentIds);
-        deleteByColumnIn(db, 'agent_mailbox', 'to_agent_id', agentIds);
-        deleteByColumnIn(db, 'rollcall_sessions', 'initiator_agent_id', agentIds);
-        deleteByColumnIn(db, 'rollcall_entries', 'target_agent_id', agentIds);
-        deleteByColumnIn(db, 'messages', 'sender_agent_id', agentIds);
-      }
-
-      // Delete every workspace-scoped table.
-      for (const table of WORKSPACE_SCOPED_TABLES) {
-        try {
-          db.prepare(`DELETE FROM ${table} WHERE workspace_id = ?`).run(workspaceId);
-        } catch (err) {
-          // Surface the table name to help diagnose if something does
-          // explode — but don't swallow the error. Re-throw so the
-          // transaction rolls back.
-          console.error(`[deleteWorkspaceCascade] failed deleting from ${table}:`, err);
-          throw err;
-        }
-      }
-
-      // Finally the workspace itself.
-      db.prepare('DELETE FROM workspaces WHERE id = ?').run(workspaceId);
-    });
-
-    tx();
-  } finally {
-    // Re-enable FK enforcement on the connection regardless of outcome.
-    db.pragma('foreign_keys = ON');
-  }
+  // Single DELETE; the FK graph (migration 048) cascades through every
+  // dependent table. Wrapping in a transaction keeps the cascade atomic
+  // and gives us a clean rollback if any FK trigger throws.
+  db.transaction(() => {
+    const result = db
+      .prepare('DELETE FROM workspaces WHERE id = ?')
+      .run(workspaceId);
+    if (result.changes === 0) {
+      // Could happen in a TOCTOU race with another deleter — surface as
+      // an error so the caller can refresh.
+      throw new Error(`Workspace not found at delete time: ${workspaceId}`);
+    }
+  })();
 
   return counts;
-}
-
-/**
- * Helper: run a `SELECT … WHERE … IN (...)` against a chunked id list
- * and concatenate the rows. Uses parameterized placeholders so we
- * stay under SQLite's ~32k parameter cap.
- */
-function chunkInQuery(
-  db: Database.Database,
-  selectPrefix: string,
-  ids: string[],
-): unknown[] {
-  if (ids.length === 0) return [];
-  const CHUNK = 500;
-  const out: unknown[] = [];
-  for (let i = 0; i < ids.length; i += CHUNK) {
-    const chunk = ids.slice(i, i + CHUNK);
-    const placeholders = chunk.map(() => '?').join(',');
-    try {
-      const rows = db.prepare(`${selectPrefix} (${placeholders})`).all(...chunk) as unknown[];
-      out.push(...rows);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (/no such (table|column)/i.test(msg)) continue;
-      throw err;
-    }
-  }
-  return out;
-}
-
-/**
- * Helper: `DELETE FROM <table> WHERE <column> IN (...ids)`. Defends
- * against tables / columns that may not exist on an older database
- * (the catch swallows "no such column" / "no such table" so we don't
- * abort the whole cascade for a missing optional table).
- *
- * Uses a parameterized IN clause to keep it safe.
- */
-function deleteByColumnIn(
-  db: Database.Database,
-  table: string,
-  column: string,
-  ids: string[],
-): void {
-  if (ids.length === 0) return;
-  // SQLite has a hard parameter cap (~32k); chunk to be safe.
-  const CHUNK = 500;
-  for (let i = 0; i < ids.length; i += CHUNK) {
-    const chunk = ids.slice(i, i + CHUNK);
-    const placeholders = chunk.map(() => '?').join(',');
-    try {
-      db.prepare(`DELETE FROM ${table} WHERE ${column} IN (${placeholders})`).run(...chunk);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      // Tolerate schema drift — if the table or column doesn't exist
-      // (an older db that hasn't been migrated to add e.g. debug_events),
-      // skip it. Anything else re-throws so the transaction rolls back.
-      if (/no such (table|column)/i.test(msg)) continue;
-      throw err;
-    }
-  }
 }


### PR DESCRIPTION
## Summary
PR #53 added workspace deletion but the schema had no `ON DELETE CASCADE` on most FKs. The helper worked around it by manually walking dependents inside a `foreign_keys=OFF` transaction — brittle for future schema additions. Now that nothing's in production, fix it properly:

1. Migration 048 adds CASCADE / SET NULL to every FK that should have it.
2. Simplifies `deleteWorkspaceCascade` to `DELETE FROM workspaces` (FKs do the work).
3. New `schema-cascade.test.ts` scans the schema and fails if any FK to a top-level entity (workspaces / tasks / agents / initiatives / products / ideas / …) is missing its delete rule.

## What landed
- **Migration 048** (`fk_cascade_safety`): writable_schema patch on ~30 tables to add ON DELETE rules; bumps `schema_version` so the new FK actions take effect on the same connection (without that, the patched rules stay dormant until reopen).
- **schema.ts** updated to match — every FK now declares its delete rule.
- **deleteWorkspaceCascade** collapsed from ~250 lines (manual table walk + FK-OFF transaction) to a single `DELETE FROM workspaces` inside a transaction. `getWorkspaceCascadeCounts` kept for the UI confirm modal.
- **schema-cascade.test.ts** guardrail with two assertions:
  1. every FK to a guarded parent has `CASCADE` or `SET NULL`,
  2. every `workspace_id` FK is `CASCADE` (workspace-scoped rows are never durable past workspace deletion).
- **specs/cascade-rules.md** — per-entity CASCADE / SET NULL matrix + tradeoffs.

## Decision highlights
**SET NULL on audit-trail / durable rows:**
- `events.{agent_id, task_id}`, `messages.sender_agent_id`, `task_activities.agent_id` — audit log survives.
- `task_initiative_history.{from,to}_initiative_id`, `initiative_parent_history.{from,to}_parent_id`, both `moved_by_agent_id` — audit row survives.
- `tasks.{assigned_agent_id, created_by_agent_id, product_id, idea_id, initiative_id, workflow_template_id}` — task survives parent loss.
- `ideas.task_id`, `knowledge_entries.task_id`, `content_inventory.{idea_id, task_id}`, `product_skills.created_by_*` — durable artifacts.
- `cost_events.{product_id, task_id, cycle_id, agent_id}` — billing rows survive.

**CASCADE on NOT NULL refs (kept simple — would otherwise need to relax NOT NULL):**
- `agent_mailbox.{from,to}_agent_id` — deleting an agent purges their inbox/outbox.
- `rollcall_sessions.initiator_agent_id`, `rollcall_entries.target_agent_id` — transient state.
- `work_checkpoints.agent_id` — checkpoint is meaningless without its agent.

## Test plan
- [x] `npm test` (330/330 passing) — including `workspaces.test.ts`, which still asserts cascade safety end-to-end (the `events.task_id` test now correctly verifies SET NULL semantics rather than the old "manually deleted" semantics).
- [x] New `schema-cascade.test.ts` (2 tests) asserts CASCADE coverage on every guarded parent and CASCADE-only on `workspace_id`.
- [x] Manual end-to-end: simulated pre-048 DB, ran migration, deleted a workspace, verified agents + tasks gone, `events` row survives with `agent_id`/`task_id` nulled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)