### PR TITLE
ux: dedicated /agents page, shell-level SSE, PM markdown + sticky scroll

### DIFF
--- a/src/app/(app)/agents/page.tsx
+++ b/src/app/(app)/agents/page.tsx
@@ -1,0 +1,978 @@
+'use client';
+
+/**
+ * Dedicated Agents page — tabular roster.
+ *
+ * The card-grid version was a clear win over the legacy sidebar but still
+ * hid most agent details behind the edit modal. This pass switches to a
+ * compact sortable table that surfaces the high-frequency knobs (avatar,
+ * role, model) inline so the operator can sweep across the whole team
+ * without opening the modal for each one.
+ *
+ * Inline-editable columns commit on change/blur via PATCH /api/agents/[id]
+ * with optimistic update + rollback. The full settings (description,
+ * SOUL.md / USER.md / AGENTS.md, session_key_prefix, master flag, etc.)
+ * still live in AgentModal — clicking the agent's name opens it.
+ */
+
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import {
+  Loader2,
+  Megaphone,
+  RotateCcw,
+  Plus,
+  Search,
+  Power,
+  Pencil,
+  Zap,
+  ZapOff,
+  Users,
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
+} from 'lucide-react';
+import { useMissionControl } from '@/lib/store';
+import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
+import type { Agent, AgentStatus, AgentHealthState, OpenClawSession } from '@/lib/types';
+import { AgentModal } from '@/components/AgentModal';
+import { DiscoverAgentsModal } from '@/components/DiscoverAgentsModal';
+import { HealthIndicator } from '@/components/HealthIndicator';
+import { AgentPingIndicator } from '@/components/AgentPingIndicator';
+import { RollCallResultsPanel, type RollCallResultView } from '@/components/AgentsSidebar';
+
+type FilterTab = 'all' | 'working' | 'standby';
+
+// Sortable columns. The action column is intentionally not sortable.
+type SortKey = 'name' | 'role' | 'model' | 'status' | 'gateway';
+interface SortState { key: SortKey; dir: 'asc' | 'desc' }
+
+const EMOJI_OPTIONS = ['🤖', '🦞', '💻', '🔍', '✍️', '🎨', '📊', '🧠', '⚡', '🚀', '🎯', '🔧'];
+
+export default function AgentsPage() {
+  const { agents, setAgents, agentOpenClawSessions, setAgentOpenClawSession, updateAgent, agentPings, setAgentPings } =
+    useMissionControl();
+  const workspaceId = useCurrentWorkspaceId();
+
+  // Hydrate the agents store directly. Other plan pages (workspace,
+  // initiatives, pm) hydrate via their own fetches; /agents previously
+  // relied on a sibling page having populated the shared store first, so
+  // a direct visit / hard reload showed an empty roster.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/agents?workspace_id=${encodeURIComponent(workspaceId)}`);
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as Agent[];
+        if (!cancelled) setAgents(data);
+      } catch {
+        /* leave roster empty — UI shows the empty-state */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, setAgents]);
+
+  const [filter, setFilter] = useState<FilterTab>('all');
+  const [sort, setSort] = useState<SortState>({ key: 'name', dir: 'asc' });
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [editingAgent, setEditingAgent] = useState<Agent | null>(null);
+  const [showDiscoverModal, setShowDiscoverModal] = useState(false);
+  const [connectingAgentId, setConnectingAgentId] = useState<string | null>(null);
+  const [activeSubAgents, setActiveSubAgents] = useState(0);
+  const [agentHealth, setAgentHealth] = useState<Record<string, AgentHealthState>>({});
+  const [togglingAgentId, setTogglingAgentId] = useState<string | null>(null);
+  const [resettingAgentId, setResettingAgentId] = useState<string | null>(null);
+  const [rollCallBusy, setRollCallBusy] = useState(false);
+  const [rollCallResult, setRollCallResult] = useState<RollCallResultView | null>(null);
+  const [resetSessionsBusy, setResetSessionsBusy] = useState(false);
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [defaultModel, setDefaultModel] = useState<string>('');
+  const [emojiPickerFor, setEmojiPickerFor] = useState<string | null>(null);
+
+  // ─── data hydration ─────────────────────────────────────────────────
+
+  const loadOpenClawSessions = useCallback(async () => {
+    for (const agent of agents) {
+      try {
+        const res = await fetch(`/api/agents/${agent.id}/openclaw`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data.linked && data.session) {
+            setAgentOpenClawSession(agent.id, data.session as OpenClawSession);
+          }
+        }
+      } catch (error) {
+        console.error(`Failed to load OpenClaw session for ${agent.name}:`, error);
+      }
+    }
+  }, [agents, setAgentOpenClawSession]);
+
+  useEffect(() => {
+    if (agents.length > 0) loadOpenClawSessions();
+  }, [loadOpenClawSessions, agents.length]);
+
+  useEffect(() => {
+    const tick = async () => {
+      try {
+        const res = await fetch('/api/openclaw/sessions?session_type=subagent&status=active');
+        if (res.ok) {
+          const sessions = await res.json();
+          setActiveSubAgents(sessions.length);
+        }
+      } catch {}
+    };
+    tick();
+    const id = setInterval(tick, 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const tick = async () => {
+      try {
+        const res = await fetch('/api/agents/health');
+        if (res.ok) {
+          const data = await res.json();
+          const healthMap: Record<string, AgentHealthState> = {};
+          for (const h of data) healthMap[h.agent_id] = h.health_state;
+          setAgentHealth(healthMap);
+        }
+      } catch {}
+    };
+    tick();
+    const id = setInterval(tick, 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/agents/activity');
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as Record<string, { sentAt?: string; receivedAt?: string }>;
+        setAgentPings(data);
+      } catch {}
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [setAgentPings]);
+
+  // Models list for the inline dropdown — fetched once on mount, same as
+  // AgentModal does. The "(Default)" suffix is shown in the option label so
+  // the operator can tell which entry will be picked when model is left blank.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/openclaw/models');
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        setAvailableModels(data.availableModels || []);
+        setDefaultModel(data.defaultModel || '');
+      } catch {}
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Roll-call status polling while the panel is open.
+  useEffect(() => {
+    if (!rollCallResult?.rollcall_id) return;
+    const rid = rollCallResult.rollcall_id;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/agents/rollcall/${rid}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        setRollCallResult(prev =>
+          prev && prev.rollcall_id === rid
+            ? { ...prev, entries: data.entries, seconds_remaining: data.summary.seconds_remaining }
+            : prev,
+        );
+      } catch {}
+    };
+    tick();
+    const interval = setInterval(tick, 2_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [rollCallResult?.rollcall_id]);
+
+  // ─── header actions ─────────────────────────────────────────────────
+
+  const runRollCall = async () => {
+    setRollCallBusy(true);
+    setRollCallResult(null);
+    try {
+      const res = await fetch('/api/agents/rollcall', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ workspace_id: workspaceId, mode: 'direct', timeout_seconds: 30 }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setRollCallResult({
+          rollcall_id: '',
+          mode: 'direct',
+          seconds_remaining: 0,
+          entries: [],
+          error: data.error,
+          reason: data.reason,
+        });
+        return;
+      }
+      setRollCallResult({
+        rollcall_id: data.rollcall_id,
+        mode: data.rollcall.mode,
+        seconds_remaining: 30,
+        entries: data.entries,
+      });
+    } catch (err) {
+      setRollCallResult({
+        rollcall_id: '',
+        mode: 'direct',
+        seconds_remaining: 0,
+        entries: [],
+        error: (err as Error).message,
+      });
+    } finally {
+      setRollCallBusy(false);
+    }
+  };
+
+  const resetAllSessions = async () => {
+    if (
+      !confirm(
+        'Reset ALL agent sessions?\n\n' +
+          '  1. Aborts in-flight Product Autopilot research/ideation cycles.\n' +
+          '  2. Wipes Mission Control session tracking.\n' +
+          '  3. Sends `/reset` to every active gateway-synced agent.\n\n' +
+          'Use after editing persona files or when sessionKey routing has drifted.',
+      )
+    )
+      return;
+    setResetSessionsBusy(true);
+    try {
+      const res = await fetch('/api/openclaw/sessions', { method: 'DELETE' });
+      const data = await res.json();
+      if (!res.ok) {
+        alert(data.error || 'Failed to reset sessions');
+        return;
+      }
+      for (const agent of agents) setAgentOpenClawSession(agent.id, null);
+      const resets: Array<{ name: string; ok: boolean; error?: string }> = data.agents_reset || [];
+      const ok = resets.filter(r => r.ok).map(r => r.name);
+      const failed = resets.filter(r => !r.ok);
+      const aborted: Array<{ cycle_id: string; cycle_type: string }> = data.aborted_cycles || [];
+      const lines: string[] = [`Cleared ${data.deleted} MC session record(s).`];
+      if (aborted.length) lines.push(`Aborted ${aborted.length} in-flight autopilot cycle(s).`);
+      if (ok.length) lines.push(`Sent /reset to: ${ok.join(', ')}`);
+      if (failed.length) {
+        lines.push(`Failed to /reset: ${failed.map(f => `${f.name} (${f.error || 'unknown'})`).join('; ')}`);
+        lines.push("Fall back: run `/reset` in those agents' OpenClaw chats directly.");
+      }
+      if (data.gateway_error) lines.push(`Gateway unreachable: ${data.gateway_error}`);
+      alert(lines.join('\n'));
+    } catch (err) {
+      alert(`Failed to reset sessions: ${(err as Error).message}`);
+    } finally {
+      setResetSessionsBusy(false);
+    }
+  };
+
+  // ─── per-agent actions ──────────────────────────────────────────────
+
+  // Generic optimistic-update PATCH used by the inline avatar / role /
+  // model edits. Centralising it keeps each cell-level handler small and
+  // ensures the rollback path is uniform.
+  const patchAgent = useCallback(
+    async (agent: Agent, patch: Partial<Agent>): Promise<boolean> => {
+      const optimistic: Agent = { ...agent, ...patch };
+      updateAgent(optimistic);
+      try {
+        const res = await fetch(`/api/agents/${agent.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(patch),
+        });
+        if (!res.ok) {
+          updateAgent(agent);
+          const err = await res.json().catch(() => ({}));
+          alert(err.error || 'Failed to update agent');
+          return false;
+        }
+        const fresh = (await res.json()) as Agent;
+        updateAgent(fresh);
+        return true;
+      } catch (err) {
+        updateAgent(agent);
+        alert(`Failed to update agent: ${(err as Error).message}`);
+        return false;
+      }
+    },
+    [updateAgent],
+  );
+
+  const toggleAgentActive = async (agent: Agent) => {
+    const nextActive = !(Number(agent.is_active ?? 1) === 1);
+    setTogglingAgentId(agent.id);
+    await patchAgent(agent, { is_active: nextActive ? 1 : 0 });
+    setTogglingAgentId(null);
+  };
+
+  const resetAgentSession = async (agent: Agent) => {
+    if (!agent.gateway_agent_id) {
+      alert('This agent has no gateway_agent_id; nothing to reset on the gateway side.');
+      return;
+    }
+    if (!confirm(`Reset ${agent.name}'s session? The agent will re-init persona files on its next message.`)) return;
+    setResettingAgentId(agent.id);
+    try {
+      const res = await fetch(`/api/agents/${agent.id}/reset`, { method: 'POST' });
+      const body = await res.json().catch(() => ({}));
+      if (res.ok && body.sent) {
+        alert(`Reset sent — gateway re-init in flight (cleared ${body.deleted ?? 0} session row(s)).`);
+      } else if (res.ok && !body.sent) {
+        alert(
+          `MC-side cleared (${body.deleted ?? 0} row(s)) but gateway didn't ack: ${body.error ?? body.gateway_error ?? 'send failed'}.`,
+        );
+      } else {
+        alert(body.error || `Reset failed (${res.status})`);
+      }
+    } catch (err) {
+      alert((err as Error).message || 'Reset failed');
+    } finally {
+      setResettingAgentId(null);
+    }
+  };
+
+  const handleConnectToOpenClaw = async (agent: Agent) => {
+    setConnectingAgentId(agent.id);
+    try {
+      const existingSession = agentOpenClawSessions[agent.id];
+      if (existingSession) {
+        const res = await fetch(`/api/agents/${agent.id}/openclaw`, { method: 'DELETE' });
+        if (res.ok) setAgentOpenClawSession(agent.id, null);
+      } else {
+        const res = await fetch(`/api/agents/${agent.id}/openclaw`, { method: 'POST' });
+        if (res.ok) {
+          const data = await res.json();
+          setAgentOpenClawSession(agent.id, data.session as OpenClawSession);
+        } else {
+          const error = await res.json();
+          alert(`Failed to connect: ${error.error || 'Unknown error'}`);
+        }
+      }
+    } catch (error) {
+      console.error('OpenClaw connection error:', error);
+    } finally {
+      setConnectingAgentId(null);
+    }
+  };
+
+  // ─── derived ────────────────────────────────────────────────────────
+
+  const filteredAgents = useMemo(() => {
+    const matching = agents.filter(a => filter === 'all' || a.status === filter);
+    const byKey = (a: Agent): string => {
+      switch (sort.key) {
+        case 'name': return a.name.toLowerCase();
+        case 'role': return (a.role || '').toLowerCase();
+        case 'model': return (a.model || '').toLowerCase();
+        case 'status': return a.status;
+        case 'gateway': return (a.gateway_agent_id || '').toLowerCase();
+      }
+    };
+    const sorted = [...matching].sort((a, b) => {
+      const av = byKey(a);
+      const bv = byKey(b);
+      if (av < bv) return sort.dir === 'asc' ? -1 : 1;
+      if (av > bv) return sort.dir === 'asc' ? 1 : -1;
+      return 0;
+    });
+    return sorted;
+  }, [agents, filter, sort]);
+
+  const counts = useMemo(
+    () => ({
+      all: agents.length,
+      working: agents.filter(a => a.status === 'working').length,
+      standby: agents.filter(a => a.status === 'standby').length,
+    }),
+    [agents],
+  );
+
+  const toggleSort = (key: SortKey) =>
+    setSort(prev => ({
+      key,
+      dir: prev.key === key && prev.dir === 'asc' ? 'desc' : 'asc',
+    }));
+
+  return (
+    <div className="min-h-full bg-mc-bg p-6">
+      <div className="max-w-[1600px] mx-auto">
+        {/* Header */}
+        <header className="mb-5 flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-3">
+            <Users className="w-6 h-6 text-mc-accent" />
+            <div>
+              <h1 className="text-2xl font-bold text-mc-text">Agents</h1>
+              <p className="text-sm text-mc-text-secondary">
+                Workspace roster, OpenClaw connectivity, and session controls.
+              </p>
+            </div>
+            <span className="ml-2 px-2 py-0.5 rounded bg-mc-bg-secondary border border-mc-border text-xs text-mc-text-secondary">
+              {agents.length} total
+            </span>
+            {activeSubAgents > 0 && (
+              <span className="px-2 py-0.5 rounded bg-green-500/10 border border-green-500/30 text-xs text-green-400">
+                ● {activeSubAgents} sub-agent{activeSubAgents === 1 ? '' : 's'} active
+              </span>
+            )}
+          </div>
+
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            <HeaderButton
+              icon={rollCallBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Megaphone className="w-4 h-4" />}
+              onClick={runRollCall}
+              disabled={rollCallBusy}
+              tone="purple"
+            >
+              {rollCallBusy ? 'Calling…' : 'Roll Call'}
+            </HeaderButton>
+            <HeaderButton
+              icon={resetSessionsBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <RotateCcw className="w-4 h-4" />}
+              onClick={resetAllSessions}
+              disabled={resetSessionsBusy}
+              tone="amber"
+            >
+              {resetSessionsBusy ? 'Resetting…' : 'Reset all sessions'}
+            </HeaderButton>
+            <HeaderButton
+              icon={<Search className="w-4 h-4" />}
+              onClick={() => setShowDiscoverModal(true)}
+              tone="blue"
+            >
+              Import from Gateway
+            </HeaderButton>
+            <HeaderButton
+              icon={<Plus className="w-4 h-4" />}
+              onClick={() => setShowCreateModal(true)}
+              tone="accent"
+            >
+              Add Agent
+            </HeaderButton>
+          </div>
+        </header>
+
+        {/* Filter tabs */}
+        <div className="mb-4 flex items-center gap-2">
+          {(['all', 'working', 'standby'] as FilterTab[]).map(tab => (
+            <button
+              key={tab}
+              onClick={() => setFilter(tab)}
+              className={`px-3 py-1.5 rounded text-xs uppercase tracking-wide transition-colors ${
+                filter === tab
+                  ? 'bg-mc-accent text-mc-bg font-medium'
+                  : 'bg-mc-bg-secondary border border-mc-border text-mc-text-secondary hover:text-mc-text'
+              }`}
+            >
+              {tab} <span className="opacity-70">({counts[tab]})</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Roll-call results */}
+        {rollCallResult && (
+          <div className="mb-4 rounded-lg border border-mc-border bg-mc-bg-secondary overflow-hidden">
+            <RollCallResultsPanel result={rollCallResult} onClose={() => setRollCallResult(null)} />
+          </div>
+        )}
+
+        {/* Table */}
+        {filteredAgents.length === 0 ? (
+          <div className="p-10 rounded-lg border border-dashed border-mc-border bg-mc-bg-secondary text-center text-mc-text-secondary">
+            No agents match this filter.
+          </div>
+        ) : (
+          <div className="rounded-lg border border-mc-border bg-mc-bg-secondary overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-mc-bg/50 border-b border-mc-border">
+                  <tr className="text-left text-xs uppercase tracking-wide text-mc-text-secondary">
+                    <Th width="w-12" />
+                    <Th onSort={() => toggleSort('name')} sortDir={sort.key === 'name' ? sort.dir : null}>Name</Th>
+                    <Th onSort={() => toggleSort('role')} sortDir={sort.key === 'role' ? sort.dir : null}>Role</Th>
+                    <Th onSort={() => toggleSort('model')} sortDir={sort.key === 'model' ? sort.dir : null}>Model</Th>
+                    <Th onSort={() => toggleSort('gateway')} sortDir={sort.key === 'gateway' ? sort.dir : null}>Gateway</Th>
+                    <Th onSort={() => toggleSort('status')} sortDir={sort.key === 'status' ? sort.dir : null}>Status</Th>
+                    <Th>Activity</Th>
+                    <Th>Health</Th>
+                    <Th>Actions</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredAgents.map(agent => (
+                    <AgentRow
+                      key={agent.id}
+                      agent={agent}
+                      openclawSession={agentOpenClawSessions[agent.id]}
+                      ping={agentPings[agent.id]}
+                      health={agentHealth[agent.id]}
+                      isConnecting={connectingAgentId === agent.id}
+                      isToggling={togglingAgentId === agent.id}
+                      isResetting={resettingAgentId === agent.id}
+                      availableModels={availableModels}
+                      defaultModel={defaultModel}
+                      emojiPickerOpen={emojiPickerFor === agent.id}
+                      onOpenEmojiPicker={open => setEmojiPickerFor(open ? agent.id : null)}
+                      onPatchField={patch => patchAgent(agent, patch)}
+                      onEdit={() => setEditingAgent(agent)}
+                      onTogglePower={() => toggleAgentActive(agent)}
+                      onResetSession={() => resetAgentSession(agent)}
+                      onToggleOpenClaw={() => handleConnectToOpenClaw(agent)}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {showCreateModal && <AgentModal onClose={() => setShowCreateModal(false)} workspaceId={workspaceId} />}
+      {editingAgent && (
+        <AgentModal agent={editingAgent} onClose={() => setEditingAgent(null)} workspaceId={workspaceId} />
+      )}
+      {showDiscoverModal && (
+        <DiscoverAgentsModal onClose={() => setShowDiscoverModal(false)} workspaceId={workspaceId} />
+      )}
+    </div>
+  );
+}
+
+// ─── building blocks ──────────────────────────────────────────────────
+
+function HeaderButton({
+  icon,
+  onClick,
+  disabled,
+  children,
+  tone,
+}: {
+  icon: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+  tone: 'purple' | 'amber' | 'blue' | 'accent';
+}) {
+  const palettes = {
+    purple: 'border-purple-500/30 text-purple-300 hover:bg-purple-500/10',
+    amber: 'border-amber-500/30 text-amber-300 hover:bg-amber-500/10',
+    blue: 'border-blue-500/30 text-blue-300 hover:bg-blue-500/10',
+    accent: 'border-mc-accent/40 text-mc-accent hover:bg-mc-accent/10',
+  } as const;
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${palettes[tone]}`}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
+function Th({
+  children,
+  onSort,
+  sortDir,
+  width,
+}: {
+  children?: React.ReactNode;
+  onSort?: () => void;
+  sortDir?: 'asc' | 'desc' | null;
+  width?: string;
+}) {
+  if (!onSort) {
+    return <th className={`px-3 py-2 font-medium ${width ?? ''}`}>{children}</th>;
+  }
+  return (
+    <th className={`px-3 py-2 font-medium ${width ?? ''}`}>
+      <button
+        type="button"
+        onClick={onSort}
+        className="inline-flex items-center gap-1 hover:text-mc-text"
+      >
+        {children}
+        {sortDir === 'asc' ? (
+          <ChevronUp className="w-3 h-3" />
+        ) : sortDir === 'desc' ? (
+          <ChevronDown className="w-3 h-3" />
+        ) : (
+          <ChevronsUpDown className="w-3 h-3 opacity-40" />
+        )}
+      </button>
+    </th>
+  );
+}
+
+interface AgentRowProps {
+  agent: Agent;
+  openclawSession: OpenClawSession | null | undefined;
+  ping: { sentAt?: string; receivedAt?: string } | undefined;
+  health: AgentHealthState | undefined;
+  isConnecting: boolean;
+  isToggling: boolean;
+  isResetting: boolean;
+  availableModels: string[];
+  defaultModel: string;
+  emojiPickerOpen: boolean;
+  onOpenEmojiPicker: (open: boolean) => void;
+  onPatchField: (patch: Partial<Agent>) => Promise<boolean>;
+  onEdit: () => void;
+  onTogglePower: () => void;
+  onResetSession: () => void;
+  onToggleOpenClaw: () => void;
+}
+
+function AgentRow({
+  agent,
+  openclawSession,
+  ping,
+  health,
+  isConnecting,
+  isToggling,
+  isResetting,
+  availableModels,
+  defaultModel,
+  emojiPickerOpen,
+  onOpenEmojiPicker,
+  onPatchField,
+  onEdit,
+  onTogglePower,
+  onResetSession,
+  onToggleOpenClaw,
+}: AgentRowProps) {
+  const isActive = Number(agent.is_active ?? 1) === 1;
+  const isGatewaySynced = agent.source === 'gateway';
+
+  return (
+    <tr
+      className={`border-b border-mc-border last:border-0 ${
+        isActive ? 'hover:bg-mc-bg/30' : 'opacity-60 hover:bg-mc-bg/20'
+      }`}
+    >
+      {/* Avatar with emoji picker */}
+      <td className="px-3 py-2">
+        <EmojiCell
+          emoji={agent.avatar_emoji}
+          openclawConnected={!!openclawSession}
+          isMaster={!!agent.is_master}
+          open={emojiPickerOpen}
+          onOpen={onOpenEmojiPicker}
+          onPick={emoji => {
+            onOpenEmojiPicker(false);
+            if (emoji !== agent.avatar_emoji) onPatchField({ avatar_emoji: emoji });
+          }}
+        />
+      </td>
+
+      {/* Name (clicks open the full edit modal) */}
+      <td className="px-3 py-2">
+        <button
+          type="button"
+          onClick={onEdit}
+          className="text-left group"
+          title="Open full editor"
+        >
+          <div className="flex items-center gap-1.5">
+            <span className="font-medium text-mc-text group-hover:text-mc-accent">{agent.name}</span>
+            {!isActive && (
+              <span className="text-[10px] px-1 py-0 bg-amber-500/20 text-amber-400 rounded uppercase tracking-wider">
+                paused
+              </span>
+            )}
+          </div>
+          {agent.description && (
+            <div className="text-xs text-mc-text-secondary line-clamp-1 max-w-[24ch]" title={agent.description}>
+              {agent.description}
+            </div>
+          )}
+        </button>
+      </td>
+
+      {/* Role — inline editable text. Free-text in the DB so we don't
+          constrain to a select. Commits on blur or Enter. */}
+      <td className="px-3 py-2">
+        <InlineTextField
+          value={agent.role}
+          disabled={isGatewaySynced}
+          disabledTitle="Role is synced from the gateway"
+          onCommit={next => {
+            if (next.trim() && next !== agent.role) onPatchField({ role: next.trim() });
+          }}
+          className="w-32"
+        />
+      </td>
+
+      {/* Model — inline dropdown */}
+      <td className="px-3 py-2">
+        <select
+          value={agent.model || ''}
+          onChange={e => onPatchField({ model: e.target.value })}
+          className="bg-mc-bg border border-mc-border rounded px-2 py-1 text-xs text-mc-text focus:outline-none focus:border-mc-accent w-44"
+        >
+          <option value="">— default{defaultModel ? ` (${defaultModel})` : ''} —</option>
+          {availableModels.map(m => (
+            <option key={m} value={m}>
+              {m}
+              {defaultModel === m ? ' (default)' : ''}
+            </option>
+          ))}
+        </select>
+      </td>
+
+      {/* Gateway badge */}
+      <td className="px-3 py-2">
+        {agent.gateway_agent_id ? (
+          <span
+            className="inline-flex items-center gap-1 text-xs font-mono text-mc-text-secondary"
+            title="gateway_agent_id"
+          >
+            <span className="text-[10px] px-1 py-0 bg-blue-500/20 text-blue-400 rounded">GW</span>
+            <span className="truncate max-w-[20ch]">{agent.gateway_agent_id}</span>
+          </span>
+        ) : (
+          <span className="text-xs text-mc-text-secondary/60">local</span>
+        )}
+      </td>
+
+      {/* Status pill */}
+      <td className="px-3 py-2">
+        <span className={`text-[10px] px-2 py-0.5 rounded uppercase tracking-wide ${getStatusBadge(agent.status)}`}>
+          {agent.status}
+        </span>
+      </td>
+
+      {/* Activity ping */}
+      <td className="px-3 py-2">
+        <AgentPingIndicator sentAt={ping?.sentAt} receivedAt={ping?.receivedAt} />
+      </td>
+
+      {/* Health */}
+      <td className="px-3 py-2">
+        {health && health !== 'idle' ? (
+          <HealthIndicator state={health} size="sm" />
+        ) : (
+          <span className="text-xs text-mc-text-secondary/40">—</span>
+        )}
+      </td>
+
+      {/* Actions */}
+      <td className="px-3 py-2">
+        <div className="flex items-center gap-1">
+          <IconButton
+            icon={<Power className={`w-3.5 h-3.5 ${isActive ? '' : 'text-amber-400'}`} />}
+            onClick={onTogglePower}
+            disabled={isToggling}
+            title={isActive ? 'Pause (excludes from routing + roll-call)' : 'Activate'}
+          />
+          {agent.gateway_agent_id && (
+            <IconButton
+              icon={
+                isResetting ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <RotateCcw className="w-3.5 h-3.5" />
+                )
+              }
+              onClick={onResetSession}
+              disabled={isResetting}
+              title="Reset session — clears MC rows + sends /reset to the gateway"
+            />
+          )}
+          <IconButton icon={<Pencil className="w-3.5 h-3.5" />} onClick={onEdit} title="Edit (full settings)" />
+          {!!agent.is_master && (
+            <button
+              onClick={onToggleOpenClaw}
+              disabled={isConnecting}
+              title={openclawSession ? 'OpenClaw connected' : 'Connect to OpenClaw'}
+              className={`inline-flex items-center gap-1 px-2 py-1.5 rounded text-[10px] border transition-colors ${
+                openclawSession
+                  ? 'bg-green-500/15 border-green-500/30 text-green-400 hover:bg-green-500/25'
+                  : 'border-mc-border text-mc-text-secondary hover:text-mc-text hover:border-mc-accent/40'
+              }`}
+            >
+              {isConnecting ? (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              ) : openclawSession ? (
+                <Zap className="w-3 h-3" />
+              ) : (
+                <ZapOff className="w-3 h-3" />
+              )}
+              <span className="hidden xl:inline">{openclawSession ? 'OpenClaw' : 'Connect'}</span>
+            </button>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function IconButton({
+  icon,
+  onClick,
+  disabled,
+  title,
+}: {
+  icon: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  title?: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      className="p-1.5 rounded border border-mc-border text-mc-text-secondary hover:text-mc-text hover:border-mc-accent/40 disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {icon}
+    </button>
+  );
+}
+
+/**
+ * Avatar cell with click-to-pick emoji popover. The popover anchors to the
+ * cell's position; closes on outside click or Escape. Master ★ + OpenClaw
+ * connected dot are decorations on top of the avatar.
+ */
+function EmojiCell({
+  emoji,
+  openclawConnected,
+  isMaster,
+  open,
+  onOpen,
+  onPick,
+}: {
+  emoji: string;
+  openclawConnected: boolean;
+  isMaster: boolean;
+  open: boolean;
+  onOpen: (open: boolean) => void;
+  onPick: (emoji: string) => void;
+}) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) onOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDoc);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open, onOpen]);
+
+  return (
+    <div ref={wrapRef} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => onOpen(!open)}
+        className="text-2xl relative hover:scale-105 transition-transform"
+        title="Change avatar"
+      >
+        <span>{emoji}</span>
+        {openclawConnected && (
+          <span className="absolute -bottom-1 -right-1 w-2.5 h-2.5 bg-green-500 rounded-full border-2 border-mc-bg-secondary" />
+        )}
+        {isMaster && <span className="absolute -top-1 -right-1 text-[10px] text-mc-accent-yellow">★</span>}
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full mt-1 z-30 p-2 rounded-lg border border-mc-border bg-mc-bg shadow-lg flex flex-wrap gap-1 w-44">
+          {EMOJI_OPTIONS.map(opt => (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => onPick(opt)}
+              className={`w-8 h-8 text-xl rounded hover:bg-mc-bg-tertiary ${
+                opt === emoji ? 'bg-mc-accent/15 ring-1 ring-mc-accent' : ''
+              }`}
+              title={opt}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Inline editable text field. Commits on blur or Enter; reverts on Escape.
+ * Used for the role column where the DB column is free-text but we don't
+ * want a full-blown form for what is usually a one-word change.
+ */
+function InlineTextField({
+  value,
+  disabled,
+  disabledTitle,
+  onCommit,
+  className,
+}: {
+  value: string;
+  disabled?: boolean;
+  disabledTitle?: string;
+  onCommit: (next: string) => void;
+  className?: string;
+}) {
+  const [draft, setDraft] = useState(value);
+  // Re-sync when the upstream value changes (e.g., another tab updated it).
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+  return (
+    <input
+      type="text"
+      value={draft}
+      onChange={e => setDraft(e.target.value)}
+      onBlur={() => {
+        if (draft !== value) onCommit(draft);
+      }}
+      onKeyDown={e => {
+        if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur();
+        if (e.key === 'Escape') {
+          setDraft(value);
+          (e.currentTarget as HTMLInputElement).blur();
+        }
+      }}
+      disabled={disabled}
+      title={disabled ? disabledTitle : undefined}
+      className={`bg-mc-bg border border-mc-border rounded px-2 py-1 text-xs text-mc-text focus:outline-none focus:border-mc-accent disabled:opacity-50 disabled:cursor-not-allowed ${className ?? ''}`}
+    />
+  );
+}
+
+function getStatusBadge(status: AgentStatus): string {
+  const styles: Record<string, string> = {
+    standby: 'status-standby',
+    working: 'status-working',
+    offline: 'status-offline',
+  };
+  return styles[status] || styles.standby;
+}

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -13,7 +13,9 @@
 
 import { useEffect, useState, useCallback, useMemo, useRef, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox, Sunrise, Pin } from 'lucide-react';
+import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox, Sunrise, Pin, ArrowDown } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import {
   useCurrentWorkspaceId,
   useSetCurrentWorkspaceId,
@@ -127,6 +129,13 @@ function PmChatPageInner() {
   const [standupBanner, setStandupBanner] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const cardRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+  // Sticky-bottom: only auto-scroll if the user is already near the
+  // bottom. The page polls /api/agents/<pm>/chat every 3s — without this
+  // gate the auto-scroll yanked the operator back every poll, even when
+  // they were trying to read older proposals. We refresh the flag on
+  // scroll events using a "within 80px of bottom" threshold so a small
+  // accidental nudge doesn't break stickiness.
+  const [stuckToBottom, setStuckToBottom] = useState(true);
 
   // Phase 6: support `?proposal=<id>` deep-links — scroll to and highlight
   // the matching proposal card on load. Cleared after first successful
@@ -226,11 +235,28 @@ function PmChatPageInner() {
     return () => clearInterval(id);
   }, [pmAgent, loadMessages, loadRecent]);
 
+  // Auto-scroll only when the operator is already at the bottom. This
+  // depends on `messages` AND the latest stuckToBottom value — including
+  // stuckToBottom in the deps list would re-scroll the moment they touch
+  // the bottom again, which is the desired behaviour.
   useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, [messages]);
+    if (!stuckToBottom) return;
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages, stuckToBottom]);
+
+  const onScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const distanceFromBottom = el.scrollHeight - (el.scrollTop + el.clientHeight);
+    setStuckToBottom(distanceFromBottom < 80);
+  }, []);
+
+  const jumpToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    setStuckToBottom(true);
+  }, []);
 
   const handleSend = async () => {
     if (!input.trim() || sending) return;
@@ -250,6 +276,9 @@ function PmChatPageInner() {
         throw new Error(data.error || `Failed to dispatch (${res.status})`);
       }
       setInput('');
+      // The operator just dispatched — they want to see the result. Re-stick
+      // to the bottom even if they had been scrolled up reading old cards.
+      setStuckToBottom(true);
       await loadMessages();
       await loadRecent();
     } catch (err) {
@@ -426,7 +455,12 @@ function PmChatPageInner() {
               highlighted={highlightedProposalId === pinnedStandup.id}
             />
           )}
-          <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-3">
+          <div className="relative flex-1 min-h-0">
+            <div
+              ref={scrollRef}
+              onScroll={onScroll}
+              className="absolute inset-0 overflow-y-auto p-4 space-y-3"
+            >
             {messages.length === 0 && pmAgent && (
               <div className="text-center py-12 text-mc-text-secondary">
                 <Inbox className="w-8 h-8 mx-auto mb-3 opacity-50" />
@@ -463,6 +497,22 @@ function PmChatPageInner() {
                 />
               );
             })}
+            </div>
+            {/* Floating "jump to bottom" — only when the user has scrolled
+                up enough that auto-stick is disabled. New messages land
+                while they're scrolled up; this gives them a one-click way
+                to catch up without losing their reading position by
+                accident. */}
+            {!stuckToBottom && (
+              <button
+                type="button"
+                onClick={jumpToBottom}
+                className="absolute bottom-3 right-4 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-mc-accent text-mc-bg text-xs font-medium shadow-lg hover:bg-mc-accent/90"
+                title="Jump to latest"
+              >
+                <ArrowDown className="w-3.5 h-3.5" /> Jump to latest
+              </button>
+            )}
           </div>
 
           <div className="border-t border-mc-border p-3 space-y-2 shrink-0">
@@ -588,7 +638,7 @@ function ChatMessageRow({
           <div className="text-xs font-medium text-mc-text-secondary mb-1">
             {isUser ? 'You' : 'PM'}
           </div>
-          <div className="text-sm whitespace-pre-wrap">{message.content}</div>
+          <ChatMarkdown content={message.content} />
         </div>
       </div>
     );
@@ -619,8 +669,8 @@ function ChatMessageRow({
             {proposal.status}
           </span>
         </div>
-        <div className="p-3 text-sm whitespace-pre-wrap">
-          {message.content}
+        <div className="p-3">
+          <ChatMarkdown content={message.content} />
         </div>
         {proposal.proposed_changes.length > 0 && (
           <div className="px-3 pb-3 space-y-1 text-xs text-mc-text-secondary">
@@ -769,7 +819,9 @@ function PinnedStandupCard({
         </span>
         <span className="ml-auto text-[11px] text-mc-text-secondary/80">{created}</span>
       </div>
-      <div className="p-3 text-sm whitespace-pre-wrap">{proposal.impact_md}</div>
+      <div className="p-3">
+        <ChatMarkdown content={proposal.impact_md} />
+      </div>
       {proposal.proposed_changes.length > 0 && (
         <div className="px-3 pb-3 space-y-1 text-xs text-mc-text-secondary">
           {proposal.proposed_changes.slice(0, 6).map((c, idx) => (
@@ -803,6 +855,21 @@ function PinnedStandupCard({
           See thread below to refine.
         </span>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Render PM/operator chat content as markdown. Uses the global `.mc-md`
+ * stylesheet (defined in globals.css) tightened with `text-sm` so chat
+ * bubbles don't blow up to an article-style line-height. GFM enabled so
+ * tables, task-lists, and strikethrough render correctly — the PM's
+ * decompose / plan output frequently uses markdown tables.
+ */
+function ChatMarkdown({ content }: { content: string }) {
+  return (
+    <div className="mc-md text-sm">
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
     </div>
   );
 }

--- a/src/app/(app)/workspace/[slug]/page.tsx
+++ b/src/app/(app)/workspace/[slug]/page.tsx
@@ -19,7 +19,6 @@ import { LiveFeed } from '@/components/LiveFeed';
 import { ReadyDeliverablesPanel } from '@/components/ReadyDeliverablesPanel';
 import { SSEDebugPanel } from '@/components/SSEDebugPanel';
 import { useMissionControl } from '@/lib/store';
-import { useSSE } from '@/hooks/useSSE';
 import { debug } from '@/lib/debug';
 import { useSetCurrentWorkspaceId } from '@/components/shell/workspace-context';
 import type { Task, Workspace } from '@/lib/types';
@@ -38,7 +37,8 @@ export default function WorkspacePage() {
   const [mobileTab, setMobileTab] = useState<MobileTab>('queue');
   const [isPortrait, setIsPortrait] = useState(true);
 
-  useSSE();
+  // useSSE() now lives in AppShell — every page in the app shell receives
+  // live updates without each page re-mounting its own EventSource.
 
   useEffect(() => {
     const media = window.matchMedia('(orientation: portrait)');
@@ -222,7 +222,12 @@ export default function WorkspacePage() {
   return (
     <div className="h-full flex flex-col bg-mc-bg overflow-hidden">
       <div className="hidden lg:flex flex-1 overflow-hidden">
-        <AgentsSidebar workspaceId={workspace.id} />
+        {/*
+          Agent roster moved to its own /agents page so the task board
+          isn't sharing horizontal real estate with status pills. Mobile
+          tabs below still expose AgentsSidebar — the compact list earns
+          its place on space-constrained screens.
+        */}
         <MissionQueue workspaceId={workspace.id} />
         <LiveFeed topSlot={<ReadyDeliverablesPanel workspaceId={workspace.id} />} />
       </div>

--- a/src/components/AgentModal.tsx
+++ b/src/components/AgentModal.tsx
@@ -218,7 +218,7 @@ export function AgentModal({ agent, onClose, workspaceId, onAgentCreated }: Agen
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50 p-3 sm:p-4">
-      <div className="bg-mc-bg-secondary border border-mc-border rounded-t-xl sm:rounded-lg w-full max-w-2xl max-h-[92vh] sm:max-h-[90vh] flex flex-col pb-[env(safe-area-inset-bottom)] sm:pb-0">
+      <div className="bg-mc-bg-secondary border border-mc-border rounded-t-xl sm:rounded-lg w-full max-w-4xl max-h-[92vh] sm:max-h-[90vh] flex flex-col pb-[env(safe-area-inset-bottom)] sm:pb-0">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-mc-border">
           <h2 className="text-lg font-semibold">

--- a/src/components/AgentsSidebar.tsx
+++ b/src/components/AgentsSidebar.tsx
@@ -9,7 +9,7 @@ import { DiscoverAgentsModal } from './DiscoverAgentsModal';
 import { HealthIndicator } from './HealthIndicator';
 import { AgentPingIndicator } from './AgentPingIndicator';
 
-interface RollCallEntryView {
+export interface RollCallEntryView {
   id: string;
   target_agent_id: string;
   target_agent_name?: string;
@@ -20,7 +20,7 @@ interface RollCallEntryView {
   reply_body: string | null;
 }
 
-interface RollCallResultView {
+export interface RollCallResultView {
   rollcall_id: string;
   mode: 'direct' | 'coordinator';
   seconds_remaining: number;
@@ -604,7 +604,7 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
  * the sidebar context. Also surfaces alert-level errors (no master
  * orchestrator / multiple master orchestrators) in the same surface.
  */
-function RollCallResultsPanel({
+export function RollCallResultsPanel({
   result,
   onClose,
 }: {

--- a/src/components/shell/AppNav.tsx
+++ b/src/components/shell/AppNav.tsx
@@ -33,6 +33,7 @@ import {
   Plus,
   KanbanSquare,
   Bug,
+  Users,
 } from 'lucide-react';
 import {
   useCurrentWorkspaceId,
@@ -65,6 +66,7 @@ function buildSections(taskBoardHref: string): NavSection[] {
       title: 'Execute',
       items: [
         { href: taskBoardHref, label: 'Task Board', icon: KanbanSquare, prefix: taskBoardHref !== '/' },
+        { href: '/agents', label: 'Agents', icon: Users, prefix: true },
         { href: '/activity', label: 'Activity', icon: ActivityIcon, prefix: true },
       ],
     },

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -13,10 +13,19 @@ import { usePathname } from 'next/navigation';
 import { AppNav } from './AppNav';
 import { AppTopBar } from './AppTopBar';
 import { WorkspaceProvider } from './workspace-context';
+import { useSSE } from '@/hooks/useSSE';
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const pathname = usePathname();
+
+  // Mount the SSE listener once at shell level so every page in the app
+  // receives live updates (agent pings, task transitions, autopilot events,
+  // toasts). Previously this was mounted only inside the workspace page,
+  // which meant /agents, /pm, /initiatives etc. saw stale data — pings
+  // never updated, ready-deliverable counts froze, agent_completed toasts
+  // didn't fire on those routes.
+  useSSE();
 
   // Close the drawer whenever the route changes — the operator just tapped
   // a nav link, no point leaving the overlay up.


### PR DESCRIPTION
## Summary

- New `/agents` page: tabular roster with inline-editable role/model; AgentModal still behind the agent's name. Removes the desktop `AgentsSidebar` from the workspace page (mobile tabs keep it).
- Hoist `useSSE()` from `workspace/[slug]` into `AppShell` so `/agents`, `/pm`, `/initiatives` etc. all receive live updates (pings, `agent_completed` toasts, ready-deliverable counts) — previously they froze because the EventSource only mounted on the workspace route.
- Widen `AgentModal` from `max-w-2xl` → `max-w-4xl` so soul/user/agents textareas have room.
- PM chat: render messages and pinned standup with `react-markdown` + `remark-gfm` (the PM frequently emits tables/task-lists), and add sticky-bottom scroll with a *Jump to latest* pill so the 3 s poll stops yanking the operator back when they're reading older proposals.
- Add `Agents` nav link; export `RollCallEntryView`/`ResultView` and `RollCallResultsPanel` from `AgentsSidebar` so the new page can reuse them.

## Changes

- `src/app/(app)/agents/page.tsx` (new)
- `src/app/(app)/pm/page.tsx`
- `src/app/(app)/workspace/[slug]/page.tsx`
- `src/components/AgentModal.tsx`
- `src/components/AgentsSidebar.tsx`
- `src/components/shell/AppShell.tsx`
- `src/components/shell/AppNav.tsx`

## Test plan

- [ ] Open `/agents`, edit a role / model inline, confirm PATCH lands and rolls back on error.
- [ ] On `/agents`, `/pm`, `/initiatives`: confirm live SSE-driven UI updates (ping pulse, toast, deliverable count) without a manual refresh.
- [ ] In `/pm`: scroll up in the chat, wait for a poll, confirm the view stays put and the *Jump to latest* pill appears; click it.
- [ ] Open AgentModal, verify the wider layout doesn't clip on a typical desktop viewport.
- [ ] `yarn tsc --noEmit` — only pre-existing failures (`.next/types/validator.ts`, `pm-decompose.test.ts`); none introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)