### PR TITLE
feat(pm): split-button "With guidance" option for AI helper actions

### DIFF
--- a/src/app/(app)/initiatives/[id]/page.tsx
+++ b/src/app/(app)/initiatives/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
   InlineSelect,
   InlineDate,
 } from '@/components/inline/InlineEdit';
+import { SplitToolbarButton } from '@/components/inline/SplitToolbarButton';
 // Reuse the action modals defined alongside the list page — Move / Convert /
 // AddDep / History still make sense as focused dialogs since they have
 // non-trivial side effects beyond a simple field write.
@@ -184,11 +185,19 @@ export default function InitiativeDetailPage({
   const [showAddDepModal, setShowAddDepModal] = useState(false);
   const [showHistoryDrawer, setShowHistoryDrawer] = useState(false);
   const [showPlanPanel, setShowPlanPanel] = useState(false);
+  // Operator guidance captured via the "Plan with PM ▾ → With guidance"
+  // option in the toolbar split-button. Threaded into the initial PM
+  // dispatch (POST body's `guidance` field). Cleared on panel close
+  // so the next default click runs without stale guidance.
+  const [planGuidance, setPlanGuidance] = useState<string | null>(null);
   // Brief accent-ring on the plan panel right after it opens, so the
   // operator notices it appearing inline under the header instead of
   // wondering whether the click did anything.
   const [planPanelHighlight, setPlanPanelHighlight] = useState(false);
   const planPanelRef = useRef<HTMLDivElement>(null);
+  // Operator guidance for the initial Decompose dispatch. Same idea
+  // as planGuidance but persists for the lifetime of the modal.
+  const [decomposeHint, setDecomposeHint] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -244,14 +253,29 @@ export default function InitiativeDetailPage({
   // mounts directly under the header card, but a long header can still
   // push it below the fold on smaller viewports — scrollIntoView + a
   // brief accent ring gives the operator unambiguous feedback that the
-  // click landed.
-  const openPlanPanel = useCallback(() => {
+  // click landed. `guidance` is the optional steering text from the
+  // toolbar split-button's "With guidance" popover.
+  const openPlanPanel = useCallback((guidance?: string) => {
+    setPlanGuidance(guidance && guidance.length > 0 ? guidance : null);
     setShowPlanPanel(true);
     setPlanPanelHighlight(true);
     requestAnimationFrame(() => {
       planPanelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
     window.setTimeout(() => setPlanPanelHighlight(false), 1800);
+  }, []);
+
+  const openDecompose = useCallback((hint?: string) => {
+    setDecomposeHint(hint && hint.length > 0 ? hint : null);
+    setShowDecomposeModal(true);
+  }, []);
+
+  // Closes the plan panel AND clears any guidance so the next default
+  // "Plan with PM" click runs from a clean baseline. Used by both
+  // onClose and the post-Apply path inside the panel's onApply.
+  const closePlanPanel = useCallback(() => {
+    setShowPlanPanel(false);
+    setPlanGuidance(null);
   }, []);
 
   // PATCH a partial update to this initiative and refresh on success. The
@@ -456,23 +480,31 @@ export default function InitiativeDetailPage({
               · Destructive (Detach / Delete) — pushed to the far right
           */}
           <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-mc-border/60 pt-3">
-            <ToolbarButton
+            <SplitToolbarButton
               icon={<Sparkles className="w-3.5 h-3.5" />}
-              onClick={openPlanPanel}
-              accent
+              onClick={() => openPlanPanel()}
+              onClickWithGuidance={(g) => openPlanPanel(g)}
+              guidanceLabel="What should the PM focus the plan on?"
+              guidancePlaceholder={`e.g. "size for v1 only — defer fertility/pregnancy features"
+or "treat memory + checklist as MVP, exclude dashboard widgets"`}
+              guidanceCta="Plan with guidance"
               title="PM proposes refined description / sizing / window"
             >
               Plan with PM
-            </ToolbarButton>
+            </SplitToolbarButton>
             {(initiative.kind === 'epic' || initiative.kind === 'milestone') && (
-              <ToolbarButton
+              <SplitToolbarButton
                 icon={<Sparkles className="w-3.5 h-3.5" />}
-                onClick={() => setShowDecomposeModal(true)}
-                accent
+                onClick={() => openDecompose()}
+                onClickWithGuidance={(g) => openDecompose(g)}
+                guidanceLabel="How should the PM slice this?"
+                guidancePlaceholder={`e.g. "split by frontend / backend / data"
+or "carve out the onboarding flow as its own story first"`}
+                guidanceCta="Decompose with guidance"
                 title="Ask the PM to propose 3-7 child initiatives"
               >
                 Decompose with PM
-              </ToolbarButton>
+              </SplitToolbarButton>
             )}
             <span className="w-px h-5 bg-mc-border/60 mx-1" aria-hidden />
             <ToolbarButton icon={<MoveRight className="w-3.5 h-3.5" />} onClick={() => setShowMoveModal(true)}>
@@ -660,6 +692,7 @@ export default function InitiativeDetailPage({
               open={showPlanPanel}
               workspaceId={initiative.workspace_id}
               targetInitiativeId={initiative.id}
+              initialGuidance={planGuidance}
               draft={{
                 title: initiative.title,
                 description: initiative.description ?? '',
@@ -669,7 +702,7 @@ export default function InitiativeDetailPage({
                 target_start: initiative.target_start,
                 target_end: initiative.target_end,
               }}
-              onClose={() => setShowPlanPanel(false)}
+              onClose={() => closePlanPanel()}
               onApply={async (_s, ctx) => {
                 // Route through the proposal-accept endpoint with our
                 // initiative id as the target. The server applies the
@@ -696,7 +729,7 @@ export default function InitiativeDetailPage({
                     e instanceof Error ? e.message : 'Failed to apply suggestions',
                   );
                 }
-                setShowPlanPanel(false);
+                closePlanPanel();
               }}
             />
           </div>
@@ -827,9 +860,11 @@ export default function InitiativeDetailPage({
             kind: initiative.kind,
             workspace_id: initiative.workspace_id,
           }}
-          onClose={() => setShowDecomposeModal(false)}
+          initialHint={decomposeHint}
+          onClose={() => { setShowDecomposeModal(false); setDecomposeHint(null); }}
           onAccepted={() => {
             setShowDecomposeModal(false);
+            setDecomposeHint(null);
             refresh();
           }}
         />

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -39,6 +39,11 @@ const Body = z.object({
   // page. Persisted on the proposal so the panel can resume the same
   // draft on re-open instead of starting over.
   target_initiative_id: z.string().optional().nullable(),
+  // Free-text steering from the operator — what to focus on, what to
+  // avoid, constraints not visible in the draft. Threaded into the
+  // PM agent prompt so the produced suggestions reflect the operator's
+  // intent. Keep modest length; this isn't a place to dump specs.
+  guidance: z.string().max(2000).optional().nullable(),
   draft: z.object({
     title: z.string().min(1).max(500),
     description: z.string().max(20000).optional().nullable(),
@@ -71,10 +76,12 @@ export async function POST(request: NextRequest) {
 
     // Persist the suggestions inside trigger_text so refine() can
     // re-synthesize from the same draft without losing the planning
-    // context.
+    // context. Guidance lives on trigger_text too so refine chains and
+    // resume look-ups can see what the operator originally asked for.
     const triggerText = JSON.stringify({
       mode: 'plan_initiative',
       draft: parsed.data.draft,
+      ...(parsed.data.guidance ? { guidance: parsed.data.guidance } : {}),
     });
 
     // Dedupe identical requests fired in quick succession. React
@@ -127,6 +134,9 @@ export async function POST(request: NextRequest) {
       agent_prompt:
         `Plan an initiative draft titled "${parsed.data.draft.title}". ` +
         `Operator-provided draft: ${JSON.stringify(parsed.data.draft)}. ` +
+        (parsed.data.guidance
+          ? `Operator guidance — focus the plan on this: ${parsed.data.guidance}\n\n`
+          : '') +
         `Call \`propose_changes\` (trigger_kind='plan_initiative') with an impact_md that ` +
         `includes a "<!--pm-plan-suggestions ...-->" sidecar so the form can apply your ` +
         `suggestions. proposed_changes should be [] (advisory). See your SOUL.md.`,

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -62,10 +62,19 @@ interface ProposalRow {
 
 export default function DecomposeWithPmModal({
   initiative,
+  initialHint,
   onClose,
   onAccepted,
 }: {
   initiative: InitiativeLite;
+  /**
+   * Operator steering for the initial decompose dispatch — what to
+   * focus on, slice along, or avoid. The route already accepts a
+   * `hint` field; this just lets the host (e.g. the toolbar's split
+   * "With guidance…" option) prefill it for the first request.
+   * Refine flow keeps using the in-modal `hint` input as before.
+   */
+  initialHint?: string | null;
   onClose: () => void;
   onAccepted: () => void;
 }) {
@@ -88,7 +97,10 @@ export default function DecomposeWithPmModal({
         const res = await fetch('/api/pm/decompose-initiative', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ initiative_id: initiative.id }),
+          body: JSON.stringify({
+            initiative_id: initiative.id,
+            ...(initialHint ? { hint: initialHint } : {}),
+          }),
         });
         const body = await res.json();
         if (!res.ok) throw new Error(body.error || `Decompose failed (${res.status})`);
@@ -106,7 +118,7 @@ export default function DecomposeWithPmModal({
     return () => {
       cancelled = true;
     };
-  }, [initiative.id]);
+  }, [initiative.id, initialHint]);
 
   // Esc to close.
   useEffect(() => {

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -76,6 +76,7 @@ export default function PlanWithPmPanel({
   draft,
   knownInitiatives,
   targetInitiativeId,
+  initialGuidance,
   onClose,
   onApply,
 }: {
@@ -91,6 +92,14 @@ export default function PlanWithPmPanel({
    * with concurrent plans of unrelated drafts.
    */
   targetInitiativeId?: string | null;
+  /**
+   * Free-text operator steering threaded into the agent prompt for
+   * the initial dispatch. Captured by the host before opening the
+   * panel (e.g. via the "With guidance…" split-button option). Ignored
+   * when resuming an existing draft — the resumed proposal already
+   * incorporated whatever guidance the original dispatch carried.
+   */
+  initialGuidance?: string | null;
   onClose: () => void;
   /**
    * Operator clicked Apply. Receives the parsed suggestions plus the
@@ -168,6 +177,7 @@ export default function PlanWithPmPanel({
           body: JSON.stringify({
             workspace_id: workspaceId,
             target_initiative_id: targetInitiativeId ?? null,
+            guidance: initialGuidance ?? null,
             draft: draftRef.current,
           }),
         });
@@ -187,7 +197,7 @@ export default function PlanWithPmPanel({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, workspaceId, targetInitiativeId]);
+  }, [open, workspaceId, targetInitiativeId, initialGuidance]);
 
   const refine = async () => {
     if (!proposalId || !refineText.trim()) return;

--- a/src/components/inline/SplitToolbarButton.tsx
+++ b/src/components/inline/SplitToolbarButton.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { ChevronDown, Loader2, Send, X } from 'lucide-react';
+
+/**
+ * Two-piece toolbar button for AI-assistant actions:
+ *
+ *   [icon Plan with PM]  [▾]
+ *
+ * Main face fires the default action immediately. The chevron opens a
+ * small popover with a textarea where the operator can type
+ * additional guidance — what to focus on, what to avoid, constraints
+ * — that gets passed alongside the same default action via a separate
+ * callback. This is the reusable shape for any "freeform AI helper"
+ * button on the page; the host owns the actual action plumbing.
+ *
+ * Visual style mirrors ToolbarButton's `accent` palette so AI helpers
+ * stay distinct from structural / read-only / destructive buttons.
+ */
+export function SplitToolbarButton({
+  icon,
+  onClick,
+  onClickWithGuidance,
+  children,
+  guidanceLabel,
+  guidancePlaceholder,
+  guidanceCta,
+  title,
+  disabled,
+  busy,
+}: {
+  icon: ReactNode;
+  /** Default action — fired by clicking the main face. */
+  onClick: () => void;
+  /**
+   * Action with operator-provided guidance — fired when the operator
+   * submits the popover form. Same destination as `onClick` in
+   * practice; the host plumbs `guidance` into its API call.
+   */
+  onClickWithGuidance: (guidance: string) => void;
+  children: ReactNode;
+  /** Label above the textarea inside the popover. */
+  guidanceLabel?: string;
+  /** Placeholder inside the textarea. */
+  guidancePlaceholder?: string;
+  /** CTA button label inside the popover. Defaults to "Run with guidance". */
+  guidanceCta?: string;
+  title?: string;
+  disabled?: boolean;
+  busy?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      // Focus the textarea so the operator can start typing immediately.
+      requestAnimationFrame(() => taRef.current?.focus());
+    } else {
+      setText('');
+    }
+  }, [open]);
+
+  const submit = () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    onClickWithGuidance(trimmed);
+    setOpen(false);
+  };
+
+  const palette = 'border-mc-accent/40 text-mc-accent bg-mc-accent/5 hover:bg-mc-accent/10';
+
+  return (
+    <div className="relative inline-flex">
+      <button
+        type="button"
+        onClick={onClick}
+        title={title}
+        disabled={disabled || busy}
+        className={`inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-l border border-r-0 ${palette} disabled:opacity-50`}
+      >
+        {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : icon}
+        <span>{children}</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        title="Run with operator guidance"
+        aria-label="Run with operator guidance"
+        disabled={disabled || busy}
+        aria-expanded={open}
+        className={`inline-flex items-center px-1.5 rounded-r border ${palette} disabled:opacity-50 ${open ? 'bg-mc-accent/15' : ''}`}
+      >
+        <ChevronDown className="w-3.5 h-3.5" />
+      </button>
+
+      {open && (
+        <>
+          {/* Click-outside dismissal. */}
+          <div
+            className="fixed inset-0 z-40"
+            aria-hidden
+            onClick={() => setOpen(false)}
+          />
+          <div className="absolute top-full right-0 mt-1 w-80 z-50 bg-mc-bg-secondary border border-mc-border rounded-md shadow-lg p-3">
+            <div className="flex items-start justify-between gap-2 mb-2">
+              <span className="text-xs font-medium text-mc-text">
+                {guidanceLabel ?? 'Add guidance'}
+              </span>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="text-mc-text-secondary/70 hover:text-mc-text"
+                aria-label="Close"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </div>
+            <textarea
+              ref={taRef}
+              value={text}
+              onChange={e => setText(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  submit();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  setOpen(false);
+                }
+              }}
+              rows={4}
+              placeholder={guidancePlaceholder ?? 'What should the agent focus on?'}
+              className="w-full px-2 py-1.5 rounded bg-mc-bg border border-mc-border text-xs text-mc-text outline-none focus:border-mc-accent/60 resize-y"
+            />
+            <div className="flex items-center justify-between gap-2 mt-2">
+              <span className="text-[10px] text-mc-text-secondary/70">
+                ⌘/Ctrl+Enter to submit · Esc to cancel
+              </span>
+              <button
+                type="button"
+                onClick={submit}
+                disabled={!text.trim()}
+                className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded bg-mc-accent text-white disabled:opacity-50"
+              >
+                <Send className="w-3 h-3" /> {guidanceCta ?? 'Run with guidance'}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

**Plan with PM** and **Decompose with PM** were one-click black boxes — the operator couldn't pre-steer the dispatch with what to focus on or avoid. They had to wait for the result and then refine, spending extra LLM turns and often producing weirder output as the agent's context grew.

Both AI buttons on the initiative-detail toolbar are now split:

```
[✨ Plan with PM]  [▾]
[✨ Decompose with PM]  [▾]
```

- **Main face** — unchanged; fires the default action immediately.
- **Chevron** — opens an inline popover with a textarea. Operator types guidance ("focus on memory + checklist as MVP", "split by frontend / backend"), submits with **⌘/Ctrl+Enter** or the CTA, and the popover closes while the action dispatches with the guidance threaded into the agent prompt.

## Changes

- **New `<SplitToolbarButton>`** (`src/components/inline/SplitToolbarButton.tsx`) — accent-tinted, matches the existing `ToolbarButton` AI palette. Reusable for any future freeform AI helper.
- **`POST /api/pm/plan-initiative`** accepts optional `guidance` field; threads into the agent prompt and persists alongside the draft in `trigger_text` so refine chains and resume lookups can see the original operator intent.
- **`PlanWithPmPanel`** takes `initialGuidance` and forwards in the POST body. Resumed drafts intentionally ignore guidance — the resumed proposal already incorporated whatever the original dispatch had.
- **`DecomposeWithPmModal`** takes `initialHint` for the initial decompose POST. Route already supported `hint`; in-modal refine input unchanged.
- **Detail page** tracks `planGuidance` / `decomposeHint` and clears them on close, so default clicks never reuse stale guidance.

## Verification

Verified end-to-end against the preview server:

- [x] Click chevron → popover opens, textarea auto-focuses.
- [x] Type guidance + ⌘+Enter → `POST /api/pm/plan-initiative` carries the `guidance` field.
- [x] Server persists guidance on the proposal's `trigger_text`:
  ```json
  {"guidance":"GUIDANCE_TEST: focus on memory + checklist as MVP only","draft":{...}}
  ```
- [x] Default click (no chevron) still works without guidance.
- [x] `yarn tsc --noEmit` — only the pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)