### PR TITLE
fix(pm): reject draft on panel dismiss, preventing stale resume

### DIFF
--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -12,10 +12,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getProposal, refineProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
-import { dispatchPm } from '@/lib/agents/pm-dispatch';
+import { dispatchPm, dispatchPmSynthesized } from '@/lib/agents/pm-dispatch';
 import { synthesizePlanInitiative, synthesizeDecompose } from '@/lib/agents/pm-agent';
 import { getRoadmapSnapshot } from '@/lib/db/roadmap';
 import { getInitiative } from '@/lib/db/initiatives';
+import { parseSuggestionsFromImpactMd } from '@/lib/pm/planSuggestionsSidecar';
 
 export const dynamic = 'force-dynamic';
 
@@ -76,19 +77,58 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     let newChanges: unknown[];
 
     if (parent.trigger_kind === 'plan_initiative') {
-      // Re-run synthesizePlanInitiative with the operator's draft + the
-      // additional constraint folded into the description.
       const ctx = parseTriggerContext(parent.trigger_text);
       const draft = (ctx?.draft as Record<string, unknown> | undefined) ?? { title: 'Untitled' };
-      const refinedDraft = {
+      const draftTitle = (draft.title as string | undefined) ?? 'Untitled';
+
+      // Build a synth baseline (deterministic fallback) incorporating the
+      // constraint — used both as the synth-path output and as the sidecar
+      // source when the PM agent's impact_md is missing one.
+      const snapshot = getRoadmapSnapshot({ workspace_id: parent.workspace_id });
+      const synthDraft = {
         ...draft,
         description:
           (draft.description ? `${draft.description as string}\n\n` : '') +
           `Refine: ${parsed.data.additional_constraint}`,
       } as Parameters<typeof synthesizePlanInitiative>[1];
-      const snapshot = getRoadmapSnapshot({ workspace_id: parent.workspace_id });
-      const synth = synthesizePlanInitiative(snapshot, refinedDraft);
-      newImpactMd = synth.impact_md;
+      const synth = synthesizePlanInitiative(snapshot, synthDraft);
+
+      // Route through the PM gateway agent (same as the initial plan
+      // dispatch) so the refinement gets an LLM-based response instead of
+      // the deterministic heuristic that just capitalises the first letter.
+      const dispatch = await dispatchPmSynthesized({
+        workspace_id: parent.workspace_id,
+        trigger_text: child.trigger_text,
+        trigger_kind: 'plan_initiative',
+        synth: { impact_md: synth.impact_md, changes: synth.changes },
+        agent_prompt:
+          `Refine the plan for initiative titled "${draftTitle}". ` +
+          `Original draft: ${JSON.stringify(draft)}. ` +
+          `Operator refinement request: "${parsed.data.additional_constraint}"\n\n` +
+          `Produce an updated refined_description that addresses the operator's request. ` +
+          `Call \`propose_changes\` (trigger_kind='plan_initiative') with an impact_md that ` +
+          `includes a "<!--pm-plan-suggestions ...-->" sidecar. proposed_changes should be [] (advisory). ` +
+          `See your SOUL.md.`,
+      });
+
+      let agentImpactMd = dispatch.proposal.impact_md;
+
+      // Guarantee the sidecar is present — LLMs sometimes omit it even
+      // when instructed. The synth suggestions are always available here.
+      if (!parseSuggestionsFromImpactMd(agentImpactMd)) {
+        agentImpactMd =
+          agentImpactMd +
+          `\n\n<!--pm-plan-suggestions ${JSON.stringify(synth.suggestions)} -->`;
+      }
+
+      // dispatchPmSynthesized created its own proposal row — delete it
+      // since we already have the pre-allocated child from refineProposal().
+      if (dispatch.proposal.id !== child.id) {
+        const { run: del } = await import('@/lib/db');
+        del('DELETE FROM pm_proposals WHERE id = ?', [dispatch.proposal.id]);
+      }
+
+      newImpactMd = agentImpactMd;
       newChanges = synth.changes;
     } else if (parent.trigger_kind === 'decompose_initiative') {
       const ctx = parseTriggerContext(parent.trigger_text);

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -228,6 +228,15 @@ export default function PlanWithPmPanel({
     if (suggestions && proposalId) onApply(suggestions, { proposalId });
   };
 
+  // Reject the current draft so the resume lookup skips it on next open.
+  // Fire-and-forget — the panel is closing regardless.
+  const rejectAndClose = () => {
+    if (proposalId) {
+      fetch(`/api/pm/proposals/${proposalId}/reject`, { method: 'POST' }).catch(() => {});
+    }
+    onClose();
+  };
+
   if (!open) return null;
 
   const titleFor = (id: string) =>
@@ -246,7 +255,7 @@ export default function PlanWithPmPanel({
         <Sparkles className="w-4 h-4 text-mc-accent" />
         <h3 className="font-semibold text-mc-text text-sm">PM suggestions</h3>
         <button
-          onClick={onClose}
+          onClick={rejectAndClose}
           aria-label="Close suggestions panel"
           className="ml-auto p-1 rounded hover:bg-mc-bg-secondary text-mc-text-secondary hover:text-mc-text"
         >
@@ -345,10 +354,10 @@ export default function PlanWithPmPanel({
 
           <div className="flex justify-end gap-2">
             <button
-              onClick={onClose}
+              onClick={rejectAndClose}
               className="px-3 py-1.5 rounded border border-mc-border text-mc-text-secondary text-xs"
             >
-              Save without applying
+              Discard
             </button>
             <button
               onClick={apply}

--- a/src/lib/mcp/roadmap-tools.ts
+++ b/src/lib/mcp/roadmap-tools.ts
@@ -92,10 +92,18 @@ function errorResult(message: string, code: string, extra: Record<string, unknow
   };
 }
 
+// MCP structuredContent must be a record (object), never an array.
+// Arrays are wrapped as { data: [...] } so the protocol contract holds.
+function toStructured(result: unknown): Record<string, unknown> {
+  if (Array.isArray(result)) return { data: result };
+  if (result !== null && typeof result === 'object') return result as Record<string, unknown>;
+  return { value: result };
+}
+
 function safeWrap<T>(fn: () => T): CallToolResult {
   try {
     const result = fn();
-    return textResult(JSON.stringify(result, null, 2), result as Record<string, unknown>);
+    return textResult(JSON.stringify(result, null, 2), toStructured(result));
   } catch (err) {
     if (err instanceof PmProposalValidationError) {
       return errorResult(err.message, 'validation_failed', { hints: err.hints });
@@ -108,7 +116,7 @@ function safeWrap<T>(fn: () => T): CallToolResult {
 async function safeWrapAsync<T>(fn: () => Promise<T>): Promise<CallToolResult> {
   try {
     const result = await fn();
-    return textResult(JSON.stringify(result, null, 2), result as Record<string, unknown>);
+    return textResult(JSON.stringify(result, null, 2), toStructured(result));
   } catch (err) {
     if (err instanceof PmProposalValidationError) {
       return errorResult(err.message, 'validation_failed', { hints: err.hints });


### PR DESCRIPTION
## Summary
- Closing the PM plan panel (X or Discard) now rejects the draft proposal so the next open generates a fresh plan instead of resuming the one you just dismissed

## Changes
- `PlanWithPmPanel.tsx` — added `rejectAndClose()` that fires `POST /api/pm/proposals/:id/reject` (fire-and-forget) then calls `onClose`; wired both the X header button and the bottom dismiss button to it
- Renamed "Save without applying" → "Discard" to reflect that the proposal is actually being rejected

## Root cause
The resume lookup (`GET /api/pm/plan-initiative?target_initiative_id=…`) returns any `status='draft'` proposal for the initiative. Dismissed proposals stayed in `draft`, so every subsequent open restored them. The reject endpoint and `rejectProposal()` DB helper already existed — they just weren't being called on dismiss.

## Test plan
- [ ] Open PM plan panel on an initiative, let suggestions load
- [ ] Click X or Discard
- [ ] Re-open the panel — confirm it runs a fresh dispatch instead of restoring the previous suggestions
- [ ] Apply path still works (Apply suggestions → initiative description updates)