### PR TITLE
openclaw: timeoutMs + response on send-chat helper; sendChatToSession variant; migrate remaining call sites

### DIFF
--- a/src/app/api/agents/[id]/chat/route.ts
+++ b/src/app/api/agents/[id]/chat/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run } from '@/lib/db';
-import { getOpenClawClient } from '@/lib/openclaw/client';
 import { sendChatToAgent, buildAgentSessionKey } from '@/lib/openclaw/send-chat';
 import { attachChatListener, expectAgentReply } from '@/lib/chat-listener';
 import { broadcast } from '@/lib/events';
@@ -72,34 +71,22 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // Try chat.send with a 5s timeout — same pattern as task chat.
     let delivered = false;
     try {
-      const client = getOpenClawClient();
-      if (client.isConnected()) {
-        // Use the shared helper but enforce the same 5s budget by
-        // racing against a timeout — sendChatToAgent doesn't expose
-        // its own timeout (its only failure modes are no_session /
-        // send_failed). The race preserves the previous "if the
-        // gateway is mid-turn we still register the user message"
-        // semantics.
-        const sendPromise = sendChatToAgent({
-          agent,
-          message: message.trim(),
-          idempotencyKey: `agent-chat-${messageId}`,
-          sessionSuffix: `chat-${agent.id.slice(0, 8)}`,
-        });
-        const timeout = new Promise<{ sent: false; reason: 'send_failed'; sessionKey: string; error: Error }>((_, reject) =>
-          setTimeout(() => reject(new Error('timeout')), 5000)
+      const result = await sendChatToAgent({
+        agent,
+        message: message.trim(),
+        idempotencyKey: `agent-chat-${messageId}`,
+        sessionSuffix: `chat-${agent.id.slice(0, 8)}`,
+        timeoutMs: 5_000,
+      });
+      if (result.sent) {
+        delivered = true;
+        run(
+          `UPDATE agent_chat_messages SET status = 'delivered' WHERE id = ?`,
+          [messageId]
         );
-        const result = await Promise.race([sendPromise, timeout]);
-        if (result.sent) {
-          delivered = true;
-          run(
-            `UPDATE agent_chat_messages SET status = 'delivered' WHERE id = ?`,
-            [messageId]
-          );
-          expectAgentReply(sessionKey, agentId);
-        } else if (result.error) {
-          throw result.error;
-        }
+        expectAgentReply(sessionKey, agentId);
+      } else if (result.reason === 'send_failed' && result.error) {
+        throw result.error;
       }
     } catch (err) {
       console.warn(`[AgentChat] chat.send failed for ${sessionKey}:`, err);

--- a/src/app/api/tasks/[id]/chat/route.ts
+++ b/src/app/api/tasks/[id]/chat/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createNote, getTaskNotes, getActiveSessionForTask, markNotesDelivered } from '@/lib/task-notes';
-import { getOpenClawClient } from '@/lib/openclaw/client';
+import { sendChatToSession } from '@/lib/openclaw/send-chat';
 import { internalDispatch } from '@/lib/internal-dispatch';
 import { attachChatListener, expectReply } from '@/lib/chat-listener';
 import { queryOne } from '@/lib/db';
@@ -63,33 +63,24 @@ export async function POST(
     const sessionInfo = getActiveSessionForTask(taskId);
 
     if (sessionInfo) {
-      try {
-        const client = getOpenClawClient();
-        if (client.isConnected()) {
-          // TODO(comms-cleanup): migrate to `sendChatToAgent`. Held back
-          // because `getActiveSessionForTask` returns a pre-built
-          // `sessionKey` rather than an Agent row; either teach it to
-          // surface the agent identity, or extend the helper to accept
-          // a raw sessionKey override before migrating.
-          //
-          // Try chat.send with a 5s timeout — if agent is mid-turn, this works quickly
-          const sendPromise = client.call('chat.send', {
-            sessionKey: sessionInfo.sessionKey,
-            message: message.trim(),
-            idempotencyKey: `chat-${note.id}`
-          });
-          const timeout = new Promise((_, reject) =>
-            setTimeout(() => reject(new Error('timeout')), 5000)
-          );
-
-          await Promise.race([sendPromise, timeout]);
-          delivered = true;
-          markNotesDelivered([note.id]);
-          expectReply(sessionInfo.sessionKey, taskId);
-          console.log(`[Chat] Message delivered via chat.send to ${sessionInfo.sessionKey}`);
-        }
-      } catch {
+      // Try chat.send with a 5s timeout — if agent is mid-turn this
+      // works quickly. The helper folds in the timeout race that used
+      // to live here.
+      const result = await sendChatToSession({
+        sessionKey: sessionInfo.sessionKey,
+        message: message.trim(),
+        idempotencyKey: `chat-${note.id}`,
+        timeoutMs: 5_000,
+      });
+      if (result.sent) {
+        delivered = true;
+        markNotesDelivered([note.id]);
+        expectReply(sessionInfo.sessionKey, taskId);
+        console.log(`[Chat] Message delivered via chat.send to ${sessionInfo.sessionKey}`);
+      } else if (result.reason === 'timeout') {
         console.log('[Chat] chat.send timed out — will try dispatch fallback');
+      } else if (result.reason === 'send_failed') {
+        console.log('[Chat] chat.send failed — will try dispatch fallback:', result.error?.message);
       }
     }
 

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { sendChatToAgent } from '@/lib/openclaw/send-chat';
 import { broadcast } from '@/lib/events';
 import { getProjectsPath, getMissionControlUrl } from '@/lib/config';
 import { getTaskDeliverableDir } from '@/lib/deliverables/storage';
@@ -738,59 +739,50 @@ If you need help or clarification, ask the orchestrator.`;
     const { formatted: pendingNotes } = getPendingNotesForDispatch(id);
     const finalMessage = pendingNotes ? taskMessage + pendingNotes : taskMessage;
 
-    // Send message to agent's session using chat.send
+    // Send message to agent's session using chat.send.
+    // sessionKey resolution lives in `buildAgentSessionKey` (called by
+    // `sendChatToAgent`):
+    //   1. Explicit `agent.session_key_prefix` if set
+    //   2. `agent:<gateway_agent_id>:` for gateway-synced agents
+    //   3. `agent:<name-slug>:` as last resort
+    // The old hard-coded `agent:main:` catchall silently misrouted
+    // every MC→agent chat.send to the gateway's "main" agent.
     try {
-      // Use sessionKey for routing to the agent's session.
-      // Prefix defaults (via resolveAgentSessionKeyPrefix) are:
-      //   1. Explicit `agent.session_key_prefix` if set
-      //   2. `agent:<gateway_agent_id>:` for gateway-synced agents
-      //   3. `agent:<name-slug>:` as last resort
-      // The old hard-coded `agent:main:` catchall silently misrouted
-      // every MC→agent chat.send to the gateway's "main" agent.
-      const { resolveAgentSessionKeyPrefix } = await import('@/lib/openclaw/session-key');
-      const prefix = resolveAgentSessionKeyPrefix(agent);
-      const sessionKey = `${prefix}${session.openclaw_session_id}`;
       const idempotencyKey = `dispatch-${task.id}-${Date.now()}`;
       const chatSendStart = Date.now();
-      let chatSendResponse: unknown;
-      let chatSendError: string | null = null;
-      try {
-        // TODO(comms-cleanup): migrate to `sendChatToAgent`. Held back
-        // because this path needs the raw chat.send response (logged
-        // below as the canonical dispatch debug event) and a custom
-        // failure rethrow. The helper currently swallows transport
-        // errors; either widen its return shape or extract a thin
-        // `sendRaw` variant before migrating.
-        chatSendResponse = await client.call('chat.send', {
-          sessionKey,
-          message: finalMessage,
-          idempotencyKey,
-        });
-      } catch (err) {
-        chatSendError = (err as Error).message;
-        throw err; // preserve existing error-path behavior below
-      } finally {
-        // Debug console capture. No-op unless collection is enabled. Stores
-        // the full dispatch payload so operators can see exactly what the
-        // agent was asked to do — including injected knowledge, checkpoint
-        // context, and planning spec.
-        logDebugEvent({
-          type: 'chat.send',
-          direction: 'outbound',
-          taskId: task.id,
-          agentId: agent.id,
-          sessionKey,
-          durationMs: Date.now() - chatSendStart,
-          requestBody: { sessionKey, message: finalMessage, idempotencyKey },
-          responseBody: chatSendResponse,
-          error: chatSendError,
-          metadata: {
-            agent_name: agent.name,
-            agent_role: (agent as { role?: string }).role ?? null,
-            message_length: finalMessage.length,
-            task_status: task.status,
-          },
-        });
+      const sendResult = await sendChatToAgent({
+        agent,
+        message: finalMessage,
+        idempotencyKey,
+        sessionSuffix: session.openclaw_session_id,
+      });
+      const sessionKey = sendResult.sessionKey;
+      // Debug console capture. No-op unless collection is enabled. Stores
+      // the full dispatch payload so operators can see exactly what the
+      // agent was asked to do — including injected knowledge, checkpoint
+      // context, and planning spec.
+      logDebugEvent({
+        type: 'chat.send',
+        direction: 'outbound',
+        taskId: task.id,
+        agentId: agent.id,
+        sessionKey,
+        durationMs: Date.now() - chatSendStart,
+        requestBody: { sessionKey, message: finalMessage, idempotencyKey },
+        responseBody: sendResult.sent ? sendResult.response : undefined,
+        error: sendResult.sent ? null : (sendResult.error?.message ?? sendResult.reason ?? 'send_failed'),
+        metadata: {
+          agent_name: agent.name,
+          agent_role: (agent as { role?: string }).role ?? null,
+          message_length: finalMessage.length,
+          task_status: task.status,
+        },
+      });
+      if (!sendResult.sent) {
+        // Preserve existing error-path behavior — the outer catch
+        // updates task status, force-reconnects the client, and
+        // returns 503.
+        throw sendResult.error ?? new Error(sendResult.reason ?? 'chat.send failed');
       }
 
       // Only move to in_progress for builder dispatch (task is in 'assigned' status)

--- a/src/app/api/tasks/[id]/planning/advance/route.ts
+++ b/src/app/api/tasks/[id]/planning/advance/route.ts
@@ -19,6 +19,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { queryOne, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { sendChatToSession } from '@/lib/openclaw/send-chat';
 import { broadcast } from '@/lib/events';
 import {
   buildResearchKickoffPrompt,
@@ -95,11 +96,14 @@ export async function POST(
     // planner emits next.
     const client = getOpenClawClient();
     if (!client.isConnected()) await client.connect();
-    await client.call('chat.send', {
+    const sendResult = await sendChatToSession({
       sessionKey: task.planning_session_key,
       message: prompt,
       idempotencyKey: `planning-advance-${to}-${taskId}-${Date.now()}`,
     });
+    if (!sendResult.sent) {
+      throw sendResult.error ?? new Error(sendResult.reason ?? 'chat.send failed');
+    }
 
     // Record the transition. We store the "target" phase optimistically so the
     // UI renders the right loader while the planner responds. The poll loop

--- a/src/app/api/tasks/[id]/planning/answer/route.ts
+++ b/src/app/api/tasks/[id]/planning/answer/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { sendChatToSession } from '@/lib/openclaw/send-chat';
 import { buildClarifyAnswerPrompt } from '@/lib/planner-prompt';
 
 export const dynamic = 'force-dynamic';
@@ -60,17 +61,19 @@ export async function POST(
     console.log('[Planning Answer] Sending answer to OpenClaw, session:', task.planning_session_key);
     console.log('[Planning Answer] Answer text:', answerText);
 
-    try {
-      const sendResult = await client.call('chat.send', {
-        sessionKey: task.planning_session_key,
-        message: answerPrompt,
-        idempotencyKey: `planning-answer-${taskId}-${Date.now()}`,
-      });
-      console.log('[Planning Answer] Send successful, result:', sendResult);
-    } catch (sendError) {
-      console.error('[Planning Answer] Failed to send to OpenClaw:', sendError);
-      return NextResponse.json({ error: 'Failed to send answer to orchestrator: ' + (sendError as Error).message }, { status: 500 });
+    const sendResult = await sendChatToSession({
+      sessionKey: task.planning_session_key,
+      message: answerPrompt,
+      idempotencyKey: `planning-answer-${taskId}-${Date.now()}`,
+    });
+    if (!sendResult.sent) {
+      console.error('[Planning Answer] Failed to send to OpenClaw:', sendResult.error ?? sendResult.reason);
+      return NextResponse.json(
+        { error: 'Failed to send answer to orchestrator: ' + (sendResult.error?.message ?? sendResult.reason ?? 'unknown') },
+        { status: 500 },
+      );
     }
+    console.log('[Planning Answer] Send successful, response:', sendResult.response);
 
     // Update messages in DB
     getDb().prepare(`

--- a/src/app/api/tasks/[id]/planning/clarify-add/route.ts
+++ b/src/app/api/tasks/[id]/planning/clarify-add/route.ts
@@ -14,6 +14,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { queryOne, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { sendChatToSession } from '@/lib/openclaw/send-chat';
 import { buildClarifyAddonPrompt } from '@/lib/planner-prompt';
 import { broadcast } from '@/lib/events';
 import type { Task } from '@/lib/types';
@@ -53,11 +54,14 @@ export async function POST(
 
     const client = getOpenClawClient();
     if (!client.isConnected()) await client.connect();
-    await client.call('chat.send', {
+    const sendResult = await sendChatToSession({
       sessionKey: task.planning_session_key,
       message: buildClarifyAddonPrompt(clarification),
       idempotencyKey: `planning-clarify-add-${taskId}-${Date.now()}`,
     });
+    if (!sendResult.sent) {
+      throw sendResult.error ?? new Error(sendResult.reason ?? 'chat.send failed');
+    }
 
     // Append the user's clarification to the visible conversation log.
     const messages = task.planning_messages ? JSON.parse(task.planning_messages) : [];

--- a/src/app/api/tasks/[id]/planning/poll/route.ts
+++ b/src/app/api/tasks/[id]/planning/poll/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { queryOne, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { sendChatToSession } from '@/lib/openclaw/send-chat';
 import { broadcast } from '@/lib/events';
 import { getMessagesFromOpenClaw } from '@/lib/planning-utils';
 import { parsePlanningEnvelope, type PlanningEnvelope } from '@/lib/planning-envelope';
@@ -265,26 +266,26 @@ export async function GET(
 
         if (!alreadyReprompted) {
           const sessionKey = task.planning_session_key;
-          try {
-            const client = getOpenClawClient();
-            if (!client.isConnected()) {
-              await client.connect();
-            }
-            await client.call('chat.send', {
-              sessionKey,
-              message: buildReformatPrompt(reason || 'Not a recognized planning envelope'),
-              idempotencyKey: `planning-reprompt-${taskId}-${Date.now()}`,
-            });
-            console.log(`[Planning Poll] Sent reformat correction to planner for task ${taskId}`);
-          } catch (err) {
-            console.error(`[Planning Poll] Failed to send reformat correction:`, err);
+          const client = getOpenClawClient();
+          if (!client.isConnected()) {
+            await client.connect();
+          }
+          const sendResult = await sendChatToSession({
+            sessionKey,
+            message: buildReformatPrompt(reason || 'Not a recognized planning envelope'),
+            idempotencyKey: `planning-reprompt-${taskId}-${Date.now()}`,
+          });
+          if (!sendResult.sent) {
+            const errMsg = sendResult.error?.message ?? sendResult.reason ?? 'unknown';
+            console.error(`[Planning Poll] Failed to send reformat correction:`, errMsg);
             return NextResponse.json({
               hasUpdates: true,
-              parseError: `Planner returned invalid JSON and the reformat request also failed: ${(err as Error).message}`,
+              parseError: `Planner returned invalid JSON and the reformat request also failed: ${errMsg}`,
               rawContent: lastAssistantMsg.content.slice(0, 4000),
               messages,
             });
           }
+          console.log(`[Planning Poll] Sent reformat correction to planner for task ${taskId}`);
 
           const taggedMessages = messages.map((m: { role: string; content: string; timestamp: number; reprompted?: boolean }) =>
             m === lastAssistantMsg ? { ...m, reprompted: true } : m

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb, queryAll, queryOne, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { sendChatToSession } from '@/lib/openclaw/send-chat';
 import { broadcast } from '@/lib/events';
 import { parsePlanningEnvelope } from '@/lib/planning-envelope';
 import { getAgentRoster, formatRosterForPrompt } from '@/lib/agent-resolver';
@@ -235,16 +236,14 @@ export async function POST(
       await client.connect();
     }
 
-    // TODO(comms-cleanup): migrate to `sendChatToAgent`. Planning
-    // routes use a stored `task.planning_session_key` (full sessionKey)
-    // rather than an agent row; the helper would need a raw-sessionKey
-    // overload before this migrates cleanly. Same applies to the other
-    // /planning/* routes (tweak, advance, answer, clarify-add, poll).
-    await client.call('chat.send', {
-      sessionKey: sessionKey,
+    const sendResult = await sendChatToSession({
+      sessionKey,
       message: planningPrompt,
       idempotencyKey: `planning-start-${taskId}-${Date.now()}`,
     });
+    if (!sendResult.sent) {
+      throw sendResult.error ?? new Error(sendResult.reason ?? 'chat.send failed');
+    }
 
     // Store the session key and initial message
     const messages = [{ role: 'user', content: planningPrompt, timestamp: Date.now() }];

--- a/src/app/api/tasks/[id]/planning/tweak/route.ts
+++ b/src/app/api/tasks/[id]/planning/tweak/route.ts
@@ -15,6 +15,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { queryOne, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { sendChatToSession } from '@/lib/openclaw/send-chat';
 import { buildTweakPrompt } from '@/lib/planner-prompt';
 import { broadcast } from '@/lib/events';
 import type { Task } from '@/lib/types';
@@ -61,11 +62,14 @@ export async function POST(
 
     const client = getOpenClawClient();
     if (!client.isConnected()) await client.connect();
-    await client.call('chat.send', {
+    const sendResult = await sendChatToSession({
       sessionKey: task.planning_session_key,
       message: buildTweakPrompt(message),
       idempotencyKey: `planning-tweak-${taskId}-${Date.now()}`,
     });
+    if (!sendResult.sent) {
+      throw sendResult.error ?? new Error(sendResult.reason ?? 'chat.send failed');
+    }
 
     // Append the tweak to the message log so the UI shows the conversation.
     const messages = task.planning_messages ? JSON.parse(task.planning_messages) : [];

--- a/src/lib/openclaw/send-chat.test.ts
+++ b/src/lib/openclaw/send-chat.test.ts
@@ -10,6 +10,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   sendChatToAgent,
+  sendChatToSession,
   sendChatAndAwaitReply,
   buildAgentSessionKey,
   __setSendChatClientForTests,
@@ -348,5 +349,218 @@ test('sendChatAndAwaitReply: custom isDone predicate fires before default state=
     assert.equal(result.doneEvent!.message, 'STOP');
   } finally {
     __setSendChatClientForTests(null);
+  }
+});
+
+// ─── timeoutMs + response (sendChatToAgent) ─────────────────────────
+
+test('sendChatToAgent: timeoutMs triggers reason=timeout when send exceeds the budget', async () => {
+  const stub = makeStub({
+    callImpl: () =>
+      new Promise<unknown>(resolve => {
+        // Resolve well past the 50ms budget below — the helper should
+        // resolve with reason=timeout long before this fires.
+        setTimeout(() => resolve('eventually'), 500);
+      }),
+  });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const t0 = Date.now();
+    const result = await sendChatToAgent({
+      agent: FAKE_AGENT,
+      message: 'hi',
+      timeoutMs: 50,
+    });
+    const elapsed = Date.now() - t0;
+    assert.equal(result.sent, false);
+    assert.equal(result.reason, 'timeout');
+    assert.equal(result.response, undefined);
+    assert.ok(elapsed < 400, `helper should resolve near the deadline (got ${elapsed}ms)`);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatToAgent: timeoutMs does NOT false-positive when send completes well under budget', async () => {
+  const stub = makeStub({
+    callImpl: async () => 'ok',
+  });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatToAgent({
+      agent: FAKE_AGENT,
+      message: 'hi',
+      timeoutMs: 1_000,
+    });
+    assert.equal(result.sent, true);
+    assert.equal(result.reason, undefined);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatToAgent: response is populated on success', async () => {
+  const fakeResponse = { ok: true, deliveredAt: 'now' };
+  const stub = makeStub({
+    callImpl: async () => fakeResponse,
+  });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatToAgent({ agent: FAKE_AGENT, message: 'hi' });
+    assert.equal(result.sent, true);
+    assert.deepEqual(result.response, fakeResponse);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatToAgent: response is absent on failure', async () => {
+  const stub = makeStub({
+    callImpl: async () => {
+      throw new Error('boom');
+    },
+  });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatToAgent({ agent: FAKE_AGENT, message: 'hi' });
+    assert.equal(result.sent, false);
+    assert.equal(result.reason, 'send_failed');
+    assert.equal(result.response, undefined);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+// ─── sendChatToSession ──────────────────────────────────────────────
+
+test('sendChatToSession: forwards the exact sessionKey without agent resolution', async () => {
+  const stub = makeStub();
+  __setSendChatClientForTests(stub.client);
+  try {
+    const sessionKey = 'planner:task-12345:planning';
+    const result = await sendChatToSession({ sessionKey, message: 'plan!' });
+    assert.equal(result.sent, true);
+    assert.equal(result.sessionKey, sessionKey);
+    const params = stub.sends[0].params as Record<string, unknown>;
+    // The pre-built key flows through verbatim — no `buildAgentSessionKey`
+    // suffix or prefix mangling.
+    assert.equal(params.sessionKey, sessionKey);
+    assert.equal(params.message, 'plan!');
+    assert.equal(typeof params.idempotencyKey, 'string');
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatToSession: returns no_session when client is disconnected', async () => {
+  const stub = makeStub({ isConnected: false });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatToSession({
+      sessionKey: 'planner:task-1:planning',
+      message: 'hi',
+    });
+    assert.equal(result.sent, false);
+    assert.equal(result.reason, 'no_session');
+    assert.equal(stub.sends.length, 0);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatToSession: returns send_failed when client throws', async () => {
+  const stub = makeStub({
+    callImpl: async () => {
+      throw new Error('gateway boom');
+    },
+  });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatToSession({
+      sessionKey: 'planner:task-1:planning',
+      message: 'hi',
+    });
+    assert.equal(result.sent, false);
+    assert.equal(result.reason, 'send_failed');
+    assert.ok(result.error instanceof Error);
+    assert.match(result.error!.message, /gateway boom/);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatToSession: timeoutMs triggers reason=timeout', async () => {
+  const stub = makeStub({
+    callImpl: () => new Promise<unknown>(resolve => setTimeout(() => resolve('late'), 500)),
+  });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const result = await sendChatToSession({
+      sessionKey: 'planner:task-1:planning',
+      message: 'hi',
+      timeoutMs: 50,
+    });
+    assert.equal(result.sent, false);
+    assert.equal(result.reason, 'timeout');
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+test('sendChatToSession: explicit idempotencyKey is forwarded', async () => {
+  const stub = makeStub();
+  __setSendChatClientForTests(stub.client);
+  try {
+    await sendChatToSession({
+      sessionKey: 'planner:task-1:planning',
+      message: 'hi',
+      idempotencyKey: 'session-key-1',
+    });
+    const k = (stub.sends[0].params as { idempotencyKey: string }).idempotencyKey;
+    assert.equal(k, 'session-key-1');
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
+// ─── shared error path ─────────────────────────────────────────────
+
+test('shared error path: client throws → send_failed regardless of which wrapper', async () => {
+  const errors: Array<unknown> = [];
+  const makeThrowingStub = () =>
+    makeStub({
+      callImpl: async () => {
+        throw new Error('shared boom');
+      },
+    });
+
+  // sendChatToAgent path
+  let stub = makeThrowingStub();
+  __setSendChatClientForTests(stub.client);
+  try {
+    const r1 = await sendChatToAgent({ agent: FAKE_AGENT, message: 'a' });
+    errors.push(r1);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+
+  // sendChatToSession path
+  stub = makeThrowingStub();
+  __setSendChatClientForTests(stub.client);
+  try {
+    const r2 = await sendChatToSession({
+      sessionKey: 'planner:task-1:planning',
+      message: 'b',
+    });
+    errors.push(r2);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+
+  for (const r of errors as Array<{ sent: boolean; reason?: string; error?: Error }>) {
+    assert.equal(r.sent, false);
+    assert.equal(r.reason, 'send_failed');
+    assert.ok(r.error instanceof Error);
+    assert.match(r.error!.message, /shared boom/);
   }
 });

--- a/src/lib/openclaw/send-chat.ts
+++ b/src/lib/openclaw/send-chat.ts
@@ -1,7 +1,7 @@
 /**
  * Centralised `chat.send` helpers for MC → openclaw routing.
  *
- * Two surfaces:
+ * Three surfaces:
  *
  *   1. `sendChatToAgent(...)` — fire-and-forget chat send. Resolves the
  *      sessionKey from an Agent row via `resolveAgentSessionKeyPrefix`,
@@ -9,7 +9,12 @@
  *      than throwing. Replaces the 5+ hand-rolled
  *      `client.call('chat.send', ...)` call sites (PR #55 follow-up).
  *
- *   2. `sendChatAndAwaitReply(...)` — subscribe-then-send-then-await
+ *   2. `sendChatToSession(...)` — same shape as `sendChatToAgent` but
+ *      takes a pre-built `sessionKey` directly. Used by call sites that
+ *      have a stored session key (e.g. `task.planning_session_key`) and
+ *      no convenient agent row to resolve from.
+ *
+ *   3. `sendChatAndAwaitReply(...)` — subscribe-then-send-then-await
  *      primitive. Subscribes to the openclaw client's `chat_event` stream
  *      BEFORE sending so we never miss the first frame, then collects
  *      events until either the caller's `isDone` predicate fires or the
@@ -23,10 +28,21 @@
  *     `__setSendChatClientForTests`). It does NOT take a client param —
  *     that would make migration noisy at every call site.
  *
- *   - `sendChatToAgent` returns `{ sent: false, reason: 'no_session' }`
- *     when `client.isConnected()` is false. That mirrors the existing
- *     guard pattern (`if (client.isConnected()) ...`) used in every
- *     hand-rolled call site today.
+ *   - `sendChatToAgent` / `sendChatToSession` return
+ *     `{ sent: false, reason: 'no_session' }` when `client.isConnected()`
+ *     is false. That mirrors the existing guard pattern
+ *     (`if (client.isConnected()) ...`) used in every hand-rolled call
+ *     site today.
+ *
+ *   - When `timeoutMs` is set on a fire-and-forget send and the
+ *     underlying `chat.send` call doesn't resolve before the deadline,
+ *     the helper resolves with `{ sent: false, reason: 'timeout' }`.
+ *     The in-flight call is NOT aborted (the underlying client surface
+ *     here doesn't expose a cancellation handle — see
+ *     `OpenClawClient.call`); it completes in the background and its
+ *     resolution/rejection is discarded. Trade-off: callers can't get
+ *     surprised by a late-arriving response, at the cost of a small
+ *     wasted gateway round-trip when timeouts fire.
  *
  *   - `sendChatAndAwaitReply` does not subscribe when the underlying send
  *     fails or there's no session — it short-circuits with the
@@ -57,14 +73,39 @@ export interface SendChatInput {
   idempotencyKey?: string;
   /** Appended to the resolved prefix. Defaults to 'main'. */
   sessionSuffix?: string;
+  /**
+   * Optional per-call timeout for the underlying `chat.send`. When the
+   * deadline elapses before the call resolves, the helper resolves with
+   * `{ sent: false, reason: 'timeout' }`. The in-flight call is left to
+   * complete in the background (see file-level note). Default: no
+   * timeout — the helper waits as long as the gateway takes.
+   */
+  timeoutMs?: number;
+}
+
+export interface SendChatToSessionInput {
+  /** Pre-built full session key (NOT just the prefix). */
+  sessionKey: string;
+  message: string;
+  /** Defaults to a fresh uuid. */
+  idempotencyKey?: string;
+  /** See `SendChatInput.timeoutMs`. */
+  timeoutMs?: number;
 }
 
 export interface SendChatResult {
   sent: boolean;
   sessionKey: string;
   /** When `sent` is false, why. */
-  reason?: 'no_session' | 'send_failed';
+  reason?: 'no_session' | 'send_failed' | 'timeout';
   error?: Error;
+  /**
+   * Raw return value from the underlying `client.call('chat.send', ...)`
+   * when the call succeeded. Shape is gateway-defined and not narrowed
+   * here — callers that need structured fields should narrow via their
+   * own predicate. Absent on failure (no_session / send_failed / timeout).
+   */
+  response?: unknown;
 }
 
 /**
@@ -148,6 +189,70 @@ export function buildAgentSessionKey(
   return `${prefix}${sessionSuffix}`;
 }
 
+// ─── shared raw send ────────────────────────────────────────────────
+
+/**
+ * Sentinel returned from the timeout race so we can distinguish
+ * "deadline elapsed" from `undefined` payloads.
+ */
+const SEND_TIMEOUT_SENTINEL: unique symbol = Symbol('send-chat:timeout');
+
+/**
+ * Internal — shared by `sendChatToAgent` and `sendChatToSession`. Runs
+ * the connectivity guard, idempotency-key default, optional timeout
+ * race, and structured error mapping in one place so the two public
+ * wrappers stay thin.
+ */
+async function _sendChatRaw(params: {
+  sessionKey: string;
+  message: string;
+  idempotencyKey: string;
+  timeoutMs?: number;
+}): Promise<SendChatResult> {
+  const { sessionKey, message, idempotencyKey, timeoutMs } = params;
+  const client = getClient();
+
+  if (!client.isConnected()) {
+    return { sent: false, sessionKey, reason: 'no_session' };
+  }
+
+  const sendPromise = client.call('chat.send', {
+    sessionKey,
+    message,
+    idempotencyKey,
+  });
+
+  try {
+    let response: unknown;
+    if (timeoutMs && timeoutMs > 0) {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const timeoutPromise = new Promise<typeof SEND_TIMEOUT_SENTINEL>(resolve => {
+        timer = setTimeout(() => resolve(SEND_TIMEOUT_SENTINEL), timeoutMs);
+      });
+      // Swallow late rejection so an unhandledRejection isn't thrown
+      // when the in-flight call eventually fails after we've already
+      // resolved with `timeout`.
+      sendPromise.catch(() => {});
+      const winner = await Promise.race([sendPromise, timeoutPromise]);
+      if (timer) clearTimeout(timer);
+      if (winner === SEND_TIMEOUT_SENTINEL) {
+        return { sent: false, sessionKey, reason: 'timeout' };
+      }
+      response = winner;
+    } else {
+      response = await sendPromise;
+    }
+    return { sent: true, sessionKey, response };
+  } catch (err) {
+    return {
+      sent: false,
+      sessionKey,
+      reason: 'send_failed',
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
 // ─── sendChatToAgent ────────────────────────────────────────────────
 
 /**
@@ -159,32 +264,37 @@ export function buildAgentSessionKey(
  * Returns `{ sent: false, reason: 'no_session' }` when the openclaw
  * client reports it isn't connected. Returns
  * `{ sent: false, reason: 'send_failed', error }` when the underlying
- * call rejects (e.g. gateway timeout).
+ * call rejects (e.g. gateway timeout). Returns
+ * `{ sent: false, reason: 'timeout' }` when `timeoutMs` is set and the
+ * call doesn't resolve in time (in-flight call is not aborted).
  */
 export async function sendChatToAgent(input: SendChatInput): Promise<SendChatResult> {
-  const sessionKey = buildAgentSessionKey(input.agent, input.sessionSuffix);
-  const idempotencyKey = input.idempotencyKey ?? uuidv4();
-  const client = getClient();
+  return _sendChatRaw({
+    sessionKey: buildAgentSessionKey(input.agent, input.sessionSuffix),
+    message: input.message,
+    idempotencyKey: input.idempotencyKey ?? uuidv4(),
+    timeoutMs: input.timeoutMs,
+  });
+}
 
-  if (!client.isConnected()) {
-    return { sent: false, sessionKey, reason: 'no_session' };
-  }
+// ─── sendChatToSession ──────────────────────────────────────────────
 
-  try {
-    await client.call('chat.send', {
-      sessionKey,
-      message: input.message,
-      idempotencyKey,
-    });
-    return { sent: true, sessionKey };
-  } catch (err) {
-    return {
-      sent: false,
-      sessionKey,
-      reason: 'send_failed',
-      error: err instanceof Error ? err : new Error(String(err)),
-    };
-  }
+/**
+ * Same shape as `sendChatToAgent` but takes a pre-built `sessionKey`
+ * directly. Use this when the caller has a stored full session key
+ * (e.g. `task.planning_session_key`, or a key returned by
+ * `getActiveSessionForTask`) and no convenient agent row to resolve
+ * from. Returns the same `SendChatResult` shape.
+ */
+export async function sendChatToSession(
+  input: SendChatToSessionInput,
+): Promise<SendChatResult> {
+  return _sendChatRaw({
+    sessionKey: input.sessionKey,
+    message: input.message,
+    idempotencyKey: input.idempotencyKey ?? uuidv4(),
+    timeoutMs: input.timeoutMs,
+  });
 }
 
 // ─── sendChatAndAwaitReply ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
Two follow-ups from PR #57:
1. Helpers absorb per-call timeout (the two `Promise.race` sites) and expose the raw chat.send response (for the dispatch debug event)
2. New `sendChatToSession` variant for callers with pre-built session keys (planning routes, task chat)

All four `TODO(comms-cleanup)` sites migrated.

## What landed
- `SendChatInput.timeoutMs` (optional, default none)
- `SendChatResult.response` (raw chat.send return on success)
- `SendChatResult.reason: 'timeout'` (new enum value)
- New `sendChatToSession` for pre-built keys
- 6 call sites migrated; 0 `TODO(comms-cleanup)` remaining

## Test plan
- [x] timeoutMs triggers + does not false-positive
- [x] response populated on success
- [x] sendChatToSession resolves the right key without agent lookup
- [x] All 354+ existing tests still pass; new tests cover new behavior
- [x] yarn build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>