### PR TITLE
fix(pm): plan panel stops spinning; chat plans carry suggestions sidecar

### DIFF
--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -28,6 +28,8 @@ import { getRoadmapSnapshot } from '@/lib/db/roadmap';
 import { synthesizePlanInitiative } from '@/lib/agents/pm-agent';
 import { PmProposalValidationError } from '@/lib/db/pm-proposals';
 import { postPmChatMessage, dispatchPmSynthesized } from '@/lib/agents/pm-dispatch';
+import { parseSuggestionsFromImpactMd } from '@/lib/pm/applyPlanInitiativeProposal';
+import { run } from '@/lib/db';
 
 export const dynamic = 'force-dynamic';
 
@@ -88,7 +90,25 @@ export async function POST(request: NextRequest) {
         `includes a "<!--pm-plan-suggestions ...-->" sidecar so the form can apply your ` +
         `suggestions. proposed_changes should be [] (advisory). See your SOUL.md.`,
     });
-    const proposal = dispatch.proposal;
+    let proposal = dispatch.proposal;
+
+    // Always-embed-the-sidecar guarantee: when the PM agent answered via
+    // the gateway, its impact_md is freeform — LLMs are unreliable about
+    // including arbitrary HTML-comment JSON sidecars even when SOUL.md
+    // tells them to. Without the sidecar, the chat-card Apply flow has
+    // no structured suggestions to apply. We always have synth.suggestions
+    // here, so inject it post-hoc when missing and persist the patched
+    // impact_md to the same row. The synth path naturally already
+    // includes it, so this is a no-op there.
+    if (!parseSuggestionsFromImpactMd(proposal.impact_md)) {
+      const sidecar = `\n\n<!--pm-plan-suggestions ${JSON.stringify(synth.suggestions)} -->`;
+      const patchedMd = proposal.impact_md + sidecar;
+      run(
+        'UPDATE pm_proposals SET impact_md = ? WHERE id = ?',
+        [patchedMd, proposal.id],
+      );
+      proposal = { ...proposal, impact_md: patchedMd };
+    }
 
     // Best-effort chat echo for audit visibility in /pm. Use the
     // PROPOSAL's impact_md — when the named PM agent answered, that's

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -102,22 +102,33 @@ export default function PlanWithPmPanel({
   const [refining, setRefining] = useState(false);
   const [refineText, setRefineText] = useState('');
   const [err, setErr] = useState<string | null>(null);
-  const submittedRef = useRef(false);
+  // Snapshot the draft at open-time so React-driven re-renders of the
+  // host (which construct a fresh `draft` object every render) don't
+  // retrigger this effect and cancel the in-flight fetch.
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
 
-  // Kick off the initial plan request when the panel opens.
+  // The previous implementation guarded against a duplicate fetch with
+  // `submittedRef.current = true` set BEFORE the await. Combined with
+  // React StrictMode's mount-cleanup-mount sequence in dev, that meant:
+  //   1. effect run #1: ref→true, kicks off fetch A
+  //   2. cleanup of #1: cancelled1 = true
+  //   3. effect run #2 (StrictMode): ref is true → bail without fetching
+  //   4. fetch A resolves → cancelled1=true → state never set
+  //   → "Thinking…" forever, even though the network log shows a 201.
+  // Drop the ref-guard. Each effect run owns its own `cancelled` flag,
+  // so even if dev StrictMode fires two requests, exactly one of them
+  // wins the state-setter race. In production this runs once.
   useEffect(() => {
     if (!open) {
-      // Reset on close so the next open re-runs.
+      // Reset on close so the next open re-runs cleanly.
       setProposalId(null);
       setImpactMd('');
       setSuggestions(null);
       setErr(null);
       setRefineText('');
-      submittedRef.current = false;
       return;
     }
-    if (submittedRef.current) return;
-    submittedRef.current = true;
 
     let cancelled = false;
     (async () => {
@@ -129,7 +140,7 @@ export default function PlanWithPmPanel({
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             workspace_id: workspaceId,
-            draft,
+            draft: draftRef.current,
           }),
         });
         const body = await res.json();
@@ -147,7 +158,8 @@ export default function PlanWithPmPanel({
     return () => {
       cancelled = true;
     };
-  }, [open, workspaceId, draft]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, workspaceId]);
 
   const refine = async () => {
     if (!proposalId || !refineText.trim()) return;


### PR DESCRIPTION
## Summary

Two related disconnects in the Plan-with-PM flow that survived #68:

### 1. Detail-page Plan panel spun on "Thinking…" forever

Network logs confirmed the `POST /api/pm/plan-initiative` returned 201; the panel's loading state just never flipped. Root cause: a `submittedRef.current = true` guard set **before** the await, combined with React StrictMode's mount-cleanup-mount sequence in dev:

1. effect run #1 → `ref→true`, kicks off fetch A
2. cleanup of #1 → `cancelled1 = true`
3. effect run #2 (StrictMode double-invoke) → ref already true → **bail, no fetch B**
4. fetch A resolves → `cancelled1=true` → `setLoading(false)` skipped

Drop the ref-guard. Each effect run owns its own `cancelled` flag, so even if dev StrictMode fires two requests one of them wins the state-setter race. Production runs once.

Also snapshotted `draft` into a ref so re-renders of the host (which reconstruct the `draft` prop literal every render) don't retrigger the effect needlessly.

### 2. PM chat Accept on plan_initiative still said "0 changes"

#68 made the chat-card Accept route through a picker modal that posts `target_initiative_id` to `/accept`. But the modal couldn't actually apply anything because the chat-emitted proposal's `impact_md` was often **missing the `<!--pm-plan-suggestions ...-->` sidecar** — LLMs are unreliable about embedding arbitrary HTML-comment JSON even when SOUL.md tells them to. `parseSuggestionsFromImpactMd → null` → modal showed *"no embedded suggestions to apply"* and disabled Apply.

The `/api/pm/plan-initiative` route already has `synth.suggestions` ready. Append the sidecar to the dispatched proposal's `impact_md` when it doesn't already contain one, and persist back with an UPDATE. The synth fallback path naturally always has it, so this is a no-op there; only the gateway-PM-agent path benefits.

## Out of scope

Chat-only flows where the PM agent calls `propose_changes` MCP directly without going through `/api/pm/plan-initiative` still depend on the agent embedding its own sidecar. That's a separate gap — the modal already shows a clear *"no embedded suggestions"* warning when it occurs, so it fails loudly rather than silently.

## Test plan

Verified in preview:
- [x] `/initiatives/<id>` → click **Plan with PM** → panel transitions Thinking → suggestions in <1s with Apply enabled (was: spinner forever).
- [x] Apply suggestions → server PATCH applies fields + creates dependencies → banner reads *"Applied to <Title> — 5 fields, 1 dep"*.
- [x] Re-applying the same proposal → `dependencies_skipped: 1, dependencies_created: 0` (idempotent).
- [x] Typecheck — only the pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)