### PR TITLE
openclaw: sendChatToAgent helper + send-and-wait primitive; PM dispatch uses it

### DIFF
--- a/src/app/api/agents/[id]/chat/route.ts
+++ b/src/app/api/agents/[id]/chat/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
-import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
+import { sendChatToAgent, buildAgentSessionKey } from '@/lib/openclaw/send-chat';
 import { attachChatListener, expectAgentReply } from '@/lib/chat-listener';
 import { broadcast } from '@/lib/events';
 import type { Agent, AgentChatMessage } from '@/lib/types';
@@ -25,8 +25,7 @@ interface RouteParams {
  * misattribute these rows to a task that doesn't exist.
  */
 function agentChatSessionKey(agent: Pick<Agent, 'session_key_prefix' | 'gateway_agent_id' | 'name' | 'id'>): string {
-  const prefix = resolveAgentSessionKeyPrefix(agent);
-  return `${prefix}chat-${agent.id.slice(0, 8)}`;
+  return buildAgentSessionKey(agent, `chat-${agent.id.slice(0, 8)}`);
 }
 
 // GET /api/agents/[id]/chat — history, oldest first
@@ -75,21 +74,32 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     try {
       const client = getOpenClawClient();
       if (client.isConnected()) {
-        const sendPromise = client.call('chat.send', {
-          sessionKey,
+        // Use the shared helper but enforce the same 5s budget by
+        // racing against a timeout — sendChatToAgent doesn't expose
+        // its own timeout (its only failure modes are no_session /
+        // send_failed). The race preserves the previous "if the
+        // gateway is mid-turn we still register the user message"
+        // semantics.
+        const sendPromise = sendChatToAgent({
+          agent,
           message: message.trim(),
           idempotencyKey: `agent-chat-${messageId}`,
+          sessionSuffix: `chat-${agent.id.slice(0, 8)}`,
         });
-        const timeout = new Promise((_, reject) =>
+        const timeout = new Promise<{ sent: false; reason: 'send_failed'; sessionKey: string; error: Error }>((_, reject) =>
           setTimeout(() => reject(new Error('timeout')), 5000)
         );
-        await Promise.race([sendPromise, timeout]);
-        delivered = true;
-        run(
-          `UPDATE agent_chat_messages SET status = 'delivered' WHERE id = ?`,
-          [messageId]
-        );
-        expectAgentReply(sessionKey, agentId);
+        const result = await Promise.race([sendPromise, timeout]);
+        if (result.sent) {
+          delivered = true;
+          run(
+            `UPDATE agent_chat_messages SET status = 'delivered' WHERE id = ?`,
+            [messageId]
+          );
+          expectAgentReply(sessionKey, agentId);
+        } else if (result.error) {
+          throw result.error;
+        }
       }
     } catch (err) {
       console.warn(`[AgentChat] chat.send failed for ${sessionKey}:`, err);

--- a/src/app/api/openclaw/sessions/route.ts
+++ b/src/app/api/openclaw/sessions/route.ts
@@ -3,7 +3,7 @@ import { getOpenClawClient } from '@/lib/openclaw/client';
 import { queryAll, queryOne, run, transaction } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { logDebugEvent } from '@/lib/debug-log';
-import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
+import { sendChatToAgent } from '@/lib/openclaw/send-chat';
 import { emitAutopilotActivity } from '@/lib/autopilot/activity';
 import type { Agent, OpenClawSession, ResearchCycle, IdeationCycle } from '@/lib/types';
 
@@ -242,22 +242,21 @@ export async function DELETE() {
       }
 
       for (const agent of gatewayAgents) {
-        const prefix = resolveAgentSessionKeyPrefix(agent);
-        const sessionKey = `${prefix}main`;
-        try {
-          await client.call('chat.send', {
-            sessionKey,
-            message: '/reset',
-            idempotencyKey: `reset-${agent.id}-${Date.now()}`,
-          });
-          agentsReset.push({ agent_id: agent.id, name: agent.name, sessionKey, ok: true });
-        } catch (err) {
+        const result = await sendChatToAgent({
+          agent,
+          message: '/reset',
+          idempotencyKey: `reset-${agent.id}-${Date.now()}`,
+          // sessionSuffix defaults to 'main'.
+        });
+        if (result.sent) {
+          agentsReset.push({ agent_id: agent.id, name: agent.name, sessionKey: result.sessionKey, ok: true });
+        } else {
           agentsReset.push({
             agent_id: agent.id,
             name: agent.name,
-            sessionKey,
+            sessionKey: result.sessionKey,
             ok: false,
-            error: (err as Error).message,
+            error: result.error?.message ?? result.reason ?? 'send failed',
           });
         }
       }

--- a/src/app/api/pm/decompose-initiative/route.test.ts
+++ b/src/app/api/pm/decompose-initiative/route.test.ts
@@ -73,6 +73,33 @@ test('POST /api/pm/decompose-initiative: returns draft proposal for an epic', as
   }
 });
 
+test('POST /api/pm/decompose-initiative: chat echo posts the PROPOSAL impact_md', async () => {
+  const ws = freshWorkspace();
+  const epic = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Build something else',
+  });
+  const res = await POST(
+    postJson('/api/pm/decompose-initiative', { initiative_id: epic.id }),
+  );
+  const data = await res.json();
+  const expectedImpact = data.proposal.impact_md as string;
+
+  // Echo must mirror the proposal that landed (named-agent or synth).
+  // Posting `synth.impact_md` directly hid the named agent's output
+  // whenever the gateway path was used (PR follow-up to #55).
+  const messages = queryAll<{ role: string; content: string }>(
+    `SELECT role, content FROM agent_chat_messages
+     WHERE agent_id = (SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm')
+     ORDER BY created_at ASC`,
+    [ws],
+  );
+  const assistant = messages.find(m => m.role === 'assistant');
+  assert.ok(assistant);
+  assert.equal(assistant!.content, expectedImpact);
+});
+
 test('POST /api/pm/decompose-initiative + accept: children are created', async () => {
   const ws = freshWorkspace();
   const epic = createInitiative({

--- a/src/app/api/pm/decompose-initiative/route.ts
+++ b/src/app/api/pm/decompose-initiative/route.ts
@@ -90,6 +90,9 @@ export async function POST(request: NextRequest) {
     });
     const proposal = dispatch.proposal;
 
+    // Use the PROPOSAL's impact_md so the named-agent path's richer
+    // analysis isn't overwritten by synth's. On synth fallback the two
+    // are identical (proposal was created from synth.impact_md).
     try {
       postPmChatMessage({
         workspace_id: parent.workspace_id,
@@ -99,7 +102,7 @@ export async function POST(request: NextRequest) {
       postPmChatMessage({
         workspace_id: parent.workspace_id,
         role: 'assistant',
-        content: synth.impact_md,
+        content: proposal.impact_md,
         proposal_id: proposal.id,
       });
     } catch (err) {

--- a/src/app/api/pm/plan-initiative/route.test.ts
+++ b/src/app/api/pm/plan-initiative/route.test.ts
@@ -12,7 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { NextRequest } from 'next/server';
 import { POST } from './route';
 import { POST as refinePOST } from '../proposals/[id]/refine/route';
-import { run } from '@/lib/db';
+import { queryAll, run } from '@/lib/db';
 import { ensurePmAgent } from '@/lib/bootstrap-agents';
 import { getProposal } from '@/lib/db/pm-proposals';
 
@@ -67,6 +67,32 @@ test('POST /api/pm/plan-initiative: returns proposal_id + suggestions', async ()
   const stored = getProposal(data.proposal_id);
   assert.ok(stored);
   assert.equal(stored!.trigger_kind, 'plan_initiative');
+});
+
+test('POST /api/pm/plan-initiative: chat echo posts the PROPOSAL impact_md (not synth-only)', async () => {
+  const ws = freshWorkspace();
+  const res = await POST(
+    postJson('/api/pm/plan-initiative', {
+      workspace_id: ws,
+      draft: { title: 'Add invoicing' },
+    }),
+  );
+  const data = await res.json();
+  const expectedImpact = data.proposal.impact_md as string;
+
+  // The assistant chat row must mirror the persisted proposal's
+  // impact_md. The named-agent path can return a richer impact_md than
+  // synth — using `proposal.impact_md` keeps the echo aligned regardless
+  // of which path produced the proposal (PR follow-up to #55).
+  const messages = queryAll<{ role: string; content: string; metadata: string | null }>(
+    `SELECT role, content, metadata FROM agent_chat_messages
+     WHERE agent_id = (SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm')
+     ORDER BY created_at ASC`,
+    [ws],
+  );
+  const assistant = messages.find(m => m.role === 'assistant');
+  assert.ok(assistant);
+  assert.equal(assistant!.content, expectedImpact);
 });
 
 test('POST /api/pm/plan-initiative + refine: refine returns a child proposal with parent_proposal_id set', async () => {

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -90,7 +90,12 @@ export async function POST(request: NextRequest) {
     });
     const proposal = dispatch.proposal;
 
-    // Best-effort chat echo for audit visibility in /pm.
+    // Best-effort chat echo for audit visibility in /pm. Use the
+    // PROPOSAL's impact_md — when the named PM agent answered, that's
+    // its (potentially richer) summary; on synth fallback the proposal
+    // carries the same synth impact_md so the result is identical.
+    // Posting `synth.impact_md` directly (the old behaviour) discarded
+    // the named agent's reasoning whenever the gateway path was used.
     try {
       postPmChatMessage({
         workspace_id: parsed.data.workspace_id,
@@ -100,7 +105,7 @@ export async function POST(request: NextRequest) {
       postPmChatMessage({
         workspace_id: parsed.data.workspace_id,
         role: 'assistant',
-        content: synth.impact_md,
+        content: proposal.impact_md,
         proposal_id: proposal.id,
       });
     } catch (err) {

--- a/src/app/api/tasks/[id]/chat/route.ts
+++ b/src/app/api/tasks/[id]/chat/route.ts
@@ -66,6 +66,12 @@ export async function POST(
       try {
         const client = getOpenClawClient();
         if (client.isConnected()) {
+          // TODO(comms-cleanup): migrate to `sendChatToAgent`. Held back
+          // because `getActiveSessionForTask` returns a pre-built
+          // `sessionKey` rather than an Agent row; either teach it to
+          // surface the agent identity, or extend the helper to accept
+          // a raw sessionKey override before migrating.
+          //
           // Try chat.send with a 5s timeout — if agent is mid-turn, this works quickly
           const sendPromise = client.call('chat.send', {
             sessionKey: sessionInfo.sessionKey,

--- a/src/app/api/tasks/[id]/convoy/route.ts
+++ b/src/app/api/tasks/[id]/convoy/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createConvoy, getConvoy, updateConvoyStatus, deleteConvoy } from '@/lib/convoy';
 import { queryOne, queryAll } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
-import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
+import { sendChatToAgent, buildAgentSessionKey } from '@/lib/openclaw/send-chat';
 import { extractJSON, getMessagesFromOpenClaw } from '@/lib/planning-utils';
 import {
   getAgentRoster,
@@ -204,17 +204,21 @@ async function runAIDecomposition(task: Task): Promise<{
   // Create a unique session key for this decomposition. Uses the agent's
   // own namespace (gateway_agent_id or name) rather than the old `agent:main:`
   // default that misrouted messages to the gateway's main agent.
-  const prefix = resolveAgentSessionKeyPrefix(masterAgent);
-  const sessionKey = `${prefix}decompose:${task.id}`;
+  const sessionSuffix = `decompose:${task.id}`;
+  const sessionKey = buildAgentSessionKey(masterAgent, sessionSuffix);
 
   const prompt = buildDecompositionPrompt(task, roster);
 
-  // Send the decomposition prompt
-  await client.call('chat.send', {
-    sessionKey,
+  // Send the decomposition prompt via the shared helper.
+  const sendResult = await sendChatToAgent({
+    agent: masterAgent,
     message: prompt,
     idempotencyKey: `decompose-${task.id}-${Date.now()}`,
+    sessionSuffix,
   });
+  if (!sendResult.sent && sendResult.error) {
+    throw sendResult.error;
+  }
 
   // Poll for the response
   const startTime = Date.now();

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -755,6 +755,12 @@ If you need help or clarification, ask the orchestrator.`;
       let chatSendResponse: unknown;
       let chatSendError: string | null = null;
       try {
+        // TODO(comms-cleanup): migrate to `sendChatToAgent`. Held back
+        // because this path needs the raw chat.send response (logged
+        // below as the canonical dispatch debug event) and a custom
+        // failure rethrow. The helper currently swallows transport
+        // errors; either widen its return shape or extract a thin
+        // `sendRaw` variant before migrating.
         chatSendResponse = await client.call('chat.send', {
           sessionKey,
           message: finalMessage,

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -235,7 +235,11 @@ export async function POST(
       await client.connect();
     }
 
-    // Send planning request to the planning session
+    // TODO(comms-cleanup): migrate to `sendChatToAgent`. Planning
+    // routes use a stored `task.planning_session_key` (full sessionKey)
+    // rather than an agent row; the helper would need a raw-sessionKey
+    // overload before this migrates cleanly. Same applies to the other
+    // /planning/* routes (tweak, advance, answer, clarify-add, poll).
     await client.call('chat.send', {
       sessionKey: sessionKey,
       message: planningPrompt,

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -42,7 +42,11 @@ import {
   type PmProposalTriggerKind,
 } from '@/lib/db/pm-proposals';
 import { getOpenClawClient } from '@/lib/openclaw/client';
-import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
+import {
+  sendChatAndAwaitReply,
+  __setSendChatClientForTests,
+  type SendChatClient,
+} from '@/lib/openclaw/send-chat';
 import type { Agent } from '@/lib/types';
 
 // ─── Public API ─────────────────────────────────────────────────────
@@ -66,14 +70,22 @@ export interface DispatchPmResult {
  */
 const NAMED_AGENT_TIMEOUT_MS = 60_000;
 
-/** Dependency seam for tests — see `__setOpenClawClientForTests`. */
-type GatewayClient = {
-  isConnected: () => boolean;
-  call: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
-};
+/**
+ * Dependency seam for tests. Routes BOTH the local connection probe
+ * (`isConnected()`) and the underlying chat send through a shared mock,
+ * so tests can simulate "agent finishes its turn → final frame arrives"
+ * without needing the real openclaw client.
+ *
+ * Implementation note: the seam now sets the shared
+ * `__setSendChatClientForTests` hook in `send-chat.ts` so the new
+ * `sendChatAndAwaitReply` primitive uses the same mock. This replaces
+ * PR #55's bespoke override which only intercepted `client.call()`.
+ */
+type GatewayClient = SendChatClient;
 let openclawClientOverride: GatewayClient | null = null;
 export function __setOpenClawClientForTests(c: GatewayClient | null): void {
   openclawClientOverride = c;
+  __setSendChatClientForTests(c);
 }
 function gatewayClient(): GatewayClient {
   return openclawClientOverride ?? (getOpenClawClient() as unknown as GatewayClient);
@@ -119,7 +131,6 @@ export async function dispatchPm(input: DispatchPmInput): Promise<DispatchPmResu
           input,
           snapshot,
           pm,
-          client: gw,
         });
         if (proposal) {
           try {
@@ -200,30 +211,34 @@ interface DispatchNamedAgentParams {
   input: DispatchPmInput;
   snapshot: RoadmapSnapshot;
   pm: Pick<Agent, 'id' | 'name' | 'session_key_prefix' | 'gateway_agent_id' | 'workspace_id'>;
-  client: GatewayClient;
 }
 
 /**
- * Send the trigger to the gateway-hosted PM session, wait until a new
- * proposal lands in `pm_proposals` via the MCP `propose_changes` tool,
- * then return it.
+ * Send the trigger to the gateway-hosted PM session and wait for the
+ * agent's `final` chat frame (signalling its turn is over). Then look up
+ * the proposal it created via the MCP `propose_changes` tool and return
+ * it.
  *
- * Correlation: we record `since` (ISO time at the moment of send) and
- * include a `correlation_id` in the message body. After the round-trip
- * we look up the most recent draft proposal for the workspace whose
- * created_at >= since. This is sufficient because:
- *   - dispatch is single-flight from the operator's perspective,
- *   - we only land here on a successful `chat.send`, so synth hasn't
- *     written yet.
- * If the agent ever lands two proposals from one trigger, we return the
- * newest — refine() can chain the rest.
+ * Replaces the original "poll pm_proposals every 500ms by recency"
+ * workaround with a proper subscription-based wait via
+ * `sendChatAndAwaitReply`. The chat-listener's existing `state==='final'`
+ * is the same signal the per-agent chat surface already uses, so we get
+ * "agent turn complete" deterministically.
+ *
+ * Correlation: we still embed a `correlation_id` in the message body
+ * (audit trail). Lookup remains "most recent draft draft created since
+ * we sent" — that's deterministic given dispatch is single-flight from
+ * the operator's perspective.
+ *
+ * Returns:
+ *   - the PmProposal the agent created during this round-trip, or
+ *   - `null` if the timeout elapses, the send fails, or the agent never
+ *     called `propose_changes`. The caller falls back to synth.
  */
 async function dispatchViaNamedAgent(params: DispatchNamedAgentParams): Promise<PmProposal | null> {
-  const { input, snapshot, pm, client } = params;
+  const { input, snapshot, pm } = params;
   const correlationId = uuidv4();
   const sinceIso = new Date().toISOString();
-
-  const sessionKey = buildPmSessionKey(pm);
 
   const summary = buildSnapshotSummary(snapshot);
   const message =
@@ -235,49 +250,27 @@ async function dispatchViaNamedAgent(params: DispatchNamedAgentParams): Promise<
     `with a structured PmDiff[] and impact_md. Reference only ids that ` +
     `appear in the snapshot.`;
 
-  await client.call('chat.send', {
-    sessionKey,
+  const result = await sendChatAndAwaitReply({
+    agent: pm,
     message,
     idempotencyKey: `pm-dispatch-${correlationId}`,
+    timeoutMs: namedAgentTimeoutMs(),
   });
 
-  const deadline = Date.now() + namedAgentTimeoutMs();
-  while (Date.now() < deadline) {
-    const proposal = findProposalCreatedSince(input.workspace_id, sinceIso);
-    if (proposal) return proposal;
-    await sleep(500);
-  }
-  return null;
-}
+  // Send failed — caller falls back to synth.
+  if (!result.sent) return null;
 
-/**
- * Build the chat sessionKey for the PM. resolveAgentSessionKeyPrefix
- * returns either the explicit session_key_prefix (already including any
- * suffix) or `agent:<gateway_agent_id>:`. We always want a single ":main"
- * channel for the PM, so collapse trailing duplicates that arise when
- * session_key_prefix is set to `agent:mc-project-manager:main`.
- */
-function buildPmSessionKey(
-  pm: Pick<Agent, 'session_key_prefix' | 'gateway_agent_id' | 'name'>,
-): string {
-  const prefix = resolveAgentSessionKeyPrefix(pm);
-  // prefix always ends with ':' (the helper guarantees that). Tack on
-  // 'main' unless the prefix already ends with ':main:' (i.e. the
-  // operator/migration set session_key_prefix='agent:...:main').
-  if (/:main:$/.test(prefix)) {
-    return prefix.replace(/:$/, '');
-  }
-  return `${prefix}main`;
+  // Whether we got a `final` frame or hit the timeout, do one final
+  // check for a proposal landed by the agent's MCP `propose_changes`
+  // call. The named-agent path is "useful" only if the agent actually
+  // wrote a proposal during the round-trip.
+  return findProposalCreatedSince(input.workspace_id, sinceIso);
 }
 
 function findProposalCreatedSince(workspaceId: string, sinceIso: string): PmProposal | null {
   const drafts = listProposals({ workspace_id: workspaceId, status: 'draft', since: sinceIso });
   // listProposals returns DESC by created_at — pick the newest.
   return drafts[0] ?? null;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────
@@ -325,21 +318,23 @@ export async function dispatchPmSynthesized(
       try {
         const correlationId = uuidv4();
         const sinceIso = new Date().toISOString();
-        const sessionKey = buildPmSessionKey(pm);
-        await gw.call('chat.send', {
-          sessionKey,
+        const result = await sendChatAndAwaitReply({
+          agent: pm,
           message:
             `**PM ${input.trigger_kind} (correlation_id: ${correlationId})**\n\n` +
             input.agent_prompt,
           idempotencyKey: `pm-${input.trigger_kind}-${correlationId}`,
+          timeoutMs: namedAgentTimeoutMs(),
         });
-        const deadline = Date.now() + namedAgentTimeoutMs();
-        while (Date.now() < deadline) {
+        if (result.sent) {
+          // Whether we got a `final` frame or hit the timeout, the agent
+          // either landed a proposal via MCP `propose_changes` or didn't.
+          // Either way, this is the moment to look — same semantics as
+          // dispatchViaNamedAgent.
           const found = findProposalCreatedSince(input.workspace_id, sinceIso);
           if (found) {
             return { proposal: found, used_synthesize_fallback: false, used_named_agent: true };
           }
-          await sleep(500);
         }
       } catch (err) {
         console.warn(

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -21,7 +21,75 @@ import {
   __setOpenClawClientForTests,
   __setNamedAgentTimeoutForTests,
 } from './pm-dispatch';
+import type { ChatEvent, SendChatClient } from '@/lib/openclaw/send-chat';
 import { createProposal } from '@/lib/db/pm-proposals';
+
+/**
+ * Build a SendChatClient stub that satisfies both `client.call('chat.send')`
+ * and the chat_event subscription surface used by the new
+ * `sendChatAndAwaitReply` primitive (PR #N follow-up).
+ *
+ * Pass `onChatSend` to react to outbound sends (e.g. simulate the agent
+ * calling propose_changes via MCP). The stub auto-emits a synthetic
+ * `state: 'final'` chat_event after each send unless you set
+ * `emitFinal: false` (used to test the timeout path).
+ */
+function makeFakeClient(opts: {
+  isConnected?: boolean;
+  emitFinal?: boolean;
+  emitDelayMs?: number;
+  onChatSend?: (params: Record<string, unknown> | undefined) => void | Promise<void>;
+  callOverride?: (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => Promise<unknown>;
+}): {
+  client: SendChatClient;
+  seenSends: Array<{ method: string; params: unknown }>;
+} {
+  const seenSends: Array<{ method: string; params: unknown }> = [];
+  const listeners = new Set<(payload: ChatEvent) => void>();
+  const isConnected = opts.isConnected ?? true;
+  const emitFinal = opts.emitFinal ?? true;
+  const emitDelayMs = opts.emitDelayMs ?? 0;
+  const client: SendChatClient = {
+    isConnected: () => isConnected,
+    call: async (method: string, params?: Record<string, unknown>) => {
+      seenSends.push({ method, params });
+      if (opts.callOverride) {
+        return opts.callOverride(method, params);
+      }
+      if (method === 'chat.send') {
+        await opts.onChatSend?.(params);
+        if (emitFinal) {
+          const sessionKey = (params as { sessionKey?: string } | undefined)
+            ?.sessionKey;
+          const fire = () => {
+            for (const l of listeners) {
+              try {
+                l({ sessionKey, state: 'final' });
+              } catch {
+                // ignore listener errors
+              }
+            }
+          };
+          if (emitDelayMs > 0) setTimeout(fire, emitDelayMs);
+          else fire();
+        }
+      }
+      return undefined;
+    },
+    on: (event, listener) => {
+      if (event === 'chat_event') listeners.add(listener);
+      return client;
+    },
+    off: (event, listener) => {
+      if (event === 'chat_event') listeners.delete(listener);
+      return client;
+    },
+  };
+  return { client, seenSends };
+}
 import {
   ensurePmAgent,
   PM_GATEWAY_AGENT_ID,
@@ -202,26 +270,21 @@ test('dispatchPm: routes through named agent when openclaw is connected; mock cr
 
   // The named agent would call propose_changes via MCP. Our mock client
   // simulates that side effect: when chat.send is invoked, it inserts a
-  // pm_proposals row with rich impact_md and a structured change. The
-  // dispatch poller should pick it up and return it.
-  const seenSends: Array<{ method: string; params: unknown }> = [];
-  const fakeClient = {
-    isConnected: () => true,
-    call: async (method: string, params?: Record<string, unknown>) => {
-      seenSends.push({ method, params });
-      if (method === 'chat.send') {
-        // Simulate the agent calling propose_changes via MCP.
-        createProposal({
-          workspace_id: ws,
-          trigger_text: 'named-agent dispatch',
-          trigger_kind: 'manual',
-          impact_md: '### Named-agent verdict\n\n- richer than synth',
-          proposed_changes: [],
-        });
-      }
-      return undefined;
+  // pm_proposals row with rich impact_md, then auto-emits a final
+  // chat_event so `sendChatAndAwaitReply` resolves immediately. The
+  // dispatch handler then queries pm_proposals and returns the row.
+  const { client: fakeClient, seenSends } = makeFakeClient({
+    onChatSend: () => {
+      // Simulate the agent calling propose_changes via MCP.
+      createProposal({
+        workspace_id: ws,
+        trigger_text: 'named-agent dispatch',
+        trigger_kind: 'manual',
+        impact_md: '### Named-agent verdict\n\n- richer than synth',
+        proposed_changes: [],
+      });
     },
-  };
+  });
   __setOpenClawClientForTests(fakeClient);
   __setNamedAgentTimeoutForTests(2_000);
 
@@ -249,12 +312,8 @@ test('dispatchPm: falls back to synth when openclaw client is offline', async ()
   ensurePmAgent(ws);
   seedNamedAgent(ws, 'Sarah');
 
-  __setOpenClawClientForTests({
-    isConnected: () => false,
-    call: async () => {
-      throw new Error('should not be called when not connected');
-    },
-  });
+  const { client } = makeFakeClient({ isConnected: false });
+  __setOpenClawClientForTests(client);
 
   try {
     const result = await dispatchPm({
@@ -276,12 +335,12 @@ test('dispatchPm: falls back to synth when named-agent send throws', async () =>
   ensurePmAgent(ws);
   seedNamedAgent(ws, 'Sarah');
 
-  __setOpenClawClientForTests({
-    isConnected: () => true,
-    call: async () => {
+  const { client } = makeFakeClient({
+    callOverride: async () => {
       throw new Error('gateway boom');
     },
   });
+  __setOpenClawClientForTests(client);
   __setNamedAgentTimeoutForTests(500);
 
   try {
@@ -302,13 +361,9 @@ test('dispatchPm: falls back to synth when named agent times out without writing
   const ws = freshWorkspace();
   ensurePmAgent(ws);
 
-  __setOpenClawClientForTests({
-    isConnected: () => true,
-    call: async () => {
-      // No-op — agent never calls propose_changes.
-      return undefined;
-    },
-  });
+  // emitFinal: false → no chat_event arrives, await primitive will time out.
+  const { client } = makeFakeClient({ emitFinal: false });
+  __setOpenClawClientForTests(client);
   __setNamedAgentTimeoutForTests(500);
 
   try {

--- a/src/lib/learner.ts
+++ b/src/lib/learner.ts
@@ -7,7 +7,7 @@
 
 import { queryOne, queryAll, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
-import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
+import { sendChatToAgent } from '@/lib/openclaw/send-chat';
 import type { KnowledgeEntry, TaskRole, OpenClawSession } from '@/lib/types';
 
 /**
@@ -104,16 +104,24 @@ Focus on:
         'SELECT * FROM agents WHERE id = ?',
         [learnerRole.agent_id]
       );
-      const prefix = learnerAgent
-        ? resolveAgentSessionKeyPrefix(learnerAgent)
-        : `agent:${learnerRole.agent_id}:`;
-      const sessionKey = `${prefix}${session.openclaw_session_id}`;
-      await client.call('chat.send', {
-        sessionKey,
+      const targetAgent = learnerAgent ?? {
+        id: learnerRole.agent_id,
+        name: learnerRole.agent_name,
+        session_key_prefix: undefined,
+        gateway_agent_id: undefined,
+      };
+      const result = await sendChatToAgent({
+        agent: targetAgent,
         message: learningMessage,
-        idempotencyKey: `learner-${taskId}-${event.newStatus}-${Date.now()}`
+        idempotencyKey: `learner-${taskId}-${event.newStatus}-${Date.now()}`,
+        sessionSuffix: session.openclaw_session_id,
       });
-      console.log(`[Learner] Notified ${learnerRole.agent_name} about ${event.previousStatus}→${event.newStatus}`);
+      if (result.sent) {
+        console.log(`[Learner] Notified ${learnerRole.agent_name} about ${event.previousStatus}→${event.newStatus}`);
+      } else if (result.error) {
+        // Surface transport errors so the existing catch logs them.
+        throw result.error;
+      }
     }
   } catch (err) {
     // Learner notification is best-effort — don't fail the transition

--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -78,14 +78,11 @@ export async function sendMail(input: SendMailInput): Promise<SendMailResult> {
       await client.connect();
     }
 
-    // Build a sessionKey that targets the agent's own namespace. The prefix
-    // resolver prefers an explicit `session_key_prefix`, then the gateway
-    // agent id, then a name-slug fallback — anything but the old
-    // `agent:main:` catchall that misrouted to the gateway's main agent.
-    // We append a mail-scoped suffix so each mail occupies its own
-    // session bucket (the gateway creates it on receipt if needed — no
-    // pre-existing openclaw_sessions row required).
-    const { resolveAgentSessionKeyPrefix } = await import('@/lib/openclaw/session-key');
+    // Build a sessionKey that targets the agent's own namespace via the
+    // shared `sendChatToAgent` helper. The mail-scoped suffix ensures
+    // each mail occupies its own session bucket (the gateway creates it
+    // on receipt if needed — no pre-existing openclaw_sessions row
+    // required).
     const target = queryOne<Pick<OpenClawSession, 'id'> & { name: string; session_key_prefix: string | null; gateway_agent_id: string | null }>(
       'SELECT id, name, session_key_prefix, gateway_agent_id FROM agents WHERE id = ?',
       [toAgentId]
@@ -97,12 +94,6 @@ export async function sendMail(input: SendMailInput): Promise<SendMailResult> {
       };
     }
     const fromAgent = queryOne<{ name: string }>('SELECT name FROM agents WHERE id = ?', [fromAgentId]);
-    const prefix = resolveAgentSessionKeyPrefix({
-      session_key_prefix: target.session_key_prefix ?? undefined,
-      gateway_agent_id: target.gateway_agent_id ?? undefined,
-      name: target.name,
-    } as Agent);
-    const sessionKey = `${prefix}mc-mail-${id}`;
 
     // Frame the mail so the agent recognises it as MC→agent mail (not a
     // regular task dispatch). We deliberately don't append a generic
@@ -115,15 +106,28 @@ export async function sendMail(input: SendMailInput): Promise<SendMailResult> {
 ${subject ? `**Subject:** ${subject}\n` : ''}
 ${body}`;
 
-    await client.call('chat.send', {
-      sessionKey,
+    const { sendChatToAgent } = await import('@/lib/openclaw/send-chat');
+    const result = await sendChatToAgent({
+      agent: {
+        id: toAgentId,
+        name: target.name,
+        session_key_prefix: target.session_key_prefix ?? undefined,
+        gateway_agent_id: target.gateway_agent_id ?? undefined,
+      },
       message: framedMessage,
       idempotencyKey: `mail-${id}`,
+      sessionSuffix: `mc-mail-${id}`,
     });
 
+    if (!result.sent) {
+      return {
+        message,
+        delivery: { status: 'failed', error: result.error?.message ?? result.reason ?? 'send failed' },
+      };
+    }
     return {
       message,
-      delivery: { status: 'sent', sessionKey },
+      delivery: { status: 'sent', sessionKey: result.sessionKey },
     };
   } catch (err) {
     return {

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -1256,19 +1256,29 @@ export function registerAllTools(server: McpServer): void {
       // Notify the peer through their chat session so they see the
       // rejection inline. Best-effort — if the openclaw client is down,
       // the mailbox fallback still carries the message.
-      const peer = queryOne<{ gateway_agent_id: string | null }>(
-        'SELECT a.gateway_agent_id FROM tasks t JOIN agents a ON a.id = t.assigned_agent_id WHERE t.id = ?',
+      const peer = queryOne<{ id: string; gateway_agent_id: string | null; name: string; session_key_prefix: string | null }>(
+        'SELECT a.id, a.gateway_agent_id, a.name, a.session_key_prefix FROM tasks t JOIN agents a ON a.id = t.assigned_agent_id WHERE t.id = ?',
         [row.task_id],
       );
       if (peer?.gateway_agent_id) {
         try {
           const client = getOpenClawClient();
           if (!client.isConnected()) await client.connect();
-          await client.call('chat.send', {
-            sessionKey: `agent:${peer.gateway_agent_id}:task-${row.task_id}`,
+          const { sendChatToAgent } = await import('@/lib/openclaw/send-chat');
+          const result = await sendChatToAgent({
+            agent: {
+              id: peer.id,
+              name: peer.name,
+              gateway_agent_id: peer.gateway_agent_id,
+              session_key_prefix: peer.session_key_prefix ?? undefined,
+            },
             message: `🔁 **Subtask rejected by coordinator.**\n\n**Reason:** ${args.reason}\n\n${args.new_acceptance_criteria?.length ? `**Updated acceptance criteria:**\n${args.new_acceptance_criteria.map(c => `- ${c}`).join('\n')}\n\n` : ''}Please address the issues and re-register deliverables, then move status back to review.`,
             idempotencyKey: `reject-${args.subtask_id}-${Date.now()}`,
+            sessionSuffix: `task-${row.task_id}`,
           });
+          if (!result.sent && result.error) {
+            console.warn('[reject_subtask] chat.send notification failed:', result.error.message);
+          }
         } catch (err) {
           console.warn('[reject_subtask] chat.send notification failed:', (err as Error).message);
         }

--- a/src/lib/openclaw/send-chat.test.ts
+++ b/src/lib/openclaw/send-chat.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Unit tests for `sendChatToAgent` + `sendChatAndAwaitReply`.
+ *
+ * These exercise the helper in isolation against an in-memory client
+ * stub — no network, no DB. Integration coverage (named-agent dispatch
+ * path) lives in `src/lib/agents/pm.test.ts`.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  sendChatToAgent,
+  sendChatAndAwaitReply,
+  buildAgentSessionKey,
+  __setSendChatClientForTests,
+  type ChatEvent,
+  type SendChatClient,
+} from './send-chat';
+
+interface StubOpts {
+  isConnected?: boolean;
+  callImpl?: (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => Promise<unknown>;
+}
+
+interface Stub {
+  client: SendChatClient;
+  emit: (event: ChatEvent) => void;
+  callOrder: string[];
+  sends: Array<{ method: string; params: unknown }>;
+  /** True iff the listener was registered before the first send. */
+  subscribedBeforeSend: () => boolean;
+}
+
+function makeStub(opts: StubOpts = {}): Stub {
+  const listeners = new Set<(payload: ChatEvent) => void>();
+  const callOrder: string[] = [];
+  const sends: Array<{ method: string; params: unknown }> = [];
+  let firstListenerAt: number | null = null;
+  let firstSendAt: number | null = null;
+  const client: SendChatClient = {
+    isConnected: () => opts.isConnected ?? true,
+    call: async (method, params) => {
+      callOrder.push(`call:${method}`);
+      if (firstSendAt === null) firstSendAt = callOrder.length;
+      sends.push({ method, params });
+      if (opts.callImpl) return opts.callImpl(method, params);
+      return undefined;
+    },
+    on: (event, listener) => {
+      callOrder.push(`on:${event}`);
+      if (firstListenerAt === null) firstListenerAt = callOrder.length;
+      if (event === 'chat_event') listeners.add(listener);
+      return client;
+    },
+    off: (event, listener) => {
+      if (event === 'chat_event') listeners.delete(listener);
+      return client;
+    },
+  };
+  return {
+    client,
+    emit: payload => {
+      for (const l of listeners) l(payload);
+    },
+    callOrder,
+    sends,
+    subscribedBeforeSend: () =>
+      firstListenerAt !== null &&
+      firstSendAt !== null &&
+      firstListenerAt < firstSendAt,
+  };
+}
+
+const FAKE_AGENT = {
+  id: 'agent-001',
+  name: 'PM',
+  gateway_agent_id: 'mc-project-manager',
+  session_key_prefix: undefined,
+} as const;
+
+// ─── buildAgentSessionKey ───────────────────────────────────────────
+
+test('buildAgentSessionKey: gateway_agent_id forms agent:<id>:main', () => {
+  const sk = buildAgentSessionKey(FAKE_AGENT);
+  assert.equal(sk, 'agent:mc-project-manager:main');
+});
+
+test('buildAgentSessionKey: explicit suffix is appended', () => {
+  const sk = buildAgentSessionKey(FAKE_AGENT, 'task-abc');
+  assert.equal(sk, 'agent:mc-project-manager:task-abc');
+});
+
+test('buildAgentSessionKey: collapses :main:main when prefix already encodes :main', () => {
+  const sk = buildAgentSessionKey({
+    id: 'a1',
+    name: 'PM',
+    gateway_agent_id: 'mc-project-manager',
+    session_key_prefix: 'agent:mc-project-manager:main',
+  });
+  assert.equal(sk, 'agent:mc-project-manager:main');
+});
+
+// ─── sendChatToAgent ────────────────────────────────────────────────
+
+test('sendChatToAgent: resolves the right sessionKey for a gateway agent', async () => {
+  const stub = makeStub();
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatToAgent({
+      agent: FAKE_AGENT,
+      message: 'hi',
+    });
+    assert.equal(result.sent, true);
+    assert.equal(result.sessionKey, 'agent:mc-project-manager:main');
+    const params = stub.sends[0].params as Record<string, unknown>;
+    assert.equal(params.sessionKey, 'agent:mc-project-manager:main');
+    assert.equal(params.message, 'hi');
+    assert.equal(typeof params.idempotencyKey, 'string');
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatToAgent: returns no_session when client is disconnected', async () => {
+  const stub = makeStub({ isConnected: false });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatToAgent({
+      agent: FAKE_AGENT,
+      message: 'hi',
+    });
+    assert.equal(result.sent, false);
+    assert.equal(result.reason, 'no_session');
+    assert.equal(stub.sends.length, 0, 'should not call when disconnected');
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatToAgent: returns send_failed when client throws', async () => {
+  const stub = makeStub({
+    callImpl: async () => {
+      throw new Error('gateway boom');
+    },
+  });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatToAgent({
+      agent: FAKE_AGENT,
+      message: 'hi',
+    });
+    assert.equal(result.sent, false);
+    assert.equal(result.reason, 'send_failed');
+    assert.ok(result.error instanceof Error);
+    assert.match(result.error!.message, /gateway boom/);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatToAgent: default idempotencyKey is a fresh uuid (unique per call)', async () => {
+  const stub = makeStub();
+  __setSendChatClientForTests(stub.client);
+  try {
+    await sendChatToAgent({ agent: FAKE_AGENT, message: 'a' });
+    await sendChatToAgent({ agent: FAKE_AGENT, message: 'b' });
+    const k1 = (stub.sends[0].params as { idempotencyKey: string }).idempotencyKey;
+    const k2 = (stub.sends[1].params as { idempotencyKey: string }).idempotencyKey;
+    assert.notEqual(k1, k2);
+    // uuid v4 shape
+    assert.match(k1, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatToAgent: explicit idempotencyKey is forwarded', async () => {
+  const stub = makeStub();
+  __setSendChatClientForTests(stub.client);
+  try {
+    await sendChatToAgent({
+      agent: FAKE_AGENT,
+      message: 'hi',
+      idempotencyKey: 'my-key',
+    });
+    const k = (stub.sends[0].params as { idempotencyKey: string }).idempotencyKey;
+    assert.equal(k, 'my-key');
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+// ─── sendChatAndAwaitReply ──────────────────────────────────────────
+
+test('sendChatAndAwaitReply: resolves with reply events when done arrives', async () => {
+  const expected = 'agent:mc-project-manager:main';
+  // Build the stub so its callImpl can reference `stub` (closure binding).
+  let stub!: Stub;
+  stub = makeStub({
+    callImpl: async (method) => {
+      if (method === 'chat.send') {
+        // Use queueMicrotask so events arrive AFTER the send promise
+        // resolves but BEFORE the awaiting code times out.
+        queueMicrotask(() => {
+          stub.emit({ sessionKey: expected, state: 'streaming' });
+          stub.emit({ sessionKey: expected, state: 'final', message: 'done' });
+        });
+      }
+      return undefined;
+    },
+  });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatAndAwaitReply({
+      agent: FAKE_AGENT,
+      message: 'hi',
+      timeoutMs: 1_000,
+    });
+    assert.equal(result.sent, true);
+    assert.equal(result.timedOut, false);
+    assert.ok(result.doneEvent);
+    assert.equal(result.doneEvent!.state, 'final');
+    assert.ok((result.reply?.length ?? 0) >= 1);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatAndAwaitReply: timedOut when no done event arrives in time', async () => {
+  const stub = makeStub();
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatAndAwaitReply({
+      agent: FAKE_AGENT,
+      message: 'hi',
+      timeoutMs: 100,
+    });
+    assert.equal(result.sent, true);
+    assert.equal(result.timedOut, true);
+    assert.equal(result.doneEvent, undefined);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatAndAwaitReply: returns no_session shape without subscribing when disconnected', async () => {
+  const stub = makeStub({ isConnected: false });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatAndAwaitReply({
+      agent: FAKE_AGENT,
+      message: 'hi',
+      timeoutMs: 100,
+    });
+    assert.equal(result.sent, false);
+    assert.equal(result.reason, 'no_session');
+    assert.ok(!stub.callOrder.some(s => s.startsWith('on:')), 'should not subscribe when no session');
+    assert.equal(stub.sends.length, 0);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatAndAwaitReply: returns send_failed when client.call throws', async () => {
+  const stub = makeStub({
+    callImpl: async () => {
+      throw new Error('gateway boom');
+    },
+  });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatAndAwaitReply({
+      agent: FAKE_AGENT,
+      message: 'hi',
+      timeoutMs: 100,
+    });
+    assert.equal(result.sent, false);
+    assert.equal(result.reason, 'send_failed');
+    assert.ok(result.error instanceof Error);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatAndAwaitReply: subscribes BEFORE sending (race protection)', async () => {
+  const stub = makeStub();
+  __setSendChatClientForTests(stub.client);
+  try {
+    await sendChatAndAwaitReply({
+      agent: FAKE_AGENT,
+      message: 'hi',
+      timeoutMs: 50,
+    });
+    assert.equal(
+      stub.subscribedBeforeSend(),
+      true,
+      'listener must be wired up before chat.send is called',
+    );
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatAndAwaitReply: ignores chat events for other sessionKeys', async () => {
+  const stub = makeStub();
+  __setSendChatClientForTests(stub.client);
+  try {
+    queueMicrotask(() => {
+      stub.emit({ sessionKey: 'agent:other:main', state: 'final' });
+    });
+    const result = await sendChatAndAwaitReply({
+      agent: FAKE_AGENT,
+      message: 'hi',
+      timeoutMs: 100,
+    });
+    // Should still time out — event was for a different sessionKey.
+    assert.equal(result.timedOut, true);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatAndAwaitReply: custom isDone predicate fires before default state==="final"', async () => {
+  const sk = 'agent:mc-project-manager:main';
+  const stub = makeStub({
+    callImpl: async () => {
+      queueMicrotask(() => {
+        stub.emit({ sessionKey: sk, state: 'streaming', message: 'partial' });
+        // The custom predicate matches this — default `final` would not.
+        stub.emit({ sessionKey: sk, state: 'streaming', message: 'STOP' });
+      });
+      return undefined;
+    },
+  });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatAndAwaitReply({
+      agent: FAKE_AGENT,
+      message: 'hi',
+      timeoutMs: 200,
+      isDone: e => typeof e.message === 'string' && e.message.includes('STOP'),
+    });
+    assert.equal(result.timedOut, false);
+    assert.ok(result.doneEvent);
+    assert.equal(result.doneEvent!.message, 'STOP');
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});

--- a/src/lib/openclaw/send-chat.ts
+++ b/src/lib/openclaw/send-chat.ts
@@ -1,0 +1,299 @@
+/**
+ * Centralised `chat.send` helpers for MC → openclaw routing.
+ *
+ * Two surfaces:
+ *
+ *   1. `sendChatToAgent(...)` — fire-and-forget chat send. Resolves the
+ *      sessionKey from an Agent row via `resolveAgentSessionKeyPrefix`,
+ *      catches transport errors, and returns a structured result rather
+ *      than throwing. Replaces the 5+ hand-rolled
+ *      `client.call('chat.send', ...)` call sites (PR #55 follow-up).
+ *
+ *   2. `sendChatAndAwaitReply(...)` — subscribe-then-send-then-await
+ *      primitive. Subscribes to the openclaw client's `chat_event` stream
+ *      BEFORE sending so we never miss the first frame, then collects
+ *      events until either the caller's `isDone` predicate fires or the
+ *      deadline elapses. Used by `pm-dispatch.ts` to replace the
+ *      polling-by-recency workaround.
+ *
+ * Design notes:
+ *
+ *   - The helper deliberately shallows the openclaw client (uses the
+ *     singleton `getOpenClawClient()` by default; tests inject via
+ *     `__setSendChatClientForTests`). It does NOT take a client param —
+ *     that would make migration noisy at every call site.
+ *
+ *   - `sendChatToAgent` returns `{ sent: false, reason: 'no_session' }`
+ *     when `client.isConnected()` is false. That mirrors the existing
+ *     guard pattern (`if (client.isConnected()) ...`) used in every
+ *     hand-rolled call site today.
+ *
+ *   - `sendChatAndAwaitReply` does not subscribe when the underlying send
+ *     fails or there's no session — it short-circuits with the
+ *     `SendChatResult` shape directly. Subscribing first only matters
+ *     when we expect a reply.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { getOpenClawClient } from './client';
+import { resolveAgentSessionKeyPrefix } from './session-key';
+import type { Agent } from '@/lib/types';
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+/**
+ * Minimum agent shape needed to derive a sessionKey. Kept narrow so
+ * callers can pass partial rows (e.g. mailbox loads only a few columns).
+ */
+export type SendChatAgent = Pick<
+  Agent,
+  'session_key_prefix' | 'gateway_agent_id' | 'name' | 'id'
+>;
+
+export interface SendChatInput {
+  agent: SendChatAgent;
+  message: string;
+  /** Defaults to a fresh uuid. */
+  idempotencyKey?: string;
+  /** Appended to the resolved prefix. Defaults to 'main'. */
+  sessionSuffix?: string;
+}
+
+export interface SendChatResult {
+  sent: boolean;
+  sessionKey: string;
+  /** When `sent` is false, why. */
+  reason?: 'no_session' | 'send_failed';
+  error?: Error;
+}
+
+/**
+ * Loose mirror of the `chat_event` payload emitted by `OpenClawClient`.
+ * Matches `ChatEventPayload` in `chat-listener.ts` (kept compatible).
+ */
+export interface ChatEvent {
+  runId?: string;
+  sessionKey?: string;
+  seq?: number;
+  state?: string;
+  message?: string | { role?: string; content?: unknown };
+  // The gateway payload may include other fields; we don't model them here.
+  [key: string]: unknown;
+}
+
+export interface SendChatAndAwaitInput extends SendChatInput {
+  /** Wall-clock budget for the round-trip. Default 60_000ms. */
+  timeoutMs?: number;
+  /**
+   * Predicate to recognise the agent's "done" frame. The default matches
+   * `event.state === 'final'` — same signal the existing chat-listener
+   * uses to write replies into agent_chat_messages / task_notes.
+   */
+  isDone?: (event: ChatEvent) => boolean;
+  /** Tap for every matching event between send and done. */
+  onEvent?: (event: ChatEvent) => void;
+}
+
+export interface SendChatAndAwaitResult extends SendChatResult {
+  /** Events collected for this sessionKey between send and done. */
+  reply?: ChatEvent[];
+  doneEvent?: ChatEvent;
+  /** True when the deadline elapsed before `isDone` fired. */
+  timedOut?: boolean;
+}
+
+// ─── Test seam ──────────────────────────────────────────────────────
+
+/**
+ * Minimum surface we need from the openclaw client. The real
+ * `OpenClawClient` satisfies this implicitly; tests inject a stub.
+ */
+export interface SendChatClient {
+  isConnected: () => boolean;
+  call: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+  on: (event: 'chat_event', listener: (payload: ChatEvent) => void) => unknown;
+  off: (event: 'chat_event', listener: (payload: ChatEvent) => void) => unknown;
+}
+
+let clientOverride: SendChatClient | null = null;
+
+/** Test-only seam. Pass `null` to clear. */
+export function __setSendChatClientForTests(c: SendChatClient | null): void {
+  clientOverride = c;
+}
+
+function getClient(): SendChatClient {
+  return clientOverride ?? (getOpenClawClient() as unknown as SendChatClient);
+}
+
+// ─── sessionKey resolution ──────────────────────────────────────────
+
+/**
+ * Resolve a sessionKey from an agent + optional suffix. Mirrors the
+ * collapse logic from `pm-dispatch.buildPmSessionKey` so an agent whose
+ * `session_key_prefix` already encodes `:main` doesn't end up with
+ * `:main:main`.
+ */
+export function buildAgentSessionKey(
+  agent: SendChatAgent,
+  sessionSuffix: string = 'main',
+): string {
+  const prefix = resolveAgentSessionKeyPrefix(agent);
+  // The resolver guarantees `prefix` ends with ':'. If the suffix is
+  // 'main' AND the prefix is already `agent:<id>:main:` (set
+  // explicitly), strip the trailing ':' so we don't double up.
+  if (sessionSuffix === 'main' && /:main:$/.test(prefix)) {
+    return prefix.replace(/:$/, '');
+  }
+  return `${prefix}${sessionSuffix}`;
+}
+
+// ─── sendChatToAgent ────────────────────────────────────────────────
+
+/**
+ * Send one chat.send frame to the agent's session. Catches transport
+ * errors and returns a structured result instead of throwing — every
+ * existing call site gates on `if (connected) { ... }` and either logs
+ * or no-ops on failure, so non-throwing semantics simplify migration.
+ *
+ * Returns `{ sent: false, reason: 'no_session' }` when the openclaw
+ * client reports it isn't connected. Returns
+ * `{ sent: false, reason: 'send_failed', error }` when the underlying
+ * call rejects (e.g. gateway timeout).
+ */
+export async function sendChatToAgent(input: SendChatInput): Promise<SendChatResult> {
+  const sessionKey = buildAgentSessionKey(input.agent, input.sessionSuffix);
+  const idempotencyKey = input.idempotencyKey ?? uuidv4();
+  const client = getClient();
+
+  if (!client.isConnected()) {
+    return { sent: false, sessionKey, reason: 'no_session' };
+  }
+
+  try {
+    await client.call('chat.send', {
+      sessionKey,
+      message: input.message,
+      idempotencyKey,
+    });
+    return { sent: true, sessionKey };
+  } catch (err) {
+    return {
+      sent: false,
+      sessionKey,
+      reason: 'send_failed',
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+// ─── sendChatAndAwaitReply ──────────────────────────────────────────
+
+const DEFAULT_AWAIT_TIMEOUT_MS = 60_000;
+
+const DEFAULT_IS_DONE = (event: ChatEvent): boolean => event.state === 'final';
+
+/**
+ * Subscribe to the openclaw client's `chat_event` stream for the
+ * resolved sessionKey, send the chat frame, then resolve when either:
+ *   - `isDone(event)` returns true (default: `state === 'final'`), or
+ *   - the timeout elapses.
+ *
+ * IMPORTANT: subscribe-before-send. If we sent first and the gateway
+ * round-tripped a fast `final` frame before our listener was wired up,
+ * we'd miss it and resort to timeout — exactly the failure mode this
+ * primitive replaces in `pm-dispatch.ts`.
+ *
+ * On `no_session` / `send_failed` from the underlying send, we return
+ * the SendChatResult shape WITHOUT subscribing (no point waiting for a
+ * reply that can never arrive).
+ */
+export async function sendChatAndAwaitReply(
+  input: SendChatAndAwaitInput,
+): Promise<SendChatAndAwaitResult> {
+  const sessionKey = buildAgentSessionKey(input.agent, input.sessionSuffix);
+  const idempotencyKey = input.idempotencyKey ?? uuidv4();
+  const timeoutMs = input.timeoutMs ?? DEFAULT_AWAIT_TIMEOUT_MS;
+  const isDone = input.isDone ?? DEFAULT_IS_DONE;
+  const client = getClient();
+
+  if (!client.isConnected()) {
+    return { sent: false, sessionKey, reason: 'no_session' };
+  }
+
+  // Subscribe FIRST so we don't race the gateway's first frame.
+  const collected: ChatEvent[] = [];
+  let doneEvent: ChatEvent | undefined;
+  let resolveDone: ((event: ChatEvent | null) => void) | null = null;
+  const donePromise = new Promise<ChatEvent | null>(resolve => {
+    resolveDone = resolve;
+  });
+
+  const listener = (payload: ChatEvent) => {
+    if (!payload || payload.sessionKey !== sessionKey) return;
+    collected.push(payload);
+    try {
+      input.onEvent?.(payload);
+    } catch {
+      // Caller's tap shouldn't break the wait.
+    }
+    if (isDone(payload)) {
+      doneEvent = payload;
+      resolveDone?.(payload);
+    }
+  };
+
+  client.on('chat_event', listener);
+
+  try {
+    // Send the frame. If this fails, short-circuit with the SendChatResult
+    // shape — no point waiting for a reply that can never arrive.
+    let sendError: Error | undefined;
+    try {
+      await client.call('chat.send', {
+        sessionKey,
+        message: input.message,
+        idempotencyKey,
+      });
+    } catch (err) {
+      sendError = err instanceof Error ? err : new Error(String(err));
+    }
+
+    if (sendError) {
+      return {
+        sent: false,
+        sessionKey,
+        reason: 'send_failed',
+        error: sendError,
+      };
+    }
+
+    // Race the `done` event against the deadline.
+    let timeoutHandle: NodeJS.Timeout | null = null;
+    const timeoutPromise = new Promise<null>(resolve => {
+      timeoutHandle = setTimeout(() => resolve(null), timeoutMs);
+    });
+
+    const winner = await Promise.race([donePromise, timeoutPromise]);
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+
+    if (winner === null && !doneEvent) {
+      return {
+        sent: true,
+        sessionKey,
+        reply: collected,
+        timedOut: true,
+      };
+    }
+
+    return {
+      sent: true,
+      sessionKey,
+      reply: collected,
+      doneEvent,
+      timedOut: false,
+    };
+  } finally {
+    client.off('chat_event', listener);
+  }
+}

--- a/src/lib/task-notes.ts
+++ b/src/lib/task-notes.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { getOpenClawClient } from '@/lib/openclaw/client';
-import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
+import { sendChatToAgent } from '@/lib/openclaw/send-chat';
 import type { TaskNote, OpenClawSession, Agent } from '@/lib/types';
 
 /**
@@ -97,20 +97,34 @@ export async function deliverPendingNotesAtCheckpoint(taskId: string): Promise<n
     const client = getOpenClawClient();
     if (!client.isConnected()) await client.connect();
 
-    // Get the agent's session key prefix
+    // Get the agent's session key prefix via the shared helper.
     const agent = queryOne<Agent>('SELECT * FROM agents WHERE id = ?', [activeSession.agent_id]);
-    const prefix = agent ? resolveAgentSessionKeyPrefix(agent) : 'agent:main:';
-    const sessionKey = `${prefix}${activeSession.openclaw_session_id}`;
+    if (!agent) {
+      // Without an agent row we have no canonical prefix; preserve the
+      // old "agent:main:" fallback by synthesising a minimal stub.
+      console.warn(`[TaskNotes] No agent row for session ${activeSession.id}, falling back to default prefix`);
+    }
+    const targetAgent = agent ?? {
+      id: activeSession.agent_id,
+      name: 'main',
+      session_key_prefix: undefined,
+      gateway_agent_id: undefined,
+    };
 
     // Build the message
     const lines = notes.map(n => `- ${n.content}`);
     const message = `📌 **OPERATOR NOTES:**\n${lines.join('\n')}\n\nPlease incorporate these into your current work.`;
 
-    await client.call('chat.send', {
-      sessionKey,
+    const result = await sendChatToAgent({
+      agent: targetAgent,
       message,
-      idempotencyKey: `notes-${taskId}-${Date.now()}`
+      idempotencyKey: `notes-${taskId}-${Date.now()}`,
+      sessionSuffix: activeSession.openclaw_session_id,
     });
+    if (!result.sent) {
+      console.error(`[TaskNotes] Failed to deliver notes for task ${taskId}:`, result.error?.message ?? result.reason);
+      return 0;
+    }
 
     markNotesDelivered(notes.map(n => n.id));
     return notes.length;


### PR DESCRIPTION
## Summary
PR #55 surfaced three follow-up signals around agent comms. Fix all three in one focused cleanup:

1. **New `sendChatToAgent` helper** — dedupes the 5+ hand-rolled `chat.send` call sites
2. **New `sendChatAndAwaitReply` primitive** — replaces `pm-dispatch.ts`'s polling-by-recency workaround with proper subscription-based wait on the chat-listener
3. **Plan/decompose chat echo now posts the actual proposal's `impact_md`** rather than always synth's

## What landed
- New module `src/lib/openclaw/send-chat.ts` (helper + primitive + sessionKey collapse) and `src/lib/openclaw/send-chat.test.ts` (15 unit tests)
- 8 call sites migrated from `client.call('chat.send', ...)` to the helper:
  - `src/lib/agents/pm-dispatch.ts` (dispatchPm + dispatchPmSynthesized)
  - `src/lib/learner.ts`
  - `src/lib/mailbox.ts`
  - `src/lib/task-notes.ts`
  - `src/app/api/agents/[id]/chat/route.ts`
  - `src/app/api/openclaw/sessions/route.ts` (workspace reset)
  - `src/app/api/tasks/[id]/convoy/route.ts` (decomposition prompt)
  - `src/lib/mcp/tools.ts` (reject_subtask peer notification)
- 5 call sites left with `TODO(comms-cleanup)` tags because their flow needs structural changes before migration (planning/* routes pass a pre-built sessionKey; task dispatch needs raw chat.send response for debug logging; task chat reads sessionKey from `getActiveSessionForTask`)
- `pm-dispatch.ts` uses `sendChatAndAwaitReply`; the `while (Date.now() < deadline) { ... await sleep(500) }` polling loop is gone in both `dispatchViaNamedAgent` and `dispatchPmSynthesized`
- Chat echo fix in plan/decompose routes (~5 lines per route)
- Tests cover both primitives plus all existing pm.test paths; new regression guards on the plan/decompose chat-echo behaviour

## Notes for the reviewer
- `isDone` predicate defaults to `event.state === 'final'` — same signal the existing chat-listener uses to land `agent_chat_messages` rows. Match was deliberate so reuse one source of truth on "agent's turn is done".
- The mc-coordinator and mc-builder dispatch flows (`/api/tasks/[id]/dispatch/route.ts`) and the task chat route are intentionally left on raw `chat.send` with TODOs. Migrating them would either bloat the PR (dispatch needs the raw response logged as the canonical `chat.send` debug event) or require restructuring upstream (task chat takes a pre-built sessionKey from session-info, no agent in scope).
- The `chat-listener` module is untouched. The new primitive subscribes directly to the openclaw client's `chat_event` emitter — same source the listener taps — without modifying its plumbing.

## Test plan
- [x] All 354 existing tests pass; new helper/primitive tests pass
- [x] Named-agent path: chat echo uses agent's `impact_md`, not synth (asserted in plan + decompose route tests)
- [x] Synth fallback still works on timeout / no-session / send-fail (covered by 3 dispatchPm tests)
- [x] yarn build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>