### PR TITLE
mcp: expose create_child_initiative diff in propose_changes

### DIFF
--- a/src/lib/mcp/mcp.test.ts
+++ b/src/lib/mcp/mcp.test.ts
@@ -16,8 +16,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { run } from '@/lib/db';
+import { run, queryOne } from '@/lib/db';
 import { buildServer } from './server';
+import { createInitiative } from '@/lib/db/initiatives';
 
 async function makePair() {
   const [clientT, serverT] = InMemoryTransport.createLinkedPair();
@@ -419,4 +420,92 @@ test('request_knowledge scores title/tag/content hits and filters unrelated entr
   // Unrelated "Foreign entity" / "PEO" entries should not leak in — the
   // exact regression the old auto-injector produced.
   assert.ok(!payload.matches.some(m => /foreign entity|PEO/i.test(m.title)));
+});
+
+// ─── propose_changes (PM) ───────────────────────────────────────────
+
+test('propose_changes accepts decompose_initiative trigger + create_child_initiative diffs', async () => {
+  const { client } = await makePair();
+  const ws = `ws-${crypto.randomUUID().slice(0, 8)}`;
+  run(
+    `INSERT INTO workspaces (id, name, slug, icon) VALUES (?, ?, ?, '🧪')`,
+    [ws, ws, ws],
+  );
+  const me = seedAgent({ workspace: ws, role: 'pm' });
+  const parent = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Parent epic' });
+
+  const res = await client.callTool({
+    name: 'propose_changes',
+    arguments: {
+      agent_id: me,
+      workspace_id: ws,
+      trigger_text: 'decompose this epic into child stories',
+      trigger_kind: 'decompose_initiative',
+      impact_md: '- splits parent into 2 sequential children',
+      changes: [
+        {
+          kind: 'create_child_initiative',
+          parent_initiative_id: parent.id,
+          title: 'Foundation',
+          description: 'Foundation work',
+          child_kind: 'story',
+          complexity: 'M',
+          placeholder_id: '$0',
+        },
+        {
+          kind: 'create_child_initiative',
+          parent_initiative_id: parent.id,
+          title: 'Build on top',
+          child_kind: 'story',
+          complexity: 'M',
+          depends_on_initiative_ids: ['$0'],
+        },
+      ],
+    },
+  });
+  assert.equal(res.isError, undefined, 'schema must accept the documented PM decompose payload');
+  const proposal = parseStructured<{ id: string; trigger_kind: string; status: string; proposed_changes: unknown[] }>(res);
+  assert.equal(proposal.trigger_kind, 'decompose_initiative');
+  assert.equal(proposal.status, 'draft', 'apply happens at accept time, not at propose time');
+  assert.equal(proposal.proposed_changes.length, 2);
+  // Defence-in-depth: row is actually persisted with the right trigger_kind.
+  const row = queryOne<{ status: string; trigger_kind: string }>(
+    'SELECT status, trigger_kind FROM pm_proposals WHERE id = ?',
+    [proposal.id],
+  );
+  assert.equal(row?.status, 'draft');
+  assert.equal(row?.trigger_kind, 'decompose_initiative');
+});
+
+test('propose_changes rejects an unknown diff kind', async () => {
+  const { client } = await makePair();
+  const ws = `ws-${crypto.randomUUID().slice(0, 8)}`;
+  run(
+    `INSERT INTO workspaces (id, name, slug, icon) VALUES (?, ?, ?, '🧪')`,
+    [ws, ws, ws],
+  );
+  const me = seedAgent({ workspace: ws, role: 'pm' });
+
+  // The discriminated union should reject "nope" as a diff kind. Depending on
+  // the SDK transport, that surfaces either as a JSON-RPC rejection or as
+  // `isError: true` — accept either, just not silent success.
+  let rejected = false;
+  let isError = false;
+  try {
+    const res = await client.callTool({
+      name: 'propose_changes',
+      arguments: {
+        agent_id: me,
+        workspace_id: ws,
+        trigger_text: 'bad',
+        trigger_kind: 'manual',
+        impact_md: '-',
+        changes: [{ kind: 'nope', initiative_id: 'x' }],
+      },
+    });
+    isError = res.isError === true;
+  } catch {
+    rejected = true;
+  }
+  assert.ok(rejected || isError, 'unknown diff kind must not silently pass schema validation');
 });

--- a/src/lib/mcp/roadmap-tools.ts
+++ b/src/lib/mcp/roadmap-tools.ts
@@ -170,6 +170,22 @@ const DiffSchema = z.discriminatedUnion('kind', [
     initiative_id: z.string().min(1),
     status_check_md: z.string(),
   }),
+  z.object({
+    // Decompose flow: insert one child initiative under
+    // `parent_initiative_id` on accept. `depends_on_initiative_ids` may
+    // carry placeholder ids (`$0`, `$1`, …) that resolve post-insert
+    // against other create_child_initiative diffs in the same proposal.
+    kind: z.literal('create_child_initiative'),
+    parent_initiative_id: z.string().min(1),
+    title: z.string().min(1),
+    description: z.string().nullish(),
+    child_kind: z.enum(['epic', 'story']),
+    complexity: z.enum(['S', 'M', 'L', 'XL']).nullish(),
+    estimated_effort_hours: z.number().nullish(),
+    sort_order: z.number().optional(),
+    depends_on_initiative_ids: z.array(z.string().min(1)).optional(),
+    placeholder_id: z.string().optional(),
+  }),
 ]);
 
 export function registerRoadmapTools(server: McpServer): void {
@@ -566,6 +582,8 @@ export function registerRoadmapTools(server: McpServer): void {
             'scheduled_drift_scan',
             'disruption_event',
             'status_check_investigation',
+            'plan_initiative',
+            'decompose_initiative',
           ])
           .optional(),
         impact_md: z.string().min(1).max(20000),


### PR DESCRIPTION
## Summary

- Adds the missing `create_child_initiative` variant to the `propose_changes` `DiffSchema` discriminated union, mirroring `PmDiff` from `src/lib/db/pm-proposals.ts`.
- Adds `plan_initiative` and `decompose_initiative` to the `trigger_kind` enum.

## Why

The PM agent (`mc-project-manager`) is instructed by its `AGENTS.md` to emit `create_child_initiative` diffs inside a `decompose_initiative` proposal when the operator clicks "Decompose with PM". Every layer below the MCP transport already implements this end-to-end:

| Layer | Status |
|---|---|
| `PmDiff` TS type (`src/lib/db/pm-proposals.ts:78-96`) | ✅ |
| Synthesis (`src/lib/agents/pm-agent.ts:334`) | ✅ |
| Validation (`src/lib/db/pm-proposals.ts:285`) | ✅ |
| Transactional apply with `$N` placeholder dep resolution (`pm-proposals.ts:496-540, 678+`) | ✅ |
| HTTP API route + operator UI | ✅ |
| **MCP `propose_changes` zod schema** | **❌ → ✅ in this PR** |

Symptom in the live system: a `decompose_initiative` dispatch produced a proposal with `changes: []` and the decomposition stuffed into `impact_md` as advisory text — graceful degradation against a real schema gap.

## Test plan

- [x] `npx tsx --test src/lib/mcp/mcp.test.ts` — 18/18 pass, including new positive test (decompose proposal with two `create_child_initiative` diffs and a `$0` placeholder dep persists as `draft`) and negative test (unknown diff kind doesn't silently pass schema validation).
- [x] `npx tsx --test src/lib/db/pm-proposals.test.ts src/lib/agents/pm-decompose.test.ts src/app/api/pm/decompose-initiative/route.test.ts` — 30/30 pass; no regression in the existing apply/synthesis/HTTP layers.
- [x] `tsc --noEmit` clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)