### PR TITLE
initiatives: show description + target window when expanded

### DIFF
--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -16,6 +16,8 @@ import {
   CornerUpLeft,
   Sparkles,
   Network,
+  FileText,
+  CalendarRange,
 } from 'lucide-react';
 import Drawer from '@/components/Drawer';
 import ActionMenu, { ActionMenuItem } from '@/components/ActionMenu';
@@ -588,6 +590,28 @@ function DetailsPanel({
 
   return (
     <div className="space-y-3">
+      <div>
+        <div className="flex items-center gap-2 text-mc-text-secondary mb-1">
+          <FileText className="w-3.5 h-3.5" />
+          <span className="font-medium">Description</span>
+        </div>
+        {initiative.description ? (
+          <p className="text-xs text-mc-text whitespace-pre-wrap">{initiative.description}</p>
+        ) : (
+          <p className="text-xs text-mc-text-secondary italic">No description.</p>
+        )}
+      </div>
+      {(initiative.target_start || initiative.target_end) && (
+        <div>
+          <div className="flex items-center gap-2 text-mc-text-secondary mb-1">
+            <CalendarRange className="w-3.5 h-3.5" />
+            <span className="font-medium">Target window</span>
+          </div>
+          <p className="text-xs text-mc-text">
+            {initiative.target_start ? initiative.target_start.slice(0, 10) : '—'} → {initiative.target_end ? initiative.target_end.slice(0, 10) : '—'}
+          </p>
+        </div>
+      )}
       <div>
         <div className="flex items-center gap-2 text-mc-text-secondary mb-1">
           <Link2 className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Summary
The expanded details panel on /initiatives only showed Dependencies and Parent-change history — operators had to open Edit to see a description. Add a Description block (always shown) and a Target window block (when at least one date set) at the top of the panel.

## What landed
- New Description and Target window sections in DetailsPanel
- Two new lucide icons (FileText, CalendarRange)

## Test plan
- [ ] Expand an initiative — description and target window render before Dependencies
- [ ] Initiative without a description shows "No description."
- [ ] Initiative without dates omits the Target window block
- [ ] yarn build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>