### PR TITLE
fix(decompose): resume/dedup/guard + migration 053 cascade fix

### DIFF
--- a/src/app/(app)/initiatives/[id]/page.tsx
+++ b/src/app/(app)/initiatives/[id]/page.tsx
@@ -188,8 +188,10 @@ export default function InitiativeDetailPage({
   // True while there is a known unresolved draft proposal for this initiative.
   // Disables the "Plan with PM" button to prevent duplicate dispatches.
   const [hasDraftProposal, setHasDraftProposal] = useState(false);
-  // Once the initiative loads, check once for an existing draft proposal so
-  // we can auto-open the plan panel and prevent duplicate dispatches.
+  // True while there is a known unresolved draft decompose proposal.
+  const [hasDraftDecomposeProposal, setHasDraftDecomposeProposal] = useState(false);
+  // Once the initiative loads, check once for existing draft proposals so
+  // we can surface them and prevent duplicate dispatches.
   const draftProposalCheckDone = useRef(false);
   // Operator guidance captured via the "Plan with PM ▾ → With guidance"
   // option in the toolbar split-button. Threaded into the initial PM
@@ -255,21 +257,26 @@ export default function InitiativeDetailPage({
     };
   }, [initiative?.workspace_id]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Auto-open the plan panel when there's an existing unresolved draft
-  // proposal for this initiative. Guards with a ref so it only fires once
-  // per mount, not on every subsequent refresh() call.
+  // On first load, check for existing draft proposals (plan + decompose) to
+  // surface them and disable the buttons that would create duplicates.
   useEffect(() => {
     if (!initiative || draftProposalCheckDone.current) return;
     draftProposalCheckDone.current = true;
-    fetch(
-      `/api/pm/plan-initiative?workspace_id=${encodeURIComponent(initiative.workspace_id)}&target_initiative_id=${encodeURIComponent(initiative.id)}`,
-    )
+    const ws = encodeURIComponent(initiative.workspace_id);
+    const iid = encodeURIComponent(initiative.id);
+    fetch(`/api/pm/plan-initiative?workspace_id=${ws}&target_initiative_id=${iid}`)
       .then(r => r.json())
       .then((body: { proposal?: unknown }) => {
         if (body?.proposal) {
           setHasDraftProposal(true);
           setShowPlanPanel(true);
         }
+      })
+      .catch(() => {});
+    fetch(`/api/pm/decompose-initiative?workspace_id=${ws}&initiative_id=${iid}`)
+      .then(r => r.json())
+      .then((body: { proposal?: unknown }) => {
+        if (body?.proposal) setHasDraftDecomposeProposal(true);
       })
       .catch(() => {});
   }, [initiative]);
@@ -293,6 +300,11 @@ export default function InitiativeDetailPage({
   const openDecompose = useCallback((hint?: string) => {
     setDecomposeHint(hint && hint.length > 0 ? hint : null);
     setShowDecomposeModal(true);
+  }, []);
+
+  const closeDecompose = useCallback(() => {
+    setShowDecomposeModal(false);
+    setHasDraftDecomposeProposal(false);
   }, []);
 
   // Closes the plan panel AND clears any guidance so the next default
@@ -528,7 +540,8 @@ or "treat memory + checklist as MVP, exclude dashboard widgets"`}
                 guidancePlaceholder={`e.g. "split by frontend / backend / data"
 or "carve out the onboarding flow as its own story first"`}
                 guidanceCta="Decompose with guidance"
-                title="Ask the PM to propose 3-7 child initiatives"
+                title={hasDraftDecomposeProposal ? 'Resolve the existing draft decomposition first' : 'Ask the PM to propose 3-7 child initiatives'}
+                disabled={hasDraftDecomposeProposal}
               >
                 Decompose with PM
               </SplitToolbarButton>
@@ -888,9 +901,9 @@ or "carve out the onboarding flow as its own story first"`}
             workspace_id: initiative.workspace_id,
           }}
           initialHint={decomposeHint}
-          onClose={() => { setShowDecomposeModal(false); setDecomposeHint(null); }}
+          onClose={() => { closeDecompose(); setDecomposeHint(null); }}
           onAccepted={() => {
-            setShowDecomposeModal(false);
+            closeDecompose();
             setDecomposeHint(null);
             refresh();
           }}

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -617,9 +617,9 @@ function PmChatPageInner() {
             {messages.length === 0 && pmAgent && (
               <div className="text-center py-12 text-mc-text-secondary">
                 <Inbox className="w-8 h-8 mx-auto mb-3 opacity-50" />
-                <p className="text-sm">Drop a disruption to get started.</p>
+                <p className="text-sm">Drop anything that reshapes the plan.</p>
                 <p className="text-xs mt-1 opacity-70">
-                  Examples: &quot;Sarah out next week&quot; · &quot;API X delayed until 2026-05-03&quot; · &quot;We&apos;re cutting Phase 2&quot;
+                  e.g. &quot;Sarah out next week&quot; · &quot;API X delayed to 2026-05-03&quot; · &quot;New idea that could be huge — needs scoping&quot; · &quot;Customer signed early, can we pull Phase 2 forward?&quot;
                 </p>
               </div>
             )}
@@ -677,7 +677,7 @@ function PmChatPageInner() {
                 rows={2}
                 placeholder={
                   pmAgent
-                    ? 'Drop a disruption — the PM will respond with a proposal card.'
+                    ? 'Drop anything that reshapes the plan — blocker, opportunity, new idea — the PM will respond with a proposal.'
                     : 'No PM agent in this workspace.'
                 }
                 disabled={!pmAgent || sending}

--- a/src/app/api/pm/decompose-initiative/route.ts
+++ b/src/app/api/pm/decompose-initiative/route.ts
@@ -23,6 +23,7 @@ import { getInitiative } from '@/lib/db/initiatives';
 import { synthesizeDecompose } from '@/lib/agents/pm-agent';
 import { PmProposalValidationError } from '@/lib/db/pm-proposals';
 import { postPmChatMessage, dispatchPmSynthesized } from '@/lib/agents/pm-dispatch';
+import { queryOne } from '@/lib/db';
 
 export const dynamic = 'force-dynamic';
 
@@ -71,6 +72,31 @@ export async function POST(request: NextRequest) {
       hint: parsed.data.hint ?? null,
     });
 
+    // Dedup: return any identical draft dispatched in the last 2 seconds
+    // (guards against React StrictMode double-invoke and rapid re-opens).
+    const recent = queryOne<{ id: string; impact_md: string; proposed_changes: string }>(
+      `SELECT id, impact_md, proposed_changes FROM pm_proposals
+       WHERE workspace_id = ?
+         AND trigger_kind = 'decompose_initiative'
+         AND trigger_text = ?
+         AND status = 'draft'
+         AND created_at >= datetime('now', '-2 seconds')
+       ORDER BY created_at DESC LIMIT 1`,
+      [parent.workspace_id, triggerText],
+    );
+    if (recent) {
+      return NextResponse.json(
+        {
+          proposal: {
+            ...recent,
+            proposed_changes: JSON.parse(recent.proposed_changes),
+          },
+          deduped: true,
+        },
+        { status: 201 },
+      );
+    }
+
     // Try the named-agent path first (PM gateway agent at
     // ~/.openclaw/workspaces/mc-project-manager). On timeout or no
     // session, the synthesized proposal is persisted exactly like
@@ -118,4 +144,53 @@ export async function POST(request: NextRequest) {
     console.error('Failed to decompose initiative:', err);
     return NextResponse.json({ error: msg }, { status: 500 });
   }
+}
+
+/**
+ * GET /api/pm/decompose-initiative?workspace_id=…&initiative_id=…
+ *
+ * Resume-lookup. Returns the latest draft decompose_initiative proposal
+ * for the given initiative so the modal can re-open the same draft instead
+ * of dispatching a fresh one every open.
+ *
+ * 200 { proposal } when resumable, 200 { proposal: null } when none.
+ */
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const workspaceId = url.searchParams.get('workspace_id');
+  const initiativeId = url.searchParams.get('initiative_id');
+  if (!workspaceId || !initiativeId) {
+    return NextResponse.json(
+      { error: 'workspace_id and initiative_id required' },
+      { status: 400 },
+    );
+  }
+
+  const row = queryOne<{
+    id: string;
+    workspace_id: string;
+    trigger_text: string;
+    trigger_kind: string;
+    impact_md: string;
+    proposed_changes: string;
+    status: string;
+  }>(
+    `SELECT id, workspace_id, trigger_text, trigger_kind, impact_md, proposed_changes, status
+     FROM pm_proposals
+     WHERE workspace_id = ?
+       AND trigger_kind = 'decompose_initiative'
+       AND status = 'draft'
+       AND json_extract(trigger_text, '$.initiative_id') = ?
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [workspaceId, initiativeId],
+  );
+
+  if (!row) {
+    return NextResponse.json({ proposal: null });
+  }
+
+  return NextResponse.json({
+    proposal: { ...row, proposed_changes: JSON.parse(row.proposed_changes) },
+  });
 }

--- a/src/app/api/pm/proposals/[id]/accept/route.ts
+++ b/src/app/api/pm/proposals/[id]/accept/route.ts
@@ -24,6 +24,7 @@ import { queryOne } from '@/lib/db';
 import {
   applyPlanInitiativeSuggestions,
   parseSuggestionsFromImpactMd,
+  type PlanInitiativeSuggestionsBlob,
 } from '@/lib/pm/applyPlanInitiativeProposal';
 
 export const dynamic = 'force-dynamic';
@@ -61,22 +62,27 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       trigger_kind: string;
       impact_md: string;
       status: string;
+      plan_suggestions: string | null;
     }>(
-      'SELECT id, workspace_id, trigger_kind, impact_md, status FROM pm_proposals WHERE id = ?',
+      'SELECT id, workspace_id, trigger_kind, impact_md, status, plan_suggestions FROM pm_proposals WHERE id = ?',
       [id],
     );
     if (!proposal) {
       return NextResponse.json({ error: 'Proposal not found' }, { status: 404 });
     }
-    // We used to gate on `trigger_kind === 'plan_initiative'`, but the
-    // PM agent's `propose_changes` MCP call can mislabel kind (defaults
-    // to 'manual' when omitted) even though the dispatch was a plan
-    // request — and proposals created before pm-dispatch started
-    // post-hoc-stamping the kind keep the wrong label forever. The
-    // stronger signal that this is really a plan proposal is the
-    // presence of the embedded `<!--pm-plan-suggestions ...-->` sidecar.
-    // If suggestions parse, accept the apply regardless of trigger_kind.
-    const suggestions = parseSuggestionsFromImpactMd(proposal.impact_md);
+    // Prefer the structured plan_suggestions column (written by the PM agent
+    // via propose_changes). Fall back to sidecar parsing for older proposals.
+    let suggestions: PlanInitiativeSuggestionsBlob | null = null;
+    if (proposal.plan_suggestions) {
+      try {
+        suggestions = JSON.parse(proposal.plan_suggestions) as PlanInitiativeSuggestionsBlob;
+      } catch {
+        suggestions = null;
+      }
+    }
+    if (!suggestions) {
+      suggestions = parseSuggestionsFromImpactMd(proposal.impact_md);
+    }
     if (!suggestions) {
       return NextResponse.json(
         {

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -94,6 +94,20 @@ export default function DecomposeWithPmModal({
       setLoading(true);
       setErr(null);
       try {
+        // Resume path: check for an existing draft before dispatching a new one.
+        const resumeRes = await fetch(
+          `/api/pm/decompose-initiative?workspace_id=${encodeURIComponent(initiative.workspace_id)}&initiative_id=${encodeURIComponent(initiative.id)}`,
+        );
+        if (resumeRes.ok) {
+          const resumeBody = await resumeRes.json() as { proposal?: ProposalRow | null };
+          if (resumeBody?.proposal) {
+            if (cancelled) return;
+            setProposalId(resumeBody.proposal.id);
+            setImpactMd(resumeBody.proposal.impact_md);
+            setChildren(resumeBody.proposal.proposed_changes);
+            return;
+          }
+        }
         const res = await fetch('/api/pm/decompose-initiative', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -103,7 +117,7 @@ export default function DecomposeWithPmModal({
           }),
         });
         const body = await res.json();
-        if (!res.ok) throw new Error(body.error || `Decompose failed (${res.status})`);
+        if (!res.ok) throw new Error((body as { error?: string }).error || `Decompose failed (${res.status})`);
         if (cancelled) return;
         const proposal = body.proposal as ProposalRow;
         setProposalId(proposal.id);
@@ -118,7 +132,7 @@ export default function DecomposeWithPmModal({
     return () => {
       cancelled = true;
     };
-  }, [initiative.id, initialHint]);
+  }, [initiative.id, initiative.workspace_id, initialHint]);
 
   // Esc to close.
   useEffect(() => {

--- a/src/lib/agents/pm-soul.md
+++ b/src/lib/agents/pm-soul.md
@@ -1,8 +1,14 @@
 # PM Agent — Project Manager
 
 You are the project manager for this workspace's roadmap. You maintain the
-schedule, flag drift, and translate operator-supplied disruptions into
+schedule, flag drift, and translate operator-supplied signals into
 structured, reversible proposals.
+
+A "disruption" is any event — positive or negative — that might reshape
+the roadmap: a blocker, a delay, a dependency slip, but equally a schedule
+pull-in, a new customer commitment, a strategic pivot, or a big idea worth
+triaging. Treat them all the same way: analyse the impact on the current
+plan and surface a proposal.
 
 ## Identity
 
@@ -37,14 +43,15 @@ rejects / refines.
 - **Never** call any of the general write tools (`create_initiative`,
   `update_initiative`, etc.) on your own initiative. The single exception is
   `add_owner_availability` when the operator explicitly stated an
-  availability fact in their disruption (e.g. "Sarah is out next week" —
+  availability fact in their signal (e.g. "Sarah is out next week" —
   staging that availability before computing impact is part of your
   workflow).
 
-## Workflow when an operator drops a disruption
+## Workflow when an operator drops a signal
 
-1. Read the disruption text. Extract: owners mentioned, dates / windows,
-   initiatives referenced, action verbs.
+1. Read the signal. Extract: owners mentioned, dates / windows,
+   initiatives referenced, action verbs, direction of impact (positive
+   or negative).
 2. Pull `get_roadmap_snapshot` for the workspace.
 3. If the operator stated a hard availability fact, you may stage it via
    `add_owner_availability`. (This is a fact the operator told you, not a

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3259,15 +3259,24 @@ const migrations: Migration[] = [
     id: '053',
     name: 'pm_proposals_target_initiative_cascade',
     up: (db) => {
-      // Change target_initiative_id from ON DELETE SET NULL to ON DELETE CASCADE
-      // so that deleting an initiative automatically removes its scoped proposals
-      // rather than leaving them as unattributed orphans.
-      // SQLite requires a full table rebuild to change FK actions.
+      // Change target_initiative_id from ON DELETE SET NULL to ON DELETE CASCADE.
+      // Skip if the column already has CASCADE (fresh DBs get the correct schema
+      // from schema.ts and don't need the rebuild).
+      const fkList = db.prepare(`PRAGMA foreign_key_list(pm_proposals)`).all() as Array<{ from: string; on_delete: string }>;
+      const targetFk = fkList.find(fk => fk.from === 'target_initiative_id');
+      if (targetFk?.on_delete === 'CASCADE') {
+        console.log('[Migration 053] pm_proposals.target_initiative_id already CASCADE, skipping rebuild.');
+        return;
+      }
       const cols = db.prepare(`PRAGMA table_info(pm_proposals)`).all() as Array<{ name: string }>;
       const colNames = ['id', 'workspace_id', 'trigger_text', 'trigger_kind', 'impact_md',
         'proposed_changes', 'status', 'applied_at', 'applied_by_agent_id', 'parent_proposal_id',
         'created_at', 'target_initiative_id', 'plan_suggestions'].filter(c => cols.some(x => x.name === c));
       const colList = colNames.join(', ');
+      // Note: SQLite doesn't validate FK target table names at CREATE TABLE time,
+      // so REFERENCES pm_proposals(id) is correct here — it will resolve properly
+      // after the rename and avoids the dangling-reference bug that would occur
+      // with REFERENCES pm_proposals_new(id).
       db.exec(`
         CREATE TABLE pm_proposals_new (
           id TEXT PRIMARY KEY,
@@ -3281,7 +3290,7 @@ const migrations: Migration[] = [
             CHECK (status IN ('draft','accepted','rejected','superseded')),
           applied_at TEXT,
           applied_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
-          parent_proposal_id TEXT REFERENCES pm_proposals_new(id) ON DELETE SET NULL,
+          parent_proposal_id TEXT REFERENCES pm_proposals(id) ON DELETE SET NULL,
           created_at TEXT DEFAULT (datetime('now')),
           target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
           plan_suggestions TEXT


### PR DESCRIPTION
## Summary
- Decompose modal now checks for an existing draft on open (GET endpoint) and resumes it instead of dispatching a new plan — same resume pattern as plan-with-PM
- 2-second dedup window in the POST blocks React StrictMode double-invokes from creating orphaned proposals
- \`Decompose with PM\` button disabled when a draft proposal already exists (parallel to the plan button guard added in #85)
- Migration 053 fixed: skips table rebuild on fresh DBs where \`target_initiative_id\` already has CASCADE; self-referential FK now uses \`pm_proposals\` not \`pm_proposals_new\` (which was dangling after rename and caused "no such table: main.pm_proposals_new" on fresh DB startup)

## Changes
- `src/app/api/pm/decompose-initiative/route.ts` — add GET resume endpoint + POST dedup window
- `src/components/DecomposeWithPmModal.tsx` — resume before POST
- `src/app/(app)/initiatives/[id]/page.tsx` — `hasDraftDecomposeProposal` state, disabled button, `closeDecompose` clears state
- `src/lib/db/migrations.ts` — migration 053 idempotency guard + correct self-FK name

## Test plan
- [ ] Create an epic, click Decompose with PM — modal opens with fresh decompose
- [ ] Close modal without accepting; re-open — resumes the same draft, no new dispatch
- [ ] Decompose button is disabled while draft exists; re-enables after modal closes
- [ ] Fresh DB startup produces no "pm_proposals_new" error
- [ ] Existing DB with SET NULL constraint on `target_initiative_id` gets rebuilt to CASCADE