### PR TITLE
fix(pm): apply plan_initiative suggestions to a real initiative on Accept

### DIFF
--- a/src/app/(app)/initiatives/[id]/page.tsx
+++ b/src/app/(app)/initiatives/[id]/page.tsx
@@ -653,24 +653,31 @@ export default function InitiativeDetailPage({
                 target_end: initiative.target_end,
               }}
               onClose={() => setShowPlanPanel(false)}
-              onApply={async (s: PlanInitiativeSuggestions) => {
-                // Map every suggested field through patch() so the
-                // persistence path stays the same as inline edits.
-                const body: Record<string, unknown> = {};
-                if (s.refined_description) body.description = s.refined_description;
-                if (s.complexity) body.complexity = s.complexity;
-                if (s.target_start) body.target_start = s.target_start;
-                if (s.target_end) body.target_end = s.target_end;
-                if (s.status_check_md) body.status_check_md = s.status_check_md;
-                if (s.owner_agent_id) body.owner_agent_id = s.owner_agent_id;
-                if (Object.keys(body).length > 0) {
-                  try {
-                    await patch(body);
-                  } catch (e) {
-                    setActionError(
-                      e instanceof Error ? e.message : 'Failed to apply suggestions',
-                    );
+              onApply={async (_s, ctx) => {
+                // Route through the proposal-accept endpoint with our
+                // initiative id as the target. The server applies the
+                // field updates *and* the suggested dependencies in one
+                // transaction, flips the proposal to accepted, and
+                // posts a real "Applied — N updated, M deps added"
+                // banner instead of the old misleading "0 changes".
+                try {
+                  const res = await fetch(
+                    `/api/pm/proposals/${ctx.proposalId}/accept`,
+                    {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ target_initiative_id: id }),
+                    },
+                  );
+                  if (!res.ok) {
+                    const data = await res.json().catch(() => ({}));
+                    throw new Error(data.error || `Apply failed (${res.status})`);
                   }
+                  refresh();
+                } catch (e) {
+                  setActionError(
+                    e instanceof Error ? e.message : 'Failed to apply suggestions',
+                  );
                 }
                 setShowPlanPanel(false);
               }}

--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -1172,9 +1172,13 @@ export function EditDrawer({
             workspaceId={initiative.workspace_id}
             draft={planDraft}
             onClose={() => setPlanOpen(false)}
-            onApply={(s: PlanInitiativeSuggestions) => {
-              // Populate the form fields with the PM's recommendations.
-              // The operator can still tweak before Save.
+            onApply={s => {
+              // EditDrawer is still a "fill-the-form, then Save" UX —
+              // we don't go through the proposal-accept path here
+              // because the operator may keep tweaking before clicking
+              // Save (which then PATCHes everything in one shot). The
+              // proposal-id is ignored on this path; the field-level
+              // population mirrors what the PM suggested.
               if (s.refined_description) setDescription(s.refined_description);
               if (s.complexity) setComplexity(s.complexity);
               if (s.target_start) setTargetStart(s.target_start);

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -288,9 +288,22 @@ function PmChatPageInner() {
     }
   };
 
-  const onAccept = async (proposalId: string) => {
+  // plan_initiative proposals are advisory at the database level — they
+  // carry the suggestions JSON inside impact_md but no link to a target
+  // initiative. Clicking Accept on one used to flip the proposal to
+  // "accepted" and report "Applied — 0 changes" because there was no
+  // target. Now we route to a picker modal that lets the operator pick
+  // an initiative; the modal POSTs to /accept with target_initiative_id
+  // and the server applies the suggestions atomically.
+  const [planAcceptProposal, setPlanAcceptProposal] = useState<PmProposal | null>(null);
+
+  const onAccept = async (proposal: PmProposal) => {
+    if (proposal.trigger_kind === 'plan_initiative') {
+      setPlanAcceptProposal(proposal);
+      return;
+    }
     try {
-      const res = await fetch(`/api/pm/proposals/${proposalId}/accept`, { method: 'POST' });
+      const res = await fetch(`/api/pm/proposals/${proposal.id}/accept`, { method: 'POST' });
       if (!res.ok) throw new Error('Accept failed');
       await loadMessages();
       await loadRecent();
@@ -581,6 +594,19 @@ function PmChatPageInner() {
           </ul>
         </aside>
       </div>
+
+      {planAcceptProposal && (
+        <ApplyPlanToInitiativeModal
+          proposal={planAcceptProposal}
+          workspaceId={workspaceId}
+          onClose={() => setPlanAcceptProposal(null)}
+          onApplied={async () => {
+            setPlanAcceptProposal(null);
+            await loadMessages();
+            await loadRecent();
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -596,7 +622,9 @@ function parseProposalId(m: AgentChatMessage): string | null {
 interface ChatMessageRowProps {
   message: AgentChatMessage;
   proposal?: PmProposal;
-  onAccept: (id: string) => void;
+  // Pass the full proposal so the parent can branch on trigger_kind
+  // (e.g. plan_initiative routes to the Apply-to-initiative picker).
+  onAccept: (proposal: PmProposal) => void;
   onReject: (id: string) => void;
   refining: string | null;
   refineText: string;
@@ -722,7 +750,7 @@ function ChatMessageRow({
                 </button>
                 <button
                   type="button"
-                  onClick={() => onAccept(proposal.id)}
+                  onClick={() => onAccept(proposal)}
                   className="text-xs px-2 py-1 bg-emerald-500/20 border border-emerald-500/40 text-emerald-200 rounded-sm hover:bg-emerald-500/30 flex items-center gap-1"
                 >
                   <Check className="w-3 h-3" /> Accept
@@ -771,7 +799,7 @@ function shortId(id: string | null | undefined): string {
 
 interface PinnedStandupCardProps {
   proposal: PmProposal;
-  onAccept: (id: string) => void;
+  onAccept: (proposal: PmProposal) => void;
   onReject: (id: string) => void;
   setRef: (el: HTMLDivElement | null) => void;
   highlighted: boolean;
@@ -839,7 +867,7 @@ function PinnedStandupCard({
       <div className="px-3 py-2 border-t border-violet-500/30 bg-violet-500/5 flex items-center gap-2">
         <button
           type="button"
-          onClick={() => onAccept(proposal.id)}
+          onClick={() => onAccept(proposal)}
           className="text-xs px-2 py-1 bg-emerald-500/20 border border-emerald-500/40 text-emerald-200 rounded-sm hover:bg-emerald-500/30 flex items-center gap-1"
         >
           <Check className="w-3 h-3" /> Accept
@@ -870,6 +898,280 @@ function ChatMarkdown({ content }: { content: string }) {
   return (
     <div className="mc-md text-sm">
       <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    </div>
+  );
+}
+
+interface InitiativeLite {
+  id: string;
+  title: string;
+  kind: string;
+  status: string;
+  workspace_id?: string;
+}
+
+interface PlanSuggestionsLite {
+  refined_description?: string | null;
+  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+  target_start?: string | null;
+  target_end?: string | null;
+  status_check_md?: string | null;
+  owner_agent_id?: string | null;
+  dependencies?: Array<{
+    depends_on_initiative_id: string;
+    note?: string | null;
+  }>;
+}
+
+/**
+ * Modal that lands when the operator clicks Accept on a plan_initiative
+ * proposal in the PM chat. Lets them pick which initiative to apply the
+ * suggestions to (best title-match preselected from the draft) and
+ * shows a preview of what will change before they hit Apply. The actual
+ * apply runs server-side via /api/pm/proposals/<id>/accept with
+ * target_initiative_id, so it's atomic and the chat banner accurately
+ * reports what landed.
+ */
+function ApplyPlanToInitiativeModal({
+  proposal,
+  workspaceId,
+  onClose,
+  onApplied,
+}: {
+  proposal: PmProposal;
+  workspaceId: string;
+  onClose: () => void;
+  onApplied: () => void | Promise<void>;
+}) {
+  const [initiatives, setInitiatives] = useState<InitiativeLite[]>([]);
+  const [chosenId, setChosenId] = useState<string>('');
+  const [loading, setLoading] = useState(true);
+  const [applying, setApplying] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Pull the structured suggestions out of the impact_md HTML comment —
+  // same parser shape as the inline detail-page panel.
+  const suggestions: PlanSuggestionsLite | null = (() => {
+    const m = proposal.impact_md.match(/<!--pm-plan-suggestions\s+([\s\S]*?)\s*-->/);
+    if (!m) return null;
+    try {
+      return JSON.parse(m[1]) as PlanSuggestionsLite;
+    } catch {
+      return null;
+    }
+  })();
+
+  // Pull the draft title out of trigger_text so we can preselect the
+  // best-matching existing initiative.
+  const draftTitle: string = (() => {
+    try {
+      const t = JSON.parse(proposal.trigger_text);
+      return (t?.draft?.title as string) ?? '';
+    } catch {
+      return '';
+    }
+  })();
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/initiatives?workspace_id=${encodeURIComponent(workspaceId)}`);
+        if (!res.ok) throw new Error(`Failed to load initiatives (${res.status})`);
+        const list = (await res.json()) as InitiativeLite[];
+        if (cancelled) return;
+        setInitiatives(list);
+        // Preselect by case-insensitive title equality first, then by
+        // longest substring overlap. If nothing matches, leave the
+        // dropdown unselected so the operator picks consciously.
+        if (draftTitle && list.length > 0) {
+          const exact = list.find(
+            i => i.title.trim().toLowerCase() === draftTitle.trim().toLowerCase(),
+          );
+          if (exact) {
+            setChosenId(exact.id);
+          } else {
+            const lower = draftTitle.toLowerCase();
+            const partial = list.find(i => i.title.toLowerCase().includes(lower) || lower.includes(i.title.toLowerCase()));
+            if (partial) setChosenId(partial.id);
+          }
+        }
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : 'Failed to load initiatives');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, draftTitle]);
+
+  const handleApply = async () => {
+    if (!chosenId) {
+      setErr('Pick an initiative first.');
+      return;
+    }
+    setApplying(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/pm/proposals/${proposal.id}/accept`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target_initiative_id: chosenId }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Apply failed (${res.status})`);
+      }
+      await onApplied();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Apply failed');
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const titleFor = (id: string) => initiatives.find(i => i.id === id)?.title ?? id.slice(0, 8);
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50" onClick={onClose}>
+      <div
+        className="bg-mc-bg-secondary border border-mc-border rounded-lg w-full max-w-2xl max-h-[90vh] flex flex-col text-mc-text"
+        onClick={e => e.stopPropagation()}
+      >
+        <header className="p-4 border-b border-mc-border">
+          <h2 className="text-lg font-semibold">Apply PM suggestions to an initiative</h2>
+          <p className="text-xs text-mc-text-secondary mt-1">
+            Plan with PM produces an advisory proposal. Pick which initiative these suggestions
+            should land on — the server will patch its fields and create the suggested
+            dependencies in one go.
+          </p>
+        </header>
+
+        <div className="p-4 space-y-4 overflow-y-auto">
+          <div>
+            <label className="block">
+              <span className="text-xs text-mc-text-secondary uppercase tracking-wide">
+                Apply to initiative
+              </span>
+              <select
+                className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+                value={chosenId}
+                onChange={e => setChosenId(e.target.value)}
+                disabled={loading || applying}
+              >
+                <option value="">{loading ? 'Loading…' : '— pick one —'}</option>
+                {initiatives.map(i => (
+                  <option key={i.id} value={i.id}>
+                    [{i.kind}] {i.title} · {i.status}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {draftTitle && (
+              <p className="text-[11px] text-mc-text-secondary mt-1">
+                PM drafted: <span className="text-mc-text">{draftTitle}</span>
+                {chosenId
+                  ? initiatives.find(i => i.id === chosenId)?.title.toLowerCase() ===
+                    draftTitle.toLowerCase()
+                    ? ' · exact match preselected'
+                    : ' · best match preselected — change if wrong'
+                  : ''}
+              </p>
+            )}
+          </div>
+
+          {suggestions ? (
+            <div className="rounded border border-mc-border bg-mc-bg p-3 text-xs space-y-2">
+              <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">
+                Will apply
+              </div>
+              {suggestions.refined_description && (
+                <Row label="Description">
+                  <span className="text-mc-text-secondary line-clamp-3">
+                    {suggestions.refined_description}
+                  </span>
+                </Row>
+              )}
+              {suggestions.complexity && (
+                <Row label="Complexity">{suggestions.complexity}</Row>
+              )}
+              {suggestions.target_start && (
+                <Row label="Target start">{suggestions.target_start}</Row>
+              )}
+              {suggestions.target_end && (
+                <Row label="Target end">{suggestions.target_end}</Row>
+              )}
+              {suggestions.status_check_md && (
+                <Row label="Status check">
+                  <span className="font-mono text-[11px] text-mc-text-secondary line-clamp-3">
+                    {suggestions.status_check_md}
+                  </span>
+                </Row>
+              )}
+              {suggestions.owner_agent_id && (
+                <Row label="Owner">{suggestions.owner_agent_id.slice(0, 8)}…</Row>
+              )}
+              {suggestions.dependencies && suggestions.dependencies.length > 0 && (
+                <Row label={`Dependencies (${suggestions.dependencies.length})`}>
+                  <ul className="space-y-0.5">
+                    {suggestions.dependencies.map(d => (
+                      <li key={d.depends_on_initiative_id}>
+                        → <span className="font-medium">{titleFor(d.depends_on_initiative_id)}</span>
+                        {d.note ? (
+                          <span className="text-mc-text-secondary italic"> — {d.note}</span>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                </Row>
+              )}
+            </div>
+          ) : (
+            <div className="text-xs text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded p-2">
+              This proposal has no embedded suggestions to apply.
+            </div>
+          )}
+
+          {err && (
+            <div className="text-xs text-red-300 bg-red-500/10 border border-red-500/30 rounded p-2">
+              {err}
+            </div>
+          )}
+        </div>
+
+        <footer className="flex justify-end gap-2 p-4 border-t border-mc-border">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={applying}
+            className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleApply}
+            disabled={applying || !chosenId || !suggestions}
+            className="px-3 py-2 rounded bg-mc-accent text-white text-sm disabled:opacity-50"
+          >
+            {applying ? 'Applying…' : 'Apply suggestions'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-[110px_1fr] gap-2">
+      <div className="text-[10px] uppercase tracking-wide text-mc-text-secondary/70 pt-0.5">
+        {label}
+      </div>
+      <div className="text-mc-text">{children}</div>
     </div>
   );
 }

--- a/src/app/api/pm/proposals/[id]/accept/route.ts
+++ b/src/app/api/pm/proposals/[id]/accept/route.ts
@@ -1,10 +1,19 @@
 /**
  * POST /api/pm/proposals/[id]/accept
  *
- *   body: { applied_by_agent_id?: string }
+ *   body: {
+ *     applied_by_agent_id?: string,
+ *     // For plan_initiative proposals only: when provided, parse the
+ *     // embedded suggestions JSON out of impact_md and apply it to the
+ *     // chosen initiative atomically (field PATCHes + dependency INSERTs)
+ *     // instead of the no-op "advisory" path.
+ *     target_initiative_id?: string,
+ *   }
  *
- * Applies the proposal's diff list transactionally. Returns the updated
- * proposal + a count of changes applied.
+ * Applies the proposal's diff list transactionally (or, for advisory
+ * plan_initiative + target_initiative_id, applies the embedded
+ * suggestions blob). Returns the updated proposal + a count of changes
+ * applied.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -12,11 +21,16 @@ import { z } from 'zod';
 import { acceptProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
 import { postPmChatMessage } from '@/lib/agents/pm-dispatch';
 import { queryOne } from '@/lib/db';
+import {
+  applyPlanInitiativeSuggestions,
+  parseSuggestionsFromImpactMd,
+} from '@/lib/pm/applyPlanInitiativeProposal';
 
 export const dynamic = 'force-dynamic';
 
 const Body = z.object({
   applied_by_agent_id: z.string().min(1).nullish(),
+  target_initiative_id: z.string().min(1).nullish(),
 });
 
 interface RouteParams {
@@ -34,6 +48,86 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   const parsed = Body.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json({ error: 'Validation failed', details: parsed.error.issues }, { status: 400 });
+  }
+
+  // Branch: plan_initiative + chosen target → apply the embedded
+  // suggestions to that initiative before the standard accept flow
+  // flips status. Other paths fall through to acceptProposal as before.
+  const targetInitiativeId = parsed.data.target_initiative_id ?? null;
+  if (targetInitiativeId) {
+    const proposal = queryOne<{
+      id: string;
+      workspace_id: string;
+      trigger_kind: string;
+      impact_md: string;
+      status: string;
+    }>(
+      'SELECT id, workspace_id, trigger_kind, impact_md, status FROM pm_proposals WHERE id = ?',
+      [id],
+    );
+    if (!proposal) {
+      return NextResponse.json({ error: 'Proposal not found' }, { status: 404 });
+    }
+    if (proposal.trigger_kind !== 'plan_initiative') {
+      return NextResponse.json(
+        { error: `target_initiative_id is only valid for plan_initiative proposals (got ${proposal.trigger_kind})` },
+        { status: 400 },
+      );
+    }
+    const suggestions = parseSuggestionsFromImpactMd(proposal.impact_md);
+    if (!suggestions) {
+      return NextResponse.json(
+        { error: 'Proposal has no embedded suggestions to apply' },
+        { status: 400 },
+      );
+    }
+    try {
+      const applied = applyPlanInitiativeSuggestions(targetInitiativeId, suggestions);
+      // Flip the proposal to accepted via the standard path so downstream
+      // listeners see one consistent state transition.
+      const acceptResult = acceptProposal(id, parsed.data.applied_by_agent_id ?? null);
+
+      // Replace the default "Applied — 0 changes" banner with one that
+      // reflects what really happened.
+      const partsList: string[] = [];
+      if (applied.fields_updated > 0) {
+        partsList.push(`${applied.fields_updated} field${applied.fields_updated === 1 ? '' : 's'} updated`);
+      }
+      if (applied.dependencies_created > 0) {
+        partsList.push(
+          `${applied.dependencies_created} dependenc${applied.dependencies_created === 1 ? 'y' : 'ies'} added`,
+        );
+      }
+      if (applied.dependencies_skipped > 0) {
+        partsList.push(
+          `${applied.dependencies_skipped} skipped (already linked / unknown)`,
+        );
+      }
+      const summary = partsList.length > 0 ? partsList.join(', ') : 'no changes';
+      const text =
+        `Applied to **${applied.initiative_title}** — ${summary}. ` +
+        `[Open initiative](/initiatives/${targetInitiativeId})`;
+      try {
+        postPmChatMessage({
+          workspace_id: proposal.workspace_id,
+          role: 'assistant',
+          content: text,
+        });
+      } catch (err) {
+        console.warn('[pm-accept] chat insert failed:', (err as Error).message);
+      }
+
+      return NextResponse.json({
+        ...acceptResult,
+        applied_to_initiative: targetInitiativeId,
+        changes_applied: applied.fields_updated + applied.dependencies_created,
+        plan_apply: applied,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to apply suggestions';
+      console.error('Failed to apply plan_initiative suggestions:', err);
+      return NextResponse.json({ error: msg }, { status: 500 });
+    }
   }
 
   try {

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -83,8 +83,17 @@ export default function PlanWithPmPanel({
   draft: PlanInitiativeDraft;
   knownInitiatives?: KnownInitiative[];
   onClose: () => void;
-  /** Operator clicked Apply — receive the suggestions to populate the form. */
-  onApply: (suggestions: PlanInitiativeSuggestions) => void;
+  /**
+   * Operator clicked Apply. Receives the parsed suggestions plus the
+   * server-side proposal id (so callers that route through
+   * `POST /api/pm/proposals/:id/accept` with `target_initiative_id` can
+   * apply atomically server-side instead of doing the PATCH dance
+   * client-side).
+   */
+  onApply: (
+    suggestions: PlanInitiativeSuggestions,
+    ctx: { proposalId: string },
+  ) => void;
 }) {
   const [proposalId, setProposalId] = useState<string | null>(null);
   const [impactMd, setImpactMd] = useState<string>('');
@@ -166,7 +175,7 @@ export default function PlanWithPmPanel({
   };
 
   const apply = () => {
-    if (suggestions) onApply(suggestions);
+    if (suggestions && proposalId) onApply(suggestions, { proposalId });
   };
 
   if (!open) return null;
@@ -236,7 +245,9 @@ export default function PlanWithPmPanel({
             </div>
             {suggestions.dependencies.length > 0 && (
               <div>
-                <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">Possible dependencies</div>
+                <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">
+                  Will create on Apply ({suggestions.dependencies.length} dependenc{suggestions.dependencies.length === 1 ? 'y' : 'ies'})
+                </div>
                 <ul className="text-mc-text mt-1 space-y-1">
                   {suggestions.dependencies.map(d => (
                     <li key={d.depends_on_initiative_id}>

--- a/src/lib/pm/applyPlanInitiativeProposal.ts
+++ b/src/lib/pm/applyPlanInitiativeProposal.ts
@@ -1,0 +1,153 @@
+/**
+ * Apply the embedded `<!--pm-plan-suggestions ...-->` JSON inside a
+ * plan_initiative proposal's impact_md to a chosen target initiative.
+ *
+ * Why this exists: plan_initiative proposals are dispatched as advisory
+ * (proposed_changes = []) because at dispatch time the system doesn't
+ * know which initiative — if any — the operator wants the suggestions
+ * applied to. The structured suggestions live in an HTML comment in the
+ * impact_md. When the operator picks a target (either via the chat
+ * Accept picker or via the inline detail-page panel), this helper does
+ * the actual write — atomically, per-initiative.
+ */
+import { v4 as uuidv4 } from 'uuid';
+import { getDb, queryOne, run } from '@/lib/db';
+
+export interface PlanInitiativeSuggestionsBlob {
+  refined_description?: string | null;
+  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+  target_start?: string | null;
+  target_end?: string | null;
+  status_check_md?: string | null;
+  owner_agent_id?: string | null;
+  dependencies?: Array<{
+    depends_on_initiative_id: string;
+    kind?: 'finish_to_start' | 'start_to_start' | 'blocking' | 'informational';
+    note?: string | null;
+  }>;
+}
+
+/**
+ * Pull the suggestions blob out of an impact_md string. The PM agent
+ * embeds it as `<!--pm-plan-suggestions {json} -->` so the markdown
+ * stays human-readable but a client can parse the structured form.
+ */
+export function parseSuggestionsFromImpactMd(
+  md: string,
+): PlanInitiativeSuggestionsBlob | null {
+  // [\s\S] matches anything including newlines without needing the `s`
+  // flag, which keeps this compatible with older lib targets.
+  const m = md.match(/<!--pm-plan-suggestions\s+([\s\S]*?)\s*-->/);
+  if (!m) return null;
+  try {
+    return JSON.parse(m[1]) as PlanInitiativeSuggestionsBlob;
+  } catch {
+    return null;
+  }
+}
+
+export interface ApplyPlanResult {
+  fields_updated: number;
+  dependencies_created: number;
+  dependencies_skipped: number; // duplicates / self-edges
+  initiative_title: string;
+}
+
+/**
+ * Apply a plan_initiative suggestions blob to a real initiative in a
+ * single transaction:
+ *   - UPDATE the initiative with any provided field suggestions
+ *   - INSERT each suggested dependency (skipping self-edges and dupes)
+ *
+ * Throws if the initiative isn't found. Per-dependency errors that
+ * aren't fatal (FK violations, duplicate edges) are silently counted as
+ * `dependencies_skipped` rather than aborting the whole apply, so the
+ * field updates still land.
+ */
+export function applyPlanInitiativeSuggestions(
+  initiativeId: string,
+  suggestions: PlanInitiativeSuggestionsBlob,
+): ApplyPlanResult {
+  const initiative = queryOne<{ id: string; title: string }>(
+    'SELECT id, title FROM initiatives WHERE id = ?',
+    [initiativeId],
+  );
+  if (!initiative) {
+    throw new Error(`Initiative ${initiativeId} not found`);
+  }
+
+  // Build the UPDATE column-by-column so empty suggestions don't
+  // overwrite existing values.
+  const sets: string[] = [];
+  const vals: unknown[] = [];
+  const push = (col: string, val: unknown) => {
+    sets.push(`${col} = ?`);
+    vals.push(val);
+  };
+  if (suggestions.refined_description) push('description', suggestions.refined_description);
+  if (suggestions.complexity) push('complexity', suggestions.complexity);
+  if (suggestions.target_start) push('target_start', suggestions.target_start);
+  if (suggestions.target_end) push('target_end', suggestions.target_end);
+  if (suggestions.status_check_md) push('status_check_md', suggestions.status_check_md);
+  if (suggestions.owner_agent_id) push('owner_agent_id', suggestions.owner_agent_id);
+
+  const db = getDb();
+  let fieldsUpdated = 0;
+  let depsCreated = 0;
+  let depsSkipped = 0;
+
+  const tx = db.transaction(() => {
+    if (sets.length > 0) {
+      sets.push("updated_at = datetime('now')");
+      run(
+        `UPDATE initiatives SET ${sets.join(', ')} WHERE id = ?`,
+        [...vals, initiativeId],
+      );
+      fieldsUpdated = sets.length - 1; // -1 for the auto-updated_at
+    }
+
+    for (const dep of suggestions.dependencies ?? []) {
+      // Sanity guards: never link an initiative to itself, and never
+      // crash on a stale id the PM might have made up.
+      if (!dep.depends_on_initiative_id || dep.depends_on_initiative_id === initiativeId) {
+        depsSkipped++;
+        continue;
+      }
+      const target = queryOne<{ id: string }>(
+        'SELECT id FROM initiatives WHERE id = ?',
+        [dep.depends_on_initiative_id],
+      );
+      if (!target) {
+        depsSkipped++;
+        continue;
+      }
+      try {
+        run(
+          `INSERT INTO initiative_dependencies (id, initiative_id, depends_on_initiative_id, kind, note)
+           VALUES (?, ?, ?, ?, ?)`,
+          [
+            uuidv4(),
+            initiativeId,
+            dep.depends_on_initiative_id,
+            dep.kind ?? 'finish_to_start',
+            dep.note ?? null,
+          ],
+        );
+        depsCreated++;
+      } catch {
+        // UNIQUE(initiative_id, depends_on_initiative_id) collision —
+        // this edge already exists. Treat as a skip rather than an error
+        // so re-applying a proposal stays idempotent.
+        depsSkipped++;
+      }
+    }
+  });
+  tx();
+
+  return {
+    fields_updated: fieldsUpdated,
+    dependencies_created: depsCreated,
+    dependencies_skipped: depsSkipped,
+    initiative_title: initiative.title,
+  };
+}


### PR DESCRIPTION
## Summary

`plan_initiative` proposals are dispatched as advisory (`proposed_changes = []`) because at dispatch time the system doesn't know which initiative — if any — the suggestions should land on. The structured suggestions live in an HTML comment in `impact_md` but were never read by the accept flow, so:

- **Detail-page Plan-with-PM panel:** Apply ran a client-side PATCH for the field suggestions and ignored the suggested *dependencies* entirely.
- **PM chat card:** Accept just flipped the proposal to `accepted` and posted the misleading *"Applied — 0 changes"* banner because there was no target to write to.

Both paths now route through the same server endpoint:

```
POST /api/pm/proposals/[id]/accept   body: { target_initiative_id? }
```

When `trigger_kind === 'plan_initiative'` AND a target is provided, the server parses the embedded suggestions JSON, applies field `UPDATE`s and dependency `INSERT`s in a single transaction, flips the proposal to accepted, and posts a real *"Applied to **<Title>** — 5 fields, 1 dependency"* banner. Duplicate dependency edges and self-edges are silently skipped so re-applying a proposal is idempotent.

## Changes

- **`src/lib/pm/applyPlanInitiativeProposal.ts`** (new) — `parseSuggestionsFromImpactMd()` + `applyPlanInitiativeSuggestions(initiativeId, suggestions)`. Wrapped in a `db.transaction(() => { … })` so partial failure rolls back; per-dependency duplicate/missing-target errors are counted as `dependencies_skipped` instead of aborting the whole apply.
- **`src/app/api/pm/proposals/[id]/accept/route.ts`** — accepts optional `target_initiative_id`; new branch handles plan_initiative, builds the better banner. Other proposal kinds untouched.
- **`src/components/PlanWithPmPanel.tsx`** — `onApply` now passes `{ proposalId }` so callers can route through the server endpoint. *"Possible dependencies"* → *"Will create on Apply (N)"* so the operator knows what they're consenting to.
- **`src/app/(app)/initiatives/[id]/page.tsx`** — detail-page `onApply` POSTs to the accept endpoint with `target_initiative_id` = current id; refresh shows the applied fields *and* the new outgoing dependency.
- **`src/app/(app)/pm/page.tsx`** — Accept on a plan_initiative proposal opens an `ApplyPlanToInitiativeModal`: initiative picker (best title-match against the draft preselected), suggestions preview (description / sizing / dates / status check / dependencies-to-be-created), Apply button POSTs accept with the chosen target. Other trigger_kinds keep their old behaviour.
- **`src/app/(app)/initiatives/page.tsx`** — `EditDrawer` updated for the new `onApply` signature; behaviour unchanged (still populates form fields for the operator to tweak before Save).

## Test plan

Verified end-to-end against the preview server:

- Seeded a real `plan_initiative` proposal (5 field suggestions + 1 dep) → POST accept with target_initiative_id → server returned `{ fields_updated: 5, dependencies_created: 1 }`; subsequent fetch confirmed all 5 fields patched on the initiative and the outgoing dependency created with the suggested note.
- Re-applied the same suggestions to the same initiative (idempotency) → `{ fields_updated: 5, dependencies_created: 0, dependencies_skipped: 1 }` — duplicate edge skipped, no error.
- `yarn tsc --noEmit` — only the pre-existing failures (`.next/types/validator.ts`, `pm-decompose.test.ts`); none introduced here.

Manual checklist:
- [ ] In `/pm`, ask PM to plan an existing initiative → wait for the proposal card → click **Accept** → modal opens with picker preselected to the matching initiative + suggestions preview → click **Apply suggestions** → chat banner reads *"Applied to <Title> — N fields, M deps"* → open the initiative and confirm the description, dates, complexity, status check, and outgoing dependency landed.
- [ ] On `/initiatives/<id>`, click **Plan with PM** → panel opens under the header → click **Apply suggestions** → same outcome via the same code path.
- [ ] Accept on a non-`plan_initiative` proposal still uses the existing diff-based path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)