### PR TITLE
fix(pm): structured plan_suggestions column + dispatch stability

### DIFF
--- a/src/app/(app)/initiatives/[id]/page.tsx
+++ b/src/app/(app)/initiatives/[id]/page.tsx
@@ -185,6 +185,12 @@ export default function InitiativeDetailPage({
   const [showAddDepModal, setShowAddDepModal] = useState(false);
   const [showHistoryDrawer, setShowHistoryDrawer] = useState(false);
   const [showPlanPanel, setShowPlanPanel] = useState(false);
+  // True while there is a known unresolved draft proposal for this initiative.
+  // Disables the "Plan with PM" button to prevent duplicate dispatches.
+  const [hasDraftProposal, setHasDraftProposal] = useState(false);
+  // Once the initiative loads, check once for an existing draft proposal so
+  // we can auto-open the plan panel and prevent duplicate dispatches.
+  const draftProposalCheckDone = useRef(false);
   // Operator guidance captured via the "Plan with PM ▾ → With guidance"
   // option in the toolbar split-button. Threaded into the initial PM
   // dispatch (POST body's `guidance` field). Cleared on panel close
@@ -249,6 +255,25 @@ export default function InitiativeDetailPage({
     };
   }, [initiative?.workspace_id]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Auto-open the plan panel when there's an existing unresolved draft
+  // proposal for this initiative. Guards with a ref so it only fires once
+  // per mount, not on every subsequent refresh() call.
+  useEffect(() => {
+    if (!initiative || draftProposalCheckDone.current) return;
+    draftProposalCheckDone.current = true;
+    fetch(
+      `/api/pm/plan-initiative?workspace_id=${encodeURIComponent(initiative.workspace_id)}&target_initiative_id=${encodeURIComponent(initiative.id)}`,
+    )
+      .then(r => r.json())
+      .then((body: { proposal?: unknown }) => {
+        if (body?.proposal) {
+          setHasDraftProposal(true);
+          setShowPlanPanel(true);
+        }
+      })
+      .catch(() => {});
+  }, [initiative]);
+
   // Open the inline Plan-with-PM panel and pull it into view. The panel
   // mounts directly under the header card, but a long header can still
   // push it below the fold on smaller viewports — scrollIntoView + a
@@ -276,6 +301,7 @@ export default function InitiativeDetailPage({
   const closePlanPanel = useCallback(() => {
     setShowPlanPanel(false);
     setPlanGuidance(null);
+    setHasDraftProposal(false);
   }, []);
 
   // PATCH a partial update to this initiative and refresh on success. The
@@ -488,7 +514,8 @@ export default function InitiativeDetailPage({
               guidancePlaceholder={`e.g. "size for v1 only — defer fertility/pregnancy features"
 or "treat memory + checklist as MVP, exclude dashboard widgets"`}
               guidanceCta="Plan with guidance"
-              title="PM proposes refined description / sizing / window"
+              title={hasDraftProposal ? 'Resolve the existing draft proposal first' : 'PM proposes refined description / sizing / window'}
+              disabled={hasDraftProposal}
             >
               Plan with PM
             </SplitToolbarButton>

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -13,6 +13,7 @@
 
 import { useEffect, useState, useCallback, useMemo, useRef, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
 import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox, Sunrise, Pin, ArrowDown, MessageSquarePlus, Trash2, RotateCcw, Info, Sparkles } from 'lucide-react';
 import {
   parseSuggestionsFromImpactMd,
@@ -715,19 +716,24 @@ function PmChatPageInner() {
               </li>
             )}
             {recentProposals.map(p => (
-              <li key={p.id} className="px-4 py-3 hover:bg-mc-bg/50">
-                <div className="flex items-center gap-2 text-xs mb-1">
-                  <span className={`px-2 py-0.5 rounded-sm ${STATUS_BADGE[p.status]}`}>{p.status}</span>
-                  <span className="text-mc-text-secondary">
-                    {p.proposed_changes.length} change{p.proposed_changes.length === 1 ? '' : 's'}
-                  </span>
-                  <span className="ml-auto text-mc-text-secondary/70">
-                    {new Date(p.created_at.endsWith('Z') ? p.created_at : p.created_at + 'Z').toLocaleString()}
-                  </span>
-                </div>
-                <p className="text-xs text-mc-text-secondary line-clamp-2 break-words">
-                  {p.trigger_text}
-                </p>
+              <li key={p.id}>
+                <Link
+                  href={`/pm/proposals/${p.id}`}
+                  className="block px-4 py-3 hover:bg-mc-bg-secondary transition-colors"
+                >
+                  <div className="flex items-center gap-2 text-xs mb-1">
+                    <span className={`px-2 py-0.5 rounded-sm ${STATUS_BADGE[p.status]}`}>{p.status}</span>
+                    <span className="text-mc-text-secondary">
+                      {p.proposed_changes.length} change{p.proposed_changes.length === 1 ? '' : 's'}
+                    </span>
+                    <span className="ml-auto text-mc-text-secondary/70">
+                      {new Date(p.created_at.endsWith('Z') ? p.created_at : p.created_at + 'Z').toLocaleString()}
+                    </span>
+                  </div>
+                  <p className="text-xs text-mc-text-secondary line-clamp-2 break-words">
+                    {p.trigger_text}
+                  </p>
+                </Link>
               </li>
             ))}
           </ul>

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -1,0 +1,365 @@
+'use client';
+
+import { useEffect, useState, use } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, Check, X, RefreshCw, AlertTriangle } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import {
+  stripSuggestionsSidecar,
+  parseSuggestionsFromImpactMd,
+} from '@/lib/pm/planSuggestionsSidecar';
+
+interface PmDiff {
+  kind: string;
+  initiative_id?: string;
+  agent_id?: string;
+  status?: string;
+  target_start?: string;
+  target_end?: string;
+  start?: string;
+  end?: string;
+  reason?: string;
+  depends_on_initiative_id?: string;
+  dependency_id?: string;
+  parent_id?: string | null;
+  child_ids_in_order?: string[];
+}
+
+interface PmProposal {
+  id: string;
+  workspace_id: string;
+  trigger_text: string;
+  trigger_kind: string;
+  impact_md: string;
+  proposed_changes: PmDiff[];
+  plan_suggestions: Record<string, unknown> | null;
+  status: 'draft' | 'accepted' | 'rejected' | 'superseded';
+  applied_at: string | null;
+  parent_proposal_id: string | null;
+  target_initiative_id: string | null;
+  created_at: string;
+}
+
+const STATUS_BADGE: Record<PmProposal['status'], string> = {
+  draft: 'bg-amber-500/20 text-amber-300',
+  accepted: 'bg-emerald-500/20 text-emerald-300',
+  rejected: 'bg-red-500/20 text-red-300',
+  superseded: 'bg-zinc-500/20 text-zinc-300',
+};
+
+const TRIGGER_BADGE: Record<string, { label: string; cls: string }> = {
+  manual: { label: 'manual', cls: 'bg-blue-500/15 text-blue-300 border-blue-500/30' },
+  scheduled_drift_scan: { label: 'scheduled', cls: 'bg-violet-500/15 text-violet-300 border-violet-500/30' },
+  disruption_event: { label: 'disruption', cls: 'bg-orange-500/15 text-orange-300 border-orange-500/30' },
+  status_check_investigation: { label: 'status check', cls: 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30' },
+  plan_initiative: { label: 'plan', cls: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30' },
+  decompose_initiative: { label: 'decompose', cls: 'bg-pink-500/15 text-pink-300 border-pink-500/30' },
+};
+
+function summarizeDiff(c: PmDiff): string {
+  switch (c.kind) {
+    case 'shift_initiative_target':
+      return `shift ${short(c.initiative_id)}: ${c.target_start ?? '∅'} → ${c.target_end ?? '∅'}`;
+    case 'add_availability':
+      return `availability ${short(c.agent_id)}: ${c.start} – ${c.end}`;
+    case 'set_initiative_status':
+      return `${short(c.initiative_id)} → ${c.status}`;
+    case 'add_dependency':
+      return `dep ${short(c.initiative_id)} blocks on ${short(c.depends_on_initiative_id)}`;
+    case 'remove_dependency':
+      return `remove dep ${short(c.dependency_id)}`;
+    case 'reorder_initiatives':
+      return `reorder under ${short(c.parent_id) || 'root'} (${c.child_ids_in_order?.length ?? 0})`;
+    case 'update_status_check':
+      return `status_check ${short(c.initiative_id)}`;
+    default:
+      return c.kind ?? '?';
+  }
+}
+
+function short(id: string | null | undefined): string {
+  return id ? id.slice(0, 8) : '∅';
+}
+
+export default function ProposalDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const router = useRouter();
+  const [proposal, setProposal] = useState<PmProposal | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [acting, setActing] = useState<'accept' | 'reject' | null>(null);
+  const [refining, setRefining] = useState(false);
+  const [refineText, setRefineText] = useState('');
+  const [refineErr, setRefineErr] = useState<string | null>(null);
+  const [showRefineInput, setShowRefineInput] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setErr(null);
+      try {
+        const res = await fetch(`/api/pm/proposals/${id}`);
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error((body as { error?: string }).error || `Failed to load (${res.status})`);
+        }
+        const data = await res.json();
+        if (!cancelled) setProposal(data as PmProposal);
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : 'Failed to load proposal');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [id]);
+
+  const accept = async () => {
+    if (!proposal) return;
+    setActing('accept');
+    try {
+      const res = await fetch(`/api/pm/proposals/${proposal.id}/accept`, { method: 'POST' });
+      const body = await res.json();
+      if (!res.ok) throw new Error((body as { error?: string }).error || 'Accept failed');
+      setProposal(prev => prev ? { ...prev, status: 'accepted' } : prev);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Accept failed');
+    } finally {
+      setActing(null);
+    }
+  };
+
+  const reject = async () => {
+    if (!proposal) return;
+    setActing('reject');
+    try {
+      const res = await fetch(`/api/pm/proposals/${proposal.id}/reject`, { method: 'POST' });
+      const body = await res.json();
+      if (!res.ok) throw new Error((body as { error?: string }).error || 'Reject failed');
+      setProposal(prev => prev ? { ...prev, status: 'rejected' } : prev);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Reject failed');
+    } finally {
+      setActing(null);
+    }
+  };
+
+  const refine = async () => {
+    if (!proposal || !refineText.trim()) return;
+    setRefining(true);
+    setRefineErr(null);
+    try {
+      const res = await fetch(`/api/pm/proposals/${proposal.id}/refine`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ additional_constraint: refineText.trim() }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error((body as { error?: string }).error || 'Refine failed');
+      // Refine creates a new child proposal — navigate there.
+      const newId = (body as { proposal?: { id?: string } }).proposal?.id;
+      if (newId) {
+        router.push(`/pm/proposals/${newId}`);
+      } else {
+        setRefineText('');
+        setShowRefineInput(false);
+      }
+    } catch (e) {
+      setRefineErr(e instanceof Error ? e.message : 'Refine failed');
+    } finally {
+      setRefining(false);
+    }
+  };
+
+  const trigger = proposal ? (TRIGGER_BADGE[proposal.trigger_kind] ?? TRIGGER_BADGE.manual) : null;
+  const displayMd = proposal ? stripSuggestionsSidecar(proposal.impact_md).trim() : '';
+  const suggestions = proposal?.trigger_kind === 'plan_initiative'
+    ? parseSuggestionsFromImpactMd(proposal.impact_md)
+    : null;
+
+  return (
+    <div className="min-h-screen bg-mc-bg text-mc-text">
+      <div className="max-w-3xl mx-auto px-4 py-6">
+        <div className="mb-4">
+          <Link
+            href="/pm"
+            className="inline-flex items-center gap-1.5 text-sm text-mc-text-secondary hover:text-mc-text"
+          >
+            <ArrowLeft className="w-4 h-4" /> PM Chat
+          </Link>
+        </div>
+
+        {loading && (
+          <div className="flex items-center gap-2 text-mc-text-secondary text-sm py-12 justify-center">
+            <RefreshCw className="w-4 h-4 animate-spin" /> Loading proposal…
+          </div>
+        )}
+
+        {err && (
+          <div className="p-3 rounded bg-red-500/10 border border-red-500/30 text-red-300 text-sm">
+            {err}
+          </div>
+        )}
+
+        {proposal && (
+          <>
+            {/* Header */}
+            <div className="border border-amber-500/40 bg-amber-500/5 rounded-md overflow-hidden mb-4">
+              <div className="px-4 py-3 bg-amber-500/10 border-b border-amber-500/30 flex flex-wrap items-center gap-2">
+                <AlertTriangle className="w-4 h-4 text-amber-300 shrink-0" />
+                <span className="text-sm font-semibold text-amber-200">
+                  Proposal — {proposal.proposed_changes.length} change{proposal.proposed_changes.length === 1 ? '' : 's'}
+                </span>
+                {trigger && (
+                  <span className={`px-1.5 py-0.5 text-[10px] rounded-sm border uppercase tracking-wide ${trigger.cls}`}>
+                    {trigger.label}
+                  </span>
+                )}
+                <span className={`px-2 py-0.5 text-xs rounded-sm ${STATUS_BADGE[proposal.status]}`}>
+                  {proposal.status}
+                </span>
+                <span className="ml-auto text-xs text-mc-text-secondary/70">
+                  {new Date(proposal.created_at.endsWith('Z') ? proposal.created_at : proposal.created_at + 'Z').toLocaleString()}
+                </span>
+              </div>
+
+              {/* Plan suggestions summary for plan_initiative proposals */}
+              {suggestions && (
+                <div className="px-4 py-3 border-b border-amber-500/20 grid grid-cols-3 gap-3 text-xs">
+                  <div className="col-span-3">
+                    <div className="text-mc-text-secondary uppercase tracking-wide text-[10px] mb-1">Refined description</div>
+                    <p className="text-mc-text whitespace-pre-wrap font-sans">{(suggestions as { refined_description?: string }).refined_description}</p>
+                  </div>
+                  {(['complexity', 'target_start', 'target_end'] as const).map(field => (
+                    <div key={field}>
+                      <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">
+                        {field.replace('_', ' ')}
+                      </div>
+                      <div className="text-mc-text font-medium">
+                        {(suggestions as Record<string, unknown>)[field] as string ?? '—'}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Impact markdown */}
+              {displayMd && (
+                <div className="px-4 py-3 border-b border-amber-500/20 prose prose-invert prose-sm max-w-none">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{displayMd}</ReactMarkdown>
+                </div>
+              )}
+
+              {/* Proposed changes */}
+              {proposal.proposed_changes.length > 0 && (
+                <div className="px-4 py-3 border-b border-amber-500/20 space-y-1 text-xs text-mc-text-secondary font-mono">
+                  {proposal.proposed_changes.map((c, i) => (
+                    <div key={i}>· {summarizeDiff(c)}</div>
+                  ))}
+                </div>
+              )}
+
+              {/* Actions */}
+              {proposal.status === 'draft' && (
+                <div className="px-4 py-3 bg-amber-500/5 flex flex-wrap items-center gap-2">
+                  {showRefineInput ? (
+                    <>
+                      <input
+                        type="text"
+                        autoFocus
+                        value={refineText}
+                        onChange={e => setRefineText(e.target.value)}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') { e.preventDefault(); refine(); }
+                          if (e.key === 'Escape') setShowRefineInput(false);
+                        }}
+                        placeholder="Add a constraint…"
+                        className="flex-1 bg-mc-bg border border-mc-border rounded-sm px-2 py-1 text-xs focus:outline-hidden focus:border-mc-accent"
+                        disabled={refining}
+                      />
+                      <button
+                        type="button"
+                        onClick={refine}
+                        disabled={refining || !refineText.trim()}
+                        className="text-xs px-2 py-1 bg-mc-accent text-mc-bg rounded-sm hover:bg-mc-accent/90 disabled:opacity-50"
+                      >
+                        {refining ? 'Sending…' : 'Send'}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setShowRefineInput(false)}
+                        className="text-xs px-2 py-1 text-mc-text-secondary hover:text-mc-text"
+                      >
+                        Cancel
+                      </button>
+                      {refineErr && (
+                        <span className="text-xs text-red-300 w-full">{refineErr}</span>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => setShowRefineInput(true)}
+                        className="text-xs px-2 py-1 border border-mc-border rounded-sm hover:bg-mc-bg/50 flex items-center gap-1"
+                      >
+                        <RefreshCw className="w-3 h-3" /> Refine
+                      </button>
+                      <button
+                        type="button"
+                        onClick={accept}
+                        disabled={acting !== null}
+                        className="text-xs px-2 py-1 bg-emerald-500/20 border border-emerald-500/40 text-emerald-200 rounded-sm hover:bg-emerald-500/30 flex items-center gap-1 disabled:opacity-50"
+                      >
+                        <Check className="w-3 h-3" /> {acting === 'accept' ? 'Accepting…' : 'Accept'}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={reject}
+                        disabled={acting !== null}
+                        className="text-xs px-2 py-1 bg-red-500/20 border border-red-500/40 text-red-200 rounded-sm hover:bg-red-500/30 flex items-center gap-1 disabled:opacity-50"
+                      >
+                        <X className="w-3 h-3" /> {acting === 'reject' ? 'Rejecting…' : 'Reject'}
+                      </button>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Metadata */}
+            <div className="text-xs text-mc-text-secondary space-y-1">
+              <div><span className="font-medium text-mc-text">ID</span> {proposal.id}</div>
+              {proposal.parent_proposal_id && (
+                <div>
+                  <span className="font-medium text-mc-text">Parent</span>{' '}
+                  <Link href={`/pm/proposals/${proposal.parent_proposal_id}`} className="underline hover:text-mc-text">
+                    {proposal.parent_proposal_id.slice(0, 8)}…
+                  </Link>
+                </div>
+              )}
+              {proposal.target_initiative_id && (
+                <div>
+                  <span className="font-medium text-mc-text">Initiative</span> {proposal.target_initiative_id.slice(0, 8)}…
+                </div>
+              )}
+              {proposal.applied_at && (
+                <div>
+                  <span className="font-medium text-mc-text">Applied</span>{' '}
+                  {new Date(proposal.applied_at.endsWith('Z') ? proposal.applied_at : proposal.applied_at + 'Z').toLocaleString()}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -139,16 +139,16 @@ export async function POST(request: NextRequest) {
       trigger_kind: 'plan_initiative',
       target_initiative_id: parsed.data.target_initiative_id ?? null,
       planSessionKey,
-      synth: { impact_md: synth.impact_md, changes: synth.changes },
+      synth: { impact_md: synth.impact_md, changes: synth.changes, plan_suggestions: synth.suggestions as unknown as Record<string, unknown> },
       agent_prompt:
         `Plan an initiative draft titled "${parsed.data.draft.title}". ` +
         `Operator-provided draft: ${JSON.stringify(parsed.data.draft)}. ` +
         (parsed.data.guidance
           ? `Operator guidance — focus the plan on this: ${parsed.data.guidance}\n\n`
           : '') +
-        `Call \`propose_changes\` (trigger_kind='plan_initiative') with an impact_md that ` +
-        `includes a "<!--pm-plan-suggestions ...-->" sidecar so the form can apply your ` +
-        `suggestions. proposed_changes should be [] (advisory). See your SOUL.md.`,
+        `Call \`propose_changes\` (trigger_kind='plan_initiative') with proposed_changes=[] and ` +
+        `pass the structured plan_suggestions parameter directly (do NOT embed JSON in impact_md). ` +
+        `See your SOUL.md for the plan_suggestions shape.`,
     });
     let proposal = dispatch.proposal;
 
@@ -192,9 +192,13 @@ export async function POST(request: NextRequest) {
       console.warn('[pm-plan] chat insert failed:', (err as Error).message);
     }
 
-    // Prefer the agent's parsed suggestions when available; fall back to
-    // the deterministic synth only when the sidecar is absent or unparseable.
-    const responseSuggestions = parseSuggestionsFromImpactMd(proposal.impact_md) ?? synth.suggestions;
+    // Prefer structured plan_suggestions stored on the proposal (set by the
+    // agent via the propose_changes MCP tool, or by the synth fallback).
+    // Fall back to sidecar parsing for older proposals, then synth.
+    const responseSuggestions =
+      (proposal.plan_suggestions as typeof synth.suggestions | null) ??
+      parseSuggestionsFromImpactMd(proposal.impact_md) ??
+      synth.suggestions;
 
     return NextResponse.json(
       {
@@ -252,6 +256,7 @@ export async function GET(request: NextRequest) {
     trigger_kind: string;
     impact_md: string;
     proposed_changes: string;
+    plan_suggestions: string | null;
     status: string;
     applied_at: string | null;
     applied_by_agent_id: string | null;
@@ -272,11 +277,12 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ proposal: null });
   }
 
-  const suggestions = parseSuggestionsFromImpactMd(row.impact_md);
-  // Require refined_description — proposals without it are incomplete agent
-  // responses (e.g. only complexity/dates, no actual description rewrite).
-  // Treat them as non-resumable so a fresh dispatch runs and produces a
-  // complete set of suggestions rather than showing a blank description field.
+  // Prefer structured plan_suggestions; fall back to sidecar for older rows.
+  const parsedPlanSuggestions = row.plan_suggestions
+    ? (() => { try { return JSON.parse(row.plan_suggestions!) as { refined_description?: string }; } catch { return null; } })()
+    : null;
+  const suggestions = parsedPlanSuggestions ?? parseSuggestionsFromImpactMd(row.impact_md);
+  // Require refined_description — proposals without it are incomplete.
   if (!suggestions?.refined_description) {
     return NextResponse.json({ proposal: null });
   }

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -192,11 +192,15 @@ export async function POST(request: NextRequest) {
       console.warn('[pm-plan] chat insert failed:', (err as Error).message);
     }
 
+    // Prefer the agent's parsed suggestions when available; fall back to
+    // the deterministic synth only when the sidecar is absent or unparseable.
+    const responseSuggestions = parseSuggestionsFromImpactMd(proposal.impact_md) ?? synth.suggestions;
+
     return NextResponse.json(
       {
         proposal_id: proposal.id,
         proposal,
-        suggestions: synth.suggestions,
+        suggestions: responseSuggestions,
       },
       { status: 201 },
     );

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -273,12 +273,19 @@ export async function GET(request: NextRequest) {
   }
 
   const suggestions = parseSuggestionsFromImpactMd(row.impact_md);
+  // Require refined_description — proposals without it are incomplete agent
+  // responses (e.g. only complexity/dates, no actual description rewrite).
+  // Treat them as non-resumable so a fresh dispatch runs and produces a
+  // complete set of suggestions rather than showing a blank description field.
+  if (!suggestions?.refined_description) {
+    return NextResponse.json({ proposal: null });
+  }
   return NextResponse.json({
     proposal_id: row.id,
     proposal: {
       ...row,
       proposed_changes: JSON.parse(row.proposed_changes),
     },
-    suggestions: suggestions ?? null,
+    suggestions,
   });
 }

--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -75,6 +75,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     let newImpactMd: string;
     let newChanges: unknown[];
+    let newPlanSuggestions: unknown = null;
 
     if (parent.trigger_kind === 'plan_initiative') {
       const ctx = parseTriggerContext(parent.trigger_text);
@@ -117,20 +118,20 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           `Original draft: ${JSON.stringify(draft)}. ` +
           `Operator refinement request: "${parsed.data.additional_constraint}"\n\n` +
           `Produce an updated refined_description that addresses the operator's request. ` +
-          `Call \`propose_changes\` (trigger_kind='plan_initiative') with an impact_md that ` +
-          `includes a "<!--pm-plan-suggestions ...-->" sidecar. proposed_changes should be [] (advisory). ` +
-          `See your SOUL.md.`,
+          `Call \`propose_changes\` (trigger_kind='plan_initiative') with proposed_changes=[] and ` +
+          `pass the structured plan_suggestions parameter directly (do NOT embed JSON in impact_md). ` +
+          `See your SOUL.md for the plan_suggestions shape.`,
       });
 
-      let agentImpactMd = dispatch.proposal.impact_md;
-
-      // Guarantee the sidecar is present — LLMs sometimes omit it even
-      // when instructed. The synth suggestions are always available here.
-      if (!parseSuggestionsFromImpactMd(agentImpactMd)) {
-        agentImpactMd =
-          agentImpactMd +
-          `\n\n<!--pm-plan-suggestions ${JSON.stringify(synth.suggestions)} -->`;
-      }
+      const agentImpactMd = dispatch.proposal.impact_md;
+      // Resolve structured suggestions: prefer what the agent wrote into
+      // plan_suggestions (via propose_changes MCP param), then sidecar,
+      // then the deterministic synth. This eliminates the sidecar-injection
+      // band-aid that was applied here before.
+      const refinedSuggestions =
+        (dispatch.proposal.plan_suggestions as typeof synth.suggestions | null) ??
+        parseSuggestionsFromImpactMd(agentImpactMd) ??
+        synth.suggestions;
 
       // dispatchPmSynthesized created its own proposal row — delete it
       // since we already have the pre-allocated child from refineProposal().
@@ -141,6 +142,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
       newImpactMd = agentImpactMd;
       newChanges = synth.changes;
+      newPlanSuggestions = refinedSuggestions;
     } else if (parent.trigger_kind === 'decompose_initiative') {
       const ctx = parseTriggerContext(parent.trigger_text);
       const initiativeId = ctx?.initiative_id as string | undefined;
@@ -175,8 +177,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     const { run } = await import('@/lib/db');
     run(
-      `UPDATE pm_proposals SET impact_md = ?, proposed_changes = ? WHERE id = ?`,
-      [newImpactMd, JSON.stringify(newChanges), child.id],
+      `UPDATE pm_proposals SET impact_md = ?, proposed_changes = ?, plan_suggestions = ? WHERE id = ?`,
+      [newImpactMd, JSON.stringify(newChanges), newPlanSuggestions != null ? JSON.stringify(newPlanSuggestions) : null, child.id],
     );
 
     const refreshed = getProposal(child.id)!;

--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -78,7 +78,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     if (parent.trigger_kind === 'plan_initiative') {
       const ctx = parseTriggerContext(parent.trigger_text);
-      const draft = (ctx?.draft as Record<string, unknown> | undefined) ?? { title: 'Untitled' };
+      // When trigger_text is old free-text format, extract the title from
+      // quoted strings as a best-effort fallback (e.g. `Plan initiative flow
+      // for "Smart Snappy" epic.` → "Smart Snappy").
+      let draft = (ctx?.draft as Record<string, unknown> | undefined);
+      if (!draft) {
+        const m = parent.trigger_text.match(/"([^"]+)"/);
+        draft = { title: m ? m[1] : parent.trigger_text.slice(0, 80) };
+      }
       const draftTitle = (draft.title as string | undefined) ?? 'Untitled';
       // Reuse the same session so multi-turn refinements share context with
       // the PM agent's prior turns in this planning conversation.

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -204,8 +204,11 @@ export default function PlanWithPmPanel({
       const newProposal = body.proposal;
       setProposalId(newProposal.id);
       setImpactMd(newProposal.impact_md);
-      const parsed = parseSuggestionsFromImpactMd(newProposal.impact_md);
-      if (parsed) setSuggestions(parsed);
+      // Prefer structured plan_suggestions column; fall back to sidecar parsing.
+      const refined =
+        (newProposal.plan_suggestions as PlanInitiativeSuggestions | null) ??
+        parseSuggestionsFromImpactMd(newProposal.impact_md);
+      if (refined) setSuggestions(refined);
       setRefineText('');
     } catch (e) {
       setErr(e instanceof Error ? e.message : 'Refine failed');

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -22,7 +22,8 @@
  */
 
 import { useState, useEffect, useRef } from 'react';
-import { Sparkles, Send, X, RefreshCw } from 'lucide-react';
+import { Sparkles, Send, X, RefreshCw, ChevronDown, ChevronRight } from 'lucide-react';
+import { parseSuggestionsFromImpactMd as parseSharedSuggestions } from '@/lib/pm/planSuggestionsSidecar';
 
 export interface PlanInitiativeDraft {
   title: string;
@@ -48,21 +49,8 @@ export interface PlanInitiativeSuggestions {
   owner_agent_id: string | null;
 }
 
-/**
- * Extract the structured suggestions JSON from a proposal's impact_md
- * (we embed it in an HTML comment so the markdown stays human-readable
- * but the client can pull suggestions out of any /refine response).
- */
 function parseSuggestionsFromImpactMd(md: string): PlanInitiativeSuggestions | null {
-  // [\s\S] matches anything including newlines (the `s` flag is ES2018+
-  // and the project's tsconfig predates that — works on a wider range).
-  const m = md.match(/<!--pm-plan-suggestions\s+([\s\S]*?)\s*-->/);
-  if (!m) return null;
-  try {
-    return JSON.parse(m[1]) as PlanInitiativeSuggestions;
-  } catch {
-    return null;
-  }
+  return parseSharedSuggestions(md) as PlanInitiativeSuggestions | null;
 }
 
 interface KnownInitiative {
@@ -120,6 +108,7 @@ export default function PlanWithPmPanel({
   const [refining, setRefining] = useState(false);
   const [refineText, setRefineText] = useState('');
   const [err, setErr] = useState<string | null>(null);
+  const [draftOpen, setDraftOpen] = useState(false);
   // Snapshot the draft at open-time so React-driven re-renders of the
   // host (which construct a fresh `draft` object every render) don't
   // retrigger this effect and cancel the in-flight fetch.
@@ -145,6 +134,7 @@ export default function PlanWithPmPanel({
       setSuggestions(null);
       setErr(null);
       setRefineText('');
+      setDraftOpen(false);
       return;
     }
 
@@ -263,13 +253,22 @@ export default function PlanWithPmPanel({
         </button>
       </header>
 
-      <div className="rounded border border-mc-border bg-mc-bg-secondary p-3 mb-3 text-xs">
-        <div className="text-mc-text-secondary uppercase tracking-wide text-[10px] mb-1">Your draft</div>
-        <div className="text-mc-text">
-          <strong>{draft.title}</strong>
-          {draft.description ? <p className="text-mc-text-secondary mt-1 whitespace-pre-wrap">{draft.description}</p> : null}
+      <button
+        type="button"
+        onClick={() => setDraftOpen(o => !o)}
+        className="w-full flex items-center gap-1 text-[10px] text-mc-text-secondary uppercase tracking-wide mb-3 hover:text-mc-text transition-colors"
+      >
+        {draftOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+        Your draft
+      </button>
+      {draftOpen && (
+        <div className="rounded border border-mc-border bg-mc-bg-secondary p-3 mb-3 text-xs">
+          <div className="text-mc-text">
+            <strong>{draft.title}</strong>
+            {draft.description ? <p className="text-mc-text-secondary mt-1 whitespace-pre-wrap">{draft.description}</p> : null}
+          </div>
         </div>
-      </div>
+      )}
 
       {err && (
         <div className="p-2 rounded bg-red-500/10 border border-red-500/30 text-red-300 text-xs mb-3">
@@ -302,13 +301,13 @@ export default function PlanWithPmPanel({
                 <div className="text-mc-text font-medium">{suggestions.target_end}</div>
               </div>
             </div>
-            {suggestions.dependencies.length > 0 && (
+            {(suggestions.dependencies?.length ?? 0) > 0 && (
               <div>
                 <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">
-                  Will create on Apply ({suggestions.dependencies.length} dependenc{suggestions.dependencies.length === 1 ? 'y' : 'ies'})
+                  Will create on Apply ({suggestions.dependencies!.length} dependenc{suggestions.dependencies!.length === 1 ? 'y' : 'ies'})
                 </div>
                 <ul className="text-mc-text mt-1 space-y-1">
-                  {suggestions.dependencies.map(d => (
+                  {suggestions.dependencies!.map(d => (
                     <li key={d.depends_on_initiative_id}>
                       <span className="font-medium">{titleFor(d.depends_on_initiative_id)}</span>{' '}
                       <span className="text-mc-text-secondary italic">— {d.note}</span>

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -255,9 +255,9 @@ async function dispatchViaNamedAgent(params: DispatchNamedAgentParams): Promise<
     message,
     idempotencyKey: `pm-dispatch-${correlationId}`,
     timeoutMs: namedAgentTimeoutMs(),
-    // Fresh session per disruption — prevents context from one disruption
-    // analysis bleeding into the next independent request.
-    sessionSuffix: `dispatch-${correlationId}`,
+    // Stable session keeps the PM agent warm between disruption dispatches.
+    // Fresh plan-<uuid> sessions are used for plan/decompose flows instead.
+    sessionSuffix: 'dispatch-main',
   });
 
   // Send failed — caller falls back to synth.

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -305,7 +305,7 @@ export interface DispatchSynthesizedInput {
   trigger_text: string;
   trigger_kind: PmProposalTriggerKind;
   /** Synth output ready to persist as a fallback. */
-  synth: { impact_md: string; changes: PmDiff[] };
+  synth: { impact_md: string; changes: PmDiff[]; plan_suggestions?: Record<string, unknown> | null };
   /** Free-text prompt sent to the named agent. */
   agent_prompt: string;
   parent_proposal_id?: string | null;
@@ -411,6 +411,7 @@ export async function dispatchPmSynthesized(
     trigger_kind: input.trigger_kind,
     impact_md: input.synth.impact_md,
     proposed_changes: input.synth.changes,
+    plan_suggestions: input.synth.plan_suggestions ?? null,
     parent_proposal_id: input.parent_proposal_id ?? null,
     target_initiative_id: input.target_initiative_id ?? null,
   });

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -300,7 +300,7 @@ test('dispatchPm: routes through named agent when openclaw is connected; mock cr
     const send = seenSends.find(s => s.method === 'chat.send');
     assert.ok(send);
     const sk = (send!.params as { sessionKey?: string }).sessionKey;
-    assert.equal(sk, `agent:${PM_GATEWAY_AGENT_ID}:main`);
+    assert.equal(sk, `agent:${PM_GATEWAY_AGENT_ID}:main:dispatch-main`);
   } finally {
     __setOpenClawClientForTests(null);
     __setNamedAgentTimeoutForTests(null);

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3256,6 +3256,46 @@ const migrations: Migration[] = [
     },
   },
   {
+    id: '053',
+    name: 'pm_proposals_target_initiative_cascade',
+    up: (db) => {
+      // Change target_initiative_id from ON DELETE SET NULL to ON DELETE CASCADE
+      // so that deleting an initiative automatically removes its scoped proposals
+      // rather than leaving them as unattributed orphans.
+      // SQLite requires a full table rebuild to change FK actions.
+      const cols = db.prepare(`PRAGMA table_info(pm_proposals)`).all() as Array<{ name: string }>;
+      const colNames = ['id', 'workspace_id', 'trigger_text', 'trigger_kind', 'impact_md',
+        'proposed_changes', 'status', 'applied_at', 'applied_by_agent_id', 'parent_proposal_id',
+        'created_at', 'target_initiative_id', 'plan_suggestions'].filter(c => cols.some(x => x.name === c));
+      const colList = colNames.join(', ');
+      db.exec(`
+        CREATE TABLE pm_proposals_new (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          trigger_text TEXT NOT NULL,
+          trigger_kind TEXT NOT NULL DEFAULT 'manual'
+            CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation','plan_initiative','decompose_initiative')),
+          impact_md TEXT NOT NULL,
+          proposed_changes TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'draft'
+            CHECK (status IN ('draft','accepted','rejected','superseded')),
+          applied_at TEXT,
+          applied_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+          parent_proposal_id TEXT REFERENCES pm_proposals_new(id) ON DELETE SET NULL,
+          created_at TEXT DEFAULT (datetime('now')),
+          target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
+          plan_suggestions TEXT
+        )
+      `);
+      db.exec(`INSERT INTO pm_proposals_new (${colList}) SELECT ${colList} FROM pm_proposals`);
+      db.exec(`DROP TABLE pm_proposals`);
+      db.exec(`ALTER TABLE pm_proposals_new RENAME TO pm_proposals`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_status ON pm_proposals(status, created_at DESC)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_target_init ON pm_proposals(target_initiative_id, status, created_at DESC)`);
+      console.log('[Migration 053] pm_proposals.target_initiative_id changed to ON DELETE CASCADE.');
+    },
+  },
+  {
     id: '051',
     name: 'workspaces_workspace_path',
     up: (db) => {

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3245,6 +3245,17 @@ const migrations: Migration[] = [
     },
   },
   {
+    id: '052',
+    name: 'pm_proposals_plan_suggestions',
+    up: (db) => {
+      const cols = db.prepare(`PRAGMA table_info(pm_proposals)`).all() as Array<{ name: string }>;
+      if (!cols.some(c => c.name === 'plan_suggestions')) {
+        db.exec(`ALTER TABLE pm_proposals ADD COLUMN plan_suggestions TEXT`);
+      }
+      console.log('[Migration 052] pm_proposals.plan_suggestions added.');
+    },
+  },
+  {
     id: '051',
     name: 'workspaces_workspace_path',
     up: (db) => {

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -102,13 +102,13 @@ export interface PmProposal {
   trigger_kind: PmProposalTriggerKind;
   impact_md: string;
   proposed_changes: PmDiff[];
+  /** Structured plan suggestions stored as a proper field, bypassing the
+   *  fragile <!--pm-plan-suggestions {json} --> sidecar in impact_md. */
+  plan_suggestions: Record<string, unknown> | null;
   status: PmProposalStatus;
   applied_at: string | null;
   applied_by_agent_id: string | null;
   parent_proposal_id: string | null;
-  // Set when this proposal was generated FOR an existing initiative
-  // (e.g. operator clicked "Plan with PM" on the detail page). Lets the
-  // panel resume the draft on re-open instead of re-running the PM.
   target_initiative_id: string | null;
   created_at: string;
 }
@@ -120,6 +120,7 @@ interface PmProposalRow {
   trigger_kind: PmProposalTriggerKind;
   impact_md: string;
   proposed_changes: string;
+  plan_suggestions: string | null;
   status: PmProposalStatus;
   applied_at: string | null;
   applied_by_agent_id: string | null;
@@ -339,6 +340,10 @@ function rowToProposal(row: PmProposalRow): PmProposal {
   } catch {
     parsed = [];
   }
+  let planSuggestions: Record<string, unknown> | null = null;
+  if (row.plan_suggestions) {
+    try { planSuggestions = JSON.parse(row.plan_suggestions) as Record<string, unknown>; } catch { /* leave null */ }
+  }
   return {
     id: row.id,
     workspace_id: row.workspace_id,
@@ -346,6 +351,7 @@ function rowToProposal(row: PmProposalRow): PmProposal {
     trigger_kind: row.trigger_kind,
     impact_md: row.impact_md,
     proposed_changes: parsed,
+    plan_suggestions: planSuggestions,
     status: row.status,
     applied_at: row.applied_at,
     applied_by_agent_id: row.applied_by_agent_id,
@@ -363,6 +369,7 @@ export interface CreateProposalInput {
   trigger_kind?: PmProposalTriggerKind;
   impact_md: string;
   proposed_changes: PmDiff[];
+  plan_suggestions?: Record<string, unknown> | null;
   parent_proposal_id?: string | null;
   target_initiative_id?: string | null;
 }
@@ -387,8 +394,8 @@ export function createProposal(input: CreateProposalInput): PmProposal {
   run(
     `INSERT INTO pm_proposals (
        id, workspace_id, trigger_text, trigger_kind, impact_md,
-       proposed_changes, status, parent_proposal_id, target_initiative_id, created_at
-     ) VALUES (?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?)`,
+       proposed_changes, plan_suggestions, status, parent_proposal_id, target_initiative_id, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?)`,
     [
       id,
       input.workspace_id,
@@ -396,6 +403,7 @@ export function createProposal(input: CreateProposalInput): PmProposal {
       input.trigger_kind ?? 'manual',
       input.impact_md,
       JSON.stringify(input.proposed_changes ?? []),
+      input.plan_suggestions != null ? JSON.stringify(input.plan_suggestions) : null,
       input.parent_proposal_id ?? null,
       input.target_initiative_id ?? null,
       now,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -924,7 +924,9 @@ CREATE TABLE IF NOT EXISTS pm_proposals (
   applied_at TEXT,
   applied_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
   parent_proposal_id TEXT REFERENCES pm_proposals(id) ON DELETE SET NULL,
-  created_at TEXT DEFAULT (datetime('now'))
+  created_at TEXT DEFAULT (datetime('now')),
+  target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
+  plan_suggestions TEXT
 );
 
 -- Indexes for performance

--- a/src/lib/mcp/roadmap-tools.ts
+++ b/src/lib/mcp/roadmap-tools.ts
@@ -598,52 +598,25 @@ export function registerRoadmapTools(server: McpServer): void {
         impact_md: z.string().min(1).max(20000),
         changes: z.array(DiffSchema),
         parent_proposal_id: z.string().nullish(),
+        /**
+         * Structured planning suggestions for plan_initiative proposals.
+         * Pass the suggestions object here directly rather than embedding
+         * JSON in impact_md — avoids all sidecar parsing problems.
+         * Required fields: refined_description, complexity.
+         * Optional: target_start, target_end, status_check_md, dependencies.
+         */
+        plan_suggestions: z.record(z.string(), z.unknown()).nullish(),
       },
       annotations: { destructiveHint: false, openWorldHint: false },
     },
     async (args) => safeWrap(() => {
-      // For plan_initiative proposals, the chat-side Apply flow needs
-      // a `<!--pm-plan-suggestions ...-->` JSON sidecar in impact_md.
-      // SOUL.md asks the agent to embed it, but LLMs are unreliable
-      // about arbitrary HTML-comment JSON. When it's missing AND the
-      // agent passed a parseable draft in trigger_text, re-derive
-      // suggestions deterministically and inject. Graceful degradation:
-      // if trigger_text isn't a draft blob (or synth fails), proceed
-      // without — the chat picker modal will show a clear "no embedded
-      // suggestions" warning instead of silently failing.
-      let impactMd = args.impact_md;
-      if (
-        args.trigger_kind === 'plan_initiative' &&
-        !/<!--pm-plan-suggestions/.test(impactMd)
-      ) {
-        try {
-          const parsed = JSON.parse(args.trigger_text) as {
-            mode?: string;
-            draft?: {
-              title: string;
-              description?: string | null;
-              kind?: 'theme' | 'milestone' | 'epic' | 'story';
-              complexity?: 'S' | 'M' | 'L' | 'XL' | null;
-              parent_initiative_id?: string | null;
-              target_start?: string | null;
-              target_end?: string | null;
-            };
-          };
-          if (parsed?.mode === 'plan_initiative' && parsed.draft?.title) {
-            const snapshot = getRoadmapSnapshot({ workspace_id: args.workspace_id });
-            const synth = synthesizePlanInitiative(snapshot, parsed.draft);
-            impactMd = `${impactMd.trim()}\n\n<!--pm-plan-suggestions ${JSON.stringify(synth.suggestions)} -->`;
-          }
-        } catch {
-          // trigger_text wasn't a JSON draft blob — leave impact_md as-is.
-        }
-      }
       return createProposal({
         workspace_id: args.workspace_id,
         trigger_text: args.trigger_text,
         trigger_kind: args.trigger_kind,
-        impact_md: impactMd,
+        impact_md: args.impact_md,
         proposed_changes: args.changes as PmDiff[],
+        plan_suggestions: args.plan_suggestions ?? null,
         parent_proposal_id: args.parent_proposal_id ?? null,
       });
     }),

--- a/src/lib/pm/planSuggestionsSidecar.ts
+++ b/src/lib/pm/planSuggestionsSidecar.ts
@@ -31,43 +31,79 @@ const SIDECAR_PATTERN_GLOBAL =
   /<!(?:--|—|–)\s*pm-plan-suggestions\s+([\s\S]*?)\s*(?:--|—|–)>/g;
 
 /**
+ * Extract a JSON object string from arbitrary text. Uses a greedy match
+ * from the first `{` to the last `}` — safe for PM-generated markdown
+ * which doesn't contain bare `}` outside JSON blocks.
+ */
+function extractLeadingJsonObject(text: string): string | null {
+  if (!text.trimStart().startsWith('{')) return null;
+  const m = text.match(/(\{[\s\S]*\})/);
+  return m ? m[1] : null;
+}
+
+/**
  * Pull the suggestions blob out of an impact_md string. Returns null
  * when no sidecar matches or the JSON is malformed.
  *
- * Handles a malformed variant the PM agent sometimes produces:
- *   <!--pm-plan-suggestions {JSON}'><!--pm-plan-suggestions end-->
- * In that case the regex captures `{JSON}'>...end` — we fall back to
- * extracting the leading balanced JSON object (`{...}`) from the capture.
+ * Handles two malformed variants the PM agent produces:
+ *
+ *   Pattern A (inline garbage):
+ *     <!--pm-plan-suggestions {JSON}'><!--pm-plan-suggestions end-->
+ *     The regex captures `{JSON}'>...end`; we strip the trailing garbage
+ *     by extracting just the leading `{...}` object.
+ *
+ *   Pattern B (empty tag, JSON outside):
+ *     <!--pm-plan-suggestions-->
+ *     { "refined_description": "...", ... }
+ *     The comment closes immediately; the JSON sits on the next line(s)
+ *     outside any comment. The canonical regex never matches because
+ *     `\s+` requires content inside the tag.
  */
 export function parseSuggestionsFromImpactMd(
   md: string,
 ): PlanInitiativeSuggestionsBlob | null {
-  // Use a single-shot non-global copy of the pattern (regex.exec on a
-  // shared global keeps state in `lastIndex`).
+  // Pattern A: JSON inside the comment (canonical + stylized dash variants).
   const m = md.match(/<!(?:--|—|–)\s*pm-plan-suggestions\s+([\s\S]*?)\s*(?:--|—|–)>/);
-  if (!m) return null;
-  const raw = m[1].trim();
-  try {
-    return JSON.parse(raw) as PlanInitiativeSuggestionsBlob;
-  } catch {
-    // Malformed sidecar — try to extract just the leading JSON object.
-    // `\{[\s\S]*\}` is greedy so it backtracks to the LAST `}`, which is
-    // the closing brace of the JSON rather than any garbage that follows.
-    const objMatch = raw.match(/^(\{[\s\S]*\})/);
-    if (objMatch) {
+  if (m) {
+    const raw = m[1].trim();
+    try {
+      return JSON.parse(raw) as PlanInitiativeSuggestionsBlob;
+    } catch {
+      const extracted = extractLeadingJsonObject(raw);
+      if (extracted) {
+        try {
+          return JSON.parse(extracted) as PlanInitiativeSuggestionsBlob;
+        } catch { /* fall through */ }
+      }
+    }
+  }
+
+  // Pattern B: empty `<!--pm-plan-suggestions-->` tag, JSON follows outside.
+  const emptyTagIdx = md.indexOf('<!--pm-plan-suggestions-->');
+  if (emptyTagIdx !== -1) {
+    const afterTag = md.slice(emptyTagIdx + '<!--pm-plan-suggestions-->'.length).trimStart();
+    const extracted = extractLeadingJsonObject(afterTag);
+    if (extracted) {
       try {
-        return JSON.parse(objMatch[1]) as PlanInitiativeSuggestionsBlob;
+        return JSON.parse(extracted) as PlanInitiativeSuggestionsBlob;
       } catch { /* fall through */ }
     }
-    return null;
   }
+
+  return null;
 }
 
 /**
  * Remove every pm-plan-suggestions sidecar from a markdown string for
- * display purposes. Handles canonical and stylized variants. Trims any
- * leftover blank lines so the output reads clean.
+ * display purposes. Handles canonical, stylized, and empty-tag variants.
+ * Trims leftover blank lines so the output reads clean.
  */
 export function stripSuggestionsSidecar(md: string): string {
-  return md.replace(SIDECAR_PATTERN_GLOBAL, '').replace(/\n{3,}/g, '\n\n').trim();
+  // Strip Pattern A: JSON inside the comment.
+  let result = md.replace(SIDECAR_PATTERN_GLOBAL, '');
+  // Strip Pattern B: empty tag + JSON block immediately following.
+  result = result.replace(/<!--pm-plan-suggestions-->\s*\{[\s\S]*?\}(?=\s*\n\n|\s*$|\s*\n[^{])/g, '');
+  // Fallback: bare empty tag with no JSON (already stripped if JSON matched above).
+  result = result.replace(/<!--pm-plan-suggestions-->/g, '');
+  return result.replace(/\n{3,}/g, '\n\n').trim();
 }

--- a/src/lib/pm/planSuggestionsSidecar.ts
+++ b/src/lib/pm/planSuggestionsSidecar.ts
@@ -33,6 +33,11 @@ const SIDECAR_PATTERN_GLOBAL =
 /**
  * Pull the suggestions blob out of an impact_md string. Returns null
  * when no sidecar matches or the JSON is malformed.
+ *
+ * Handles a malformed variant the PM agent sometimes produces:
+ *   <!--pm-plan-suggestions {JSON}'><!--pm-plan-suggestions end-->
+ * In that case the regex captures `{JSON}'>...end` — we fall back to
+ * extracting the leading balanced JSON object (`{...}`) from the capture.
  */
 export function parseSuggestionsFromImpactMd(
   md: string,
@@ -41,9 +46,19 @@ export function parseSuggestionsFromImpactMd(
   // shared global keeps state in `lastIndex`).
   const m = md.match(/<!(?:--|—|–)\s*pm-plan-suggestions\s+([\s\S]*?)\s*(?:--|—|–)>/);
   if (!m) return null;
+  const raw = m[1].trim();
   try {
-    return JSON.parse(m[1]) as PlanInitiativeSuggestionsBlob;
+    return JSON.parse(raw) as PlanInitiativeSuggestionsBlob;
   } catch {
+    // Malformed sidecar — try to extract just the leading JSON object.
+    // `\{[\s\S]*\}` is greedy so it backtracks to the LAST `}`, which is
+    // the closing brace of the JSON rather than any garbage that follows.
+    const objMatch = raw.match(/^(\{[\s\S]*\})/);
+    if (objMatch) {
+      try {
+        return JSON.parse(objMatch[1]) as PlanInitiativeSuggestionsBlob;
+      } catch { /* fall through */ }
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Eliminates all sidecar parsing whack-a-mole by adding `plan_suggestions TEXT` column (migration 052) to `pm_proposals` — the PM agent now passes structured suggestions directly via the `propose_changes` MCP tool parameter, bypassing HTML comment embedding entirely
- Fixes cold-start timeouts from PR #84 by reverting to a stable `dispatch-main` session key (instead of per-request `dispatch-${uuid}` that started a fresh cold session every time)
- Fixes the resume loop where proposals with partial suggestions (no `refined_description`) were causing GET → null → POST → repeat on every panel open

## Changes
- `src/lib/db/migrations.ts` — migration 052: `ALTER TABLE pm_proposals ADD COLUMN plan_suggestions TEXT`
- `src/lib/db/pm-proposals.ts` — `plan_suggestions` field on `PmProposal` type + `createProposal` INSERT
- `src/lib/mcp/roadmap-tools.ts` — `propose_changes` tool accepts `plan_suggestions: z.record(z.string(), z.unknown()).nullish()` as a first-class param; removed unreliable sidecar injection code
- `src/lib/agents/pm-dispatch.ts` — `DispatchSynthesizedInput.synth` adds `plan_suggestions`; synth fallback persists it; `sessionSuffix` reverted to `'dispatch-main'`
- `src/app/api/pm/plan-initiative/route.ts` — GET/POST prefer `proposal.plan_suggestions` over sidecar parsing; GET requires `refined_description` before treating proposal as resumable
- `src/app/api/pm/proposals/[id]/refine/route.ts` — persists `plan_suggestions` in UPDATE; resolves suggestions from structured column → sidecar → synth
- `src/components/PlanWithPmPanel.tsx` — reads `plan_suggestions` from refine response; collapsible "Your Draft" section (default collapsed)
- `~/.openclaw/workspaces/mc-project-manager/SOUL.md` — documents `plan_suggestions` parameter shape so the PM agent passes it directly
- `src/lib/agents/pm.test.ts` — updates session key assertion to match `dispatch-main` suffix

## Test plan
- [ ] 375/375 tests passing (`yarn test`)
- [ ] Typecheck clean (`yarn tsc --noEmit`) — 2 pre-existing failures in `pm-decompose.test.ts` unrelated to this change
- [ ] Open "Plan with PM" panel on a new initiative → verify "Refined description" shows the agent's output, not the original
- [ ] Refine with a constraint → verify the refined description updates
- [ ] Navigate away and back → verify the draft resumes (GET path) without re-triggering POST