### PR TITLE
fix(pm): structured plan summary in chat + strip leaked JSON sidecar

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -13,7 +13,12 @@
 
 import { useEffect, useState, useCallback, useMemo, useRef, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox, Sunrise, Pin, ArrowDown, MessageSquarePlus, Trash2, RotateCcw, Info } from 'lucide-react';
+import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox, Sunrise, Pin, ArrowDown, MessageSquarePlus, Trash2, RotateCcw, Info, Sparkles } from 'lucide-react';
+import {
+  parseSuggestionsFromImpactMd,
+  stripSuggestionsSidecar,
+  type PlanInitiativeSuggestionsBlob,
+} from '@/lib/pm/planSuggestionsSidecar';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -831,9 +836,34 @@ function ChatMessageRow({
             {proposal.status}
           </span>
         </div>
-        <div className="p-3">
-          <ChatMarkdown content={message.content} />
-        </div>
+        {/*
+          For plan_initiative proposals, render a structured summary
+          card at the top so the operator can read the suggestions at
+          a glance without hunting through prose. The freeform
+          narrative still renders below (with the JSON sidecar
+          stripped) for callers who want the agent's reasoning.
+          For other proposal kinds, just strip any leaked sidecar JSON
+          (some emit em-dash variants that markdown doesn't recognize
+          as HTML comments) and render normally.
+        */}
+        {(() => {
+          const suggestions = proposal.trigger_kind === 'plan_initiative'
+            ? parseSuggestionsFromImpactMd(proposal.impact_md)
+            : null;
+          const cleanContent = stripSuggestionsSidecar(message.content);
+          return (
+            <>
+              {suggestions && (
+                <div className="border-b border-amber-500/20">
+                  <PlanSuggestionsSummary suggestions={suggestions} />
+                </div>
+              )}
+              <div className="p-3">
+                <ChatMarkdown content={cleanContent} />
+              </div>
+            </>
+          );
+        })()}
         {proposal.proposed_changes.length > 0 && (
           <div className="px-3 pb-3 space-y-1 text-xs text-mc-text-secondary">
             {proposal.proposed_changes.slice(0, 6).map((c, idx) => (
@@ -982,7 +1012,7 @@ function PinnedStandupCard({
         <span className="ml-auto text-[11px] text-mc-text-secondary/80">{created}</span>
       </div>
       <div className="p-3">
-        <ChatMarkdown content={proposal.impact_md} />
+        <ChatMarkdown content={stripSuggestionsSidecar(proposal.impact_md)} />
       </div>
       {proposal.proposed_changes.length > 0 && (
         <div className="px-3 pb-3 space-y-1 text-xs text-mc-text-secondary">
@@ -1032,6 +1062,110 @@ function ChatMarkdown({ content }: { content: string }) {
   return (
     <div className="mc-md text-sm">
       <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    </div>
+  );
+}
+
+/**
+ * Structured at-a-glance summary of a plan_initiative proposal's
+ * suggestions blob. Replaces the JSON-soup users used to see when the
+ * PM agent's sidecar leaked through markdown rendering. Renders the
+ * fields the operator actually cares about (description, complexity,
+ * window, status check, dependencies) as labeled rows; the freeform
+ * narrative still renders below for callers who want the full text.
+ */
+function PlanSuggestionsSummary({
+  suggestions,
+}: {
+  suggestions: PlanInitiativeSuggestionsBlob;
+}) {
+  const rows: Array<{ label: string; node: React.ReactNode }> = [];
+
+  if (suggestions.refined_description) {
+    rows.push({
+      label: 'Description',
+      node: (
+        <div className="mc-md text-xs text-mc-text-secondary line-clamp-6">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {suggestions.refined_description}
+          </ReactMarkdown>
+        </div>
+      ),
+    });
+  }
+
+  const sizingBits: string[] = [];
+  if (suggestions.complexity) sizingBits.push(`Complexity ${suggestions.complexity}`);
+  const windowBits: string[] = [];
+  if (suggestions.target_start) windowBits.push(suggestions.target_start);
+  if (suggestions.target_end) windowBits.push(suggestions.target_end);
+  if (sizingBits.length > 0 || windowBits.length > 0) {
+    rows.push({
+      label: 'Sizing',
+      node: (
+        <div className="text-xs text-mc-text">
+          {sizingBits.join(' · ')}
+          {windowBits.length > 0 && (
+            <span className="text-mc-text-secondary">
+              {sizingBits.length > 0 ? ' · ' : ''}
+              Window {windowBits.join(' → ')}
+            </span>
+          )}
+        </div>
+      ),
+    });
+  }
+
+  if (suggestions.status_check_md) {
+    rows.push({
+      label: 'Status check',
+      node: (
+        <pre className="text-[11px] text-mc-text-secondary whitespace-pre-wrap font-mono line-clamp-4">
+          {suggestions.status_check_md}
+        </pre>
+      ),
+    });
+  }
+
+  if (suggestions.dependencies && suggestions.dependencies.length > 0) {
+    rows.push({
+      label: `Deps (${suggestions.dependencies.length})`,
+      node: (
+        <ul className="text-xs text-mc-text-secondary space-y-0.5">
+          {suggestions.dependencies.slice(0, 5).map((d, i) => (
+            <li key={i}>
+              → <span className="text-mc-text">{shortId(d.depends_on_initiative_id)}</span>
+              {d.note ? <span className="italic"> — {d.note}</span> : null}
+            </li>
+          ))}
+          {suggestions.dependencies.length > 5 && (
+            <li className="text-mc-text-secondary/70">
+              …and {suggestions.dependencies.length - 5} more
+            </li>
+          )}
+        </ul>
+      ),
+    });
+  }
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="px-3 py-3 bg-mc-bg-secondary/40">
+      <div className="flex items-center gap-2 mb-2 text-[10px] uppercase tracking-wide text-mc-accent">
+        <Sparkles className="w-3 h-3" />
+        PM suggests
+      </div>
+      <div className="space-y-2">
+        {rows.map((r, i) => (
+          <div key={i} className="grid grid-cols-[88px_1fr] gap-2">
+            <div className="text-[10px] uppercase tracking-wide text-mc-text-secondary/70 pt-0.5">
+              {r.label}
+            </div>
+            <div className="min-w-0">{r.node}</div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/lib/pm/applyPlanInitiativeProposal.ts
+++ b/src/lib/pm/applyPlanInitiativeProposal.ts
@@ -13,38 +13,14 @@
 import { v4 as uuidv4 } from 'uuid';
 import { getDb, queryOne, run } from '@/lib/db';
 
-export interface PlanInitiativeSuggestionsBlob {
-  refined_description?: string | null;
-  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
-  target_start?: string | null;
-  target_end?: string | null;
-  status_check_md?: string | null;
-  owner_agent_id?: string | null;
-  dependencies?: Array<{
-    depends_on_initiative_id: string;
-    kind?: 'finish_to_start' | 'start_to_start' | 'blocking' | 'informational';
-    note?: string | null;
-  }>;
-}
-
-/**
- * Pull the suggestions blob out of an impact_md string. The PM agent
- * embeds it as `<!--pm-plan-suggestions {json} -->` so the markdown
- * stays human-readable but a client can parse the structured form.
- */
-export function parseSuggestionsFromImpactMd(
-  md: string,
-): PlanInitiativeSuggestionsBlob | null {
-  // [\s\S] matches anything including newlines without needing the `s`
-  // flag, which keeps this compatible with older lib targets.
-  const m = md.match(/<!--pm-plan-suggestions\s+([\s\S]*?)\s*-->/);
-  if (!m) return null;
-  try {
-    return JSON.parse(m[1]) as PlanInitiativeSuggestionsBlob;
-  } catch {
-    return null;
-  }
-}
+// Re-export from the client-safe module so server callers can keep
+// importing parser/stripper from this file without changing.
+export {
+  parseSuggestionsFromImpactMd,
+  stripSuggestionsSidecar,
+  type PlanInitiativeSuggestionsBlob,
+} from './planSuggestionsSidecar';
+import type { PlanInitiativeSuggestionsBlob } from './planSuggestionsSidecar';
 
 export interface ApplyPlanResult {
   fields_updated: number;

--- a/src/lib/pm/planSuggestionsSidecar.ts
+++ b/src/lib/pm/planSuggestionsSidecar.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure-string helpers for the `<!--pm-plan-suggestions {json} -->`
+ * sidecar embedded in plan_initiative impact_md. Lives in its own
+ * module so client components can import it without dragging in the
+ * server-only DB layer that the apply helper depends on.
+ */
+
+export interface PlanInitiativeSuggestionsBlob {
+  refined_description?: string | null;
+  complexity?: 'S' | 'M' | 'L' | 'XL' | null;
+  target_start?: string | null;
+  target_end?: string | null;
+  status_check_md?: string | null;
+  owner_agent_id?: string | null;
+  dependencies?: Array<{
+    depends_on_initiative_id: string;
+    kind?: 'finish_to_start' | 'start_to_start' | 'blocking' | 'informational';
+    note?: string | null;
+  }>;
+}
+
+/**
+ * Single regex that matches both the canonical `<!--pm-plan-suggestions
+ * {json} -->` sidecar AND stylized variants the PM agent sometimes
+ * emits (em-dash `—` instead of `--`, en-dash `–`). Markdown renderers
+ * only strip the canonical form, so the stylized variants leak through
+ * as visible JSON in the chat — both for parsing AND for rendering, we
+ * want to recognize them all.
+ */
+const SIDECAR_PATTERN_GLOBAL =
+  /<!(?:--|—|–)\s*pm-plan-suggestions\s+([\s\S]*?)\s*(?:--|—|–)>/g;
+
+/**
+ * Pull the suggestions blob out of an impact_md string. Returns null
+ * when no sidecar matches or the JSON is malformed.
+ */
+export function parseSuggestionsFromImpactMd(
+  md: string,
+): PlanInitiativeSuggestionsBlob | null {
+  // Use a single-shot non-global copy of the pattern (regex.exec on a
+  // shared global keeps state in `lastIndex`).
+  const m = md.match(/<!(?:--|—|–)\s*pm-plan-suggestions\s+([\s\S]*?)\s*(?:--|—|–)>/);
+  if (!m) return null;
+  try {
+    return JSON.parse(m[1]) as PlanInitiativeSuggestionsBlob;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove every pm-plan-suggestions sidecar from a markdown string for
+ * display purposes. Handles canonical and stylized variants. Trims any
+ * leftover blank lines so the output reads clean.
+ */
+export function stripSuggestionsSidecar(md: string): string {
+  return md.replace(SIDECAR_PATTERN_GLOBAL, '').replace(/\n{3,}/g, '\n\n').trim();
+}


### PR DESCRIPTION
## Summary

The PM chat dumped the entire `impact_md` verbatim. That usually worked because markdown strips `<!--pm-plan-suggestions {json} -->` HTML comments from output — but the PM agent often emits a **stylized variant** with em-dashes (`<!—...—>`) that markdown does **not** recognise as a comment. The raw JSON leaked through as visible text, producing the giant unreadable blob in the screenshot. And even when the sidecar rendered correctly, the operator still had to hunt through prose to find the actual suggestions.

## Changes

**1. New `src/lib/pm/planSuggestionsSidecar.ts`** — pure-string helpers (`parseSuggestionsFromImpactMd`, `stripSuggestionsSidecar`) that tolerate canonical `--`, em-dash `—`, and en-dash `–` variants. Lives in its own module so client components can import it without dragging in the server-only DB layer that the apply helper depends on. The apply helper re-exports for backward compatibility.

**2. `ChatMessageRow` renders a structured `✨ PM SUGGESTS` block** at the top of any `plan_initiative` proposal card, before the freeform narrative. Surfaces the fields the operator actually cares about:

- **Description** (markdown-rendered, clamped to 6 lines)
- **Sizing** — `Complexity X · Window start → end`
- **Status check** (mono, clamped to 4 lines)
- **Dependencies** (id + note, capped at 5)

The freeform narrative still renders below — with the sidecar stripped in any form — so callers who want the agent's full reasoning keep it. `PinnedStandupCard` also strips the sidecar.

## Verification

Verified end-to-end against the preview server:
- Seeded a chat message containing the bad em-dash sidecar (`<!—...—>`) — the exact failure mode in the user's screenshot.
- Reloaded `/pm`. The structured `PM SUGGESTS` summary renders with Complexity, Window, Status check, and Deps extracted correctly. The string `pm-plan-suggestions` no longer appears anywhere on the page.
- `yarn tsc --noEmit` — only the pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)