### PR TITLE
feat(pm): persist plan_initiative drafts per-initiative; resume on re-open

### DIFF
--- a/src/app/(app)/initiatives/[id]/page.tsx
+++ b/src/app/(app)/initiatives/[id]/page.tsx
@@ -659,6 +659,7 @@ export default function InitiativeDetailPage({
             <PlanWithPmPanel
               open={showPlanPanel}
               workspaceId={initiative.workspace_id}
+              targetInitiativeId={initiative.id}
               draft={{
                 title: initiative.title,
                 description: initiative.description ?? '',

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -35,6 +35,10 @@ export const dynamic = 'force-dynamic';
 
 const Body = z.object({
   workspace_id: z.string().min(1),
+  // Set when the panel was opened on an existing initiative's detail
+  // page. Persisted on the proposal so the panel can resume the same
+  // draft on re-open instead of starting over.
+  target_initiative_id: z.string().optional().nullable(),
   draft: z.object({
     title: z.string().min(1).max(500),
     description: z.string().max(20000).optional().nullable(),
@@ -118,6 +122,7 @@ export async function POST(request: NextRequest) {
       workspace_id: parsed.data.workspace_id,
       trigger_text: triggerText,
       trigger_kind: 'plan_initiative',
+      target_initiative_id: parsed.data.target_initiative_id ?? null,
       synth: { impact_md: synth.impact_md, changes: synth.changes },
       agent_prompt:
         `Plan an initiative draft titled "${parsed.data.draft.title}". ` +
@@ -184,4 +189,69 @@ export async function POST(request: NextRequest) {
     console.error('Failed to plan initiative:', err);
     return NextResponse.json({ error: msg }, { status: 500 });
   }
+}
+
+/**
+ * GET /api/pm/plan-initiative?workspace_id=…&target_initiative_id=…
+ *
+ * Resume-lookup. Returns the latest non-terminal plan_initiative draft
+ * for the given target initiative — including its parsed suggestions
+ * sidecar — so the panel can re-open the same draft instead of running
+ * a fresh PM dispatch every time the operator clicks away and back.
+ *
+ * 200 with { proposal_id, proposal, suggestions } when a resumable
+ * draft exists. 200 with { proposal: null } when there is none (so the
+ * client can branch on body.proposal without handling 404 specially).
+ */
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const workspaceId = url.searchParams.get('workspace_id');
+  const targetInitiativeId = url.searchParams.get('target_initiative_id');
+  if (!workspaceId || !targetInitiativeId) {
+    return NextResponse.json(
+      { error: 'workspace_id and target_initiative_id required' },
+      { status: 400 },
+    );
+  }
+
+  // Latest draft proposal for this initiative. Refines mark prior
+  // proposals 'superseded', so the draft chain always has at most one
+  // 'draft' row at a time. Order by created_at DESC for safety.
+  const row = queryOne<{
+    id: string;
+    workspace_id: string;
+    trigger_text: string;
+    trigger_kind: string;
+    impact_md: string;
+    proposed_changes: string;
+    status: string;
+    applied_at: string | null;
+    applied_by_agent_id: string | null;
+    parent_proposal_id: string | null;
+    target_initiative_id: string | null;
+    created_at: string;
+  }>(
+    `SELECT * FROM pm_proposals
+     WHERE workspace_id = ?
+       AND target_initiative_id = ?
+       AND trigger_kind = 'plan_initiative'
+       AND status = 'draft'
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [workspaceId, targetInitiativeId],
+  );
+
+  if (!row) {
+    return NextResponse.json({ proposal: null });
+  }
+
+  const suggestions = parseSuggestionsFromImpactMd(row.impact_md);
+  return NextResponse.json({
+    proposal_id: row.id,
+    proposal: {
+      ...row,
+      proposed_changes: JSON.parse(row.proposed_changes),
+    },
+    suggestions: suggestions ?? null,
+  });
 }

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -75,6 +75,7 @@ export default function PlanWithPmPanel({
   workspaceId,
   draft,
   knownInitiatives,
+  targetInitiativeId,
   onClose,
   onApply,
 }: {
@@ -82,6 +83,14 @@ export default function PlanWithPmPanel({
   workspaceId: string;
   draft: PlanInitiativeDraft;
   knownInitiatives?: KnownInitiative[];
+  /**
+   * When set, the panel resumes any in-progress draft proposal for
+   * this initiative on open (GET) instead of always running a fresh
+   * PM dispatch (POST). The server stamps target_initiative_id on the
+   * proposal so the resume lookup is initiative-scoped and won't fight
+   * with concurrent plans of unrelated drafts.
+   */
+  targetInitiativeId?: string | null;
   onClose: () => void;
   /**
    * Operator clicked Apply. Receives the parsed suggestions plus the
@@ -135,11 +144,30 @@ export default function PlanWithPmPanel({
       setLoading(true);
       setErr(null);
       try {
+        // Resume path: when we have a target initiative, ask the server
+        // for any existing draft first. This is what makes "click away
+        // and come back" preserve refinements instead of starting over.
+        if (targetInitiativeId) {
+          const resumeRes = await fetch(
+            `/api/pm/plan-initiative?workspace_id=${encodeURIComponent(workspaceId)}&target_initiative_id=${encodeURIComponent(targetInitiativeId)}`,
+          );
+          if (resumeRes.ok) {
+            const resumeBody = await resumeRes.json();
+            if (resumeBody?.proposal && resumeBody?.suggestions) {
+              if (cancelled) return;
+              setProposalId(resumeBody.proposal_id);
+              setImpactMd(resumeBody.proposal.impact_md ?? '');
+              setSuggestions(resumeBody.suggestions);
+              return; // Skip the POST — we resumed an existing draft.
+            }
+          }
+        }
         const res = await fetch('/api/pm/plan-initiative', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             workspace_id: workspaceId,
+            target_initiative_id: targetInitiativeId ?? null,
             draft: draftRef.current,
           }),
         });
@@ -159,7 +187,7 @@ export default function PlanWithPmPanel({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, workspaceId]);
+  }, [open, workspaceId, targetInitiativeId]);
 
   const refine = async () => {
     if (!proposalId || !refineText.trim()) return;

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -306,6 +306,13 @@ export interface DispatchSynthesizedInput {
   /** Free-text prompt sent to the named agent. */
   agent_prompt: string;
   parent_proposal_id?: string | null;
+  /**
+   * Set when the proposal is being generated FOR a real initiative
+   * (e.g. the operator clicked Plan with PM on the detail page).
+   * Persisted on the proposal row so the panel can resume the draft on
+   * re-open instead of throwing away their refinements.
+   */
+  target_initiative_id?: string | null;
 }
 
 export async function dispatchPmSynthesized(
@@ -333,6 +340,26 @@ export async function dispatchPmSynthesized(
           // dispatchViaNamedAgent.
           const found = findProposalCreatedSince(input.workspace_id, sinceIso);
           if (found) {
+            // The MCP `propose_changes` tool doesn't accept
+            // target_initiative_id (chat-only callers don't have one),
+            // so when this dispatch carries one, stamp it onto the row
+            // post-hoc. Lets the panel resume the draft next time the
+            // operator opens it on the same initiative.
+            if (input.target_initiative_id) {
+              try {
+                run(
+                  'UPDATE pm_proposals SET target_initiative_id = ? WHERE id = ? AND target_initiative_id IS NULL',
+                  [input.target_initiative_id, found.id],
+                );
+                return {
+                  proposal: { ...found, target_initiative_id: input.target_initiative_id },
+                  used_synthesize_fallback: false,
+                  used_named_agent: true,
+                };
+              } catch (err) {
+                console.warn('[pm-dispatch] target stamp failed:', (err as Error).message);
+              }
+            }
             return { proposal: found, used_synthesize_fallback: false, used_named_agent: true };
           }
         }
@@ -352,6 +379,7 @@ export async function dispatchPmSynthesized(
     impact_md: input.synth.impact_md,
     proposed_changes: input.synth.changes,
     parent_proposal_id: input.parent_proposal_id ?? null,
+    target_initiative_id: input.target_initiative_id ?? null,
   });
   return { proposal, used_synthesize_fallback: true, used_named_agent: false };
 }

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3224,6 +3224,26 @@ const migrations: Migration[] = [
       console.log(`[Migration 049] linked=${linked} renamed=${renamed}`);
     },
   },
+  {
+    id: '050',
+    name: 'pm_proposals_target_initiative',
+    up: (db) => {
+      // Add target_initiative_id so plan_initiative proposals dispatched
+      // FROM a real initiative can be linked back to it. Lets the panel
+      // resume an in-progress draft when the operator clicks away and
+      // returns later, instead of throwing away their refinements and
+      // re-prompting the PM agent (which often gets weirder results on
+      // repeated re-plans of the same draft).
+      const cols = db.prepare(`PRAGMA table_info(pm_proposals)`).all() as Array<{ name: string }>;
+      if (!cols.some(c => c.name === 'target_initiative_id')) {
+        db.exec(`ALTER TABLE pm_proposals ADD COLUMN target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE SET NULL`);
+      }
+      // Composite index optimised for the resume-lookup query:
+      //   "latest draft plan_initiative proposal for this initiative".
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_target_init ON pm_proposals(target_initiative_id, status, created_at DESC)`);
+      console.log('[Migration 050] pm_proposals.target_initiative_id added.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -106,6 +106,10 @@ export interface PmProposal {
   applied_at: string | null;
   applied_by_agent_id: string | null;
   parent_proposal_id: string | null;
+  // Set when this proposal was generated FOR an existing initiative
+  // (e.g. operator clicked "Plan with PM" on the detail page). Lets the
+  // panel resume the draft on re-open instead of re-running the PM.
+  target_initiative_id: string | null;
   created_at: string;
 }
 
@@ -120,6 +124,7 @@ interface PmProposalRow {
   applied_at: string | null;
   applied_by_agent_id: string | null;
   parent_proposal_id: string | null;
+  target_initiative_id: string | null;
   created_at: string;
 }
 
@@ -345,6 +350,7 @@ function rowToProposal(row: PmProposalRow): PmProposal {
     applied_at: row.applied_at,
     applied_by_agent_id: row.applied_by_agent_id,
     parent_proposal_id: row.parent_proposal_id,
+    target_initiative_id: row.target_initiative_id ?? null,
     created_at: row.created_at,
   };
 }
@@ -358,6 +364,7 @@ export interface CreateProposalInput {
   impact_md: string;
   proposed_changes: PmDiff[];
   parent_proposal_id?: string | null;
+  target_initiative_id?: string | null;
 }
 
 export function createProposal(input: CreateProposalInput): PmProposal {
@@ -380,8 +387,8 @@ export function createProposal(input: CreateProposalInput): PmProposal {
   run(
     `INSERT INTO pm_proposals (
        id, workspace_id, trigger_text, trigger_kind, impact_md,
-       proposed_changes, status, parent_proposal_id, created_at
-     ) VALUES (?, ?, ?, ?, ?, ?, 'draft', ?, ?)`,
+       proposed_changes, status, parent_proposal_id, target_initiative_id, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?)`,
     [
       id,
       input.workspace_id,
@@ -390,6 +397,7 @@ export function createProposal(input: CreateProposalInput): PmProposal {
       input.impact_md,
       JSON.stringify(input.proposed_changes ?? []),
       input.parent_proposal_id ?? null,
+      input.target_initiative_id ?? null,
       now,
     ],
   );
@@ -774,8 +782,8 @@ export function refineProposal(
     run(
       `INSERT INTO pm_proposals (
          id, workspace_id, trigger_text, trigger_kind, impact_md,
-         proposed_changes, status, parent_proposal_id, created_at
-       ) VALUES (?, ?, ?, ?, ?, ?, 'draft', ?, ?)`,
+         proposed_changes, status, parent_proposal_id, target_initiative_id, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?)`,
       [
         childId,
         parent.workspace_id,
@@ -784,6 +792,7 @@ export function refineProposal(
         '_(refining…)_',
         '[]',
         parentId,
+        parent.target_initiative_id,
         now,
       ],
     );


### PR DESCRIPTION
## Summary

Clicking **Plan with PM** on an initiative, refining the proposal a few times, then clicking away and coming back used to throw the work away — every panel open POSTed a fresh `/api/pm/plan-initiative`, created a new proposal, and re-prompted the PM agent. The agent's session, asked to plan the *same* draft N times in a row without seeing its own prior plan, would get progressively weirder and visibly annoyed.

This PR persists `plan_initiative` drafts against the initiative they were generated for, and resumes the latest in-progress draft on re-open.

## Changes

**Schema (migration 050)**
```sql
ALTER TABLE pm_proposals ADD COLUMN target_initiative_id TEXT
  REFERENCES initiatives(id) ON DELETE SET NULL;
CREATE INDEX idx_pm_proposals_target_init
  ON pm_proposals(target_initiative_id, status, created_at DESC);
```

**Backend**
- `createProposal` + `refineProposal` carry `target_initiative_id` forward so refine chains stay attached to the same initiative.
- `dispatchPmSynthesized` accepts a target and stamps it onto whichever row landed (synth fallback *or* named-agent path) before returning.
- `POST /api/pm/plan-initiative` accepts optional `target_initiative_id` and persists it on the proposal.
- **New `GET /api/pm/plan-initiative?workspace_id&target_initiative_id`** — resume-lookup that returns the latest `draft` plan_initiative proposal (with parsed suggestions sidecar) for that initiative, or `{ proposal: null }` when there's none.

**Frontend**
- `PlanWithPmPanel` takes optional `targetInitiativeId`. On open with a target, it tries the GET resume first; if a draft exists, hydrate `proposalId` / `impact_md` / `suggestions` from it. If not, fall back to the existing POST flow.
- Initiative detail page passes `initiative.id` as `targetInitiativeId`.

## Verification

Verified end-to-end against the preview server (fresh DB so migration 050 ran clean):

| Step | Network |
|---|---|
| Open panel #1 | `POST /api/pm/plan-initiative` → 201 (creates proposal A) |
| Refine | `POST /api/pm/proposals/A/refine` → 201 (creates child B; A→`superseded`) |
| Close panel, reopen | `GET /api/pm/plan-initiative?...` → 200 returns proposal B |

- `proposal.target_initiative_id` = expected on both POST creation *and* refine child.
- Panel re-open issued **GETs only**, no POST. Refinements preserved.
- `yarn tsc --noEmit` — only the pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)