### PR TITLE
fix(autopilot): pass product name + description into research/ideation prompts

### DIFF
--- a/src/app/(app)/autopilot/new/page.tsx
+++ b/src/app/(app)/autopilot/new/page.tsx
@@ -16,6 +16,34 @@ function isValidUrl(str: string): boolean {
   }
 }
 
+// Starter Product Program. Used both as the textarea placeholder and as
+// the auto-seed value when the operator transitions to Step 2 with no
+// program defined. Echoes the basics they already typed so they don't
+// have to repeat themselves and so a "Skip for now" with an empty Step 1
+// description doesn't leave the LLM with zero context.
+function buildProgramTemplate(name: string, description: string): string {
+  const safeName = name.trim() || 'this product';
+  const purposeLine = description.trim()
+    ? description.trim()
+    : `What this product does and who it's for.`;
+  return `# Product Program: ${safeName}
+
+## Purpose
+${purposeLine}
+
+## Target Users
+Who uses this and what problems they have.
+
+## Priorities
+What matters most — growth, stability, features, UX, performance, etc.
+
+## Research Directives
+Specific areas to focus research on.
+
+## Exclusions
+Things you do NOT want suggested.`;
+}
+
 export default function NewProductPage() {
   const router = useRouter();
   const [step, setStep] = useState<Step>('basics');
@@ -155,6 +183,19 @@ export default function NewProductPage() {
       if (res.ok) {
         const product = await res.json();
         setProductId(product.id);
+        // Seed the Product Program textarea from name + description so the
+        // operator entering Step 2 sees real, editable starter content
+        // instead of grey placeholder text. If they "Skip for now" the
+        // seeded value is never persisted (handleSaveProgram isn't called),
+        // so this never injects unwanted content into the saved program.
+        // It just removes a foot-gun where users wrote a great
+        // name/description, skipped Step 2, and got Mission-Control-themed
+        // ideation results because the LLM had no product context.
+        setForm(f =>
+          f.product_program.trim().length > 0
+            ? f
+            : { ...f, product_program: buildProgramTemplate(f.name, f.description) },
+        );
         setStep('program');
       }
     } catch (error) {
@@ -381,7 +422,7 @@ export default function NewProductPage() {
                 onChange={e => setForm(f => ({ ...f, product_program: e.target.value }))}
                 className="w-full bg-mc-bg-tertiary border border-mc-border rounded-lg px-4 py-3 text-mc-text font-mono text-sm focus:outline-hidden focus:border-mc-accent resize-none"
                 rows={20}
-                placeholder={`# Product Program: ${form.name}\n\n## Purpose\nWhat this product does and who it's for.\n\n## Target Users\nWho uses this and what problems they have.\n\n## Priorities\nWhat matters most — growth, stability, features, UX, performance, etc.\n\n## Research Directives\nSpecific areas to focus research on.\n\n## Exclusions\nThings you do NOT want suggested.`}
+                placeholder={buildProgramTemplate(form.name, form.description)}
               />
             </div>
             <div className="flex gap-3">

--- a/src/lib/autopilot/ideation.ts
+++ b/src/lib/autopilot/ideation.ts
@@ -41,9 +41,13 @@ function buildIdeationPrompt(
    - target_user_segment: who benefits (optional)
    - revenue_potential: money impact (optional)
 
+## Product
+
+**Name:** ${product.name}
+${product.description ? `\n**Description:** ${product.description}\n` : ''}${product.repo_url ? `**Repo:** ${product.repo_url}\n` : ''}${product.live_url ? `**Live URL:** ${product.live_url}\n` : ''}
 ## Product Program
 
-${product.product_program || 'No product program defined yet.'}
+${product.product_program || '_No detailed product program — treat the **Product** section above as the source of truth for what this product is and who it serves. Generate ideas that fit the stated domain, not generic SaaS features._'}
 
 ## Research Report
 

--- a/src/lib/autopilot/research.ts
+++ b/src/lib/autopilot/research.ts
@@ -36,9 +36,13 @@ Include specific, actionable findings — not generic observations. Every findin
 
 IMPORTANT: Respond with ONLY the JSON object. No markdown, no code blocks, no explanation text before or after. Just the raw JSON.
 
+## Product
+
+**Name:** ${product.name}
+${product.description ? `\n**Description:** ${product.description}\n` : ''}
 ## Product Program
 
-${product.product_program || 'No product program defined yet.'}
+${product.product_program || '_No detailed product program — treat the **Product** section above as the source of truth for what this product is and who it serves. Research within that domain, not generic SaaS / Mission Control features._'}
 
 ${product.repo_url ? `## Repository\n${product.repo_url}` : ''}
 ${product.live_url ? `## Live URL\n${product.live_url}` : ''}


### PR DESCRIPTION
## Summary

Autopilot ideation/research prompts only ever read `product.product_program`, falling back to *"No product program defined yet."* when it was empty. `product.name` and `product.description` were **never** included. Result: when an operator created a product (e.g. *"A local self-hosted AI security system — jetson orin nano + IP cameras"*) and skipped Step 2 of the wizard, the LLM saw only:

> You are a Product Ideation Agent for Mission Control.

…and dutifully generated Mission Control feature ideas. Doing the right thing with the wrong inputs.

Confirmed root cause from the user's debug log: the outbound `chat.completions` request body's user message contained `## Product Program\n\nNo product program defined yet.` with zero name/description content. The product's name and description in the DB were correctly populated — they just never made it into the prompt. No agent sessions involved either (`agent_id=None`, `session=None`), so the user's stale-session hypothesis was ruled out by the log.

## Changes

**Two-layer fix** so we don't silently regress later:

1. **`src/lib/autopilot/ideation.ts` + `src/lib/autopilot/research.ts`** — both prompts now lead with a `## Product` section that always includes `name` + `description` (and repo/live URL when present). The `## Product Program` section follows; when empty, the fallback explicitly tells the LLM to treat the Product section above as the source of truth and generate ideas in the stated domain, not generic SaaS features.

2. **`src/app/(app)/autopilot/new/page.tsx`** — extracted a `buildProgramTemplate(name, description)` helper used both as the Step 2 textarea placeholder *and* as the auto-seed value when the operator transitions into Step 2 with an empty program. The seed echoes the basics into the `# Purpose` heading so they don't have to retype themselves; "Skip for now" still doesn't persist the seeded value (`handleSaveProgram` is only called by the explicit Next button), so the UX of intentionally-empty programs is preserved.

## Out of scope

- Ephemeral planning agents — worth doing eventually for defence-in-depth, but wouldn't have fixed *this* bug since autopilot doesn't use stateful agents.
- Hard-blocking cycle runs when both `product_program` and `description` are empty — soft warning would be enough; happy to add as a follow-up if desired.

## Test plan

- [ ] `/autopilot/new`: type a name + description → Next → Step 2 textarea opens pre-filled with the seeded template (name in heading, description in Purpose), editable.
- [ ] Skip Step 2 → product is created with `product_program: ''` (the seeded value is not persisted).
- [ ] Trigger a research or ideation cycle for a product whose `product_program` is empty → outbound prompt contains the Product section with name + description; the LLM generates ideas in the stated domain.
- [ ] `yarn tsc --noEmit` — only pre-existing failures (`.next/types/validator.ts`, `pm-decompose.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)