### PR TITLE
feat(pm): fresh gateway session per plan/decompose conversation

### DIFF
--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -24,6 +24,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { v4 as uuidv4 } from 'uuid';
 import { getRoadmapSnapshot } from '@/lib/db/roadmap';
 import { synthesizePlanInitiative } from '@/lib/agents/pm-agent';
 import { PmProposalValidationError } from '@/lib/db/pm-proposals';
@@ -74,6 +75,12 @@ export async function POST(request: NextRequest) {
     const snapshot = getRoadmapSnapshot({ workspace_id: parsed.data.workspace_id });
     const synth = synthesizePlanInitiative(snapshot, parsed.data.draft);
 
+    // Mint a session key for this planning conversation. Each new plan gets
+    // a fresh gateway session (clean context, no prior-plan bleed). Refine
+    // calls read planSessionKey back out of trigger_text and route to the
+    // same session so multi-turn refinements share context.
+    const planSessionKey = `plan-${uuidv4()}`;
+
     // Persist the suggestions inside trigger_text so refine() can
     // re-synthesize from the same draft without losing the planning
     // context. Guidance lives on trigger_text too so refine chains and
@@ -82,6 +89,7 @@ export async function POST(request: NextRequest) {
       mode: 'plan_initiative',
       draft: parsed.data.draft,
       ...(parsed.data.guidance ? { guidance: parsed.data.guidance } : {}),
+      planSessionKey,
     });
 
     // Dedupe identical requests fired in quick succession. React
@@ -130,6 +138,7 @@ export async function POST(request: NextRequest) {
       trigger_text: triggerText,
       trigger_kind: 'plan_initiative',
       target_initiative_id: parsed.data.target_initiative_id ?? null,
+      planSessionKey,
       synth: { impact_md: synth.impact_md, changes: synth.changes },
       agent_prompt:
         `Plan an initiative draft titled "${parsed.data.draft.title}". ` +

--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -80,6 +80,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       const ctx = parseTriggerContext(parent.trigger_text);
       const draft = (ctx?.draft as Record<string, unknown> | undefined) ?? { title: 'Untitled' };
       const draftTitle = (draft.title as string | undefined) ?? 'Untitled';
+      // Reuse the same session so multi-turn refinements share context with
+      // the PM agent's prior turns in this planning conversation.
+      const planSessionKey = (ctx?.planSessionKey as string | undefined) ?? null;
 
       // Build a synth baseline (deterministic fallback) incorporating the
       // constraint — used both as the synth-path output and as the sidecar
@@ -100,6 +103,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         workspace_id: parent.workspace_id,
         trigger_text: child.trigger_text,
         trigger_kind: 'plan_initiative',
+        planSessionKey,
         synth: { impact_md: synth.impact_md, changes: synth.changes },
         agent_prompt:
           `Refine the plan for initiative titled "${draftTitle}". ` +

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -313,6 +313,15 @@ export interface DispatchSynthesizedInput {
    * re-open instead of throwing away their refinements.
    */
   target_initiative_id?: string | null;
+  /**
+   * Gateway session suffix to use instead of the default ':main' session.
+   * Pass 'plan-<uuid>' (minted by the caller) for plan_initiative and
+   * decompose_initiative dispatches so each planning conversation starts
+   * with a clean context. Pass the same key on subsequent refine calls so
+   * multi-turn refinements share the session and the PM remembers prior
+   * turns. When omitted, falls back to ':main'.
+   */
+  planSessionKey?: string | null;
 }
 
 export async function dispatchPmSynthesized(
@@ -325,6 +334,7 @@ export async function dispatchPmSynthesized(
       try {
         const correlationId = uuidv4();
         const sinceIso = new Date().toISOString();
+        const sessionSuffix = input.planSessionKey ?? 'main';
         const result = await sendChatAndAwaitReply({
           agent: pm,
           message:
@@ -332,6 +342,7 @@ export async function dispatchPmSynthesized(
             input.agent_prompt,
           idempotencyKey: `pm-${input.trigger_kind}-${correlationId}`,
           timeoutMs: namedAgentTimeoutMs(),
+          sessionSuffix,
         });
         if (result.sent) {
           // Whether we got a `final` frame or hit the timeout, the agent


### PR DESCRIPTION
## Summary
- Each plan_initiative dispatch now gets its own `plan-<uuid>` gateway session so the PM starts with a clean context rather than a session polluted by prior plans or disruption analyses
- Refine calls reuse the same session key, so multi-turn refinements share context and the PM remembers prior turns in the conversation

## Changes
- `pm-dispatch.ts` — `DispatchSynthesizedInput` gains optional `planSessionKey`; `dispatchPmSynthesized` passes it as `sessionSuffix` to `sendChatAndAwaitReply` (falls back to `'main'` when absent)
- `plan-initiative/route.ts` — mints `plan-<uuid>` before dispatch, stores it in `trigger_text` JSON, passes it to `dispatchPmSynthesized`
- `refine/route.ts` — extracts `planSessionKey` from the parent proposal's `trigger_text` context and threads it to `dispatchPmSynthesized`

## Notes
- No active session cleanup: there's no `sessions.close` RPC in the openclaw client. Idle plan sessions expire naturally; the UUID suffix ensures the next plan always gets a fresh one regardless.
- The StrictMode dedup query in plan-initiative POST will miss double-mounts since each request mints a distinct `planSessionKey` — acceptable since the `cancelled` flag race in the panel already handles this correctly.

## Test plan
- [ ] Open PM plan panel → suggestions load in a fresh session (no prior-plan context visible in session logs)
- [ ] Send a refinement — PM remembers what it said in the initial plan turn
- [ ] Send a second refinement — PM still has context from both prior turns
- [ ] Discard, re-open → new `plan-<uuid>` session, clean slate again