### PR TITLE
ux(initiatives): inline edit on detail page in place of right-side drawer

### DIFF
--- a/src/app/(app)/initiatives/[id]/page.tsx
+++ b/src/app/(app)/initiatives/[id]/page.tsx
@@ -11,18 +11,25 @@ import {
   History,
   Link2,
   Sparkles,
-  Pencil,
   MoveRight,
   Shuffle,
   CornerUpLeft,
   Trash2,
 } from 'lucide-react';
 import DecomposeWithPmModal from '@/components/DecomposeWithPmModal';
-// Reuse the modal components defined alongside the list page so the detail
-// page exposes the same action surface — but as visible buttons rather than
-// behind a dropdown, since the operator already drilled into one initiative.
+import PlanWithPmPanel, {
+  type PlanInitiativeSuggestions,
+} from '@/components/PlanWithPmPanel';
 import {
-  EditDrawer,
+  InlineText,
+  InlineTextarea,
+  InlineSelect,
+  InlineDate,
+} from '@/components/inline/InlineEdit';
+// Reuse the action modals defined alongside the list page — Move / Convert /
+// AddDep / History still make sense as focused dialogs since they have
+// non-trivial side effects beyond a simple field write.
+import {
   MoveModal,
   ConvertModal,
   AddDependencyModal,
@@ -92,6 +99,36 @@ interface DepEdges {
   incoming: DepRow[];
 }
 
+// Minimal agent shape for the owner inline-select. Mirrors the AgentLite
+// declared next to EditDrawer in ../page.tsx; kept local to avoid churning
+// that file's public exports.
+interface AgentLite {
+  id: string;
+  name: string;
+  role: string;
+  avatar_emoji: string;
+  workspace_id: string;
+}
+
+type Complexity = 'S' | 'M' | 'L' | 'XL';
+
+const STATUS_OPTIONS: { value: Status; label: string }[] = [
+  { value: 'planned', label: 'planned' },
+  { value: 'in_progress', label: 'in_progress' },
+  { value: 'at_risk', label: 'at_risk' },
+  { value: 'blocked', label: 'blocked' },
+  { value: 'done', label: 'done' },
+  { value: 'cancelled', label: 'cancelled' },
+];
+
+const COMPLEXITY_OPTIONS: { value: Complexity | ''; label: string }[] = [
+  { value: '', label: '(unset)' },
+  { value: 'S', label: 'S' },
+  { value: 'M', label: 'M' },
+  { value: 'L', label: 'L' },
+  { value: 'XL', label: 'XL' },
+];
+
 const KIND_BADGE: Record<Kind, string> = {
   theme: 'bg-purple-500/20 text-purple-300',
   milestone: 'bg-amber-500/20 text-amber-300',
@@ -137,13 +174,14 @@ export default function InitiativeDetailPage({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [agents, setAgents] = useState<AgentLite[]>([]);
   const [showPromoteModal, setShowPromoteModal] = useState(false);
   const [showDecomposeModal, setShowDecomposeModal] = useState(false);
-  const [showEditDrawer, setShowEditDrawer] = useState(false);
   const [showMoveModal, setShowMoveModal] = useState(false);
   const [showConvertModal, setShowConvertModal] = useState(false);
   const [showAddDepModal, setShowAddDepModal] = useState(false);
   const [showHistoryDrawer, setShowHistoryDrawer] = useState(false);
+  const [showPlanPanel, setShowPlanPanel] = useState(false);
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -172,6 +210,53 @@ export default function InitiativeDetailPage({
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  // Load agents in this workspace for the owner inline-select. Mirrors the
+  // pattern used in EditDrawer.
+  useEffect(() => {
+    if (!initiative) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(
+          `/api/agents?workspace_id=${encodeURIComponent(initiative.workspace_id)}`,
+        );
+        if (!r.ok) return;
+        const list = await r.json();
+        if (!cancelled && Array.isArray(list)) setAgents(list);
+      } catch {
+        // Non-fatal: the owner select just falls back to "Unassigned".
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [initiative?.workspace_id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // PATCH a partial update to this initiative and refresh on success. The
+  // route's Zod schema treats every field as optional, so callers can send
+  // exactly the slice they're editing.
+  const patch = useCallback(
+    async (body: Record<string, unknown>) => {
+      const res = await fetch(`/api/initiatives/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Update failed (${res.status})`);
+      }
+      // Optimistically merge so the field reflects the new value before the
+      // network round-trip completes; refresh() catches up everything else.
+      const next = await res.json().catch(() => null);
+      if (next) {
+        setInitiative(prev => (prev ? { ...prev, ...next } : prev));
+      }
+      refresh();
+    },
+    [id, refresh],
+  );
 
   const titleFor = useCallback(
     (initId: string | null) => {
@@ -287,19 +372,53 @@ export default function InitiativeDetailPage({
 
         <header className="mb-6 p-5 rounded-lg bg-mc-bg-secondary border border-mc-border">
           <div className="flex items-start justify-between gap-3">
-            <div>
+            <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 mb-2">
-                <span className={`px-2 py-0.5 rounded text-xs uppercase tracking-wide ${KIND_BADGE[initiative.kind]}`}>
+                {/*
+                  Kind badge is a click-target that opens the ConvertModal —
+                  changing kind has migration semantics (e.g. story-only
+                  promote) so it shouldn't be a flat inline select.
+                */}
+                <button
+                  onClick={() => setShowConvertModal(true)}
+                  title="Change kind (opens converter)"
+                  className={`px-2 py-0.5 rounded text-xs uppercase tracking-wide hover:ring-1 hover:ring-mc-accent/40 ${KIND_BADGE[initiative.kind]}`}
+                >
                   {initiative.kind}
-                </span>
-                <span className="text-xs text-mc-text-secondary uppercase">{initiative.status}</span>
+                </button>
+                <InlineSelect<Status>
+                  value={initiative.status}
+                  options={STATUS_OPTIONS}
+                  onSave={next => patch({ status: next })}
+                  className="text-xs uppercase"
+                  renderDisplay={v => (
+                    <span className="text-mc-text-secondary uppercase">{v}</span>
+                  )}
+                  label="Edit status"
+                />
               </div>
-              <h1 className="text-2xl font-semibold text-mc-text">{initiative.title}</h1>
-              {initiative.description && (
-                <p className="text-mc-text-secondary mt-2 whitespace-pre-wrap">{initiative.description}</p>
-              )}
+              <InlineText
+                value={initiative.title}
+                onSave={next => patch({ title: next })}
+                className="text-2xl font-semibold text-mc-text block"
+                inputClassName="w-full px-2 py-1 rounded bg-mc-bg border border-mc-accent/60 text-mc-text outline-none text-2xl font-semibold"
+                placeholder="Untitled"
+                label="Edit title"
+              />
+              <div className="mt-2">
+                <InlineTextarea
+                  value={initiative.description ?? ''}
+                  onSave={next =>
+                    patch({ description: next.length > 0 ? next : null })
+                  }
+                  className="text-mc-text-secondary block"
+                  placeholder="Add a description…"
+                  minRows={6}
+                  label="Edit description"
+                />
+              </div>
             </div>
-            <div className="flex flex-col items-end gap-2">
+            <div className="flex flex-col items-end gap-2 shrink-0">
               <PromoteButton
                 kind={initiative.kind}
                 onClick={() => setShowPromoteModal(true)}
@@ -317,15 +436,16 @@ export default function InitiativeDetailPage({
           </div>
 
           {/*
-            Secondary action toolbar — surfaces every action that lives in
-            the ⋮ overflow menu on the list page, but as visible buttons
-            since this is a dedicated detail page and the operator already
-            committed to one initiative. Destructive actions (Detach,
-            Delete) sit at the right with a divider and tinted styling.
+            Secondary action toolbar. The old "Edit" button is gone — every
+            field is now click-to-edit in place. We surface "Plan with PM"
+            here in its place so the PM-suggested fills stay one click away.
           */}
           <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-mc-border/60 pt-3">
-            <ToolbarButton icon={<Pencil className="w-3.5 h-3.5" />} onClick={() => setShowEditDrawer(true)}>
-              Edit
+            <ToolbarButton
+              icon={<Sparkles className="w-3.5 h-3.5" />}
+              onClick={() => setShowPlanPanel(true)}
+            >
+              Plan with PM
             </ToolbarButton>
             <ToolbarButton icon={<MoveRight className="w-3.5 h-3.5" />} onClick={() => setShowMoveModal(true)}>
               Move
@@ -362,30 +482,120 @@ export default function InitiativeDetailPage({
           <dl className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4 text-xs text-mc-text-secondary">
             <div>
               <dt className="uppercase tracking-wide">Target start</dt>
-              <dd className="text-mc-text">{initiative.target_start ?? '—'}</dd>
+              <dd className="text-mc-text mt-0.5">
+                <InlineDate
+                  value={initiative.target_start ?? ''}
+                  onSave={next => patch({ target_start: next || null })}
+                  label="Edit target start"
+                />
+              </dd>
             </div>
             <div>
               <dt className="uppercase tracking-wide">Target end</dt>
-              <dd className="text-mc-text">{initiative.target_end ?? '—'}</dd>
+              <dd className="text-mc-text mt-0.5">
+                <InlineDate
+                  value={initiative.target_end ?? ''}
+                  onSave={next => patch({ target_end: next || null })}
+                  label="Edit target end"
+                />
+              </dd>
             </div>
             <div>
               <dt className="uppercase tracking-wide">Committed end</dt>
-              <dd className="text-mc-text">{initiative.committed_end ?? '—'}</dd>
+              <dd className="text-mc-text mt-0.5">
+                <InlineDate
+                  value={initiative.committed_end ?? ''}
+                  onSave={next => patch({ committed_end: next || null })}
+                  label="Edit committed end"
+                />
+              </dd>
             </div>
             <div>
               <dt className="uppercase tracking-wide">Owner</dt>
-              <dd className="text-mc-text">{initiative.owner_agent_id ?? '—'}</dd>
+              <dd className="text-mc-text mt-0.5">
+                <InlineSelect<string>
+                  value={initiative.owner_agent_id ?? ''}
+                  onSave={next =>
+                    patch({ owner_agent_id: next.length > 0 ? next : null })
+                  }
+                  options={[
+                    { value: '', label: 'Unassigned' },
+                    ...agents.map(a => ({
+                      value: a.id,
+                      label: `${a.avatar_emoji}  ${a.name}  ${a.role}`,
+                    })),
+                  ]}
+                  renderDisplay={v => {
+                    const a = agents.find(x => x.id === v);
+                    return a ? (
+                      <span>
+                        {a.avatar_emoji} {a.name}
+                      </span>
+                    ) : (
+                      <span className="text-mc-text-secondary">—</span>
+                    );
+                  }}
+                  label="Edit owner"
+                />
+              </dd>
             </div>
           </dl>
 
-          {initiative.status_check_md && (
-            <div className="mt-4 p-3 rounded border border-mc-border/60 bg-mc-bg text-sm text-mc-text-secondary whitespace-pre-wrap font-mono text-xs">
-              <div className="uppercase tracking-wide text-[10px] text-mc-text-secondary/70 mb-1">
-                Status check
-              </div>
-              {initiative.status_check_md}
+          <dl className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-3 text-xs text-mc-text-secondary">
+            <div>
+              <dt className="uppercase tracking-wide">Complexity</dt>
+              <dd className="text-mc-text mt-0.5">
+                <InlineSelect<Complexity | ''>
+                  value={(initiative.complexity ?? '') as Complexity | ''}
+                  options={COMPLEXITY_OPTIONS}
+                  onSave={next => patch({ complexity: next || null })}
+                  renderDisplay={v =>
+                    v ? <span>{v}</span> : <span className="text-mc-text-secondary">—</span>
+                  }
+                  label="Edit complexity"
+                />
+              </dd>
             </div>
-          )}
+            <div>
+              <dt className="uppercase tracking-wide">Effort (hours)</dt>
+              <dd className="text-mc-text mt-0.5">
+                <InlineText
+                  value={
+                    initiative.estimated_effort_hours == null
+                      ? ''
+                      : String(initiative.estimated_effort_hours)
+                  }
+                  onSave={next =>
+                    patch({
+                      estimated_effort_hours: next === '' ? null : Number(next),
+                    })
+                  }
+                  type="number"
+                  step="0.5"
+                  placeholder="—"
+                  label="Edit effort hours"
+                />
+              </dd>
+            </div>
+          </dl>
+
+          <div className="mt-4">
+            <div className="uppercase tracking-wide text-[10px] text-mc-text-secondary/70 mb-1">
+              Status check
+            </div>
+            <div className="p-3 rounded border border-mc-border/60 bg-mc-bg">
+              <InlineTextarea
+                value={initiative.status_check_md ?? ''}
+                onSave={next =>
+                  patch({ status_check_md: next.length > 0 ? next : null })
+                }
+                placeholder="Linked PR / waiting on / customer demo / etc."
+                minRows={4}
+                mono
+                label="Edit status check"
+              />
+            </div>
+          </div>
         </header>
 
         {actionError && (
@@ -520,14 +730,43 @@ export default function InitiativeDetailPage({
           }}
         />
       )}
-      <EditDrawer
-        initiative={showEditDrawer ? (initiative as ListInitiative) : null}
-        onClose={() => setShowEditDrawer(false)}
-        onSaved={() => {
-          setShowEditDrawer(false);
-          refresh();
-        }}
-      />
+      {showPlanPanel && (
+        <PlanWithPmPanel
+          open={showPlanPanel}
+          workspaceId={initiative.workspace_id}
+          draft={{
+            title: initiative.title,
+            description: initiative.description ?? '',
+            kind: initiative.kind,
+            complexity: initiative.complexity,
+            parent_initiative_id: initiative.parent_initiative_id,
+            target_start: initiative.target_start,
+            target_end: initiative.target_end,
+          }}
+          onClose={() => setShowPlanPanel(false)}
+          onApply={async (s: PlanInitiativeSuggestions) => {
+            // Map every suggested field through patch() so the persistence
+            // path stays the same as inline edits.
+            const body: Record<string, unknown> = {};
+            if (s.refined_description) body.description = s.refined_description;
+            if (s.complexity) body.complexity = s.complexity;
+            if (s.target_start) body.target_start = s.target_start;
+            if (s.target_end) body.target_end = s.target_end;
+            if (s.status_check_md) body.status_check_md = s.status_check_md;
+            if (s.owner_agent_id) body.owner_agent_id = s.owner_agent_id;
+            if (Object.keys(body).length > 0) {
+              try {
+                await patch(body);
+              } catch (e) {
+                setActionError(
+                  e instanceof Error ? e.message : 'Failed to apply suggestions',
+                );
+              }
+            }
+            setShowPlanPanel(false);
+          }}
+        />
+      )}
       {showMoveModal && (
         <MoveModal
           initiative={initiative as ListInitiative}

--- a/src/components/inline/InlineEdit.tsx
+++ b/src/components/inline/InlineEdit.tsx
@@ -1,0 +1,519 @@
+'use client';
+
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  type ReactNode,
+  type KeyboardEvent,
+} from 'react';
+import { Check, X, Pencil } from 'lucide-react';
+
+type SaveResult = void | Promise<void>;
+
+interface CommonProps<T> {
+  value: T;
+  onSave: (next: T) => SaveResult;
+  /** Render the read-only display. Defaults vary per primitive. */
+  renderDisplay?: (value: T) => ReactNode;
+  /** Shown when value is empty and not editing. */
+  placeholder?: string;
+  /** Wrapper className for both display and edit modes (layout). */
+  className?: string;
+  /** Disable editing entirely (still renders display). */
+  disabled?: boolean;
+  /** Optional aria-label for the edit trigger. */
+  label?: string;
+}
+
+function useInlineEdit<T>(value: T, onSave: (next: T) => SaveResult) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<T>(value);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Re-sync the draft when the saved value changes from outside while idle.
+  useEffect(() => {
+    if (!editing) setDraft(value);
+  }, [value, editing]);
+
+  const begin = useCallback(() => {
+    setDraft(value);
+    setErr(null);
+    setEditing(true);
+  }, [value]);
+
+  const cancel = useCallback(() => {
+    setDraft(value);
+    setErr(null);
+    setEditing(false);
+  }, [value]);
+
+  const commit = useCallback(
+    async (next: T) => {
+      setSaving(true);
+      setErr(null);
+      try {
+        await onSave(next);
+        setEditing(false);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : 'Save failed');
+      } finally {
+        setSaving(false);
+      }
+    },
+    [onSave],
+  );
+
+  return { editing, draft, setDraft, saving, err, begin, cancel, commit };
+}
+
+function ActionRow({
+  onSave,
+  onCancel,
+  saving,
+  err,
+}: {
+  onSave: () => void;
+  onCancel: () => void;
+  saving: boolean;
+  err: string | null;
+}) {
+  return (
+    <div className="flex items-center gap-2 mt-2">
+      <button
+        type="button"
+        onClick={onSave}
+        disabled={saving}
+        className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-mc-accent text-white disabled:opacity-50"
+      >
+        <Check className="w-3 h-3" /> {saving ? 'Saving…' : 'Save'}
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={saving}
+        className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-mc-border text-mc-text-secondary"
+      >
+        <X className="w-3 h-3" /> Cancel
+      </button>
+      {err && <span className="text-xs text-red-400 ml-1">{err}</span>}
+    </div>
+  );
+}
+
+const HOVER_CLS =
+  'group relative cursor-text rounded -mx-1 px-1 hover:bg-mc-accent/5 hover:outline hover:outline-1 hover:outline-mc-accent/20';
+
+function PencilHint() {
+  return (
+    <Pencil className="absolute right-1 top-1 w-3 h-3 text-mc-text-secondary/40 opacity-0 group-hover:opacity-100" />
+  );
+}
+
+/* ---------- InlineText (single line) ---------- */
+
+interface InlineTextProps extends CommonProps<string> {
+  inputClassName?: string;
+  /** number / text. Default text. */
+  type?: 'text' | 'number';
+  step?: string;
+}
+
+export function InlineText({
+  value,
+  onSave,
+  renderDisplay,
+  placeholder = 'Click to edit',
+  className,
+  disabled,
+  inputClassName,
+  type = 'text',
+  step,
+  label,
+}: InlineTextProps) {
+  const { editing, draft, setDraft, saving, err, begin, cancel, commit } =
+    useInlineEdit<string>(value, onSave);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commit(draft);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      cancel();
+    }
+  };
+
+  if (editing) {
+    return (
+      <div className={className}>
+        <input
+          ref={inputRef}
+          type={type}
+          step={step}
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          onKeyDown={onKey}
+          disabled={saving}
+          className={
+            inputClassName ??
+            'w-full px-2 py-1 rounded bg-mc-bg border border-mc-accent/60 text-mc-text outline-none'
+          }
+        />
+        <ActionRow
+          onSave={() => commit(draft)}
+          onCancel={cancel}
+          saving={saving}
+          err={err}
+        />
+      </div>
+    );
+  }
+
+  const isEmpty = value == null || value === '';
+  return (
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-label={label ?? 'Edit'}
+      onClick={() => !disabled && begin()}
+      onKeyDown={e => {
+        if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          begin();
+        }
+      }}
+      className={`${className ?? ''} ${disabled ? '' : HOVER_CLS}`}
+    >
+      {isEmpty ? (
+        <span className="text-mc-text-secondary/60 italic">{placeholder}</span>
+      ) : renderDisplay ? (
+        renderDisplay(value)
+      ) : (
+        <span>{value}</span>
+      )}
+      {!disabled && <PencilHint />}
+    </div>
+  );
+}
+
+/* ---------- InlineTextarea (multi-line) ---------- */
+
+interface InlineTextareaProps extends CommonProps<string> {
+  textareaClassName?: string;
+  /** Min rows for the textarea while editing. Default 6. */
+  minRows?: number;
+  /** Render display as `<pre>`-like wrap. Default true. */
+  preWrap?: boolean;
+  /** Apply mono font in both display and edit. */
+  mono?: boolean;
+}
+
+export function InlineTextarea({
+  value,
+  onSave,
+  renderDisplay,
+  placeholder = 'Click to add…',
+  className,
+  disabled,
+  textareaClassName,
+  minRows = 6,
+  preWrap = true,
+  mono = false,
+  label,
+}: InlineTextareaProps) {
+  const { editing, draft, setDraft, saving, err, begin, cancel, commit } =
+    useInlineEdit<string>(value, onSave);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      const ta = taRef.current;
+      if (ta) {
+        ta.focus();
+        // Place caret at end.
+        ta.setSelectionRange(ta.value.length, ta.value.length);
+        autoResize(ta);
+      }
+    }
+  }, [editing]);
+
+  const autoResize = (ta: HTMLTextAreaElement) => {
+    ta.style.height = 'auto';
+    ta.style.height = `${ta.scrollHeight}px`;
+  };
+
+  const onKey = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      commit(draft);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      cancel();
+    }
+  };
+
+  if (editing) {
+    return (
+      <div className={className}>
+        <textarea
+          ref={taRef}
+          value={draft}
+          onChange={e => {
+            setDraft(e.target.value);
+            autoResize(e.currentTarget);
+          }}
+          onKeyDown={onKey}
+          rows={minRows}
+          disabled={saving}
+          className={
+            textareaClassName ??
+            `w-full px-3 py-2 rounded bg-mc-bg border border-mc-accent/60 text-mc-text outline-none resize-y ${
+              mono ? 'font-mono text-xs' : ''
+            }`
+          }
+        />
+        <div className="flex items-center justify-between gap-2 mt-2">
+          <ActionRow
+            onSave={() => commit(draft)}
+            onCancel={cancel}
+            saving={saving}
+            err={err}
+          />
+          <span className="text-[10px] text-mc-text-secondary/60">
+            ⌘/Ctrl+Enter saves · Esc cancels
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const isEmpty = value == null || value === '';
+  return (
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-label={label ?? 'Edit'}
+      onClick={() => !disabled && begin()}
+      onKeyDown={e => {
+        if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          begin();
+        }
+      }}
+      className={`${className ?? ''} ${disabled ? '' : HOVER_CLS} ${
+        preWrap ? 'whitespace-pre-wrap' : ''
+      } ${mono ? 'font-mono text-xs' : ''} min-h-[1.5em]`}
+    >
+      {isEmpty ? (
+        <span className="text-mc-text-secondary/60 italic">{placeholder}</span>
+      ) : renderDisplay ? (
+        renderDisplay(value)
+      ) : (
+        <span>{value}</span>
+      )}
+      {!disabled && <PencilHint />}
+    </div>
+  );
+}
+
+/* ---------- InlineSelect ---------- */
+
+export interface InlineSelectOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface InlineSelectProps<T extends string> extends CommonProps<T> {
+  options: InlineSelectOption<T>[];
+  selectClassName?: string;
+}
+
+export function InlineSelect<T extends string>({
+  value,
+  onSave,
+  options,
+  renderDisplay,
+  placeholder = 'Click to set',
+  className,
+  disabled,
+  selectClassName,
+  label,
+}: InlineSelectProps<T>) {
+  const { editing, draft, setDraft, saving, err, begin, cancel, commit } =
+    useInlineEdit<T>(value, onSave);
+  const selectRef = useRef<HTMLSelectElement>(null);
+
+  useEffect(() => {
+    if (editing) selectRef.current?.focus();
+  }, [editing]);
+
+  if (editing) {
+    return (
+      <div className={className}>
+        <select
+          ref={selectRef}
+          value={draft}
+          onChange={e => setDraft(e.target.value as T)}
+          onKeyDown={e => {
+            if (e.key === 'Escape') {
+              e.preventDefault();
+              cancel();
+            }
+          }}
+          disabled={saving}
+          className={
+            selectClassName ??
+            'w-full px-2 py-1 rounded bg-mc-bg border border-mc-accent/60 text-mc-text outline-none'
+          }
+        >
+          {options.map(o => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <ActionRow
+          onSave={() => commit(draft)}
+          onCancel={cancel}
+          saving={saving}
+          err={err}
+        />
+      </div>
+    );
+  }
+
+  const isEmpty = value == null || (value as unknown as string) === '';
+  return (
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-label={label ?? 'Edit'}
+      onClick={() => !disabled && begin()}
+      onKeyDown={e => {
+        if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          begin();
+        }
+      }}
+      className={`${className ?? ''} ${disabled ? '' : HOVER_CLS} inline-block`}
+    >
+      {isEmpty ? (
+        <span className="text-mc-text-secondary/60 italic">{placeholder}</span>
+      ) : renderDisplay ? (
+        renderDisplay(value)
+      ) : (
+        <span>{options.find(o => o.value === value)?.label ?? value}</span>
+      )}
+      {!disabled && <PencilHint />}
+    </div>
+  );
+}
+
+/* ---------- InlineDate (yyyy-mm-dd) ---------- */
+
+interface InlineDateProps extends CommonProps<string> {
+  /** Allow null/clearing — if true, an explicit "Clear" button appears. */
+  clearable?: boolean;
+}
+
+export function InlineDate({
+  value,
+  onSave,
+  placeholder = '—',
+  className,
+  disabled,
+  clearable = true,
+  label,
+}: InlineDateProps) {
+  const { editing, draft, setDraft, saving, err, begin, cancel, commit } =
+    useInlineEdit<string>(value ?? '', onSave);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  if (editing) {
+    return (
+      <div className={className}>
+        <input
+          ref={inputRef}
+          type="date"
+          value={draft.slice(0, 10)}
+          onChange={e => setDraft(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              commit(draft);
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              cancel();
+            }
+          }}
+          disabled={saving}
+          className="w-full px-2 py-1 rounded bg-mc-bg border border-mc-accent/60 text-mc-text outline-none"
+        />
+        <div className="flex items-center gap-2 mt-2">
+          <button
+            type="button"
+            onClick={() => commit(draft)}
+            disabled={saving}
+            className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-mc-accent text-white disabled:opacity-50"
+          >
+            <Check className="w-3 h-3" /> {saving ? 'Saving…' : 'Save'}
+          </button>
+          <button
+            type="button"
+            onClick={cancel}
+            disabled={saving}
+            className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-mc-border text-mc-text-secondary"
+          >
+            <X className="w-3 h-3" /> Cancel
+          </button>
+          {clearable && (
+            <button
+              type="button"
+              onClick={() => commit('')}
+              disabled={saving}
+              className="text-xs px-2 py-1 rounded border border-mc-border text-mc-text-secondary ml-auto"
+              title="Clear this date"
+            >
+              Clear
+            </button>
+          )}
+          {err && <span className="text-xs text-red-400 ml-1">{err}</span>}
+        </div>
+      </div>
+    );
+  }
+
+  const display = value && value.length > 0 ? value.slice(0, 10) : null;
+  return (
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-label={label ?? 'Edit date'}
+      onClick={() => !disabled && begin()}
+      onKeyDown={e => {
+        if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          begin();
+        }
+      }}
+      className={`${className ?? ''} ${disabled ? '' : HOVER_CLS}`}
+    >
+      {display ?? (
+        <span className="text-mc-text-secondary/60">{placeholder}</span>
+      )}
+      {!disabled && <PencilHint />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The initiative detail page was a roomy preview behind an `Edit` button that opened a 520 px right-side drawer. The Description field — the one thing that benefits most from real estate — got squeezed into an `h-28` textarea while the wide preview sat idle behind it. This PR flips the model: the detail page **is** the edit surface.

- Every header field is click-to-edit: title, description, status, target/committed dates, owner, complexity, effort, status check.
- Each save is a partial `PATCH /api/initiatives/[id]` (the route's `PatchInitiativeSchema` already accepts every field as optional — no API change).
- `Esc` cancels everywhere, `Enter` saves single-line, `⌘/Ctrl+Enter` saves multi-line. Auto-grow textarea so long descriptions get the full main-column width.
- Replace the `Edit` toolbar button with `Plan with PM` (its panel now opens directly from the detail toolbar and routes suggestions through the same `patch()` helper).
- Kind badge remains a click-target for the existing `ConvertModal` (kind change has migration semantics that shouldn't be a flat inline select).
- `EditDrawer` stays exported from `initiatives/page.tsx` — the list-page row menu still uses it.

Before / after — the description editor now has full main-column width when active.

## Changes

- `src/components/inline/InlineEdit.tsx` (new): `InlineText`, `InlineTextarea`, `InlineSelect<T>`, `InlineDate`. Common pattern, accessible (`role=button`, keyboard activation), inline per-field error display.
- `src/app/(app)/initiatives/[id]/page.tsx`: wire every header field through the new primitives, add a `patch(partial)` helper, add the Sizing row (complexity + effort), move Plan-with-PM to the toolbar, drop the `EditDrawer` import + state.

## Out of scope (follow-ups)

- TaskModal inline-ification — much larger redesign.
- Markdown rendering of description/status_check (currently `whitespace-pre-wrap`) — distinct concern.
- AgentModal restructure — already roomy at `max-w-4xl` after #64.

## Test plan

- [ ] Open an initiative detail page; click the title, edit, Save → persists.
- [ ] Click description, paste a multi-paragraph note with a URL, ⌘+Enter → persists; reload to confirm.
- [ ] Click each schedule date and the owner select; toggle status; toggle complexity; edit effort hours. Each fires a single `PATCH /api/initiatives/<id>` with only the changed field.
- [ ] Mid-edit Esc cancels and reverts to the saved value; the Cancel button does the same.
- [ ] Click the kind badge → opens `ConvertModal` (existing flow preserved).
- [ ] Click `Plan with PM` from the toolbar → panel opens, accepts suggestions, and writes through `patch()`.
- [ ] On `/initiatives` (list page), the row `⋮ → Edit` still opens the original `EditDrawer`.
- [ ] `yarn tsc --noEmit` — only pre-existing failures (`.next/types/validator.ts`, `pm-decompose.test.ts`); none introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)