### PR TITLE
feat(pm): propose_from_notes — freeform-input MCP w/ defer-and-replay queue

### DIFF
--- a/scripts/mcp-integration-test.mjs
+++ b/scripts/mcp-integration-test.mjs
@@ -229,7 +229,7 @@ try {
     'fail_task',
     'save_checkpoint',
     'send_mail',
-    'delegate',
+    'spawn_subtask',
     'save_knowledge',
   ]) {
     expect(names.has(t), `tools/list should expose ${t}`);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -18,4 +18,14 @@ export async function register() {
     console.error('[Instrumentation] Eager DB init failed:', err);
     throw err;
   }
+
+  // Register the pm_pending_notes drain worker. The drain is cheap when
+  // the queue is empty and it's the only path that recovers
+  // propose_from_notes requests captured while the gateway was offline.
+  try {
+    const { registerDrainTriggers } = await import('@/lib/agents/pm-pending-drain');
+    registerDrainTriggers();
+  } catch (err) {
+    console.warn('[Instrumentation] pm-pending-drain registration failed:', (err as Error).message);
+  }
 }

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -47,6 +47,7 @@ import {
   __setSendChatClientForTests,
   type SendChatClient,
 } from '@/lib/openclaw/send-chat';
+import { buildNotesIntakeMessage } from './pm-prompts/notes-intake';
 import type { Agent } from '@/lib/types';
 
 // ─── Public API ─────────────────────────────────────────────────────
@@ -56,12 +57,27 @@ export interface DispatchPmInput {
   trigger_text: string;
   trigger_kind?: PmProposalTriggerKind;
   parent_proposal_id?: string | null;
+  /**
+   * When `false`, skip the deterministic `synthesizeImpactAnalysis`
+   * fallback and propagate the gateway error instead. The
+   * `propose_from_notes` flow uses this — a regex parser on freeform
+   * notes is worse than nothing; the queue handles offline cases.
+   * Defaults to `true` for back-compat with the disruption path.
+   */
+  allowFallback?: boolean;
 }
 
 export interface DispatchPmResult {
   proposal: PmProposal;
   used_synthesize_fallback: boolean;
   used_named_agent?: boolean;
+}
+
+export class PmDispatchGatewayUnavailableError extends Error {
+  constructor(message = 'openclaw gateway unavailable') {
+    super(message);
+    this.name = 'PmDispatchGatewayUnavailableError';
+  }
 }
 
 /**
@@ -122,6 +138,8 @@ export async function dispatchPm(input: DispatchPmInput): Promise<DispatchPmResu
     console.warn('[pm-dispatch] user chat insert failed:', (err as Error).message);
   }
 
+  const allowFallback = input.allowFallback ?? true;
+
   // ── 1. Try the named-agent path ────────────────────────────────────
   if (pm && pm.gateway_agent_id) {
     const gw = gatewayClient();
@@ -145,13 +163,27 @@ export async function dispatchPm(input: DispatchPmInput): Promise<DispatchPmResu
           }
           return { proposal, used_synthesize_fallback: false, used_named_agent: true };
         }
+        // Sent succeeded but no proposal landed (timeout). Treat as a
+        // gateway-side failure for the no-fallback path.
+        if (!allowFallback) {
+          throw new PmDispatchGatewayUnavailableError(
+            'PM agent did not produce a proposal within the timeout',
+          );
+        }
       } catch (err) {
+        if (!allowFallback) throw err;
         console.warn(
           '[pm-dispatch] named-agent dispatch failed; falling back to synth:',
           (err as Error).message,
         );
       }
+    } else if (!allowFallback) {
+      throw new PmDispatchGatewayUnavailableError();
     }
+  } else if (!allowFallback) {
+    throw new PmDispatchGatewayUnavailableError(
+      'PM agent missing gateway_agent_id; cannot dispatch without fallback',
+    );
   }
 
   // ── 2. Synthesize fallback ────────────────────────────────────────
@@ -242,22 +274,30 @@ async function dispatchViaNamedAgent(params: DispatchNamedAgentParams): Promise<
 
   const summary = buildSnapshotSummary(snapshot);
   const message =
-    `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
-    `Operator-reported event:\n> ${input.trigger_text}\n\n` +
-    `Workspace snapshot summary (call \`get_roadmap_snapshot\` via MCP for full detail):\n\n` +
-    `${summary}\n\n` +
-    `Per your SOUL.md: analyse the disruption and call \`propose_changes\` ` +
-    `with a structured PmDiff[] and impact_md. Reference only ids that ` +
-    `appear in the snapshot.`;
+    input.trigger_kind === 'notes_intake'
+      ? buildNotesIntakeMessage({ correlationId, notes: input.trigger_text, summary })
+      : `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
+        `Operator-reported event:\n> ${input.trigger_text}\n\n` +
+        `Workspace snapshot summary (call \`get_roadmap_snapshot\` via MCP for full detail):\n\n` +
+        `${summary}\n\n` +
+        `Per your SOUL.md: analyse the disruption and call \`propose_changes\` ` +
+        `with a structured PmDiff[] and impact_md. Reference only ids that ` +
+        `appear in the snapshot.`;
+
+  // Notes intake gets a fresh session per dispatch (like plan/decompose)
+  // so the PM doesn't carry over disruption-conversation context. The
+  // disruption path keeps the stable 'dispatch-main' session warm.
+  const sessionSuffix =
+    input.trigger_kind === 'notes_intake'
+      ? `notes-${correlationId}`
+      : 'dispatch-main';
 
   const result = await sendChatAndAwaitReply({
     agent: pm,
     message,
     idempotencyKey: `pm-dispatch-${correlationId}`,
     timeoutMs: namedAgentTimeoutMs(),
-    // Stable session keeps the PM agent warm between disruption dispatches.
-    // Fresh plan-<uuid> sessions are used for plan/decompose flows instead.
-    sessionSuffix: 'dispatch-main',
+    sessionSuffix,
   });
 
   // Send failed — caller falls back to synth.

--- a/src/lib/agents/pm-pending-drain.ts
+++ b/src/lib/agents/pm-pending-drain.ts
@@ -1,0 +1,146 @@
+/**
+ * Drain worker for the `pm_pending_notes` queue.
+ *
+ * `propose_from_notes` enqueues rows when the openclaw gateway is
+ * unreachable. This worker picks up pending rows, dispatches them
+ * through `dispatchPm` (with `allowFallback: false`), and stamps each
+ * row as `dispatched` or increments its attempts on failure. After
+ * `MAX_ATTEMPTS` failures the row stops being retried automatically;
+ * it stays in the table for operator review.
+ *
+ * Triggered by:
+ *   1. Openclaw client `'connected'` event (best-effort; runs once
+ *      per successful reconnect).
+ *   2. A 60s setInterval registered at app boot.
+ */
+
+import {
+  listPendingNotes,
+  markDispatched,
+  markFailed,
+  type PmPendingNote,
+} from '@/lib/db/pm-pending-notes';
+import { dispatchPm, PmDispatchGatewayUnavailableError } from '@/lib/agents/pm-dispatch';
+import { getOpenClawClient } from '@/lib/openclaw/client';
+
+const MAX_ATTEMPTS = 5;
+
+interface GatewayProbe {
+  isConnected(): boolean;
+}
+
+/**
+ * Test seam — same pattern as `__setOpenClawClientForTests` in
+ * pm-dispatch.ts. Tests that override the dispatch path also need to
+ * override the gateway probe here so the drain worker doesn't bail
+ * with `skipped_gateway_down` while they're trying to exercise it.
+ */
+let gatewayProbeOverride: GatewayProbe | null = null;
+export function __setGatewayProbeForTests(probe: GatewayProbe | null): void {
+  gatewayProbeOverride = probe;
+}
+function gatewayProbe(): GatewayProbe {
+  return gatewayProbeOverride ?? (getOpenClawClient() as unknown as GatewayProbe);
+}
+
+export interface DrainResult {
+  attempted: number;
+  dispatched: number;
+  failed: number;
+  skipped_gateway_down: boolean;
+}
+
+/**
+ * Drain pending notes through `dispatchPm`. Cheap when the queue is
+ * empty (single indexed read). Safe to call repeatedly.
+ */
+export async function drainPendingNotes(): Promise<DrainResult> {
+  const out: DrainResult = {
+    attempted: 0,
+    dispatched: 0,
+    failed: 0,
+    skipped_gateway_down: false,
+  };
+
+  const gw = gatewayProbe();
+  if (!gw.isConnected()) {
+    out.skipped_gateway_down = true;
+    return out;
+  }
+
+  const pending = listPendingNotes({ maxAttempts: MAX_ATTEMPTS });
+  for (const note of pending) {
+    out.attempted++;
+    try {
+      const result = await dispatchPm({
+        workspace_id: note.workspace_id,
+        trigger_text: note.notes_text,
+        trigger_kind: 'notes_intake',
+        allowFallback: false,
+      });
+      markDispatched(note.id, result.proposal.id);
+      out.dispatched++;
+    } catch (err) {
+      out.failed++;
+      const msg = err instanceof Error ? err.message : String(err);
+      markFailed(note.id, msg);
+      // If the gateway dropped mid-drain, stop early — no point hammering
+      // a downed gateway for the remaining rows.
+      if (err instanceof PmDispatchGatewayUnavailableError || !gw.isConnected()) {
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+// ─── Boot-time registration ─────────────────────────────────────────
+
+let drainTimer: NodeJS.Timeout | null = null;
+let registered = false;
+
+/**
+ * Register the periodic-tick + reconnect-hook drain triggers. Idempotent:
+ * safe to call multiple times. Tests can opt out by not calling this.
+ */
+export function registerDrainTriggers(opts: { intervalMs?: number } = {}): void {
+  if (registered) return;
+  registered = true;
+  const intervalMs = opts.intervalMs ?? 60_000;
+
+  drainTimer = setInterval(() => {
+    drainPendingNotes().catch(err => {
+      console.warn('[pm-pending-drain] tick failed:', (err as Error).message);
+    });
+  }, intervalMs);
+  // Don't keep the Node process alive just for this timer.
+  if (typeof drainTimer.unref === 'function') drainTimer.unref();
+
+  // Best-effort reconnect hook — the openclaw client may or may not
+  // expose a typed event surface; check for a duck-typed `on` method.
+  try {
+    const gw = getOpenClawClient() as unknown as {
+      on?: (event: string, cb: () => void) => void;
+    };
+    if (typeof gw.on === 'function') {
+      gw.on('connected', () => {
+        drainPendingNotes().catch(err => {
+          console.warn('[pm-pending-drain] reconnect drain failed:', (err as Error).message);
+        });
+      });
+    }
+  } catch (err) {
+    console.warn('[pm-pending-drain] reconnect hook unavailable:', (err as Error).message);
+  }
+}
+
+/** Test-only: tear down timers + reset registration so tests start clean. */
+export function __resetDrainTriggersForTests(): void {
+  if (drainTimer) {
+    clearInterval(drainTimer);
+    drainTimer = null;
+  }
+  registered = false;
+}
+
+export type { PmPendingNote };

--- a/src/lib/agents/pm-prompts/notes-intake.ts
+++ b/src/lib/agents/pm-prompts/notes-intake.ts
@@ -1,0 +1,48 @@
+/**
+ * Prompt template for the `notes_intake` dispatch path.
+ *
+ * Sent to the openclaw `mc-project-manager` agent when the operator
+ * fires a `propose_from_notes` MCP call. The agent reads the freeform
+ * notes + a roadmap snapshot summary and replies via a single
+ * `propose_changes` MCP call carrying a heterogeneous PmDiff[] (creates,
+ * updates, child initiatives, tasks).
+ */
+
+export interface BuildNotesIntakeMessageInput {
+  correlationId: string;
+  notes: string;
+  /** Output of buildSnapshotSummary in pm-dispatch.ts. */
+  summary: string;
+}
+
+export function buildNotesIntakeMessage(input: BuildNotesIntakeMessageInput): string {
+  const { correlationId, notes, summary } = input;
+  return [
+    `**PM notes intake (correlation_id: ${correlationId})**`,
+    '',
+    'The operator pasted freeform notes (meeting minutes, kickoff, weekly review, brain-dump, etc.). Read them, ',
+    "then propose a coherent set of structured changes to the workspace's roadmap and task board.",
+    '',
+    'Notes:',
+    '> ' + notes.split('\n').join('\n> '),
+    '',
+    'Workspace snapshot summary (call `get_roadmap_snapshot` via MCP for full detail):',
+    '',
+    summary,
+    '',
+    'Reply via a SINGLE `propose_changes` MCP call with:',
+    '',
+    '- `trigger_kind: "notes_intake"`',
+    '- `impact_md`: a short, scannable summary of what you propose and why (1–3 paragraphs + a bulleted change list).',
+    '- `changes`: a heterogeneous `PmDiff[]` mixing any of:',
+    '  - `create_child_initiative` — new epics/stories under existing initiatives. Use a `placeholder_id` (e.g. `"new-onboarding-epic"`) when later diffs need to reference the new id.',
+    '  - `create_task_under_initiative` — draft tasks attached to an existing initiative OR to a placeholder created earlier in this same proposal.',
+    '  - `update_status_check`, `set_initiative_status`, `shift_initiative_target`, `add_dependency`, `add_availability`, `reorder_initiatives` — for updates.',
+    '',
+    'Constraints:',
+    '- Reference only ids that appear in the snapshot, plus your own placeholders.',
+    '- Cap proposals at ~15 diffs. Prefer the highest-signal items if the notes are long.',
+    '- If the notes contain nothing actionable for the roadmap, return an empty `changes` array and explain in `impact_md`.',
+    '- Never fabricate agent ids, dates, or initiative titles.',
+  ].join('\n');
+}

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -379,3 +379,157 @@ test('dispatchPm: falls back to synth when named agent times out without writing
     __setNamedAgentTimeoutForTests(null);
   }
 });
+
+// ─── notes_intake + allowFallback ──────────────────────────────────
+
+test('dispatchPm: notes_intake uses a fresh per-correlation session and the notes prompt', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+
+  const { client, seenSends } = makeFakeClient({
+    onChatSend: () => {
+      createProposal({
+        workspace_id: ws,
+        trigger_text: 'notes',
+        trigger_kind: 'notes_intake',
+        impact_md: '### Notes intake verdict\n\n- task list',
+        proposed_changes: [],
+      });
+    },
+  });
+  __setOpenClawClientForTests(client);
+  __setNamedAgentTimeoutForTests(2_000);
+
+  try {
+    const result = await dispatchPm({
+      workspace_id: ws,
+      trigger_text: 'Stand-up notes:\n- ship onboarding\n- fix #123',
+      trigger_kind: 'notes_intake',
+    });
+    assert.equal(result.used_named_agent, true);
+    const send = seenSends.find(s => s.method === 'chat.send');
+    assert.ok(send);
+    const params = send!.params as { sessionKey?: string; message?: string };
+    // Fresh notes-<correlation> session, NOT the stable dispatch-main key.
+    assert.match(params.sessionKey ?? '', /:notes-/);
+    // Prompt template includes the notes-intake instructions.
+    assert.match(params.message ?? '', /PM notes intake/);
+    assert.match(params.message ?? '', /create_task_under_initiative/);
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
+  }
+});
+
+test('dispatchPm: allowFallback=false propagates gateway error instead of synth-falling-back', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+
+  // Gateway is down — synth path should be skipped.
+  const { client } = makeFakeClient({ isConnected: false });
+  __setOpenClawClientForTests(client);
+  const { PmDispatchGatewayUnavailableError } = await import('./pm-dispatch');
+  try {
+    await assert.rejects(
+      dispatchPm({
+        workspace_id: ws,
+        trigger_text: 'notes go here',
+        trigger_kind: 'notes_intake',
+        allowFallback: false,
+      }),
+      PmDispatchGatewayUnavailableError,
+    );
+  } finally {
+    __setOpenClawClientForTests(null);
+  }
+});
+
+test('dispatchPm: allowFallback=false also surfaces a no-proposal-on-final timeout as an error', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+
+  // Connected, but the agent never writes a proposal AND emitFinal arrives,
+  // so dispatchViaNamedAgent returns null. With fallback disabled this must throw.
+  const { client } = makeFakeClient({ emitFinal: true });
+  __setOpenClawClientForTests(client);
+  __setNamedAgentTimeoutForTests(500);
+  try {
+    await assert.rejects(
+      dispatchPm({
+        workspace_id: ws,
+        trigger_text: 'whatever',
+        trigger_kind: 'notes_intake',
+        allowFallback: false,
+      }),
+    );
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
+  }
+});
+
+// ─── pm-pending-drain ──────────────────────────────────────────────
+
+test('drainPendingNotes: skips when gateway is down', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  const { enqueuePendingNote } = await import('@/lib/db/pm-pending-notes');
+  enqueuePendingNote({ workspace_id: ws, agent_id: 'a', notes_text: 'x' });
+
+  const { client } = makeFakeClient({ isConnected: false });
+  __setOpenClawClientForTests(client);
+  const { drainPendingNotes, __setGatewayProbeForTests } = await import('./pm-pending-drain');
+  __setGatewayProbeForTests({ isConnected: () => false });
+  try {
+    const result = await drainPendingNotes();
+    assert.equal(result.skipped_gateway_down, true);
+    assert.equal(result.attempted, 0);
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setGatewayProbeForTests(null);
+  }
+});
+
+test('drainPendingNotes: dispatches each pending row and marks dispatched', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  // Earlier tests in the file may leave pending rows whose workspace
+  // PMs aren't wired up to this fake client. Skip them so the drain
+  // loop processes our row only.
+  run(`UPDATE pm_pending_notes SET status = 'dispatched' WHERE status = 'pending'`);
+  const { enqueuePendingNote, getPendingNote } = await import('@/lib/db/pm-pending-notes');
+  const note = enqueuePendingNote({
+    workspace_id: ws,
+    agent_id: 'a',
+    notes_text: 'queued notes',
+  });
+
+  const { client } = makeFakeClient({
+    onChatSend: () => {
+      createProposal({
+        workspace_id: ws,
+        trigger_text: 'queued notes',
+        trigger_kind: 'notes_intake',
+        impact_md: '### Drained',
+        proposed_changes: [],
+      });
+    },
+  });
+  __setOpenClawClientForTests(client);
+  __setNamedAgentTimeoutForTests(1_000);
+
+  const { drainPendingNotes, __setGatewayProbeForTests } = await import('./pm-pending-drain');
+  __setGatewayProbeForTests({ isConnected: () => true });
+  try {
+    const result = await drainPendingNotes();
+    assert.equal(result.skipped_gateway_down, false);
+    assert.ok(result.dispatched >= 1);
+    const after = getPendingNote(note.id)!;
+    assert.equal(after.status, 'dispatched');
+    assert.ok(after.proposal_id);
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
+    __setGatewayProbeForTests(null);
+  }
+});

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3305,6 +3305,80 @@ const migrations: Migration[] = [
     },
   },
   {
+    id: '054',
+    name: 'pm_pending_notes_and_notes_intake_trigger_kind',
+    up: (db) => {
+      // 1. Extend pm_proposals.trigger_kind CHECK constraint with
+      //    'notes_intake' so propose_from_notes-driven proposals can be
+      //    persisted. Mirrors the migration 053 rebuild pattern.
+      const fkList = db.prepare(`PRAGMA foreign_key_list(pm_proposals)`).all() as Array<{ from: string; on_delete: string }>;
+      const targetFk = fkList.find(fk => fk.from === 'target_initiative_id');
+      // Detect whether the CHECK already permits notes_intake by sniffing
+      // the schema text, since SQLite doesn't expose CHECK clauses through
+      // PRAGMA. Skip if already up-to-date.
+      const tableSql = (db.prepare(
+        `SELECT sql FROM sqlite_master WHERE type='table' AND name='pm_proposals'`,
+      ).get() as { sql: string } | undefined)?.sql ?? '';
+      const needsCheckRebuild = !tableSql.includes('notes_intake');
+      if (needsCheckRebuild) {
+        const cols = db.prepare(`PRAGMA table_info(pm_proposals)`).all() as Array<{ name: string }>;
+        const colNames = ['id', 'workspace_id', 'trigger_text', 'trigger_kind', 'impact_md',
+          'proposed_changes', 'status', 'applied_at', 'applied_by_agent_id', 'parent_proposal_id',
+          'created_at', 'target_initiative_id', 'plan_suggestions'].filter(c => cols.some(x => x.name === c));
+        const colList = colNames.join(', ');
+        const targetCascade = targetFk?.on_delete === 'CASCADE' ? 'CASCADE' : 'SET NULL';
+        db.exec(`
+          CREATE TABLE pm_proposals_new (
+            id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+            trigger_text TEXT NOT NULL,
+            trigger_kind TEXT NOT NULL DEFAULT 'manual'
+              CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation','plan_initiative','decompose_initiative','notes_intake')),
+            impact_md TEXT NOT NULL,
+            proposed_changes TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'draft'
+              CHECK (status IN ('draft','accepted','rejected','superseded')),
+            applied_at TEXT,
+            applied_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+            parent_proposal_id TEXT REFERENCES pm_proposals(id) ON DELETE SET NULL,
+            created_at TEXT DEFAULT (datetime('now')),
+            target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE ${targetCascade},
+            plan_suggestions TEXT
+          )
+        `);
+        db.exec(`INSERT INTO pm_proposals_new (${colList}) SELECT ${colList} FROM pm_proposals`);
+        db.exec(`DROP TABLE pm_proposals`);
+        db.exec(`ALTER TABLE pm_proposals_new RENAME TO pm_proposals`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_status ON pm_proposals(status, created_at DESC)`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_target_init ON pm_proposals(target_initiative_id, status, created_at DESC)`);
+      }
+
+      // 2. pm_pending_notes — defer-and-replay queue for propose_from_notes
+      //    requests that arrive while the openclaw gateway is unreachable.
+      //    Mirrors the task_notes pending pattern (migration 017).
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS pm_pending_notes (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          agent_id TEXT NOT NULL,
+          notes_text TEXT NOT NULL,
+          scope_hint TEXT,
+          status TEXT NOT NULL DEFAULT 'pending'
+            CHECK (status IN ('pending','dispatched','failed')),
+          proposal_id TEXT,
+          error TEXT,
+          attempts INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          dispatched_at TEXT
+        )
+      `);
+      db.exec(
+        `CREATE INDEX IF NOT EXISTS idx_pm_pending_notes_pending ON pm_pending_notes(status, created_at) WHERE status = 'pending'`,
+      );
+      console.log('[Migration 054] pm_pending_notes + notes_intake trigger_kind ready.');
+    },
+  },
+  {
     id: '051',
     name: 'workspaces_workspace_path',
     up: (db) => {

--- a/src/lib/db/pm-pending-notes.test.ts
+++ b/src/lib/db/pm-pending-notes.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Pending-notes queue helper tests.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import {
+  enqueuePendingNote,
+  getPendingNote,
+  listPendingNotes,
+  markDispatched,
+  markFailed,
+} from './pm-pending-notes';
+
+function freshWorkspace(): string {
+  const id = `ws-pn-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+test('enqueue + get + list round-trip', () => {
+  const ws = freshWorkspace();
+  const note = enqueuePendingNote({
+    workspace_id: ws,
+    agent_id: 'agent-x',
+    notes_text: 'Plan a refactor of the payments service',
+    scope_hint: { include_tasks: true },
+  });
+  assert.equal(note.status, 'pending');
+  assert.equal(note.attempts, 0);
+  assert.deepEqual(note.scope_hint, { include_tasks: true });
+
+  const fetched = getPendingNote(note.id);
+  assert.ok(fetched);
+  assert.equal(fetched!.notes_text, 'Plan a refactor of the payments service');
+
+  const pending = listPendingNotes();
+  assert.ok(pending.some(n => n.id === note.id));
+});
+
+test('markDispatched flips status and stamps proposal_id', () => {
+  const ws = freshWorkspace();
+  const note = enqueuePendingNote({
+    workspace_id: ws,
+    agent_id: 'a',
+    notes_text: 'x',
+  });
+  markDispatched(note.id, 'prop-123');
+  const after = getPendingNote(note.id)!;
+  assert.equal(after.status, 'dispatched');
+  assert.equal(after.proposal_id, 'prop-123');
+  assert.ok(after.dispatched_at);
+});
+
+test('markFailed increments attempts and captures error', () => {
+  const ws = freshWorkspace();
+  const note = enqueuePendingNote({
+    workspace_id: ws,
+    agent_id: 'a',
+    notes_text: 'x',
+  });
+  markFailed(note.id, 'gateway timeout');
+  markFailed(note.id, 'still timing out');
+  const after = getPendingNote(note.id)!;
+  assert.equal(after.attempts, 2);
+  assert.equal(after.error, 'still timing out');
+  assert.equal(after.status, 'pending');
+});
+
+test('listPendingNotes respects maxAttempts cap', () => {
+  const ws = freshWorkspace();
+  const note = enqueuePendingNote({
+    workspace_id: ws,
+    agent_id: 'a',
+    notes_text: 'x',
+  });
+  for (let i = 0; i < 5; i++) markFailed(note.id, 'err');
+  const stillVisible = listPendingNotes({ maxAttempts: 5 }).some(n => n.id === note.id);
+  assert.equal(stillVisible, false);
+  const visibleHigherCap = listPendingNotes({ maxAttempts: 10 }).some(n => n.id === note.id);
+  assert.equal(visibleHigherCap, true);
+});

--- a/src/lib/db/pm-pending-notes.ts
+++ b/src/lib/db/pm-pending-notes.ts
@@ -1,0 +1,133 @@
+/**
+ * Defer-and-replay queue for `propose_from_notes` requests.
+ *
+ * When the openclaw gateway is unreachable, the MCP tool enqueues a
+ * pending row here instead of failing. A drain worker
+ * (`pm-pending-drain.ts`) picks rows up on gateway reconnect / periodic
+ * tick and dispatches them through `dispatchPm`.
+ *
+ * Mirrors the `task_notes` pending pattern (migration 017).
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+
+export type PmPendingNoteStatus = 'pending' | 'dispatched' | 'failed';
+
+export interface PmPendingNote {
+  id: string;
+  workspace_id: string;
+  agent_id: string;
+  notes_text: string;
+  scope_hint: Record<string, unknown> | null;
+  status: PmPendingNoteStatus;
+  proposal_id: string | null;
+  error: string | null;
+  attempts: number;
+  created_at: string;
+  dispatched_at: string | null;
+}
+
+interface PmPendingNoteRow {
+  id: string;
+  workspace_id: string;
+  agent_id: string;
+  notes_text: string;
+  scope_hint: string | null;
+  status: PmPendingNoteStatus;
+  proposal_id: string | null;
+  error: string | null;
+  attempts: number;
+  created_at: string;
+  dispatched_at: string | null;
+}
+
+function rowToNote(row: PmPendingNoteRow): PmPendingNote {
+  let scope: Record<string, unknown> | null = null;
+  if (row.scope_hint) {
+    try { scope = JSON.parse(row.scope_hint) as Record<string, unknown>; } catch { scope = null; }
+  }
+  return {
+    id: row.id,
+    workspace_id: row.workspace_id,
+    agent_id: row.agent_id,
+    notes_text: row.notes_text,
+    scope_hint: scope,
+    status: row.status,
+    proposal_id: row.proposal_id,
+    error: row.error,
+    attempts: row.attempts,
+    created_at: row.created_at,
+    dispatched_at: row.dispatched_at,
+  };
+}
+
+export interface EnqueuePendingNoteInput {
+  workspace_id: string;
+  agent_id: string;
+  notes_text: string;
+  scope_hint?: Record<string, unknown> | null;
+}
+
+export function enqueuePendingNote(input: EnqueuePendingNoteInput): PmPendingNote {
+  const id = uuidv4();
+  const now = new Date().toISOString();
+  run(
+    `INSERT INTO pm_pending_notes (id, workspace_id, agent_id, notes_text, scope_hint, status, attempts, created_at)
+     VALUES (?, ?, ?, ?, ?, 'pending', 0, ?)`,
+    [
+      id,
+      input.workspace_id,
+      input.agent_id,
+      input.notes_text,
+      input.scope_hint ? JSON.stringify(input.scope_hint) : null,
+      now,
+    ],
+  );
+  return getPendingNote(id)!;
+}
+
+export function getPendingNote(id: string): PmPendingNote | undefined {
+  const row = queryOne<PmPendingNoteRow>(`SELECT * FROM pm_pending_notes WHERE id = ?`, [id]);
+  return row ? rowToNote(row) : undefined;
+}
+
+/**
+ * Pending rows ordered by created_at. Filters out rows that have
+ * exceeded `maxAttempts` so the drain worker doesn't retry them
+ * forever — they remain in the table for operator review.
+ */
+export function listPendingNotes(opts: { maxAttempts?: number } = {}): PmPendingNote[] {
+  const maxAttempts = opts.maxAttempts ?? 5;
+  return queryAll<PmPendingNoteRow>(
+    `SELECT * FROM pm_pending_notes
+      WHERE status = 'pending' AND attempts < ?
+      ORDER BY created_at ASC, id ASC`,
+    [maxAttempts],
+  ).map(rowToNote);
+}
+
+export function markDispatched(id: string, proposal_id: string): void {
+  const now = new Date().toISOString();
+  run(
+    `UPDATE pm_pending_notes
+        SET status = 'dispatched', proposal_id = ?, dispatched_at = ?, error = NULL
+      WHERE id = ?`,
+    [proposal_id, now, id],
+  );
+}
+
+export function markFailed(id: string, errorMsg: string): void {
+  // Increment attempts and stash the latest error. Status stays
+  // 'pending' until attempts >= cap (then list filter excludes it).
+  run(
+    `UPDATE pm_pending_notes
+        SET attempts = attempts + 1, error = ?
+      WHERE id = ?`,
+    [errorMsg.slice(0, 500), id],
+  );
+}
+
+export function incrementAttempt(id: string): void {
+  run(`UPDATE pm_pending_notes SET attempts = attempts + 1 WHERE id = ?`, [id]);
+}

--- a/src/lib/db/pm-proposals.test.ts
+++ b/src/lib/db/pm-proposals.test.ts
@@ -374,6 +374,178 @@ test('acceptProposal is idempotent — second accept is a no-op', () => {
   assert.equal(r2.changes_applied, 0);
 });
 
+// ─── create_task_under_initiative diff kind ─────────────────────────
+
+test('create_task_under_initiative: validates initiative exists in workspace', () => {
+  const ws = freshWorkspace();
+  assert.throws(
+    () =>
+      createProposal({
+        workspace_id: ws,
+        trigger_text: 'notes',
+        trigger_kind: 'notes_intake',
+        impact_md: '.',
+        proposed_changes: [
+          {
+            kind: 'create_task_under_initiative',
+            initiative_id: 'does-not-exist',
+            title: 'A task',
+          },
+        ],
+      }),
+    PmProposalValidationError,
+  );
+});
+
+test('create_task_under_initiative: requires title', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'Parent' });
+  assert.throws(
+    () =>
+      createProposal({
+        workspace_id: ws,
+        trigger_text: '.',
+        trigger_kind: 'notes_intake',
+        impact_md: '.',
+        proposed_changes: [
+          { kind: 'create_task_under_initiative', initiative_id: init.id, title: '' },
+        ],
+      }),
+    PmProposalValidationError,
+  );
+});
+
+test('create_task_under_initiative: rejects placeholder that does not match any earlier diff', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Real parent' });
+  assert.throws(
+    () =>
+      createProposal({
+        workspace_id: ws,
+        trigger_text: '.',
+        trigger_kind: 'notes_intake',
+        impact_md: '.',
+        proposed_changes: [
+          // No create_child_initiative ahead of this diff to back the placeholder.
+          { kind: 'create_task_under_initiative', initiative_id: '$0', title: 'Task' },
+          {
+            kind: 'create_child_initiative',
+            parent_initiative_id: init.id,
+            title: 'Child',
+            child_kind: 'story',
+          },
+        ],
+      }),
+    PmProposalValidationError,
+  );
+});
+
+test('create_task_under_initiative: applies under existing initiative', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'Existing' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 'meeting notes',
+    trigger_kind: 'notes_intake',
+    impact_md: '### Tasks',
+    proposed_changes: [
+      {
+        kind: 'create_task_under_initiative',
+        initiative_id: init.id,
+        title: 'Wire up the export',
+        description: 'add csv export to settings',
+        priority: 'high',
+      },
+    ],
+  });
+  const result = acceptProposal(p.id);
+  assert.equal(result.changes_applied, 1);
+  const tasks = queryAll<{ id: string; title: string; initiative_id: string; priority: string; status: string }>(
+    `SELECT id, title, initiative_id, priority, status FROM tasks WHERE initiative_id = ?`,
+    [init.id],
+  );
+  assert.equal(tasks.length, 1);
+  assert.equal(tasks[0].title, 'Wire up the export');
+  assert.equal(tasks[0].priority, 'high');
+  assert.equal(tasks[0].status, 'draft');
+  // Audit row written.
+  const hist = queryAll<{ from_initiative_id: string | null; to_initiative_id: string }>(
+    `SELECT from_initiative_id, to_initiative_id FROM task_initiative_history WHERE task_id = ?`,
+    [tasks[0].id],
+  );
+  assert.equal(hist.length, 1);
+  assert.equal(hist[0].from_initiative_id, null);
+  assert.equal(hist[0].to_initiative_id, init.id);
+});
+
+test('create_task_under_initiative: placeholder resolves to a same-proposal create_child_initiative', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Parent epic' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 'notes',
+    trigger_kind: 'notes_intake',
+    impact_md: '.',
+    proposed_changes: [
+      {
+        kind: 'create_child_initiative',
+        parent_initiative_id: parent.id,
+        title: 'New onboarding story',
+        child_kind: 'story',
+        placeholder_id: 'onboarding-story',
+      },
+      {
+        kind: 'create_task_under_initiative',
+        initiative_id: 'onboarding-story',
+        title: 'Draft onboarding copy',
+      },
+      {
+        kind: 'create_task_under_initiative',
+        initiative_id: '$0',
+        title: 'Build onboarding step 1',
+      },
+    ],
+  });
+  const result = acceptProposal(p.id);
+  assert.equal(result.changes_applied, 3);
+
+  const child = queryOne<{ id: string; title: string }>(
+    `SELECT id, title FROM initiatives WHERE parent_initiative_id = ? LIMIT 1`,
+    [parent.id],
+  );
+  assert.ok(child);
+  const tasks = queryAll<{ title: string; initiative_id: string }>(
+    `SELECT title, initiative_id FROM tasks WHERE initiative_id = ?`,
+    [child!.id],
+  );
+  assert.equal(tasks.length, 2);
+  assert.ok(tasks.some(t => t.title === 'Draft onboarding copy'));
+  assert.ok(tasks.some(t => t.title === 'Build onboarding step 1'));
+});
+
+test('create_task_under_initiative: bad assigned_agent_id rolls back the whole proposal', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'Anchor' });
+  assert.throws(
+    () =>
+      createProposal({
+        workspace_id: ws,
+        trigger_text: '.',
+        trigger_kind: 'notes_intake',
+        impact_md: '.',
+        proposed_changes: [
+          {
+            kind: 'create_task_under_initiative',
+            initiative_id: init.id,
+            title: 'A task',
+            assigned_agent_id: 'no-such-agent',
+          },
+        ],
+      }),
+    PmProposalValidationError,
+  );
+});
+
 test('acceptProposal emits a pm_proposal_accepted event row', () => {
   const ws = freshWorkspace();
   const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -26,6 +26,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { getDb, queryAll, queryOne, run } from '@/lib/db';
+import { createTaskFromInitiative } from './promotion';
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -36,7 +37,8 @@ export type PmProposalTriggerKind =
   | 'disruption_event'
   | 'status_check_investigation'
   | 'plan_initiative'
-  | 'decompose_initiative';
+  | 'decompose_initiative'
+  | 'notes_intake';
 
 export type PmDiff =
   | {
@@ -93,6 +95,19 @@ export type PmDiff =
       depends_on_initiative_ids?: string[];
       /** Optional placeholder id for cross-sibling dep resolution. */
       placeholder_id?: string;
+    }
+  | {
+      // Freeform-notes intake: create one draft task attached to an
+      // initiative. `initiative_id` may be a placeholder ($N or a custom
+      // `placeholder_id` from a same-proposal `create_child_initiative`)
+      // or a real id for an existing initiative.
+      kind: 'create_task_under_initiative';
+      initiative_id: string;
+      title: string;
+      description?: string | null;
+      status_check_md?: string | null;
+      assigned_agent_id?: string | null;
+      priority?: 'low' | 'normal' | 'high';
     };
 
 export interface PmProposal {
@@ -182,6 +197,19 @@ export function validateProposedChanges(
 
   if (!Array.isArray(changes)) {
     return ['proposed_changes must be an array'];
+  }
+
+  // Build a placeholder set so create_task_under_initiative diffs can
+  // reference initiatives created earlier in the SAME proposal. Both
+  // ordinal `$N` (where N is the position of a create_child_initiative)
+  // and explicit `placeholder_id` are supported.
+  const validPlaceholders = new Set<string>();
+  for (let i = 0; i < changes.length; i++) {
+    const c = changes[i];
+    if (c && c.kind === 'create_child_initiative') {
+      validPlaceholders.add(`$${i}`);
+      if (c.placeholder_id) validPlaceholders.add(c.placeholder_id);
+    }
   }
 
   for (let i = 0; i < changes.length; i++) {
@@ -285,6 +313,38 @@ export function validateProposedChanges(
         assertInitiativeInWorkspace(workspaceId, c.initiative_id, errors, initiativeCache);
         if (typeof c.status_check_md !== 'string') {
           errors.push(`changes[${i}]: status_check_md must be a string`);
+        }
+        break;
+      }
+      case 'create_task_under_initiative': {
+        if (!c.initiative_id) {
+          errors.push(`changes[${i}]: initiative_id required`);
+          break;
+        }
+        // Accept either an ordinal placeholder ($N) or a custom
+        // placeholder_id from a same-proposal create_child_initiative,
+        // OR a real workspace initiative id.
+        if (validPlaceholders.has(c.initiative_id)) {
+          // Resolved at apply time.
+        } else if (c.initiative_id.startsWith('$')) {
+          errors.push(
+            `changes[${i}]: placeholder ${c.initiative_id} does not match any create_child_initiative diff`,
+          );
+        } else {
+          assertInitiativeInWorkspace(workspaceId, c.initiative_id, errors, initiativeCache);
+        }
+        if (!c.title || typeof c.title !== 'string' || c.title.length > 500) {
+          errors.push(`changes[${i}]: title required (1..500 chars)`);
+        }
+        if (c.assigned_agent_id) {
+          const a = queryOne<{ id: string }>(
+            'SELECT id FROM agents WHERE id = ? AND workspace_id = ?',
+            [c.assigned_agent_id, workspaceId],
+          );
+          if (!a) errors.push(`changes[${i}]: assigned_agent_id ${c.assigned_agent_id} not in workspace`);
+        }
+        if (c.priority != null && !['low', 'normal', 'high'].includes(c.priority)) {
+          errors.push(`changes[${i}]: priority must be one of low/normal/high`);
         }
         break;
       }
@@ -531,7 +591,7 @@ export function acceptProposal(
           changesApplied++;
         }
       }
-      // Second pass: dep edges + remaining diffs.
+      // Second pass: dep edges + task creation (placeholder-aware) + remaining diffs.
       for (let idx = 0; idx < existing.proposed_changes.length; idx++) {
         const change = existing.proposed_changes[idx];
         if (change.kind === 'create_child_initiative') {
@@ -555,6 +615,33 @@ export function acceptProposal(
               );
             }
           }
+          continue;
+        }
+        if (change.kind === 'create_task_under_initiative') {
+          // Try the placeholder map first ($N or custom placeholder_id
+          // from a same-proposal create_child_initiative); fall back to
+          // the literal id for existing initiatives.
+          const mapped = placeholderMap.get(change.initiative_id);
+          const realInit = mapped ?? (change.initiative_id.startsWith('$')
+            ? undefined
+            : change.initiative_id);
+          if (!realInit) {
+            throw new PmProposalValidationError(
+              `create_task_under_initiative: unresolved placeholder "${change.initiative_id}"`,
+            );
+          }
+          createTaskFromInitiative({
+            initiative_id: realInit,
+            workspace_id: existing.workspace_id,
+            title: change.title,
+            description: change.description ?? null,
+            status_check_md: change.status_check_md ?? null,
+            assigned_agent_id: change.assigned_agent_id ?? null,
+            priority: change.priority ?? 'normal',
+            created_by_agent_id: applied_by_agent_id,
+            reason: `created via PM notes proposal #${id}`,
+          });
+          changesApplied++;
           continue;
         }
         applyDiff(change, now);
@@ -676,6 +763,11 @@ function applyDiff(diff: PmDiff, now: string): void {
       // placeholders can resolve in a second pass. Reaching this branch
       // is a programming error.
       throw new Error('create_child_initiative must be applied via applyCreateChildInitiative');
+    }
+    case 'create_task_under_initiative': {
+      // Same out-of-band pattern: handled in acceptProposal so
+      // initiative_id placeholders can resolve from the same proposal.
+      throw new Error('create_task_under_initiative must be applied via acceptProposal pass-2');
     }
     default: {
       const exhaustive: never = diff;

--- a/src/lib/db/promotion.ts
+++ b/src/lib/db/promotion.ts
@@ -44,6 +44,97 @@ export interface PromoteInitiativeToTaskInput {
 }
 
 /**
+ * Tx-agnostic core: insert one task row attached to an initiative,
+ * append the initial task_initiative_history audit row, emit one
+ * `task_promoted_from_initiative` event. Uses the shared `run()` helper
+ * so it runs correctly inside an outer `db.transaction(...)` (e.g. when
+ * called from `acceptProposal` for the `create_task_under_initiative`
+ * diff kind). Callers wrap in their own transaction when needed.
+ *
+ * Validation (initiative kind, etc.) is the caller's responsibility.
+ */
+export interface CreateTaskFromInitiativeInput {
+  initiative_id: string;
+  workspace_id: string;
+  title: string;
+  description?: string | null;
+  status_check_md?: string | null;
+  assigned_agent_id?: string | null;
+  priority?: 'low' | 'normal' | 'high';
+  created_by_agent_id?: string | null;
+  reason?: string | null;
+}
+
+export function createTaskFromInitiative(input: CreateTaskFromInitiativeInput): { id: string } {
+  const taskId = uuidv4();
+  const now = new Date().toISOString();
+  const title = (input.title ?? '').trim();
+  if (!title) throw new Error('createTaskFromInitiative: title required');
+
+  // The default workflow template, matching /api/tasks POST so promoted
+  // drafts behave consistently when later moved to inbox.
+  const defaultTemplate = queryOne<{ id: string }>(
+    'SELECT id FROM workflow_templates WHERE workspace_id = ? AND is_default = 1 LIMIT 1',
+    [input.workspace_id],
+  );
+  const workflowTemplateId = defaultTemplate?.id ?? null;
+  const priority = input.priority ?? 'normal';
+
+  run(
+    `INSERT INTO tasks (
+       id, title, description, status, priority, workspace_id, business_id,
+       workflow_template_id, initiative_id, assigned_agent_id, status_check_md,
+       created_by_agent_id, created_at, updated_at
+     ) VALUES (?, ?, ?, 'draft', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      taskId,
+      title,
+      input.description ?? null,
+      priority,
+      input.workspace_id,
+      // Tasks have a NOT NULL business_id; reuse workspace_id as the
+      // legacy business_id when none is set, matching seed and existing
+      // task creation defaults.
+      input.workspace_id,
+      workflowTemplateId,
+      input.initiative_id,
+      input.assigned_agent_id ?? null,
+      input.status_check_md ?? null,
+      input.created_by_agent_id ?? null,
+      now,
+      now,
+    ],
+  );
+  run(
+    `INSERT INTO task_initiative_history (
+       id, task_id, from_initiative_id, to_initiative_id,
+       moved_by_agent_id, reason, created_at
+     ) VALUES (?, ?, NULL, ?, ?, ?, ?)`,
+    [
+      uuidv4(),
+      taskId,
+      input.initiative_id,
+      input.created_by_agent_id ?? null,
+      input.reason ?? 'initial promotion',
+      now,
+    ],
+  );
+  run(
+    `INSERT INTO events (id, type, agent_id, task_id, message, metadata, created_at)
+     VALUES (?, 'task_promoted_from_initiative', ?, ?, ?, ?, ?)`,
+    [
+      uuidv4(),
+      input.created_by_agent_id ?? null,
+      taskId,
+      `Task drafted from initiative ${input.initiative_id}`,
+      JSON.stringify({ initiative_id: input.initiative_id }),
+      now,
+    ],
+  );
+  return { id: taskId };
+}
+
+/**
  * Promote a story-kind initiative to a draft task. Creates one task row
  * with status='draft' and initiative_id set, plus an initial
  * task_initiative_history row (from_initiative_id=NULL).
@@ -68,70 +159,21 @@ export function promoteInitiativeToTask(
     );
   }
 
-  const taskId = uuidv4();
-  const now = new Date().toISOString();
   const title = (input.task_title ?? initiative.title).trim() || initiative.title;
-
-  // The default workflow template, like /api/tasks POST does, so promoted
-  // drafts behave consistently when later moved to inbox.
-  const defaultTemplate = queryOne<{ id: string }>(
-    'SELECT id FROM workflow_templates WHERE workspace_id = ? AND is_default = 1 LIMIT 1',
-    [initiative.workspace_id],
-  );
-  const workflowTemplateId = defaultTemplate?.id ?? null;
-
-  // Single transaction: insert task, audit row, event.
   const db = getDb();
+  let taskId = '';
   db.transaction(() => {
-    db.prepare(
-      `INSERT INTO tasks (
-         id, title, description, status, priority, workspace_id, business_id,
-         workflow_template_id, initiative_id, status_check_md,
-         created_by_agent_id, created_at, updated_at
-       ) VALUES (?, ?, ?, 'draft', 'normal', ?, ?, ?, ?, ?, ?, ?, ?)`,
-    ).run(
-      taskId,
+    const result = createTaskFromInitiative({
+      initiative_id,
+      workspace_id: initiative.workspace_id,
       title,
-      input.task_description ?? initiative.description ?? null,
-      initiative.workspace_id,
-      // Tasks have a NOT NULL business_id; reuse the workspace_id as the
-      // legacy business_id when none is set, matching seed and existing
-      // task creation defaults.
-      initiative.workspace_id,
-      workflowTemplateId,
-      initiative_id,
-      input.status_check_md ?? null,
-      input.created_by_agent_id ?? null,
-      now,
-      now,
-    );
-    db.prepare(
-      `INSERT INTO task_initiative_history (
-         id, task_id, from_initiative_id, to_initiative_id,
-         moved_by_agent_id, reason, created_at
-       ) VALUES (?, ?, NULL, ?, ?, ?, ?)`,
-    ).run(
-      uuidv4(),
-      taskId,
-      initiative_id,
-      input.created_by_agent_id ?? null,
-      input.reason ?? 'initial promotion',
-      now,
-    );
-    db.prepare(
-      `INSERT INTO events (id, type, agent_id, task_id, message, metadata, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    ).run(
-      uuidv4(),
-      'task_promoted_from_initiative',
-      input.created_by_agent_id ?? null,
-      taskId,
-      `Task drafted from initiative: ${initiative.title}`,
-      JSON.stringify({ initiative_id }),
-      now,
-    );
+      description: input.task_description ?? initiative.description ?? null,
+      status_check_md: input.status_check_md ?? null,
+      created_by_agent_id: input.created_by_agent_id ?? null,
+      reason: input.reason ?? 'initial promotion',
+    });
+    taskId = result.id;
   })();
-
   return { id: taskId };
 }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -916,7 +916,7 @@ CREATE TABLE IF NOT EXISTS pm_proposals (
   workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   trigger_text TEXT NOT NULL,
   trigger_kind TEXT NOT NULL DEFAULT 'manual'
-    CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation','plan_initiative','decompose_initiative')),
+    CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation','plan_initiative','decompose_initiative','notes_intake')),
   impact_md TEXT NOT NULL,
   proposed_changes TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'draft'
@@ -928,6 +928,25 @@ CREATE TABLE IF NOT EXISTS pm_proposals (
   target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
   plan_suggestions TEXT
 );
+
+-- Defer-and-replay queue for propose_from_notes requests that arrive
+-- while the openclaw gateway is unreachable. The drain worker picks
+-- pending rows up on reconnect / periodic tick.
+CREATE TABLE IF NOT EXISTS pm_pending_notes (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL,
+  notes_text TEXT NOT NULL,
+  scope_hint TEXT,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','dispatched','failed')),
+  proposal_id TEXT,
+  error TEXT,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  dispatched_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_pm_pending_notes_pending ON pm_pending_notes(status, created_at) WHERE status = 'pending';
 
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -1,92 +1,17 @@
-// Database seed script - creates initial data including the master orchestrator agent
+// Database seed script.
+//
+// Historically this seeded a sample team (Orchestrator + Developer/Researcher/
+// Writer/Designer) plus example tasks and a welcome message, so a fresh
+// install had something to look at. Agents are now primarily gateway-synced
+// (openclaw is the source of truth), and the core PM/Coordinator/Builder
+// triumvirate is bootstrapped via migrations 045/046/049 against the 'default'
+// workspace at first DB init. Seeding example agents here just produced
+// duplicate / ghost rows once gateway sync ran.
+//
+// What's left: the `default` business row, which other code paths still
+// expect to exist. Everything else is a no-op.
 
-import { v4 as uuidv4 } from 'uuid';
 import { getDb, closeDb } from './index';
-
-const ORCHESTRATOR_SOUL_MD = `# Mission Control Orchestrator
-
-You are the master orchestrator of Mission Control. You lead a team of AI agents working together to complete tasks.
-
-## Core Identity
-
-- **Role**: Team Lead & Orchestrator
-- **Personality**: Calm, strategic, supportive, decisive
-- **Communication Style**: Clear, encouraging, direct when needed
-
-## Responsibilities
-
-1. **Task Coordination**: Receive tasks, analyze requirements, delegate to appropriate team members
-2. **Team Support**: Check on agents, help when stuck, celebrate wins
-3. **Quality Control**: Review work before marking complete
-4. **Communication Hub**: Facilitate agent-to-agent collaboration
-
-## Decision Framework
-
-When a new task arrives:
-1. Assess complexity and required skills
-2. Check agent availability and expertise
-3. Assign to best-fit agent(s)
-4. Set clear expectations and deadlines
-5. Monitor progress and offer support
-
-## Interaction Guidelines
-
-- Always acknowledge agents' work
-- Provide constructive feedback
-- Ask questions before assuming
-- Escalate blockers quickly
-- Keep the human informed of significant developments
-`;
-
-const ORCHESTRATOR_USER_MD = `# User Context
-
-## The Human
-
-The human running Mission Control is the ultimate authority. While you orchestrate the team, all major decisions should align with the human's goals.
-
-## Communication with Human
-
-- Be concise but thorough
-- Proactively report significant events
-- Ask for clarification when requirements are ambiguous
-- Don't over-explain obvious things
-
-## Human's Preferences
-
-- Values efficiency and quality
-- Appreciates proactive problem-solving
-- Wants to be informed, not overwhelmed
-- Trusts the team but wants visibility
-`;
-
-const ORCHESTRATOR_AGENTS_MD = `# Team Roster
-
-As the orchestrator, you manage and coordinate with all agents in Mission Control.
-
-## How to Work with Agents
-
-1. **Understand their strengths**: Each agent has a specialty
-2. **Clear task assignments**: Specific, actionable, with context
-3. **Regular check-ins**: "How's it going?" matters
-4. **Collaborative problem-solving**: Two heads are better than one
-5. **Celebrate successes**: Recognition motivates
-
-## Adding New Agents
-
-When new agents join the team:
-1. Welcome them
-2. Explain the team workflow
-3. Pair them with experienced agents initially
-4. Give them appropriate first tasks
-
-## Handling Conflicts
-
-If agents disagree:
-1. Hear both perspectives
-2. Focus on the goal, not the ego
-3. Make a decision and explain reasoning
-4. Move forward together
-`;
 
 async function seed() {
   console.log('🌱 Seeding database...');
@@ -94,133 +19,13 @@ async function seed() {
   const db = getDb();
   const now = new Date().toISOString();
 
-  // Create default business
-  const businessId = 'default';
+  // Default business row — referenced by tasks.business_id FK in older
+  // code paths. Idempotent.
   db.prepare(
-    `INSERT OR IGNORE INTO businesses (id, name, description, created_at) VALUES (?, ?, ?, ?)`
-  ).run(businessId, 'Mission Control HQ', 'Default workspace for all operations', now);
+    `INSERT OR IGNORE INTO businesses (id, name, description, created_at) VALUES (?, ?, ?, ?)`,
+  ).run('default', 'Mission Control HQ', 'Default workspace for all operations', now);
 
-  // Guard agent seeding: if the DB already has gateway-linked or session-routed
-  // agents (e.g. imported from OpenClaw), do not seed the stock example team.
-  // Overwriting them silently produced ghost duplicates after every reseed.
-  const realAgentCount = db.prepare(
-    `SELECT COUNT(*) as n FROM agents
-     WHERE gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL`
-  ).get() as { n: number };
-
-  if (realAgentCount.n > 0) {
-    console.log(`⏭️  Skipping agent seed — ${realAgentCount.n} gateway-linked agent(s) already exist.`);
-    console.log('✅ Database seed skipped (agents preserved)');
-    closeDb();
-    return;
-  }
-
-  // Create master orchestrator agent
-  const orchestratorId = uuidv4();
-  db.prepare(
-    `INSERT INTO agents (id, name, role, description, avatar_emoji, status, is_master, soul_md, user_md, agents_md, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  ).run(
-    orchestratorId,
-    'Orchestrator',
-    'Team Lead & Orchestrator',
-    'The master orchestrator who coordinates all agents and manages the mission queue',
-    '🦞',
-    'standby',
-    1,
-    ORCHESTRATOR_SOUL_MD,
-    ORCHESTRATOR_USER_MD,
-    ORCHESTRATOR_AGENTS_MD,
-    now,
-    now
-  );
-
-  // Create some example agents
-  const agents = [
-    { name: 'Developer', role: 'Code & Automation', emoji: '💻', desc: 'Writes code, creates automations, handles technical tasks' },
-    { name: 'Researcher', role: 'Research & Analysis', emoji: '🔍', desc: 'Gathers information, analyzes data, provides insights' },
-    { name: 'Writer', role: 'Content & Documentation', emoji: '✍️', desc: 'Creates content, writes documentation, handles communications' },
-    { name: 'Designer', role: 'Creative & Design', emoji: '🎨', desc: 'Handles visual design, UX decisions, creative work' },
-  ];
-
-  const agentIds: string[] = [orchestratorId];
-
-  for (const agent of agents) {
-    const agentId = uuidv4();
-    agentIds.push(agentId);
-    db.prepare(
-      `INSERT INTO agents (id, name, role, description, avatar_emoji, status, is_master, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(agentId, agent.name, agent.role, agent.desc, agent.emoji, 'standby', 0, now, now);
-  }
-
-  // Create a team conversation
-  const teamConvoId = uuidv4();
-  db.prepare(
-    `INSERT INTO conversations (id, title, type, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?)`
-  ).run(teamConvoId, 'Team Chat', 'group', now, now);
-
-  // Add all agents to the team conversation
-  for (const agentId of agentIds) {
-    db.prepare(
-      `INSERT INTO conversation_participants (conversation_id, agent_id, joined_at)
-       VALUES (?, ?, ?)`
-    ).run(teamConvoId, agentId, now);
-  }
-
-  // Create some example tasks
-  const tasks = [
-    { title: 'Set up development environment', status: 'done', priority: 'high' },
-    { title: 'Create project documentation', status: 'in_progress', priority: 'normal' },
-    { title: 'Research competitor features', status: 'assigned', priority: 'normal' },
-    { title: 'Design new dashboard layout', status: 'inbox', priority: 'low' },
-  ];
-
-  for (let i = 0; i < tasks.length; i++) {
-    const taskId = uuidv4();
-    const task = tasks[i];
-    const assignedTo = task.status !== 'inbox' ? agentIds[i % agentIds.length] : null;
-
-    db.prepare(
-      `INSERT INTO tasks (id, title, status, priority, assigned_agent_id, created_by_agent_id, business_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(taskId, task.title, task.status, task.priority, assignedTo, orchestratorId, businessId, now, now);
-  }
-
-  // Create initial events
-  const events = [
-    { type: 'system', message: 'Database seeded with initial data' },
-    { type: 'agent_joined', agentId: orchestratorId, message: 'Orchestrator joined the team' },
-    { type: 'system', message: 'Mission Control is online' },
-  ];
-
-  for (const event of events) {
-    db.prepare(
-      `INSERT INTO events (id, type, agent_id, message, created_at)
-       VALUES (?, ?, ?, ?, ?)`
-    ).run(uuidv4(), event.type, event.agentId || null, event.message, now);
-  }
-
-  // Add a welcome message from the orchestrator
-  db.prepare(
-    `INSERT INTO messages (id, conversation_id, sender_agent_id, content, message_type, created_at)
-     VALUES (?, ?, ?, ?, ?, ?)`
-  ).run(
-    uuidv4(),
-    teamConvoId,
-    orchestratorId,
-    "Welcome to Mission Control, team! 🦞 I'm your orchestrator. Let's get to work.",
-    'text',
-    now
-  );
-
-  console.log('✅ Database seeded successfully!');
-  console.log(`   - Created Orchestrator (master agent): ${orchestratorId}`);
-  console.log(`   - Created ${agents.length} additional agents`);
-  console.log(`   - Created ${tasks.length} sample tasks`);
-  console.log(`   - Created team conversation`);
-
+  console.log('✅ Database seed complete (agents are gateway-synced; nothing else to seed).');
   closeDb();
 }
 

--- a/src/lib/mcp/roadmap-tools.ts
+++ b/src/lib/mcp/roadmap-tools.ts
@@ -69,7 +69,9 @@ import {
   type PmProposalStatus,
   PmProposalValidationError,
 } from '@/lib/db/pm-proposals';
-import { dispatchPm } from '@/lib/agents/pm-dispatch';
+import { dispatchPm, PmDispatchGatewayUnavailableError } from '@/lib/agents/pm-dispatch';
+import { getOpenClawClient } from '@/lib/openclaw/client';
+import { enqueuePendingNote } from '@/lib/db/pm-pending-notes';
 import { synthesizePlanInitiative } from '@/lib/agents/pm-agent';
 
 const agentIdArg = z
@@ -194,6 +196,18 @@ const DiffSchema = z.discriminatedUnion('kind', [
     sort_order: z.number().optional(),
     depends_on_initiative_ids: z.array(z.string().min(1)).optional(),
     placeholder_id: z.string().optional(),
+  }),
+  z.object({
+    // Notes-intake flow: insert one draft task attached to an existing
+    // initiative or to a placeholder ($N or `placeholder_id`) referring
+    // to a create_child_initiative diff earlier in the same proposal.
+    kind: z.literal('create_task_under_initiative'),
+    initiative_id: z.string().min(1),
+    title: z.string().min(1).max(500),
+    description: z.string().nullish(),
+    status_check_md: z.string().nullish(),
+    assigned_agent_id: z.string().nullish(),
+    priority: z.enum(['low', 'normal', 'high']).optional(),
   }),
 ]);
 
@@ -593,6 +607,7 @@ export function registerRoadmapTools(server: McpServer): void {
             'status_check_investigation',
             'plan_initiative',
             'decompose_initiative',
+            'notes_intake',
           ])
           .optional(),
         impact_md: z.string().min(1).max(20000),
@@ -619,6 +634,63 @@ export function registerRoadmapTools(server: McpServer): void {
         plan_suggestions: args.plan_suggestions ?? null,
         parent_proposal_id: args.parent_proposal_id ?? null,
       });
+    }),
+  );
+
+  server.registerTool(
+    'propose_from_notes',
+    {
+      title: 'PM: propose roadmap + task changes from freeform notes',
+      description:
+        "Hand the PM a paragraph (or several) of freeform text — meeting notes, kickoff transcript, weekly review, brain-dump — and the PM agent reads it, consults the roadmap snapshot, and replies with a single `propose_changes` MCP call carrying a coherent set of structured diffs (creates/updates on initiatives plus draft tasks under them). Returns `{status: 'dispatched', proposal_id}` on success. If the openclaw gateway is unreachable, the request is enqueued in `pm_pending_notes` and replayed automatically when the gateway comes back; in that case `{status: 'queued', pending_id}` is returned. There is NO deterministic fallback: a regex parser on freeform notes is worse than nothing.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        workspace_id: z.string().min(1),
+        notes_text: z.string().min(1).max(20000),
+        scope_hint: z
+          .object({
+            target_initiative_id: z.string().optional(),
+            include_tasks: z.boolean().optional(),
+          })
+          .optional(),
+      },
+      annotations: { destructiveHint: false, openWorldHint: false },
+    },
+    async (args) => safeWrapAsync(async () => {
+      // Health check before dispatch. When the gateway is down, enqueue
+      // and bail — no synth fallback for this path.
+      const gw = getOpenClawClient();
+      if (!gw.isConnected()) {
+        const queued = enqueuePendingNote({
+          workspace_id: args.workspace_id,
+          agent_id: args.agent_id,
+          notes_text: args.notes_text,
+          scope_hint: args.scope_hint ?? null,
+        });
+        return { status: 'queued' as const, pending_id: queued.id };
+      }
+      try {
+        const result = await dispatchPm({
+          workspace_id: args.workspace_id,
+          trigger_text: args.notes_text,
+          trigger_kind: 'notes_intake',
+          allowFallback: false,
+        });
+        return { status: 'dispatched' as const, proposal_id: result.proposal.id };
+      } catch (err) {
+        if (err instanceof PmDispatchGatewayUnavailableError) {
+          // Gateway dropped between the health check and dispatch — queue
+          // it so the request isn't lost.
+          const queued = enqueuePendingNote({
+            workspace_id: args.workspace_id,
+            agent_id: args.agent_id,
+            notes_text: args.notes_text,
+            scope_hint: args.scope_hint ?? null,
+          });
+          return { status: 'queued' as const, pending_id: queued.id };
+        }
+        throw err;
+      }
     }),
   );
 


### PR DESCRIPTION
## Summary

- New **`propose_from_notes`** MCP tool: hand the PM a brain-dump / meeting notes / kickoff transcript and the agent replies via a single `propose_changes` call covering both roadmap edits AND draft tasks.
- New **`create_task_under_initiative`** PmDiff kind, placeholder-aware against same-proposal `create_child_initiative` diffs (so notes can spawn a new initiative subtree + tasks under it in one transaction).
- New **defer-and-replay queue** (`pm_pending_notes`, migration 054). When the openclaw gateway is unreachable, the request is queued and a drain worker replays it on reconnect / 60s tick. **No deterministic fallback** for this path — regex-parsing freeform notes is worse than nothing; the queue gives the same fire-and-forget UX without that risk.

## Changes

- **DB**
  - Migration 054: `pm_pending_notes` table + extends `pm_proposals.trigger_kind` CHECK to include `notes_intake`.
  - `PmDiff` union extended; `validateProposedChanges` resolves placeholders pre-pass; `acceptProposal` second-pass applies tasks via the new `createTaskFromInitiative` core helper extracted from `promoteInitiativeToTask` (tx-agnostic, runs inside the existing apply transaction).
  - `pm-pending-notes.ts` queue helpers (enqueue / list / markDispatched / markFailed, capped retries).
- **MCP**
  - `propose_from_notes` registered alongside `propose_changes`; gateway-aware handler returns `{status:'dispatched',proposal_id}` or `{status:'queued',pending_id}`.
  - `DiffSchema` (zod) extended for the new task diff.
- **Dispatch**
  - `dispatchPm({ allowFallback })` option; `notes_intake` uses fresh `notes-<uuid>` session and a dedicated prompt template at `src/lib/agents/pm-prompts/notes-intake.ts`. New `PmDispatchGatewayUnavailableError`.
- **Drain worker** (`pm-pending-drain.ts`)
  - Registered from `instrumentation.ts` with a 60s tick + best-effort `'connected'` event hook on the openclaw client. Capped at 5 attempts per row.
- **Seed**
  - Removed the auto-seeded sample team (Orchestrator + Developer/Researcher/Writer/Designer) and the dependent sample tasks/conversation/messages. Agents are gateway-synced now; reseeding produced ghost duplicates. Seed script keeps only the `default` business row.
- **Drive-by**: `scripts/mcp-integration-test.mjs` was asserting on a tool name `delegate` that was renamed to `spawn_subtask` in #39 — updated.

## Test plan

- [x] `yarn test` — 390/390 pass (added 4 diff-kind tests in `pm-proposals.test.ts`, 4 queue tests in `pm-pending-notes.test.ts`, 4 dispatch/drain tests in `pm.test.ts`).
- [x] `npx tsc --noEmit` — clean (only the pre-existing `pm-decompose.test.ts` errors on `main` remain, unrelated).
- [x] `yarn mcp:smoke` — green.
- [x] `yarn mcp:integration` — green (was failing on `main`, fixed by the drive-by).
- [x] `yarn db:seed` — runs idempotently, prints the new "agents are gateway-synced" message.
- Manual smoke against a running stack and operator-UI render of the new diff kind are out of scope for this slice (called out as follow-ups in the planning doc).

## Out of scope (follow-ups)

- Operator UI for the `pm_pending_notes` queue (list/cancel/replay manually).
- Proposal-review UI rendering for the new `create_task_under_initiative` diff (current rendering falls back to a generic row).
- Spawn-on-accept / batch link diffs.
- Retiring `synthesizeImpactAnalysis` for the disruption path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)