### PR TITLE
PM agent: link to named openclaw agent (mc-project-manager)

### DIFF
--- a/src/app/api/pm/decompose-initiative/route.ts
+++ b/src/app/api/pm/decompose-initiative/route.ts
@@ -21,8 +21,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getInitiative } from '@/lib/db/initiatives';
 import { synthesizeDecompose } from '@/lib/agents/pm-agent';
-import { createProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
-import { postPmChatMessage } from '@/lib/agents/pm-dispatch';
+import { PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { postPmChatMessage, dispatchPmSynthesized } from '@/lib/agents/pm-dispatch';
 
 export const dynamic = 'force-dynamic';
 
@@ -71,13 +71,24 @@ export async function POST(request: NextRequest) {
       hint: parsed.data.hint ?? null,
     });
 
-    const proposal = createProposal({
+    // Try the named-agent path first (PM gateway agent at
+    // ~/.openclaw/workspaces/mc-project-manager). On timeout or no
+    // session, the synthesized proposal is persisted exactly like
+    // before so the operator always has something to react to.
+    const dispatch = await dispatchPmSynthesized({
       workspace_id: parent.workspace_id,
       trigger_text: triggerText,
       trigger_kind: 'decompose_initiative',
-      impact_md: synth.impact_md,
-      proposed_changes: synth.changes,
+      synth: { impact_md: synth.impact_md, changes: synth.changes },
+      agent_prompt:
+        `Decompose initiative ${parent.id} ("${parent.title}", kind=${parent.kind}) ` +
+        `into 3-7 child initiatives.` +
+        (parsed.data.hint ? ` Operator hint: ${parsed.data.hint}.` : '') +
+        ` Call \`propose_changes\` (trigger_kind='decompose_initiative') with one ` +
+        `\`create_child_initiative\` diff per child. Pre-wire each child to depend on the ` +
+        `prior sibling using placeholder ids \`$0\`, \`$1\`, etc. See your SOUL.md.`,
     });
+    const proposal = dispatch.proposal;
 
     try {
       postPmChatMessage({

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -26,8 +26,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getRoadmapSnapshot } from '@/lib/db/roadmap';
 import { synthesizePlanInitiative } from '@/lib/agents/pm-agent';
-import { createProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
-import { postPmChatMessage } from '@/lib/agents/pm-dispatch';
+import { PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { postPmChatMessage, dispatchPmSynthesized } from '@/lib/agents/pm-dispatch';
 
 export const dynamic = 'force-dynamic';
 
@@ -71,18 +71,24 @@ export async function POST(request: NextRequest) {
       draft: parsed.data.draft,
     });
 
-    // Stash the suggestions in proposed_changes as a synthetic single-diff
-    // payload via update_status_check on a sentinel that we never apply
-    // (advisory accept short-circuits). We use a JSON sidecar block in
-    // impact_md instead so client can read suggestions without parsing
-    // diffs. proposed_changes stays an empty array = nothing to apply.
-    const proposal = createProposal({
+    // Try the named-agent path first (PM gateway agent at
+    // ~/.openclaw/workspaces/mc-project-manager). On timeout or no
+    // session, the synthesized advisory proposal is persisted exactly
+    // like before. proposed_changes stays an empty array for the
+    // advisory plan_initiative case = nothing to apply on accept.
+    const dispatch = await dispatchPmSynthesized({
       workspace_id: parsed.data.workspace_id,
       trigger_text: triggerText,
       trigger_kind: 'plan_initiative',
-      impact_md: synth.impact_md,
-      proposed_changes: synth.changes,
+      synth: { impact_md: synth.impact_md, changes: synth.changes },
+      agent_prompt:
+        `Plan an initiative draft titled "${parsed.data.draft.title}". ` +
+        `Operator-provided draft: ${JSON.stringify(parsed.data.draft)}. ` +
+        `Call \`propose_changes\` (trigger_kind='plan_initiative') with an impact_md that ` +
+        `includes a "<!--pm-plan-suggestions ...-->" sidecar so the form can apply your ` +
+        `suggestions. proposed_changes should be [] (advisory). See your SOUL.md.`,
     });
+    const proposal = dispatch.proposal;
 
     // Best-effort chat echo for audit visibility in /pm.
     try {

--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -111,7 +111,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       // Default disruption-analysis path. We borrow dispatchPm's
       // synthesizer and patch the result onto the pre-allocated child
       // row, then delete the side-effect row dispatchPm created.
-      const synthesized = dispatchPm({
+      const synthesized = await dispatchPm({
         workspace_id: parent.workspace_id,
         trigger_text: child.trigger_text,
         trigger_kind: parent.trigger_kind,

--- a/src/app/api/pm/proposals/route.ts
+++ b/src/app/api/pm/proposals/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       );
     }
-    const result = dispatchPm(parsed.data);
+    const result = await dispatchPm(parsed.data);
     return NextResponse.json(
       {
         proposal: result.proposal,

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -1,29 +1,33 @@
 /**
- * PM dispatch path (Phase 5).
+ * PM dispatch path.
  *
- * Translates an operator-supplied disruption text into a `pm_proposals`
- * row. Phase 5 ships the **synthesize fallback** — a deterministic parser
- * that does naive regex extraction (dates, owner names, initiative refs)
- * and produces a valid PmDiff[] from the snapshot.
+ * The PM is now a NAMED openclaw agent at
+ *   `~/.openclaw/workspaces/mc-project-manager/`
+ * (full SOUL.md/IDENTITY.md/AGENTS.md/etc. — same layout as
+ * mc-coordinator/mc-builder). Migration 049 + `ensurePmAgent` link the MC
+ * `agents` row to that gateway agent via `gateway_agent_id` and
+ * `session_key_prefix`.
  *
- * Why a fallback rather than an LLM call:
+ * Routing (single seam — `dispatchPm` and the plan/decompose helpers):
  *
- *   - MC has no Anthropic SDK wired today. Adding one is its own
- *     project (auth, model selection, cost cap integration, eval).
- *   - The lifecycle (disruption → proposal → accept → DB change) needs
- *     to be exercised end-to-end before we layer in LLM polish. A
- *     deterministic path is testable and cheap.
- *   - The MCP `propose_changes` tool is ALSO available, so an out-of-band
- *     PM session running through openclaw + sc-mission-control can
- *     produce richer proposals; the synthesize path is the "operator
- *     hits enter, gets something useful back instantly" floor.
+ *   1. Look up the PM agent for the workspace.
+ *   2. If it has a `gateway_agent_id` AND the openclaw client is connected,
+ *      send the trigger + snapshot context (with a correlation_id) to
+ *      `agent:mc-project-manager:main` via `chat.send`. Wait for the agent
+ *      to call `propose_changes` (its SOUL.md instructs it to). The
+ *      proposal lands in `pm_proposals` via the MCP path; we look it up
+ *      by recency and return it.
+ *   3. On timeout / no gateway / send failure, fall back to
+ *      `synthesizeImpactAnalysis` — the deterministic parser preserved
+ *      from Phase 5 so MC stays useful with or without the gateway running.
  *
- * The contract: given a workspace snapshot and a free-text trigger,
- * return a draft proposal whose changes only reference real ids in the
- * snapshot. Hallucinated ids are a bug (tests cover this).
+ * The synthesize fallback is intentionally kept forever: it's the
+ * "operator hits enter, gets something useful instantly" floor and the
+ * only path that works offline. Never delete it.
  *
- * Phase 6 may swap this implementation for an LLM-driven one — the
- * caller surface (`synthesizeImpactAnalysis`) stays stable.
+ * Hallucinated ids are a bug — `createProposal` validates every diff
+ * against the workspace snapshot, so even the gateway path can't slip
+ * through bad references.
  */
 
 import { getRoadmapSnapshot, type RoadmapSnapshot } from '@/lib/db/roadmap';
@@ -32,10 +36,14 @@ import { queryAll, queryOne, run } from '@/lib/db';
 import { v4 as uuidv4 } from 'uuid';
 import {
   createProposal,
+  listProposals,
   type PmDiff,
   type PmProposal,
   type PmProposalTriggerKind,
 } from '@/lib/db/pm-proposals';
+import { getOpenClawClient } from '@/lib/openclaw/client';
+import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
+import type { Agent } from '@/lib/types';
 
 // ─── Public API ─────────────────────────────────────────────────────
 
@@ -48,19 +56,95 @@ export interface DispatchPmInput {
 
 export interface DispatchPmResult {
   proposal: PmProposal;
-  used_synthesize_fallback: true;
+  used_synthesize_fallback: boolean;
+  used_named_agent?: boolean;
 }
 
 /**
- * Top-level dispatch entry. Today it always uses the synthesize fallback;
- * Phase 6 may add a route to an LLM. Persists the proposal as a side
- * effect and posts a chat message on the PM agent's chat thread referencing
- * the proposal_id (so the /pm UI's card renderer fires).
+ * Default time we wait for the named PM agent to respond (i.e. land a
+ * row via `propose_changes`) before falling back to the synth path.
  */
-export function dispatchPm(input: DispatchPmInput): DispatchPmResult {
-  const snapshot = getRoadmapSnapshot({ workspace_id: input.workspace_id });
-  const synth = synthesizeImpactAnalysis(snapshot, input.trigger_text);
+const NAMED_AGENT_TIMEOUT_MS = 60_000;
 
+/** Dependency seam for tests — see `__setOpenClawClientForTests`. */
+type GatewayClient = {
+  isConnected: () => boolean;
+  call: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+};
+let openclawClientOverride: GatewayClient | null = null;
+export function __setOpenClawClientForTests(c: GatewayClient | null): void {
+  openclawClientOverride = c;
+}
+function gatewayClient(): GatewayClient {
+  return openclawClientOverride ?? (getOpenClawClient() as unknown as GatewayClient);
+}
+
+/** Likewise — tests override the timeout to keep the suite fast. */
+let namedAgentTimeoutOverride: number | null = null;
+export function __setNamedAgentTimeoutForTests(ms: number | null): void {
+  namedAgentTimeoutOverride = ms;
+}
+function namedAgentTimeoutMs(): number {
+  return namedAgentTimeoutOverride ?? NAMED_AGENT_TIMEOUT_MS;
+}
+
+/**
+ * Top-level dispatch entry. Routes through the named openclaw agent when
+ * available; falls back to `synthesizeImpactAnalysis` otherwise. Always
+ * persists a proposal + posts the operator/PM messages into the PM
+ * agent's chat thread so the /pm UI's card renderer fires.
+ */
+export async function dispatchPm(input: DispatchPmInput): Promise<DispatchPmResult> {
+  const snapshot = getRoadmapSnapshot({ workspace_id: input.workspace_id });
+  const pm = lookupPmAgent(input.workspace_id);
+
+  // Always echo the operator's trigger as a user message regardless of
+  // path so the /pm chat reflects the conversation faithfully.
+  try {
+    postPmChatMessage({
+      workspace_id: input.workspace_id,
+      content: input.trigger_text,
+      role: 'user',
+    });
+  } catch (err) {
+    console.warn('[pm-dispatch] user chat insert failed:', (err as Error).message);
+  }
+
+  // ── 1. Try the named-agent path ────────────────────────────────────
+  if (pm && pm.gateway_agent_id) {
+    const gw = gatewayClient();
+    if (gw.isConnected()) {
+      try {
+        const proposal = await dispatchViaNamedAgent({
+          input,
+          snapshot,
+          pm,
+          client: gw,
+        });
+        if (proposal) {
+          try {
+            postPmChatMessage({
+              workspace_id: input.workspace_id,
+              content: proposal.impact_md,
+              proposal_id: proposal.id,
+              role: 'assistant',
+            });
+          } catch (err) {
+            console.warn('[pm-dispatch] assistant chat insert failed:', (err as Error).message);
+          }
+          return { proposal, used_synthesize_fallback: false, used_named_agent: true };
+        }
+      } catch (err) {
+        console.warn(
+          '[pm-dispatch] named-agent dispatch failed; falling back to synth:',
+          (err as Error).message,
+        );
+      }
+    }
+  }
+
+  // ── 2. Synthesize fallback ────────────────────────────────────────
+  const synth = synthesizeImpactAnalysis(snapshot, input.trigger_text);
   const proposal = createProposal({
     workspace_id: input.workspace_id,
     trigger_text: input.trigger_text,
@@ -69,10 +153,6 @@ export function dispatchPm(input: DispatchPmInput): DispatchPmResult {
     proposed_changes: synth.changes,
     parent_proposal_id: input.parent_proposal_id ?? null,
   });
-
-  // Best-effort: post the impact summary into the PM agent's chat with
-  // a metadata.proposal_id so the /pm UI renders it as a card. Fails
-  // silently (the proposal still exists; the chat is a UX nicety).
   try {
     postPmChatMessage({
       workspace_id: input.workspace_id,
@@ -80,20 +160,205 @@ export function dispatchPm(input: DispatchPmInput): DispatchPmResult {
       proposal_id: proposal.id,
       role: 'assistant',
     });
-    // Also echo the operator's trigger as a 'user' message so the chat
-    // shows the conversation. Safe to add here because this dispatch is
-    // currently the only entry point — when Phase 6 adds a real chat
-    // input pipe we'll move this to that route.
-    postPmChatMessage({
-      workspace_id: input.workspace_id,
-      content: input.trigger_text,
-      role: 'user',
-    });
   } catch (err) {
     console.warn('[pm-dispatch] chat insert failed:', (err as Error).message);
   }
+  return { proposal, used_synthesize_fallback: true, used_named_agent: false };
+}
 
-  return { proposal, used_synthesize_fallback: true };
+// ─── Named-agent dispatch ───────────────────────────────────────────
+
+/**
+ * Build a compact roadmap snapshot summary so the PM agent doesn't have
+ * to round-trip MCP for `get_roadmap_snapshot` on every dispatch. Only
+ * fields the PM needs to reason about disruptions: ids, titles, owners,
+ * status, target dates. Capped at 50 initiatives so the prompt stays
+ * sane on busy workspaces.
+ */
+function buildSnapshotSummary(snapshot: RoadmapSnapshot): string {
+  const lines: string[] = [`Workspace: ${snapshot.workspace_id}`];
+  const initiatives = snapshot.initiatives.slice(0, 50);
+  if (initiatives.length > 0) {
+    lines.push('', 'Initiatives:');
+    for (const i of initiatives) {
+      lines.push(
+        `- ${i.id} | ${i.kind} | "${i.title}" | status=${i.status}` +
+          (i.target_end ? ` | target_end=${i.target_end}` : '') +
+          (i.owner_agent_id ? ` | owner=${i.owner_agent_id}` : ''),
+      );
+    }
+    if (snapshot.initiatives.length > 50) {
+      lines.push(
+        `(... ${snapshot.initiatives.length - 50} more not shown — call get_roadmap_snapshot via MCP for full list)`,
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+interface DispatchNamedAgentParams {
+  input: DispatchPmInput;
+  snapshot: RoadmapSnapshot;
+  pm: Pick<Agent, 'id' | 'name' | 'session_key_prefix' | 'gateway_agent_id' | 'workspace_id'>;
+  client: GatewayClient;
+}
+
+/**
+ * Send the trigger to the gateway-hosted PM session, wait until a new
+ * proposal lands in `pm_proposals` via the MCP `propose_changes` tool,
+ * then return it.
+ *
+ * Correlation: we record `since` (ISO time at the moment of send) and
+ * include a `correlation_id` in the message body. After the round-trip
+ * we look up the most recent draft proposal for the workspace whose
+ * created_at >= since. This is sufficient because:
+ *   - dispatch is single-flight from the operator's perspective,
+ *   - we only land here on a successful `chat.send`, so synth hasn't
+ *     written yet.
+ * If the agent ever lands two proposals from one trigger, we return the
+ * newest — refine() can chain the rest.
+ */
+async function dispatchViaNamedAgent(params: DispatchNamedAgentParams): Promise<PmProposal | null> {
+  const { input, snapshot, pm, client } = params;
+  const correlationId = uuidv4();
+  const sinceIso = new Date().toISOString();
+
+  const sessionKey = buildPmSessionKey(pm);
+
+  const summary = buildSnapshotSummary(snapshot);
+  const message =
+    `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
+    `Operator-reported event:\n> ${input.trigger_text}\n\n` +
+    `Workspace snapshot summary (call \`get_roadmap_snapshot\` via MCP for full detail):\n\n` +
+    `${summary}\n\n` +
+    `Per your SOUL.md: analyse the disruption and call \`propose_changes\` ` +
+    `with a structured PmDiff[] and impact_md. Reference only ids that ` +
+    `appear in the snapshot.`;
+
+  await client.call('chat.send', {
+    sessionKey,
+    message,
+    idempotencyKey: `pm-dispatch-${correlationId}`,
+  });
+
+  const deadline = Date.now() + namedAgentTimeoutMs();
+  while (Date.now() < deadline) {
+    const proposal = findProposalCreatedSince(input.workspace_id, sinceIso);
+    if (proposal) return proposal;
+    await sleep(500);
+  }
+  return null;
+}
+
+/**
+ * Build the chat sessionKey for the PM. resolveAgentSessionKeyPrefix
+ * returns either the explicit session_key_prefix (already including any
+ * suffix) or `agent:<gateway_agent_id>:`. We always want a single ":main"
+ * channel for the PM, so collapse trailing duplicates that arise when
+ * session_key_prefix is set to `agent:mc-project-manager:main`.
+ */
+function buildPmSessionKey(
+  pm: Pick<Agent, 'session_key_prefix' | 'gateway_agent_id' | 'name'>,
+): string {
+  const prefix = resolveAgentSessionKeyPrefix(pm);
+  // prefix always ends with ':' (the helper guarantees that). Tack on
+  // 'main' unless the prefix already ends with ':main:' (i.e. the
+  // operator/migration set session_key_prefix='agent:...:main').
+  if (/:main:$/.test(prefix)) {
+    return prefix.replace(/:$/, '');
+  }
+  return `${prefix}main`;
+}
+
+function findProposalCreatedSince(workspaceId: string, sinceIso: string): PmProposal | null {
+  const drafts = listProposals({ workspace_id: workspaceId, status: 'draft', since: sinceIso });
+  // listProposals returns DESC by created_at — pick the newest.
+  return drafts[0] ?? null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function lookupPmAgent(workspaceId: string): Agent | null {
+  const row = queryOne<Agent>(
+    `SELECT * FROM agents WHERE workspace_id = ? AND role = 'pm' LIMIT 1`,
+    [workspaceId],
+  );
+  return row ?? null;
+}
+
+/**
+ * Same routing as `dispatchPm` but for already-synthesized proposals
+ * (plan-initiative + decompose-initiative paths). Tries the named PM
+ * session first; falls back to persisting the caller's synth output
+ * when the gateway is unreachable.
+ *
+ * The plan/decompose synthesizers produce ADVISORY proposals (no diffs
+ * to apply for plan_initiative; pre-wired children for decompose), so
+ * the round-trip semantics are slightly different than dispatchPm: we
+ * still poll for any new draft proposal in the workspace, but on
+ * timeout we persist the synthesized proposal we were given so the
+ * operator always sees something. Returns whichever proposal landed
+ * plus fallback flags.
+ */
+export interface DispatchSynthesizedInput {
+  workspace_id: string;
+  trigger_text: string;
+  trigger_kind: PmProposalTriggerKind;
+  /** Synth output ready to persist as a fallback. */
+  synth: { impact_md: string; changes: PmDiff[] };
+  /** Free-text prompt sent to the named agent. */
+  agent_prompt: string;
+  parent_proposal_id?: string | null;
+}
+
+export async function dispatchPmSynthesized(
+  input: DispatchSynthesizedInput,
+): Promise<{ proposal: PmProposal; used_synthesize_fallback: boolean; used_named_agent: boolean }> {
+  const pm = lookupPmAgent(input.workspace_id);
+  if (pm && pm.gateway_agent_id) {
+    const gw = gatewayClient();
+    if (gw.isConnected()) {
+      try {
+        const correlationId = uuidv4();
+        const sinceIso = new Date().toISOString();
+        const sessionKey = buildPmSessionKey(pm);
+        await gw.call('chat.send', {
+          sessionKey,
+          message:
+            `**PM ${input.trigger_kind} (correlation_id: ${correlationId})**\n\n` +
+            input.agent_prompt,
+          idempotencyKey: `pm-${input.trigger_kind}-${correlationId}`,
+        });
+        const deadline = Date.now() + namedAgentTimeoutMs();
+        while (Date.now() < deadline) {
+          const found = findProposalCreatedSince(input.workspace_id, sinceIso);
+          if (found) {
+            return { proposal: found, used_synthesize_fallback: false, used_named_agent: true };
+          }
+          await sleep(500);
+        }
+      } catch (err) {
+        console.warn(
+          '[pm-dispatch] synthesized named-agent dispatch failed; falling back:',
+          (err as Error).message,
+        );
+      }
+    }
+  }
+  // Fallback — persist the synthesized proposal exactly like before.
+  const proposal = createProposal({
+    workspace_id: input.workspace_id,
+    trigger_text: input.trigger_text,
+    trigger_kind: input.trigger_kind,
+    impact_md: input.synth.impact_md,
+    proposed_changes: input.synth.changes,
+    parent_proposal_id: input.parent_proposal_id ?? null,
+  });
+  return { proposal, used_synthesize_fallback: true, used_named_agent: false };
 }
 
 // ─── Synthesize fallback ────────────────────────────────────────────

--- a/src/lib/agents/pm-e2e.test.ts
+++ b/src/lib/agents/pm-e2e.test.ts
@@ -29,7 +29,7 @@ function freshWorkspace(): string {
   return id;
 }
 
-test('PM lifecycle: dispatch → draft → accept → diff applied + event emitted', () => {
+test('PM lifecycle: dispatch → draft → accept → diff applied + event emitted', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
 
@@ -58,7 +58,7 @@ test('PM lifecycle: dispatch → draft → accept → diff applied + event emitt
   });
 
   // 1. Operator drops a disruption.
-  const dispatch = dispatchPm({
+  const dispatch = await dispatchPm({
     workspace_id: ws,
     trigger_text: 'Sarah out 2026-05-01 to 2026-05-08',
   });

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -15,8 +15,20 @@ import { v4 as uuidv4 } from 'uuid';
 import { queryAll, queryOne, run } from '@/lib/db';
 import { createInitiative } from '@/lib/db/initiatives';
 import { getRoadmapSnapshot } from '@/lib/db/roadmap';
-import { synthesizeImpactAnalysis, dispatchPm } from './pm-dispatch';
-import { ensurePmAgent } from '@/lib/bootstrap-agents';
+import {
+  synthesizeImpactAnalysis,
+  dispatchPm,
+  __setOpenClawClientForTests,
+  __setNamedAgentTimeoutForTests,
+} from './pm-dispatch';
+import { createProposal } from '@/lib/db/pm-proposals';
+import {
+  ensurePmAgent,
+  PM_GATEWAY_AGENT_ID,
+  PM_SESSION_KEY_PREFIX,
+  PM_NAMED_AGENT_NAME,
+  PM_NAMED_AGENT_AVATAR,
+} from '@/lib/bootstrap-agents';
 
 function freshWorkspace(): string {
   const id = `ws-${uuidv4().slice(0, 8)}`;
@@ -107,12 +119,12 @@ test('synthesizeImpactAnalysis: explicit date + delay verb → shift_initiative_
 
 // ─── dispatchPm ────────────────────────────────────────────────────
 
-test('dispatchPm: persists a draft proposal AND posts to PM chat with metadata', () => {
+test('dispatchPm: persists a draft proposal AND posts to PM chat with metadata', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
   const sarahId = seedNamedAgent(ws, 'Sarah');
 
-  const result = dispatchPm({
+  const result = await dispatchPm({
     workspace_id: ws,
     trigger_text: 'Sarah out 2026-05-01 to 2026-05-05',
   });
@@ -146,11 +158,169 @@ test('dispatchPm: persists a draft proposal AND posts to PM chat with metadata',
   }
 });
 
-test('dispatchPm: returns a usable proposal even when nothing is parsed', () => {
+test('dispatchPm: returns a usable proposal even when nothing is parsed', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
-  const result = dispatchPm({ workspace_id: ws, trigger_text: 'qqq xyz' });
+  const result = await dispatchPm({ workspace_id: ws, trigger_text: 'qqq xyz' });
   assert.equal(result.proposal.status, 'draft');
   assert.equal(result.proposal.proposed_changes.length, 0);
   assert.match(result.proposal.impact_md, /could not extract|No structured changes/);
+});
+
+// ─── Bootstrap: PM is now a named gateway agent ────────────────────
+
+test('ensurePmAgent: seeds the PM as a named gateway agent', () => {
+  const ws = freshWorkspace();
+  const r = ensurePmAgent(ws);
+  assert.equal(r.created, true);
+  const row = queryOne<{
+    name: string;
+    avatar_emoji: string;
+    role: string;
+    source: string;
+    gateway_agent_id: string;
+    session_key_prefix: string;
+  }>(
+    `SELECT name, avatar_emoji, role, source, gateway_agent_id, session_key_prefix
+       FROM agents WHERE id = ?`,
+    [r.id],
+  );
+  assert.ok(row);
+  assert.equal(row!.role, 'pm');
+  assert.equal(row!.gateway_agent_id, PM_GATEWAY_AGENT_ID);
+  assert.equal(row!.session_key_prefix, PM_SESSION_KEY_PREFIX);
+  assert.equal(row!.source, 'gateway');
+  assert.equal(row!.name, PM_NAMED_AGENT_NAME);
+  assert.equal(row!.avatar_emoji, PM_NAMED_AGENT_AVATAR);
+});
+
+// ─── Named-agent dispatch routing ──────────────────────────────────
+
+test('dispatchPm: routes through named agent when openclaw is connected; mock creates proposal via propose_changes simulation', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+
+  // The named agent would call propose_changes via MCP. Our mock client
+  // simulates that side effect: when chat.send is invoked, it inserts a
+  // pm_proposals row with rich impact_md and a structured change. The
+  // dispatch poller should pick it up and return it.
+  const seenSends: Array<{ method: string; params: unknown }> = [];
+  const fakeClient = {
+    isConnected: () => true,
+    call: async (method: string, params?: Record<string, unknown>) => {
+      seenSends.push({ method, params });
+      if (method === 'chat.send') {
+        // Simulate the agent calling propose_changes via MCP.
+        createProposal({
+          workspace_id: ws,
+          trigger_text: 'named-agent dispatch',
+          trigger_kind: 'manual',
+          impact_md: '### Named-agent verdict\n\n- richer than synth',
+          proposed_changes: [],
+        });
+      }
+      return undefined;
+    },
+  };
+  __setOpenClawClientForTests(fakeClient);
+  __setNamedAgentTimeoutForTests(2_000);
+
+  try {
+    const result = await dispatchPm({
+      workspace_id: ws,
+      trigger_text: 'Operator says we lost a sprint',
+    });
+    assert.equal(result.used_synthesize_fallback, false);
+    assert.equal(result.used_named_agent, true);
+    assert.match(result.proposal.impact_md, /Named-agent verdict/);
+    // chat.send went to the canonical PM session.
+    const send = seenSends.find(s => s.method === 'chat.send');
+    assert.ok(send);
+    const sk = (send!.params as { sessionKey?: string }).sessionKey;
+    assert.equal(sk, `agent:${PM_GATEWAY_AGENT_ID}:main`);
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
+  }
+});
+
+test('dispatchPm: falls back to synth when openclaw client is offline', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  seedNamedAgent(ws, 'Sarah');
+
+  __setOpenClawClientForTests({
+    isConnected: () => false,
+    call: async () => {
+      throw new Error('should not be called when not connected');
+    },
+  });
+
+  try {
+    const result = await dispatchPm({
+      workspace_id: ws,
+      trigger_text: 'Sarah out next week',
+    });
+    assert.equal(result.used_synthesize_fallback, true);
+    assert.equal(result.used_named_agent, false);
+    // The synth path produced a real availability diff.
+    const avail = result.proposal.proposed_changes.find(c => c.kind === 'add_availability');
+    assert.ok(avail, 'expected synth fallback to produce add_availability');
+  } finally {
+    __setOpenClawClientForTests(null);
+  }
+});
+
+test('dispatchPm: falls back to synth when named-agent send throws', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  seedNamedAgent(ws, 'Sarah');
+
+  __setOpenClawClientForTests({
+    isConnected: () => true,
+    call: async () => {
+      throw new Error('gateway boom');
+    },
+  });
+  __setNamedAgentTimeoutForTests(500);
+
+  try {
+    const result = await dispatchPm({
+      workspace_id: ws,
+      trigger_text: 'Sarah out next week',
+    });
+    assert.equal(result.used_synthesize_fallback, true);
+    assert.equal(result.used_named_agent, false);
+    assert.equal(result.proposal.status, 'draft');
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
+  }
+});
+
+test('dispatchPm: falls back to synth when named agent times out without writing', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+
+  __setOpenClawClientForTests({
+    isConnected: () => true,
+    call: async () => {
+      // No-op — agent never calls propose_changes.
+      return undefined;
+    },
+  });
+  __setNamedAgentTimeoutForTests(500);
+
+  try {
+    const result = await dispatchPm({
+      workspace_id: ws,
+      trigger_text: 'no agent will respond',
+    });
+    assert.equal(result.used_synthesize_fallback, true);
+    assert.equal(result.used_named_agent, false);
+    assert.match(result.proposal.impact_md, /No structured changes|could not extract/);
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
+  }
 });

--- a/src/lib/bootstrap-agents.ts
+++ b/src/lib/bootstrap-agents.ts
@@ -234,9 +234,26 @@ export function bootstrapCoreAgentsRaw(
  * soul_md from the .md file next to the pm-agent module so operators can
  * tweak the prompt without redeploying. Safe to call from API routes.
  *
- * Migration 045 also seeds PMs at startup; this function exists so freshly
- * created workspaces (after migrations have run) get one too.
+ * The PM is now seeded as a NAMED gateway agent (source='gateway') linked
+ * to the openclaw workspace at `~/.openclaw/workspaces/mc-project-manager/`.
+ * That workspace ships with full agent files (SOUL.md, IDENTITY.md, etc.)
+ * — same pattern as mc-coordinator/mc-builder/etc. The `gateway_agent_id`
+ * + `session_key_prefix` are what let `resolveAgentSessionKeyPrefix` route
+ * real chat.send traffic to the gateway-hosted PM session.
+ *
+ * Migration 045 originally seeded PMs as ephemeral source='local' rows
+ * with no gateway link; migration 049 backfills those rows so they pick
+ * up the new routing.
+ *
+ * If a PM row already exists for the workspace this function does NOT
+ * mutate it — operators may have customised it, and migration 049 owns
+ * the backfill for older rows.
  */
+export const PM_GATEWAY_AGENT_ID = 'mc-project-manager';
+export const PM_SESSION_KEY_PREFIX = `agent:${PM_GATEWAY_AGENT_ID}:main`;
+export const PM_NAMED_AGENT_NAME = 'Margaret "Maps" Hamilton';
+export const PM_NAMED_AGENT_AVATAR = '🗺️';
+
 export function ensurePmAgent(workspaceId: string): { id: string; created: boolean } {
   const db = getDb();
   const existing = db.prepare(
@@ -251,12 +268,26 @@ export function ensurePmAgent(workspaceId: string): { id: string; created: boole
 
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
+  // source='gateway' matches the convention used by agent-catalog-sync
+  // for every gateway-hosted named agent (mc-coordinator, mc-builder, …).
   db.prepare(`
     INSERT INTO agents (
       id, name, role, description, avatar_emoji, status, is_master,
-      workspace_id, soul_md, source, is_active, created_at, updated_at
-    ) VALUES (?, 'PM', 'pm', ?, '📋', 'standby', 0, ?, ?, 'local', 1, ?, ?)
-  `).run(id, PM_AGENT_DESCRIPTION, workspaceId, getPmSoulMd(), now, now);
+      workspace_id, soul_md, source, gateway_agent_id, session_key_prefix,
+      is_active, created_at, updated_at
+    ) VALUES (?, ?, 'pm', ?, ?, 'standby', 0, ?, ?, 'gateway', ?, ?, 1, ?, ?)
+  `).run(
+    id,
+    PM_NAMED_AGENT_NAME,
+    PM_AGENT_DESCRIPTION,
+    PM_NAMED_AGENT_AVATAR,
+    workspaceId,
+    getPmSoulMd(),
+    PM_GATEWAY_AGENT_ID,
+    PM_SESSION_KEY_PREFIX,
+    now,
+    now,
+  );
   return { id, created: true };
 }
 

--- a/src/lib/db/migration-049.test.ts
+++ b/src/lib/db/migration-049.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Migration 049 (`pm_named_agent_link`) backfill behaviour.
+ *
+ * Verifies the SQL the migration runs against rows that look like
+ * pre-049 PM seeds (source='local', gateway_agent_id=NULL). The shared
+ * test DB has already applied 049, so we *simulate* a legacy row by
+ * stripping the link off a freshly-ensured PM, then re-run the
+ * migration's UPDATE statements verbatim.
+ *
+ * Real migration runs are exercised by the broader test harness (every
+ * test that touches getDb() runs the full migration list at startup);
+ * this file checks the backfill semantics specifically.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { getDb, queryOne, run } from '@/lib/db';
+import { ensurePmAgent } from '@/lib/bootstrap-agents';
+
+function freshWorkspace(): string {
+  const id = `ws-mig049-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+test('migration 049: backfills pre-049 PM rows with gateway link + persona', () => {
+  const ws = freshWorkspace();
+  const r = ensurePmAgent(ws);
+
+  // Simulate a legacy row: clear the gateway link, reset name, and put
+  // source back to 'local' so it matches the migration 045 shape.
+  run(
+    `UPDATE agents
+        SET gateway_agent_id = NULL,
+            session_key_prefix = NULL,
+            source = 'local',
+            name = 'PM',
+            avatar_emoji = '📋'
+      WHERE id = ?`,
+    [r.id],
+  );
+
+  // Replay migration 049's logic.
+  const db = getDb();
+  const rows = db
+    .prepare(
+      `SELECT id, name FROM agents
+        WHERE role = 'pm' AND gateway_agent_id IS NULL`,
+    )
+    .all() as { id: string; name: string }[];
+  assert.ok(
+    rows.some(x => x.id === r.id),
+    'expected legacy PM row to be picked up by migration filter',
+  );
+
+  const updateLinked = db.prepare(
+    `UPDATE agents
+        SET gateway_agent_id = 'mc-project-manager',
+            session_key_prefix = 'agent:mc-project-manager:main',
+            source = 'gateway',
+            updated_at = ?
+      WHERE id = ?`,
+  );
+  const updateRenamed = db.prepare(
+    `UPDATE agents
+        SET name = 'Margaret "Maps" Hamilton',
+            avatar_emoji = '🗺️',
+            updated_at = ?
+      WHERE id = ?`,
+  );
+  const now = new Date().toISOString();
+  for (const row of rows) {
+    updateLinked.run(now, row.id);
+    if (row.name === 'PM') updateRenamed.run(now, row.id);
+  }
+
+  const after = queryOne<{
+    name: string;
+    avatar_emoji: string;
+    source: string;
+    gateway_agent_id: string;
+    session_key_prefix: string;
+  }>(
+    `SELECT name, avatar_emoji, source, gateway_agent_id, session_key_prefix
+       FROM agents WHERE id = ?`,
+    [r.id],
+  );
+  assert.ok(after);
+  assert.equal(after!.gateway_agent_id, 'mc-project-manager');
+  assert.equal(after!.session_key_prefix, 'agent:mc-project-manager:main');
+  assert.equal(after!.source, 'gateway');
+  assert.equal(after!.name, 'Margaret "Maps" Hamilton');
+  assert.equal(after!.avatar_emoji, '🗺️');
+});
+
+test('migration 049: preserves operator-customized PM name', () => {
+  const ws = freshWorkspace();
+  const r = ensurePmAgent(ws);
+
+  // Operator-customized row: legacy state + a non-default name.
+  run(
+    `UPDATE agents
+        SET gateway_agent_id = NULL,
+            session_key_prefix = NULL,
+            source = 'local',
+            name = 'PM Bob',
+            avatar_emoji = '🦊'
+      WHERE id = ?`,
+    [r.id],
+  );
+
+  // Replay only the rename guard.
+  const db = getDb();
+  const updateLinked = db.prepare(
+    `UPDATE agents
+        SET gateway_agent_id = 'mc-project-manager',
+            session_key_prefix = 'agent:mc-project-manager:main',
+            source = 'gateway',
+            updated_at = ?
+      WHERE id = ?`,
+  );
+  const updateRenamed = db.prepare(
+    `UPDATE agents
+        SET name = 'Margaret "Maps" Hamilton',
+            avatar_emoji = '🗺️',
+            updated_at = ?
+      WHERE id = ?`,
+  );
+  const now = new Date().toISOString();
+  updateLinked.run(now, r.id);
+  // Replay the migration's name-guarded rename only when name === 'PM'.
+  const cur = queryOne<{ name: string }>(`SELECT name FROM agents WHERE id = ?`, [r.id]);
+  if (cur?.name === 'PM') updateRenamed.run(now, r.id);
+
+  const after = queryOne<{ name: string; avatar_emoji: string; gateway_agent_id: string }>(
+    `SELECT name, avatar_emoji, gateway_agent_id FROM agents WHERE id = ?`,
+    [r.id],
+  );
+  assert.ok(after);
+  // Gateway link applied …
+  assert.equal(after!.gateway_agent_id, 'mc-project-manager');
+  // … but operator-customized name + emoji preserved.
+  assert.equal(after!.name, 'PM Bob');
+  assert.equal(after!.avatar_emoji, '🦊');
+});

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3168,6 +3168,62 @@ const migrations: Migration[] = [
       console.log(`[Migration 048] Complete. Patched ${tablesPatched.length} tables: ${tablesPatched.join(', ')}`);
     },
   },
+  {
+    id: '049',
+    name: 'pm_named_agent_link',
+    up: (db) => {
+      // Phase 5/6 follow-up: link existing PM agents to the named openclaw
+      // workspace at `~/.openclaw/workspaces/mc-project-manager/`.
+      //
+      // Migration 045 seeded each workspace's PM as `source='local'` with no
+      // `gateway_agent_id` and no `session_key_prefix` — that meant MC had
+      // no way to route chat.send traffic to a real openclaw session for
+      // the PM, and the dispatch path silently fell through to the
+      // synthesize parser. The operator has now created a real openclaw
+      // workspace; this migration links every existing PM row to that
+      // gateway agent so the named-agent dispatch route can find a session.
+      //
+      // Idempotent — only updates rows that still have NULL gateway_agent_id.
+      // Operator-customised names ("PM Bob") are preserved; only rows still
+      // named the default 'PM' get renamed to the persona in IDENTITY.md.
+      const rows = db
+        .prepare(
+          `SELECT id, name FROM agents
+            WHERE role = 'pm' AND gateway_agent_id IS NULL`,
+        )
+        .all() as { id: string; name: string | null }[];
+
+      const updateLinked = db.prepare(
+        `UPDATE agents
+            SET gateway_agent_id = 'mc-project-manager',
+                session_key_prefix = 'agent:mc-project-manager:main',
+                source = 'gateway',
+                updated_at = ?
+          WHERE id = ?`,
+      );
+      const updateRenamed = db.prepare(
+        `UPDATE agents
+            SET name = 'Margaret "Maps" Hamilton',
+                avatar_emoji = '🗺️',
+                updated_at = ?
+          WHERE id = ?`,
+      );
+
+      const now = new Date().toISOString();
+      let linked = 0;
+      let renamed = 0;
+      for (const r of rows) {
+        updateLinked.run(now, r.id);
+        linked++;
+        if (r.name === 'PM') {
+          updateRenamed.run(now, r.id);
+          renamed++;
+        }
+      }
+      console.log('[Migration 049] PM linked to gateway agent at ~/.openclaw/workspaces/mc-project-manager');
+      console.log(`[Migration 049] linked=${linked} renamed=${renamed}`);
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/mcp/roadmap-tools.ts
+++ b/src/lib/mcp/roadmap-tools.ts
@@ -104,6 +104,19 @@ function safeWrap<T>(fn: () => T): CallToolResult {
   }
 }
 
+async function safeWrapAsync<T>(fn: () => Promise<T>): Promise<CallToolResult> {
+  try {
+    const result = await fn();
+    return textResult(JSON.stringify(result, null, 2), result as Record<string, unknown>);
+  } catch (err) {
+    if (err instanceof PmProposalValidationError) {
+      return errorResult(err.message, 'validation_failed', { hints: err.hints });
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return errorResult(msg, 'internal_error');
+  }
+}
+
 const KINDS = z.enum(['theme', 'milestone', 'epic', 'story']);
 const INIT_STATUSES = z.enum([
   'planned',
@@ -586,7 +599,7 @@ export function registerRoadmapTools(server: McpServer): void {
       },
       annotations: { destructiveHint: false, openWorldHint: false },
     },
-    async (args) => safeWrap(() => {
+    async (args) => safeWrapAsync(async () => {
       // The DB helper creates an empty child slot; the dispatch path
       // fills it with a freshly-synthesized impact + changes.
       const parent = queryOne<{ workspace_id: string }>(
@@ -598,7 +611,7 @@ export function registerRoadmapTools(server: McpServer): void {
       // Re-dispatch so the new draft has impact_md + changes filled in.
       // We do this here (instead of relying on the API route refine
       // path) so MCP-driven refines also work.
-      const result = dispatchPm({
+      const result = await dispatchPm({
         workspace_id: parent.workspace_id,
         trigger_text: args.additional_constraint,
         trigger_kind: 'manual',


### PR DESCRIPTION
## Summary
The PM was seeded as a \`source='local'\` ephemeral row, so MC had no way to route a real LLM session to it. Operator created the workspace at \`~/.openclaw/workspaces/mc-project-manager/\` with full agent files. This PR links MC's PM agent row to that gateway agent and refactors the dispatch path to prefer the named-agent route, with the deterministic synthesize as fallback.

## What landed
- \`ensurePmAgent\` now seeds with \`gateway_agent_id='mc-project-manager'\`, \`session_key_prefix='agent:mc-project-manager:main'\`, \`source='gateway'\` (matching agent-catalog-sync's named-agent convention), and renames to "Margaret \"Maps\" Hamilton" 🗺️
- Migration 049 backfills any existing PM rows; preserves operator-customized names (only default \`'PM'\` rows pick up the persona)
- \`pm-dispatch.ts\` (and the plan/decompose helpers via \`dispatchPmSynthesized\`) try the gateway session first, fall back to synthesize on timeout/missing session/send failure
- The synth path is preserved forever as the offline floor — never deleted
- Tests cover both paths plus the migration backfill

## Test plan
- [x] Fresh DB: PM agent has gateway link (\`pm.test.ts\` `ensurePmAgent: seeds the PM as a named gateway agent\`)
- [x] DB with old PM row: migration backfills it (\`migration-049.test.ts\`)
- [x] Dispatch hits gateway when session exists (\`pm.test.ts\` named-agent route test)
- [x] Synth runs when client offline / send throws / agent times out
- [x] Existing reactive flow still works (\`pm-e2e.test.ts\`)
- [x] Plan-initiative and decompose-initiative still work via either path
- [x] yarn build green; all 337 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>