### PR TITLE
ux: decompose modal sizing, initiative detail toolbar, per-agent reset

### DIFF
--- a/src/app/(app)/initiatives/[id]/page.tsx
+++ b/src/app/(app)/initiatives/[id]/page.tsx
@@ -1,9 +1,34 @@
 'use client';
 
 import { useState, useEffect, useCallback, use } from 'react';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft, ChevronRight, Plus, Send, History, Link2, Sparkles } from 'lucide-react';
+import {
+  ArrowLeft,
+  ChevronRight,
+  Plus,
+  Send,
+  History,
+  Link2,
+  Sparkles,
+  Pencil,
+  MoveRight,
+  Shuffle,
+  CornerUpLeft,
+  Trash2,
+} from 'lucide-react';
 import DecomposeWithPmModal from '@/components/DecomposeWithPmModal';
+// Reuse the modal components defined alongside the list page so the detail
+// page exposes the same action surface — but as visible buttons rather than
+// behind a dropdown, since the operator already drilled into one initiative.
+import {
+  EditDrawer,
+  MoveModal,
+  ConvertModal,
+  AddDependencyModal,
+  HistoryDrawer,
+  type Initiative as ListInitiative,
+} from '../page';
 
 type Kind = 'theme' | 'milestone' | 'epic' | 'story';
 type Status = 'planned' | 'in_progress' | 'at_risk' | 'blocked' | 'done' | 'cancelled';
@@ -27,6 +52,9 @@ interface Initiative {
   committed_end: string | null;
   status_check_md: string | null;
   source_idea_id: string | null;
+  // Required by the list-page Initiative shape that the shared modals
+  // (Move/Convert/AddDependency) consume; the API returns it on every row.
+  sort_order: number;
   created_at: string;
   updated_at: string;
 }
@@ -101,6 +129,7 @@ export default function InitiativeDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = use(params);
+  const router = useRouter();
   const [initiative, setInitiative] = useState<InitiativeWithRelations | null>(null);
   const [allInitiatives, setAllInitiatives] = useState<Initiative[]>([]);
   const [history, setHistory] = useState<HistoryRow[]>([]);
@@ -110,6 +139,11 @@ export default function InitiativeDetailPage({
   const [actionError, setActionError] = useState<string | null>(null);
   const [showPromoteModal, setShowPromoteModal] = useState(false);
   const [showDecomposeModal, setShowDecomposeModal] = useState(false);
+  const [showEditDrawer, setShowEditDrawer] = useState(false);
+  const [showMoveModal, setShowMoveModal] = useState(false);
+  const [showConvertModal, setShowConvertModal] = useState(false);
+  const [showAddDepModal, setShowAddDepModal] = useState(false);
+  const [showHistoryDrawer, setShowHistoryDrawer] = useState(false);
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -146,6 +180,45 @@ export default function InitiativeDetailPage({
     },
     [allInitiatives],
   );
+
+  // Detach (move to no parent). Mirrors the action on the list page so the
+  // detail page can break a parent link without a round-trip via Move.
+  const detach = useCallback(async () => {
+    if (!initiative) return;
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/initiatives/${initiative.id}/move`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to_parent_id: null, reason: 'detach' }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Detach failed (${res.status})`);
+      }
+      refresh();
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : 'Detach failed');
+    }
+  }, [initiative, refresh]);
+
+  // Delete with confirm. On success, route back to the list — the detail
+  // page no longer has a row to render.
+  const deleteInitiative = useCallback(async () => {
+    if (!initiative) return;
+    if (!confirm(`Delete "${initiative.title}"? This cannot be undone.`)) return;
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/initiatives/${initiative.id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Delete failed (${res.status})`);
+      }
+      router.push('/initiatives');
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : 'Delete failed');
+    }
+  }, [initiative, router]);
 
   const promoteDraft = async (taskId: string) => {
     setActionError(null);
@@ -240,6 +313,49 @@ export default function InitiativeDetailPage({
                   <Sparkles className="w-4 h-4" /> Decompose with PM
                 </button>
               )}
+            </div>
+          </div>
+
+          {/*
+            Secondary action toolbar — surfaces every action that lives in
+            the ⋮ overflow menu on the list page, but as visible buttons
+            since this is a dedicated detail page and the operator already
+            committed to one initiative. Destructive actions (Detach,
+            Delete) sit at the right with a divider and tinted styling.
+          */}
+          <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-mc-border/60 pt-3">
+            <ToolbarButton icon={<Pencil className="w-3.5 h-3.5" />} onClick={() => setShowEditDrawer(true)}>
+              Edit
+            </ToolbarButton>
+            <ToolbarButton icon={<MoveRight className="w-3.5 h-3.5" />} onClick={() => setShowMoveModal(true)}>
+              Move
+            </ToolbarButton>
+            <ToolbarButton icon={<Shuffle className="w-3.5 h-3.5" />} onClick={() => setShowConvertModal(true)}>
+              Convert kind
+            </ToolbarButton>
+            <ToolbarButton icon={<Link2 className="w-3.5 h-3.5" />} onClick={() => setShowAddDepModal(true)}>
+              Add dependency
+            </ToolbarButton>
+            <ToolbarButton icon={<History className="w-3.5 h-3.5" />} onClick={() => setShowHistoryDrawer(true)}>
+              View history
+            </ToolbarButton>
+            <div className="ml-auto flex items-center gap-2">
+              {initiative.parent_initiative_id && (
+                <ToolbarButton
+                  icon={<CornerUpLeft className="w-3.5 h-3.5" />}
+                  onClick={detach}
+                  title="Move to no parent"
+                >
+                  Detach
+                </ToolbarButton>
+              )}
+              <ToolbarButton
+                icon={<Trash2 className="w-3.5 h-3.5" />}
+                onClick={deleteInitiative}
+                destructive
+              >
+                Delete
+              </ToolbarButton>
             </div>
           </div>
 
@@ -404,7 +520,82 @@ export default function InitiativeDetailPage({
           }}
         />
       )}
+      <EditDrawer
+        initiative={showEditDrawer ? (initiative as ListInitiative) : null}
+        onClose={() => setShowEditDrawer(false)}
+        onSaved={() => {
+          setShowEditDrawer(false);
+          refresh();
+        }}
+      />
+      {showMoveModal && (
+        <MoveModal
+          initiative={initiative as ListInitiative}
+          allInitiatives={allInitiatives as ListInitiative[]}
+          onClose={() => setShowMoveModal(false)}
+          onSaved={() => {
+            setShowMoveModal(false);
+            refresh();
+          }}
+        />
+      )}
+      {showConvertModal && (
+        <ConvertModal
+          initiative={initiative as ListInitiative}
+          onClose={() => setShowConvertModal(false)}
+          onSaved={() => {
+            setShowConvertModal(false);
+            refresh();
+          }}
+        />
+      )}
+      {showAddDepModal && (
+        <AddDependencyModal
+          initiative={initiative as ListInitiative}
+          allInitiatives={allInitiatives as ListInitiative[]}
+          onClose={() => setShowAddDepModal(false)}
+          onSaved={() => {
+            setShowAddDepModal(false);
+            refresh();
+          }}
+        />
+      )}
+      {showHistoryDrawer && (
+        <HistoryDrawer
+          initiative={initiative as ListInitiative}
+          allInitiatives={allInitiatives as ListInitiative[]}
+          onClose={() => setShowHistoryDrawer(false)}
+        />
+      )}
     </div>
+  );
+}
+
+function ToolbarButton({
+  icon,
+  onClick,
+  children,
+  destructive,
+  title,
+}: {
+  icon: React.ReactNode;
+  onClick: () => void;
+  children: React.ReactNode;
+  destructive?: boolean;
+  title?: string;
+}) {
+  const palette = destructive
+    ? 'border-red-500/30 text-red-300 hover:bg-red-500/10 hover:border-red-500/50'
+    : 'border-mc-border text-mc-text-secondary hover:text-mc-text hover:border-mc-accent/40';
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      className={`inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded border ${palette}`}
+    >
+      {icon}
+      <span>{children}</span>
+    </button>
   );
 }
 

--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -27,10 +27,10 @@ import DecomposeWithPmModal from '@/components/DecomposeWithPmModal';
 // Local types (kept separate from src/lib/types.ts so Phase 1 doesn't touch
 // the central type module — Phase 2 can promote these once the broader API
 // surface stabilises).
-type Kind = 'theme' | 'milestone' | 'epic' | 'story';
-type Status = 'planned' | 'in_progress' | 'at_risk' | 'blocked' | 'done' | 'cancelled';
+export type Kind = 'theme' | 'milestone' | 'epic' | 'story';
+export type Status = 'planned' | 'in_progress' | 'at_risk' | 'blocked' | 'done' | 'cancelled';
 
-interface Initiative {
+export interface Initiative {
   id: string;
   workspace_id: string;
   parent_initiative_id: string | null;
@@ -726,7 +726,7 @@ function ModalShell({
   );
 }
 
-function CreateModal({
+export function CreateModal({
   parentId,
   allInitiatives,
   onClose,
@@ -840,7 +840,7 @@ type Complexity = 'S' | 'M' | 'L' | 'XL';
  * stays reachable when the form scrolls. All save semantics are preserved
  * from the previous modal.
  */
-function EditDrawer({
+export function EditDrawer({
   initiative,
   onClose,
   onSaved,
@@ -1198,7 +1198,7 @@ function FormSection({ heading, children }: { heading: string; children: React.R
   );
 }
 
-function MoveModal({
+export function MoveModal({
   initiative,
   allInitiatives,
   onClose,
@@ -1283,7 +1283,7 @@ function MoveModal({
   );
 }
 
-function ConvertModal({
+export function ConvertModal({
   initiative,
   onClose,
   onSaved,
@@ -1445,7 +1445,7 @@ function PromoteModal({
  * Standalone "Add dependency" modal — fired from the action menu, since the
  * inline DetailsPanel only appears when the row is expanded.
  */
-function AddDependencyModal({
+export function AddDependencyModal({
   initiative,
   allInitiatives,
   onClose,
@@ -1525,7 +1525,7 @@ function AddDependencyModal({
  * Read-only history drawer launched from the action menu. Reuses the
  * Drawer shell so it matches the edit affordance shape.
  */
-function HistoryDrawer({
+export function HistoryDrawer({
   initiative,
   allInitiatives,
   onClose,

--- a/src/app/api/agents/[id]/reset/route.ts
+++ b/src/app/api/agents/[id]/reset/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { queryOne, run, transaction } from '@/lib/db';
+import { getOpenClawClient } from '@/lib/openclaw/client';
+import { sendChatToAgent } from '@/lib/openclaw/send-chat';
+import { broadcast } from '@/lib/events';
+import { logDebugEvent } from '@/lib/debug-log';
+import type { Agent } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+// POST /api/agents/[id]/reset
+//
+// Reset a single agent's session — the per-agent equivalent of
+// `DELETE /api/openclaw/sessions` (the bulk "Reset all sessions" action in
+// the sidebar). Used by the Agent info modal so the operator can re-init
+// one agent (e.g., after editing its SOUL.md / AGENTS.md / USER.md) without
+// blowing away every session in the workspace.
+//
+// Two phases, mirroring the bulk reset:
+//   1. Wipe this agent's rows in `openclaw_sessions` so MC's session map
+//      stops pointing at the soon-to-be-restarted session.
+//   2. Send `/reset` via chat to the agent's main session, forcing the
+//      gateway to re-init. The agent's next message reloads its persona
+//      files. `/reset` is one of OpenClaw's built-in init commands.
+//
+// Returns: { success, deleted, sent, sessionKey, error?, gateway_error? }
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const agent = queryOne<Agent>('SELECT * FROM agents WHERE id = ?', [id]);
+    if (!agent) {
+      return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
+    }
+    if (!agent.gateway_agent_id) {
+      // Local-only agents have no gateway session to reset — surface a
+      // clear error rather than silently doing nothing.
+      return NextResponse.json(
+        { error: 'Agent has no gateway_agent_id; nothing to reset on the gateway side.' },
+        { status: 400 },
+      );
+    }
+
+    // Phase 1: clear MC's session map for this agent + flip status to
+    // standby so the sidebar doesn't show stale "active" pills until the
+    // gateway re-init lands.
+    let deleted = 0;
+    transaction(() => {
+      const result = run('DELETE FROM openclaw_sessions WHERE agent_id = ?', [agent.id]);
+      deleted = result.changes ?? 0;
+      run('UPDATE agents SET status = ? WHERE id = ?', ['standby', agent.id]);
+    });
+
+    logDebugEvent({
+      type: 'session.end',
+      direction: 'internal',
+      agentId: agent.id,
+      metadata: { reason: 'single_agent_reset', deleted },
+    });
+
+    // Phase 2: ask the gateway to re-init the agent's main session.
+    const client = getOpenClawClient();
+    try {
+      if (!client.isConnected()) await client.connect();
+    } catch (err) {
+      // MC-side already cleared. Operator can fall back to typing `/reset`
+      // in that agent's chat once the gateway is reachable again.
+      return NextResponse.json({
+        success: true,
+        deleted,
+        sent: false,
+        sessionKey: null,
+        gateway_error: (err as Error).message,
+      });
+    }
+
+    const result = await sendChatToAgent({
+      agent,
+      message: '/reset',
+      idempotencyKey: `reset-${agent.id}-${Date.now()}`,
+    });
+
+    broadcast({
+      type: 'agent_completed',
+      payload: {
+        reset: true,
+        agent_id: agent.id,
+        sent: result.sent,
+        deleted,
+      },
+    });
+
+    if (result.sent) {
+      return NextResponse.json({
+        success: true,
+        deleted,
+        sent: true,
+        sessionKey: result.sessionKey,
+      });
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        deleted,
+        sent: false,
+        sessionKey: result.sessionKey,
+        error: result.error?.message ?? result.reason ?? 'send failed',
+      },
+      { status: 502 },
+    );
+  } catch (error) {
+    console.error('Failed to reset agent session:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/AgentModal.tsx
+++ b/src/components/AgentModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { X, Save, Trash2, Lock } from 'lucide-react';
+import { X, Save, Trash2, Lock, RotateCcw } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import type { Agent, AgentStatus } from '@/lib/types';
 import { AgentActivityTab } from '@/components/AgentActivityTab';
@@ -26,6 +26,9 @@ export function AgentModal({ agent, onClose, workspaceId, onAgentCreated }: Agen
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [defaultModel, setDefaultModel] = useState<string>('');
   const [modelsLoading, setModelsLoading] = useState(true);
+  const [isResetting, setIsResetting] = useState(false);
+  // Inline feedback after a reset attempt — null clears the strip.
+  const [resetMsg, setResetMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
 
   const [form, setForm] = useState({
     name: agent?.name || '',
@@ -151,6 +154,48 @@ export function AgentModal({ agent, onClose, workspaceId, onAgentCreated }: Agen
       }
     } catch (error) {
       console.error('Failed to delete agent:', error);
+    }
+  };
+
+  // Reset just this agent's session — the per-agent equivalent of the
+  // sidebar's "Reset all sessions". Hits POST /api/agents/[id]/reset which
+  // clears MC-side session rows and sends `/reset` to the gateway.
+  const handleReset = async () => {
+    if (!agent) return;
+    if (!confirm(`Reset ${agent.name}'s session? The agent will re-init its persona files on the next message.`)) {
+      return;
+    }
+    setIsResetting(true);
+    setResetMsg(null);
+    try {
+      const res = await fetch(`/api/agents/${agent.id}/reset`, { method: 'POST' });
+      const body = await res.json().catch(() => ({}));
+      if (res.ok && body.sent) {
+        setResetMsg({
+          kind: 'ok',
+          text: `Reset sent — gateway re-init in flight (cleared ${body.deleted ?? 0} session row(s)).`,
+        });
+      } else if (res.ok && !body.sent) {
+        // Phase 1 succeeded but gateway send didn't land (offline, no
+        // session, etc.). Surface it so the operator knows MC-side is
+        // clean but they may need to type `/reset` in the chat manually.
+        setResetMsg({
+          kind: 'err',
+          text: `MC-side cleared (${body.deleted ?? 0} row(s)) but gateway didn't ack: ${body.error ?? body.gateway_error ?? 'send failed'}.`,
+        });
+      } else {
+        setResetMsg({
+          kind: 'err',
+          text: body.error ?? `Reset failed (${res.status})`,
+        });
+      }
+    } catch (e) {
+      setResetMsg({
+        kind: 'err',
+        text: e instanceof Error ? e.message : 'Reset failed',
+      });
+    } finally {
+      setIsResetting(false);
     }
   };
 
@@ -368,6 +413,47 @@ export function AgentModal({ agent, onClose, workspaceId, onAgentCreated }: Agen
                   &quot;agent:&lt;gateway_agent_id&gt;:&quot; (or &quot;agent:&lt;name&gt;:&quot; for local agents).
                 </p>
               </div>
+
+              {/*
+                Per-agent session reset. Mirrors the sidebar's "Reset all
+                sessions" action but scoped to this one agent — clears the
+                agent's openclaw_sessions rows and sends `/reset` to the
+                gateway so the agent re-init's its persona files. Gated on
+                an existing agent with a gateway_agent_id, since the route
+                400s for local-only agents.
+              */}
+              {agent?.id && agent.gateway_agent_id && (
+                <div className="pt-2 border-t border-mc-border">
+                  <label className="block text-sm font-medium mb-1">Session</label>
+                  <button
+                    type="button"
+                    onClick={handleReset}
+                    disabled={isResetting}
+                    className="inline-flex items-center gap-2 px-3 py-2 rounded-sm border border-mc-border text-sm hover:bg-mc-bg disabled:opacity-50"
+                  >
+                    <RotateCcw className={`w-4 h-4 ${isResetting ? 'animate-spin' : ''}`} />
+                    {isResetting ? 'Resetting…' : 'Reset session'}
+                  </button>
+                  <p className="text-xs text-mc-text-secondary mt-1">
+                    Clears MC-side session rows for this agent and sends
+                    <code className="mx-1 px-1 rounded bg-mc-bg">/reset</code>
+                    to the gateway. The agent re-init&rsquo;s its persona files
+                    (SOUL.md / AGENTS.md / USER.md) on its next message.
+                  </p>
+                  {resetMsg && (
+                    <p
+                      className={`mt-2 text-xs px-2 py-1.5 rounded border ${
+                        resetMsg.kind === 'ok'
+                          ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300'
+                          : 'bg-red-500/10 border-red-500/30 text-red-300'
+                      }`}
+                      role="status"
+                    >
+                      {resetMsg.text}
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
           )}
 

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -223,7 +223,7 @@ export default function DecomposeWithPmModal({
       aria-label="Decompose initiative with PM"
     >
       <div
-        className="bg-mc-bg-secondary border border-mc-border rounded-lg w-full max-w-3xl max-h-[90vh] flex flex-col text-mc-text"
+        className="bg-mc-bg-secondary border border-mc-border rounded-lg w-full max-w-5xl h-[88vh] flex flex-col text-mc-text"
         onClick={e => e.stopPropagation()}
       >
         <header className="flex items-center justify-between px-5 py-3 border-b border-mc-border">
@@ -241,7 +241,14 @@ export default function DecomposeWithPmModal({
           </button>
         </header>
 
-        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+        {/*
+          Body is a flex column with min-h-0 so the children list (the only
+          flex-1 region inside) can scroll independently. Without min-h-0 a
+          flex child's intrinsic height wins and the inner overflow-y-auto
+          collapses. Impact summary gets its own capped height so a long
+          blurb can't push the children list out of view.
+        */}
+        <div className="flex-1 min-h-0 flex flex-col px-5 py-4 gap-4">
           {err && (
             <div className="p-3 rounded bg-red-500/10 border border-red-500/30 text-red-300 text-sm">
               {err}
@@ -255,13 +262,13 @@ export default function DecomposeWithPmModal({
           ) : (
             <>
               {displayMd && (
-                <div className="text-xs text-mc-text-secondary whitespace-pre-wrap rounded border border-mc-border bg-mc-bg p-3">
+                <div className="shrink-0 max-h-32 overflow-y-auto text-xs text-mc-text-secondary whitespace-pre-wrap rounded border border-mc-border bg-mc-bg p-3">
                   {displayMd}
                 </div>
               )}
 
-              <div>
-                <div className="flex items-center gap-2 mb-2">
+              <div className="flex-1 min-h-0 flex flex-col">
+                <div className="shrink-0 flex items-center gap-2 mb-2">
                   <h3 className="text-sm font-medium text-mc-text">
                     Proposed children ({children.length})
                   </h3>
@@ -276,7 +283,7 @@ export default function DecomposeWithPmModal({
                 {children.length === 0 ? (
                   <p className="text-sm text-mc-text-secondary">No children proposed. Add one manually above or refine below.</p>
                 ) : (
-                  <ul className="space-y-2">
+                  <ul className="flex-1 min-h-0 overflow-y-auto space-y-2 pr-1">
                     {children.map((c, i) => (
                       <li
                         key={i}
@@ -341,7 +348,7 @@ export default function DecomposeWithPmModal({
                           value={c.description ?? ''}
                           onChange={e => updateChild(i, { description: e.target.value })}
                           placeholder="Description (optional)"
-                          className="w-full px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border text-xs h-12"
+                          className="w-full px-2 py-1.5 rounded bg-mc-bg-secondary border border-mc-border text-xs min-h-[80px] resize-y leading-relaxed"
                           aria-label={`Description for child ${i + 1}`}
                         />
                       </li>
@@ -350,7 +357,7 @@ export default function DecomposeWithPmModal({
                 )}
               </div>
 
-              <div className="space-y-2">
+              <div className="shrink-0 space-y-2">
                 <label className="block">
                   <span className="text-xs text-mc-text-secondary">
                     Refine (e.g., &ldquo;skip the marketing step&rdquo;, &ldquo;add a security review child&rdquo;)


### PR DESCRIPTION
## Summary

Three operator-console polish changes:

1. **Decompose-with-PM modal** is now wider (`max-w-3xl` → `max-w-5xl`) and consistently tall (`h-[88vh]`). The proposed-children list has its own scroll region so a long impact summary can't squeeze it, and per-child description textareas grew from `h-12` → `min-h-[80px] resize-y` so each row is actually readable.
2. **Initiative detail page** (`/initiatives/[id]`) gains a visible action toolbar exposing every action that lived in the list-page ⋮ menu: Edit, Move, Convert kind, Add dependency, View history, Detach (conditional), Delete. The list-page modal components were promoted to named exports and reused — no duplication.
3. **Per-agent session reset** in the Agent info modal. New `POST /api/agents/[id]/reset` mirrors the bulk `DELETE /api/openclaw/sessions` flow but scoped to one agent: clears its `openclaw_sessions` rows, flips status to standby, sends `/reset` to the gateway via `sendChatToAgent`. The Info tab grows a Session panel with a Reset session button (gated on existing agent + `gateway_agent_id`), confirmation dialog, spinner, and a tinted status strip.

## Test plan

- [x] `tsc --noEmit` clean for all touched files
- [ ] Decompose a "Smart Snappy"-shaped epic and confirm the modal fills the screen, children list scrolls, and description textareas are readable
- [ ] Open an initiative detail page and exercise each toolbar action: Edit, Move, Convert kind, Add dependency, View history, Detach (on a parented initiative), Delete (confirms and routes back to `/initiatives`)
- [ ] Open an Agent info modal for a gateway-synced agent (e.g. `mc-project-manager`), click Reset session, confirm; expect green status strip and a `/reset` landing in that agent's session
- [ ] Open the Agent info modal for a local-only agent and confirm the Session panel is hidden
- [ ] With OpenClaw stopped, click Reset session; expect MC-side rows cleared but a red "gateway didn't ack" status strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)