### PR TITLE
fix(pm): reconcile trigger_kind when PM agent mislabels plan proposals

### DIFF
--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -217,6 +217,11 @@ export async function GET(request: NextRequest) {
   // Latest draft proposal for this initiative. Refines mark prior
   // proposals 'superseded', so the draft chain always has at most one
   // 'draft' row at a time. Order by created_at DESC for safety.
+  // Match on target_initiative_id alone (no trigger_kind filter): the
+  // target column is only ever set by plan dispatch, so any row with it
+  // populated is a plan proposal — even if the PM agent mislabeled
+  // trigger_kind via propose_changes (now reconciled in pm-dispatch,
+  // but historic rows may still be 'manual').
   const row = queryOne<{
     id: string;
     workspace_id: string;
@@ -234,7 +239,6 @@ export async function GET(request: NextRequest) {
     `SELECT * FROM pm_proposals
      WHERE workspace_id = ?
        AND target_initiative_id = ?
-       AND trigger_kind = 'plan_initiative'
        AND status = 'draft'
      ORDER BY created_at DESC
      LIMIT 1`,

--- a/src/app/api/pm/proposals/[id]/accept/route.ts
+++ b/src/app/api/pm/proposals/[id]/accept/route.ts
@@ -68,16 +68,23 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     if (!proposal) {
       return NextResponse.json({ error: 'Proposal not found' }, { status: 404 });
     }
-    if (proposal.trigger_kind !== 'plan_initiative') {
-      return NextResponse.json(
-        { error: `target_initiative_id is only valid for plan_initiative proposals (got ${proposal.trigger_kind})` },
-        { status: 400 },
-      );
-    }
+    // We used to gate on `trigger_kind === 'plan_initiative'`, but the
+    // PM agent's `propose_changes` MCP call can mislabel kind (defaults
+    // to 'manual' when omitted) even though the dispatch was a plan
+    // request — and proposals created before pm-dispatch started
+    // post-hoc-stamping the kind keep the wrong label forever. The
+    // stronger signal that this is really a plan proposal is the
+    // presence of the embedded `<!--pm-plan-suggestions ...-->` sidecar.
+    // If suggestions parse, accept the apply regardless of trigger_kind.
     const suggestions = parseSuggestionsFromImpactMd(proposal.impact_md);
     if (!suggestions) {
       return NextResponse.json(
-        { error: 'Proposal has no embedded suggestions to apply' },
+        {
+          error:
+            proposal.trigger_kind === 'plan_initiative'
+              ? 'Proposal has no embedded suggestions to apply'
+              : `target_initiative_id is only valid for plan_initiative proposals (got ${proposal.trigger_kind}); this one has no embedded suggestions either`,
+        },
         { status: 400 },
       );
     }

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -340,24 +340,43 @@ export async function dispatchPmSynthesized(
           // dispatchViaNamedAgent.
           const found = findProposalCreatedSince(input.workspace_id, sinceIso);
           if (found) {
-            // The MCP `propose_changes` tool doesn't accept
-            // target_initiative_id (chat-only callers don't have one),
-            // so when this dispatch carries one, stamp it onto the row
-            // post-hoc. Lets the panel resume the draft next time the
-            // operator opens it on the same initiative.
-            if (input.target_initiative_id) {
+            // Reconcile the row with this dispatch's intent. The PM
+            // agent's `propose_changes` call is freeform — it can pass
+            // a wrong trigger_kind (defaults to 'manual' if omitted)
+            // and doesn't accept target_initiative_id at all. We know
+            // what kind of dispatch this was and where it came from,
+            // so stamp both onto the row so the downstream Apply path
+            // (which validates trigger_kind === 'plan_initiative' when
+            // target_initiative_id is supplied) doesn't reject what is
+            // really a plan_initiative proposal.
+            const fixes: string[] = [];
+            const vals: unknown[] = [];
+            let nextTriggerKind = found.trigger_kind;
+            let nextTarget = found.target_initiative_id;
+            if (found.trigger_kind !== input.trigger_kind) {
+              fixes.push('trigger_kind = ?');
+              vals.push(input.trigger_kind);
+              nextTriggerKind = input.trigger_kind;
+            }
+            if (input.target_initiative_id && !found.target_initiative_id) {
+              fixes.push('target_initiative_id = ?');
+              vals.push(input.target_initiative_id);
+              nextTarget = input.target_initiative_id;
+            }
+            if (fixes.length > 0) {
               try {
-                run(
-                  'UPDATE pm_proposals SET target_initiative_id = ? WHERE id = ? AND target_initiative_id IS NULL',
-                  [input.target_initiative_id, found.id],
-                );
+                run(`UPDATE pm_proposals SET ${fixes.join(', ')} WHERE id = ?`, [...vals, found.id]);
                 return {
-                  proposal: { ...found, target_initiative_id: input.target_initiative_id },
+                  proposal: {
+                    ...found,
+                    trigger_kind: nextTriggerKind,
+                    target_initiative_id: nextTarget,
+                  },
                   used_synthesize_fallback: false,
                   used_named_agent: true,
                 };
               } catch (err) {
-                console.warn('[pm-dispatch] target stamp failed:', (err as Error).message);
+                console.warn('[pm-dispatch] post-hoc stamp failed:', (err as Error).message);
               }
             }
             return { proposal: found, used_synthesize_fallback: false, used_named_agent: true };


### PR DESCRIPTION
## Symptom

Clicking **Apply** on a Plan-with-PM panel sometimes failed with:

> `target_initiative_id is only valid for plan_initiative proposals (got manual)`

The accepted suggestion was lost.

## Root cause

When the PM agent answers a plan dispatch via the gateway and emits the proposal through the MCP `propose_changes` tool, that tool is freeform — the agent can pass a wrong `trigger_kind` (or omit it, in which case it defaults to `manual`). The proposal was really a `plan_initiative` as far as the dispatch was concerned, but the row label said `manual`. The accept route's strict `trigger_kind === 'plan_initiative'` gate then refused the apply.

## Fix

Three coordinated changes:

1. **`pm-dispatch` reconciles after the named-agent path returns.** We know what kind we asked for, so when the persisted row's `trigger_kind` diverges from `input.trigger_kind`, `UPDATE` it to match. The same `UPDATE` stamps `target_initiative_id` when the dispatch had one (was previously a separate write). Single round-trip; defence-in-depth that covers any future trigger_kind the agent might mislabel.

2. **Accept route gates on the suggestions sidecar's presence rather than `trigger_kind`.** The `<!--pm-plan-suggestions ...-->` JSON in `impact_md` is a stronger "this is really a plan proposal" signal than the kind label — and crucially, it works for **historic rows that were created before the dispatch reconciler landed** and are permanently mislabeled. Error message still mentions `trigger_kind` as a hint when the sidecar is also missing.

3. **`GET /api/pm/plan-initiative` resume-lookup drops the `trigger_kind` filter** for the same reason. `target_initiative_id` is only ever set by plan dispatch paths, so any row with it populated is by definition a plan proposal regardless of how the agent labeled it.

## Verification

Verified end-to-end against the preview server:
- Seeded a draft row with `trigger_kind='manual'` and a valid sidecar (the exact mislabel that triggered the user's error).
- `POST /api/pm/proposals/<id>/accept` with `target_initiative_id` → `200`; `5 fields updated` on the target initiative; banner reads *"Applied to Resume Demo — 5 fields updated"*. Was `400` before this PR.
- `yarn tsc --noEmit` — only the pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)