### PR TITLE
docker: ignore .tmp, .claude, db-backups in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,17 @@ node_modules
 .next
 coverage
 
+# Local development / agent state — never ship in the image
+.tmp
+.claude
+data
+db-backups
+openclaw-workspaces
+presentation
+.cursor
+.vscode
+.idea
+
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
## Summary
\`docker build\` was transferring 2.84 GB of context because \`.tmp/\` (test DBs), \`.claude/\` (agent worktrees), and \`db-backups/\` (4.8 GB!) were not ignored. Add them plus other local-only dirs so the build context shrinks by an order of magnitude.

## What was already ignored
- \`node_modules\`, \`.next\`, \`coverage\`, \`.git\`, env files, \`mission-control.db*\`

## What's now also ignored
- \`.tmp\` — test DBs (per-process isolation can balloon fast)
- \`.claude\` — agent worktrees from background subagents
- \`data\` — local data dir
- \`db-backups\` — 4.8 GB of historical snapshots
- \`openclaw-workspaces\` — gateway-local agent workspaces
- \`presentation\`, \`.cursor\`, \`.vscode\`, \`.idea\` — IDE / dev artifacts

## Test plan
- [ ] \`docker build .\` transfers a small fraction of what it did before
- [ ] Image still boots and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>