### PR TITLE
mcp(whoami): accept gateway_agent_id; nav: add Debug link

### DIFF
--- a/src/components/shell/AppNav.tsx
+++ b/src/components/shell/AppNav.tsx
@@ -32,6 +32,7 @@ import {
   X,
   Plus,
   KanbanSquare,
+  Bug,
 } from 'lucide-react';
 import {
   useCurrentWorkspaceId,
@@ -85,6 +86,7 @@ function buildSections(taskBoardHref: string): NavSection[] {
       title: 'Workspace',
       items: [
         { href: '/settings', label: 'Settings', icon: SettingsIcon },
+        { href: '/debug', label: 'Debug', icon: Bug, prefix: true },
       ],
     },
   ];

--- a/src/lib/mcp/mcp.test.ts
+++ b/src/lib/mcp/mcp.test.ts
@@ -106,6 +106,32 @@ test('whoami returns identity, assigned tasks, and peer roster', async () => {
   );
 });
 
+test('whoami resolves identity by gateway_agent_id (bootstrap path)', async () => {
+  const { client } = await makePair();
+  const gw = `mc-bootstrap-${crypto.randomUUID().slice(0, 8)}`;
+  const me = seedAgent({ role: 'builder', gateway: gw });
+  const task = seedTask({ assigned: me, status: 'in_progress' });
+
+  const res = await client.callTool({
+    name: 'whoami',
+    arguments: { agent_id: gw },
+  });
+  assert.equal(res.isError, undefined);
+  const payload = parseStructured<{
+    id: string;
+    gateway_agent_id: string;
+    assigned_task_ids: string[];
+    peers: Record<string, unknown>;
+  }>(res);
+  assert.equal(payload.id, me, 'returns the MC agent_id, not the gateway id');
+  assert.equal(payload.gateway_agent_id, gw);
+  assert.ok(payload.assigned_task_ids.includes(task), 'tasks resolved via me.id');
+  assert.ok(
+    !Object.keys(payload.peers).includes(gw),
+    'caller should not appear in their own peer list',
+  );
+});
+
 test('whoami returns an error for an unknown agent_id', async () => {
   const { client } = await makePair();
   const res = await client.callTool({

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -65,13 +65,7 @@ function trace<TArgs extends { agent_id?: string; task_id?: string }>(
         taskId: args.task_id ?? null,
         ok: !result.isError,
         durationMs: Date.now() - started,
-        error: result.isError
-          ? result.structuredContent &&
-            typeof result.structuredContent === 'object' &&
-            'message' in result.structuredContent
-            ? String((result.structuredContent as { message?: unknown }).message)
-            : 'tool returned isError'
-          : undefined,
+        error: result.isError ? extractErrorMessage(result) : undefined,
       });
       return result;
     } catch (err) {
@@ -100,6 +94,18 @@ function trace<TArgs extends { agent_id?: string; task_id?: string }>(
   };
 }
 
+function extractErrorMessage(result: CallToolResult): string {
+  const sc = result.structuredContent;
+  if (sc && typeof sc === 'object') {
+    const obj = sc as Record<string, unknown>;
+    if (typeof obj.message === 'string' && obj.message) return obj.message;
+    if (typeof obj.error === 'string' && obj.error) return obj.error;
+  }
+  const first = result.content?.[0];
+  if (first && first.type === 'text' && first.text) return first.text;
+  return 'tool returned isError';
+}
+
 function textResult(text: string, structured?: Record<string, unknown>): CallToolResult {
   return {
     content: [{ type: 'text', text }],
@@ -117,7 +123,14 @@ export function registerAllTools(server: McpServer): void {
       title: 'Identify the calling agent',
       description:
         "Returns the calling agent's identity, assigned task ids, and the peer roster (gateway_id → MC agent_id). Call this once at session start to learn your own agent_id and peers.",
-      inputSchema: { agent_id: agentIdArg },
+      inputSchema: {
+        agent_id: z
+          .string()
+          .min(1)
+          .describe(
+            "Your agent identity — accepts either MC agent_id (UUID) or gateway_agent_id (e.g. 'mc-project-manager'). whoami is the bootstrap call, so either form works; other tools require the MC agent_id this returns.",
+          ),
+      },
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
     trace('whoami', async ({ agent_id }) => {
@@ -130,13 +143,13 @@ export function registerAllTools(server: McpServer): void {
         is_active: number | null;
       }>(
         `SELECT id, name, role, workspace_id, gateway_agent_id, is_active
-           FROM agents WHERE id = ? LIMIT 1`,
-        [agent_id],
+           FROM agents WHERE id = ? OR gateway_agent_id = ? LIMIT 1`,
+        [agent_id, agent_id],
       );
       if (!me) {
         return {
           isError: true,
-          content: [{ type: 'text', text: `agent ${agent_id} not found` }],
+          content: [{ type: 'text', text: `agent ${agent_id} not found (tried both id and gateway_agent_id)` }],
           structuredContent: { error: 'agent_not_found', agent_id },
         };
       }
@@ -148,7 +161,7 @@ export function registerAllTools(server: McpServer): void {
               OR id IN (SELECT task_id FROM task_roles WHERE agent_id = ?))
             AND status NOT IN ('done', 'cancelled')
           ORDER BY updated_at DESC`,
-        [me.workspace_id, agent_id, agent_id],
+        [me.workspace_id, me.id, me.id],
       );
 
       const peers = queryAll<{ id: string; gateway_agent_id: string; name: string; role: string }>(
@@ -156,7 +169,7 @@ export function registerAllTools(server: McpServer): void {
           WHERE workspace_id = ?
             AND gateway_agent_id IS NOT NULL AND gateway_agent_id != ''
             AND id != ?`,
-        [me.workspace_id, agent_id],
+        [me.workspace_id, me.id],
       );
       const peerMap: Record<string, { id: string; name: string; role: string }> = {};
       for (const p of peers) {


### PR DESCRIPTION
## Summary
Operator-authored fixes that surfaced while testing the new PM agent integration:

1. **whoami bootstrap path** — agents start out knowing only their \`gateway_agent_id\` (e.g. \`mc-project-manager\`), not the MC \`agent_id\` UUID. The previous \`whoami\` required the UUID, creating a chicken-and-egg problem. Now accepts either form; subsequent queries use the resolved MC agent_id.
2. **trace error extraction** — when a tool returns \`isError\`, extract the message from \`structuredContent.message\`, \`structuredContent.error\`, or the first text content frame. Was only checking message before.
3. **AppNav** — added a Debug entry under the Workspace section so /debug is reachable from the unified nav.

## What landed
- \`src/lib/mcp/tools.ts\` — whoami accepts either id form; \`extractErrorMessage\` helper
- \`src/lib/mcp/mcp.test.ts\` — new test for the gateway_agent_id bootstrap path
- \`src/components/shell/AppNav.tsx\` — Debug nav entry

## Test plan
- [ ] whoami with UUID still works
- [ ] whoami with gateway_agent_id resolves to the same identity
- [ ] tool errors with non-message structured content surface the error string
- [ ] /debug reachable from left nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>