### PR TITLE
ux(nav): consolidate Execute+Plan into Project; move Activity/Agents to Workspace

### DIFF
--- a/src/app/(app)/activity/page.tsx
+++ b/src/app/(app)/activity/page.tsx
@@ -1,116 +1,90 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+/**
+ * /activity is now a thin redirect: instead of asking the operator to
+ * pick a workspace, route directly to the currently-selected
+ * workspace's activity dashboard. The workspace switcher at the top
+ * of the left nav already declares "which workspace am I working in?"
+ * — making the operator click again here was a wasted step.
+ *
+ * Edge cases:
+ *   - No workspaces yet → render an empty state with a link to
+ *     /settings/workspaces. (Previously the picker rendered the same
+ *     empty state.)
+ *   - Workspaces still loading → render a small spinner so we don't
+ *     flash "no workspaces" before the fetch returns.
+ */
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Activity, ArrowRight } from 'lucide-react';
+import { Activity } from 'lucide-react';
+import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 import type { Workspace } from '@/lib/types';
 
-export default function ActivityPickerPage() {
-  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [taskCounts, setTaskCounts] = useState<Record<string, { active: number; total: number }>>({});
+export default function ActivityRedirectPage() {
+  const router = useRouter();
+  const currentWorkspaceId = useCurrentWorkspaceId();
+  const [state, setState] = useState<'loading' | 'empty'>('loading');
 
   useEffect(() => {
+    let cancelled = false;
     (async () => {
       try {
         const res = await fetch('/api/workspaces');
-        if (res.ok) {
-          const ws: Workspace[] = await res.json();
-          setWorkspaces(ws);
-
-          // Fetch task counts per workspace
-          const counts: Record<string, { active: number; total: number }> = {};
-          await Promise.all(ws.map(async (w) => {
-            try {
-              const r = await fetch(`/api/tasks?workspace_id=${w.id}`);
-              if (r.ok) {
-                const tasks = await r.json();
-                if (Array.isArray(tasks)) {
-                  const active = tasks.filter((t: { status: string }) =>
-                    ['assigned', 'in_progress', 'testing', 'verification', 'convoy_active'].includes(t.status)
-                  ).length;
-                  counts[w.id] = { active, total: tasks.length };
-                }
-              }
-            } catch { /* skip */ }
-          }));
-          setTaskCounts(counts);
+        if (!res.ok) {
+          if (!cancelled) setState('empty');
+          return;
         }
-      } catch (error) {
-        console.error('Failed to load workspaces:', error);
-      } finally {
-        setLoading(false);
+        const ws: Workspace[] = await res.json();
+        if (cancelled) return;
+        if (ws.length === 0) {
+          setState('empty');
+          return;
+        }
+        // Prefer the workspace the user has currently selected; fall
+        // back to the first one if their selected id no longer exists
+        // (e.g. it was deleted).
+        const target =
+          ws.find(w => w.id === currentWorkspaceId) ?? ws[0];
+        router.replace(`/workspace/${target.slug}/activity`);
+      } catch {
+        if (!cancelled) setState('empty');
       }
     })();
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [currentWorkspaceId, router]);
 
-  if (loading) {
+  if (state === 'loading') {
     return (
       <div className="min-h-screen bg-mc-bg flex items-center justify-center">
         <div className="text-center">
           <Activity className="w-8 h-8 text-mc-accent mx-auto mb-3 animate-pulse" />
-          <p className="text-mc-text-secondary">Loading workspaces...</p>
+          <p className="text-mc-text-secondary text-sm">
+            Routing to your workspace activity…
+          </p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-mc-bg">
-      <header className="border-b border-mc-border bg-mc-bg-secondary">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Activity className="w-6 h-6 text-mc-accent" />
-              <h1 className="text-xl font-bold text-mc-text">Activity Dashboards</h1>
-            </div>
-          </div>
-        </div>
-      </header>
-
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8">
-        {workspaces.length === 0 ? (
-          <div className="text-center py-20">
-            <Activity className="w-12 h-12 text-mc-text-secondary mx-auto mb-4" />
-            <h2 className="text-xl font-bold text-mc-text mb-2">No workspaces</h2>
-            <p className="text-mc-text-secondary">Create a workspace to see agent activity.</p>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {workspaces.map(ws => {
-              const counts = taskCounts[ws.id];
-              return (
-                <Link
-                  key={ws.id}
-                  href={`/workspace/${ws.slug}/activity`}
-                  className="group block bg-mc-bg-secondary border border-mc-border rounded-xl p-5 hover:border-mc-accent/50 transition-colors"
-                >
-                  <div className="flex items-start justify-between mb-3">
-                    <div>
-                      <h3 className="font-semibold text-mc-text group-hover:text-mc-accent transition-colors">
-                        {ws.name}
-                      </h3>
-                      <span className="text-xs text-mc-text-secondary">/{ws.slug}</span>
-                    </div>
-                    <ArrowRight className="w-4 h-4 text-mc-text-secondary group-hover:text-mc-accent transition-colors" />
-                  </div>
-                  {counts && (
-                    <div className="flex gap-4 text-xs text-mc-text-secondary">
-                      {counts.active > 0 && (
-                        <span className="flex items-center gap-1">
-                          <span className="w-1.5 h-1.5 rounded-full bg-green-400" />
-                          {counts.active} active
-                        </span>
-                      )}
-                      <span>{counts.total} total tasks</span>
-                    </div>
-                  )}
-                </Link>
-              );
-            })}
-          </div>
-        )}
-      </main>
+    <div className="min-h-screen bg-mc-bg flex items-center justify-center">
+      <div className="text-center max-w-md px-6">
+        <Activity className="w-12 h-12 text-mc-text-secondary mx-auto mb-4" />
+        <h2 className="text-xl font-bold text-mc-text mb-2">No workspaces</h2>
+        <p className="text-mc-text-secondary text-sm mb-4">
+          Create a workspace to see agent activity.
+        </p>
+        <Link
+          href="/settings/workspaces"
+          className="inline-flex items-center px-4 py-2 rounded-lg border border-mc-accent/40 text-mc-accent hover:bg-mc-accent/10 text-sm"
+        >
+          Open workspace settings
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/components/shell/AppNav.tsx
+++ b/src/components/shell/AppNav.tsx
@@ -4,16 +4,19 @@
  * Left navigation column rendered by the unified app shell. Replaces the
  * grab-bag of per-page header buttons with a single static taxonomy:
  *
- *   EXECUTE → task board, activity
- *   PLAN    → roadmap, initiatives, pm
+ *   PROJECT   → pm, initiatives, roadmap, task board
  *   AUTOPILOT → products
- *   WORKSPACE → settings
+ *   WORKSPACE → activity, agents, settings, debug
+ *
+ * EXECUTE / PLAN used to be separate sections; consolidated into
+ * PROJECT because they share an operator mental model (planning →
+ * shipping the same project). Activity + Agents moved into WORKSPACE
+ * because they're workspace-scoped views/configuration, not project-
+ * scoped action surfaces.
  *
  * The workspace switcher at the top is the single source of "which
  * workspace are we operating against?" — selecting one routes to that
- * workspace's task board (`/workspace/[slug]`). After Polish D the task
- * board lives inside the shell, so the nav stays visible while the
- * operator is queueing up work.
+ * workspace's task board (`/workspace/[slug]`).
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
@@ -63,19 +66,14 @@ interface NavSection {
 function buildSections(taskBoardHref: string): NavSection[] {
   return [
     {
-      title: 'Execute',
+      title: 'Project',
       items: [
-        { href: taskBoardHref, label: 'Task Board', icon: KanbanSquare, prefix: taskBoardHref !== '/' },
-        { href: '/agents', label: 'Agents', icon: Users, prefix: true },
-        { href: '/activity', label: 'Activity', icon: ActivityIcon, prefix: true },
-      ],
-    },
-    {
-      title: 'Plan',
-      items: [
-        { href: '/roadmap', label: 'Roadmap', icon: GanttChart },
-        { href: '/initiatives', label: 'Initiatives', icon: ListTree, prefix: true },
+        // Order is project-lifecycle: ideate (PM) → plan (Initiatives) →
+        // schedule (Roadmap) → ship (Task Board).
         { href: '/pm', label: 'PM', icon: Bot },
+        { href: '/initiatives', label: 'Initiatives', icon: ListTree, prefix: true },
+        { href: '/roadmap', label: 'Roadmap', icon: GanttChart },
+        { href: taskBoardHref, label: 'Task Board', icon: KanbanSquare, prefix: taskBoardHref !== '/' },
       ],
     },
     {
@@ -87,6 +85,13 @@ function buildSections(taskBoardHref: string): NavSection[] {
     {
       title: 'Workspace',
       items: [
+        // Workspace-scoped views + configuration. Activity used to be
+        // a top-level "EXECUTE" entry that landed on a workspace
+        // picker; it now redirects to the current workspace's activity
+        // dashboard so this entry skips the extra click. Agents are
+        // workspace-scoped configuration, so they belong here too.
+        { href: '/activity', label: 'Activity', icon: ActivityIcon, prefix: true },
+        { href: '/agents', label: 'Agents', icon: Users, prefix: true },
         { href: '/settings', label: 'Settings', icon: SettingsIcon },
         { href: '/debug', label: 'Debug', icon: Bug, prefix: true },
       ],


### PR DESCRIPTION
## Summary

Operator's mental model is project-lifecycle, not separate \"execute\" and \"plan\" surfaces. Merge them into one **PROJECT** section ordered top-down by lifecycle: ideate (PM) → plan (Initiatives) → schedule (Roadmap) → ship (Task Board).

**Activity** and **Agents** both move into **WORKSPACE**. They're workspace-scoped views/configuration, not project-scoped action surfaces. Activity in particular used to land on a workspace picker that just relisted what the workspace switcher at the top of the nav already says — a wasted click.

## Final taxonomy

| Section | Items |
|---|---|
| **PROJECT** | PM · Initiatives · Roadmap · Task Board |
| **AUTOPILOT** | Products |
| **WORKSPACE** | Activity · Agents · Settings · Debug |

## /activity is now a thin redirect

Reads the current workspace from the `WorkspaceProvider` context, looks it up in `/api/workspaces`, and `router.replace`s to `/workspace/<slug>/activity`. Edge cases:

- Selected workspace id no longer exists → falls back to the first available workspace.
- Zero workspaces → renders a clean empty state with a CTA to `/settings/workspaces`.

## Verification

Verified in preview:
- Nav DOM contains exactly `[Project, Autopilot, Workspace]` section headers (was Execute / Plan / Autopilot / Workspace).
- Nav links in order: PM, Initiatives, Roadmap, Task Board, Products, Activity, Agents, Settings, Debug.
- Hitting `/activity` lands on `/workspace/default/activity` directly (skipping the picker).
- `yarn tsc --noEmit` — only the pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)