### PR TITLE
fix(pm): fresh session per disruption dispatch

### DIFF
--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -255,6 +255,9 @@ async function dispatchViaNamedAgent(params: DispatchNamedAgentParams): Promise<
     message,
     idempotencyKey: `pm-dispatch-${correlationId}`,
     timeoutMs: namedAgentTimeoutMs(),
+    // Fresh session per disruption — prevents context from one disruption
+    // analysis bleeding into the next independent request.
+    sessionSuffix: `dispatch-${correlationId}`,
   });
 
   // Send failed — caller falls back to synth.


### PR DESCRIPTION
## Summary
- `dispatchViaNamedAgent` (PM disruption analysis) now uses a `dispatch-<correlationId>` session suffix instead of the shared `:main` session, preventing context from one disruption from bleeding into the next

## Changes
- `src/lib/agents/pm-dispatch.ts` — adds `sessionSuffix: \`dispatch-${correlationId}\`` to the `sendChatAndAwaitReply` call in `dispatchViaNamedAgent`

## Context
Audited all LLM gateway dispatch flows. This was the only outlier:

| Flow | Session | Status |
|------|---------|--------|
| PM disruption (dispatchViaNamedAgent) | `:main` → `dispatch-<uuid>` | **Fixed here** |
| PM plan/decompose (dispatchPmSynthesized) | `plan-<uuid>` per conversation | Already correct (#83) |
| Task planning (clarify→research→plan) | `planning:<task-id>` | Already correct |
| Task dispatch / chat | `openclaw_sessions.openclaw_session_id` | Already correct |
| Convoy decomposition | `decompose:<task-id>` | Already correct |
| Mail / notes / learner notifications | fire-and-forget scoped keys | Already correct |

## Test plan
- [ ] Report two unrelated disruptions back-to-back; confirm PM session logs show separate `dispatch-<uuid>` sessions with no cross-contamination