### PR TITLE
feat(pm): async dispatch + Tier 2/3 reconciler + preview test flow

### DIFF
--- a/docs/PREVIEW_TEST_FINDINGS.md
+++ b/docs/PREVIEW_TEST_FINDINGS.md
@@ -1,0 +1,184 @@
+# Preview Test Findings
+
+A running log of regressions, UX issues, and doc-drift items surfaced by walking through [PREVIEW_TEST_FLOW.md](PREVIEW_TEST_FLOW.md). Append entries here during a walkthrough; triage / file follow-ups afterwards.
+
+## Format
+
+```
+### YYYY-MM-DD · <step ref> · <short title>
+
+- Severity: blocker (RESOLVED) | regression | polish | doc-drift
+- Repro: <one-line repro from a known checkpoint>
+- Expected: <what the doc says>
+- Actual: <what we observed>
+- Notes: <root-cause hint, file paths, follow-up link>
+```
+
+---
+
+## 2026-04-27 · §1 Initial Setup walkthrough
+
+### §1.3 · Stock `Builder Agent` / `Learner Agent` rows seeded alongside gateway-synced agents
+
+- Severity: regression
+- Repro: from a wiped DB → `yarn db:reset` → `preview_start` → open `/agents`
+- Expected: only gateway-synced rows (`Builder`, `Coordinator`, `Learner`, `main`, `Project Manager`) plus any workspace-local PM. Total ≈ 5–6 agents.
+- Actual: 13 rows. Duplicates appear because the local-source rows `Builder Agent` (role=builder) and `Learner Agent` (role=learner) are seeded next to the gateway-linked `Builder` / `Learner` rows.
+- Notes: source is `bootstrapCoreAgentsRaw()` ([src/lib/bootstrap-agents.ts:64](src/lib/bootstrap-agents.ts:64), [:142](src/lib/bootstrap-agents.ts:142)) called from:
+  - migrations runner for the `default` workspace ([src/lib/db/migrations.ts:648](src/lib/db/migrations.ts:648))
+  - `POST /api/workspaces` ([src/app/api/workspaces/route.ts:110](src/app/api/workspaces/route.ts:110))
+
+  Now that gateway sync owns the worker roster, this path should be reduced. Decision needed:
+  1. Make `bootstrapCoreAgents` a no-op (workspace + workflow templates only).
+  2. Mint only the **PM** agent (MC-side, unique — gateway sync doesn't produce it).
+  3. Keep stock Builder/Learner placeholders only when no gateway is connected.
+
+  Recommendation: option 2 — PM is genuinely MC-owned; everything else is gateway. See the spawned follow-up task.
+
+---
+
+### §1.7 · "Reset all sessions" uses native `window.confirm()` — blocks automation
+
+- Severity: regression / polish (RESOLVED)
+- Repro: from `setup-stable` baseline → /agents → click **Reset all sessions**
+- Expected: in-app modal we can drive via DOM (matching the rest of the UI's modal pattern, e.g. agent edit panel).
+- Actual: native browser `confirm()` dialog. Cannot be dismissed by `preview_eval` / `preview_click` — pauses automation until a human clicks through. Also looks out of place vs. the rest of the styled UI.
+- Notes: probably a `window.confirm("…")` call in the click handler. Replace with the same modal/dialog component the agent-edit panel uses. Until then, the test flow doc must call out that this step requires manual click-through.
+
+### §2.3 · Plan-with-PM guidance popup is too narrow / clips heading
+
+- Severity: polish (RESOLVED)
+- Repro: from `setup-stable` → /initiatives → click into Smart Snappy → click ▾ chevron next to **Plan with PM**
+- Expected: popup wide enough to show heading "What should the PM focus the plan on?" and the placeholder text in full.
+- Actual: heading is clipped on the left edge ("PM focus the plan on?" visible); placeholder shows truncated like ".."; the **Submit** label is also clipped.
+- Notes: likely `max-width` on the popover is too small for the heading + actions row. Probably one Tailwind class change.
+
+### §2.3 · Plan-with-PM races: 60s timeout fires before agent responds, late agent proposal is orphaned
+
+- Severity: blocker (RESOLVED)
+- Repro: from `setup-stable` → /initiatives → click into Smart Snappy → ▾ chevron next to **Plan with PM** → paste the REFINE WITH PM GUIDANCE prompt → click **Plan with guidance**. (Reproes most reliably on a freshly-warmed PM session — cold sessions take longer.)
+- Expected: gateway PM agent's `propose_changes` lands and is shown to the operator; no duplicate synth proposal.
+- Actual: TWO proposals for one click. Confirmed via the openclaw session log:
+  - `19:19:13` — dispatch sent to PM agent (correlation `9c60387b-…`).
+  - `19:19:35` — agent calls `whoami` to gather context (22s in).
+  - `19:20:12` — MC's 60s `NAMED_AGENT_TIMEOUT_MS` elapses → `dispatchPmSynthesized` falls back to deterministic `synthesizePlanInitiative` → proposal `789c26d2-…` saved with `refined_description == input`. THIS is what the UI displays.
+  - `19:20:23` — agent finishes its turn and calls `propose_changes` (id `05591c6f-…`) with the actual high-quality refinement (full rewrite, resolved decisions table, owner-tagged follow-ups). Lands ~11s after the timeout. Orphaned — UI never shows it.
+- Notes: two underlying issues, separable:
+  1. **Timeout too aggressive for plan/decompose dispatches.** 60s default is fine for one-line disruption dispatches; it's clearly too tight for plan_initiative on a sizable epic where the agent has to read input + roadmap snapshot + compose structured output. Either bump the default specifically for plan/decompose (e.g. 120s), make the timeout configurable per dispatch kind, or auto-extend on the first observed token from the agent.
+  2. **Late-arriving agent proposals are orphaned, not reconciled.** `dispatchPmSynthesized`'s post-hoc trigger_kind / target_initiative_id stamping only runs if the agent's `propose_changes` lands inside the wait window. When it lands later, the row stays with `trigger_kind: 'manual'`, `target_initiative_id: null`, and no link back to the originally-dispatched intent — and no one supersedes the synth fallback. We need the listener (or a short tail-window after the timeout) to catch these and either (a) supersede the synth row + promote the agent row, or (b) at least mark the agent row as related to the original correlation_id.
+
+  Worth noting that the agent's actual output was excellent — full description rewrite, resolved-decisions table with owner-area columns, scoped Phase 2 deferrals — exactly what the operator guidance asked for. The bug is purely in the orchestration around it.
+
+### §2.3 · Self-dependency suggestion (initiative depends on itself)
+
+- Severity: regression (RESOLVED)
+- Repro: same as above
+- Expected: deterministic synth must not propose `depends_on_initiative_id == target_initiative_id`.
+- Actual: `dependencies[0]` in `plan_suggestions` is `{ depends_on_initiative_id: 15d41a5f-… (Smart Snappy itself), kind: 'informational', note: 'Title shares \"smart, snappy\" — confirm if this is a real dependency.' }`.
+- Notes: the title-substring matcher in `synthesizePlanInitiative` doesn't exclude the target initiative from its own candidate set. Easy fix; also: validator should reject this at proposal-create time (PmDiff `add_dependency` already rejects self-deps; the same rule should apply to plan_suggestions before they're persisted).
+
+### §2.3 · Legacy `<!--pm-plan-suggestions {json}-->` sidecar still emitted alongside structured column
+
+- Severity: regression (RESOLVED)
+- Repro: same as above; inspect `proposal.impact_md` and `proposal.plan_suggestions` returned by `/api/pm/plan-initiative?workspace_id=…&target_initiative_id=…`.
+- Expected: per #85, structured suggestions live in the `plan_suggestions` column only — no markdown sidecar.
+- Actual: impact_md trails with `<!--pm-plan-suggestions {…full json…} -->`; same JSON also appears in `plan_suggestions` column.
+- Notes: probably `synthesizePlanInitiative` (deterministic path) still appends the sidecar even after the column was added. Strip the appender now that the column is canonical.
+
+### §2.3 · `/api/pm/proposals?workspace_id=default` returns empty list while plan_initiative draft exists
+
+- Severity: polish (data inconsistency)
+- Repro: after a plan_initiative dispatch lands a draft, GET `/api/pm/proposals?workspace_id=default`.
+- Expected: at least the new draft proposal in the response.
+- Actual: `[]`. The proposal IS reachable via `/api/pm/plan-initiative?…&target_initiative_id=…` and `/pm/proposals/<id>`, just not in the workspace-wide list.
+- Notes: likely an intentional filter to keep advisory plan_initiative rows out of the operator's "open proposals" list — but the filter isn't documented anywhere and surprised us during the walkthrough. Either expose them with a flag (`?include=advisory`) or drop the filter; current behavior makes the workspace list misleading for anyone debugging.
+
+### §2.3 · Plan-with-PM concurrent dispatches cross-supersede
+
+- Severity: regression (edge case) (RESOLVED — reconciler now filters `dispatch_state !== 'pending_agent'`)
+- Repro: trigger two POST `/api/pm/plan-initiative` for the same `target_initiative_id` in quick succession (e.g. UI double-fire / accidental double-click after Discard).
+- Expected: each placeholder is superseded only by an actual agent row, never by another placeholder.
+- Actual: each background reconciler's `pollForAgentProposal` matches "any draft that isn't my placeholder" — the OTHER concurrent placeholder satisfies that filter, so placeholder A gets superseded by placeholder B (and vice versa) before the agent's row even arrives. The supersede chain ends up tangled.
+- Notes: tighten the reconciler's filter to also require `dispatch_state !== 'pending_agent'` on candidates. Fix is local to `pollForAgentProposal` in `pm-dispatch.ts`. Also worth fixing the upstream UI double-fire on the `Discard` → `Plan with guidance` path so this rarely matters in practice.
+
+### §2.4-2.5 · Agent's plan_suggestions occasionally omits target_start / target_end
+
+- Severity: polish
+- Repro: from `setup-stable` → /initiatives → Smart Snappy → Plan with PM with the standard refinement guidance; inspect the resulting `plan_suggestions` and the post-Apply initiative row.
+- Expected: target window populated (synth fallback always proposes today + N weeks based on complexity).
+- Actual: agent's `plan_suggestions.target_start` / `.target_end` are both `null`; Apply leaves them null on the initiative row.
+- Notes: low-cost fix paths:
+  1. SOUL.md instructs the agent to always propose target_* (and that's currently in there) — perhaps the agent is omitting because the prompt also says "operator can set later." Sharpen the language.
+  2. Reconciler-side: when the agent's `plan_suggestions` is missing dates, fall back to synth-derived dates rather than nulls. Cleaner than fighting the prompt.
+
+### §2.6 · Agent's `propose_changes` first call sometimes stringifies array args (intermittent retry)
+
+- Severity: regression (latency)
+- Repro: trigger Decompose with PM with a substantial hint; observe openclaw session log. The agent's tool-use layer occasionally serializes the `changes` array as a JSON string ("[{...}, ...]") rather than a real array. Validation rejects it (`changes: must be array`); the agent retries with a properly structured payload and the second call succeeds.
+- Expected: server accepts both shapes — array, or string-that-decodes-to-array — without forcing an agent retry. Retrying costs ~30-60s of agent latency on top of the already-slow plan/decompose round trip.
+- Actual: `propose_changes` MCP tool's zod schema requires `changes: array` and rejects stringified payloads outright.
+- Notes: cheap fix in `roadmap-tools.ts` `propose_changes` handler — pre-process `args.changes` and `args.plan_suggestions`: if string, attempt `JSON.parse`, fall back to current behavior on parse error. Same for `plan_suggestions`.
+
+### §2.6 · DecomposeWithPmModal not wired to SSE supersede flow
+
+- Severity: regression
+- Repro: from `setup-stable` → /initiatives → Smart Snappy → Decompose with PM (with hint) → wait for agent.
+- Expected: modal shows "PM agent is composing" indicator while `dispatch_state === 'pending_agent'`, then auto-swaps to the agent's children when supersede broadcasts `pm_proposal_replaced`.
+- Actual: modal renders only the synth placeholder (3 generic children: Discovery / Implementation / Verification). The agent's better decomposition is in the DB but the modal never updates. Operator must close + reopen, and even then the GET endpoint can't find the agent's row (next finding).
+- Notes: mirror the PlanWithPmPanel SSE wiring into DecomposeWithPmModal. Same hooks: subscribe on open + pending_agent, handle pm_proposal_replaced + pm_proposal_dispatch_state_changed, refetch on supersede, soft-disable Accept while pending.
+
+### §2.6 · Decompose GET endpoint can't find agent's row after supersede
+
+- Severity: regression (RESOLVED — supersede now copies trigger_text from placeholder)
+- Repro: after a Decompose dispatch supersedes, `GET /api/pm/decompose-initiative?initiative_id=…` returns the synth row (or null) instead of the live agent row.
+- Root cause: GET filters on `json_extract(trigger_text, '$.initiative_id')`. The agent's freeform `trigger_text` (whatever it passed via `propose_changes`) doesn't carry that JSON envelope, so the lookup misses it.
+- Fix shipped: `supersedeWithAgentProposal` in `pm-proposals.ts` now copies the placeholder's `trigger_text` onto the agent's row during supersede. Preserves the JSON envelope MC built and keeps lookups stable.
+
+### §2.8 · "Add child" not available on story-kind initiatives — doc assumed universal
+
+- Severity: doc-drift
+- Repro: from a decomposed Smart Snappy → click into any child story (e.g. "Snappy Service Architecture") → toolbar shows `Promote to task / Plan with PM / Move / Convert kind / Add dependency / View history / Detach / Delete`. No `Add child`.
+- Expected per the doc: `Add child` is always available.
+- Actual: stories are roadmap leaves. Adding sub-children requires `Convert kind` to epic first.
+- Notes: update PREVIEW_TEST_FLOW.md §2.8 to either (a) call out the convert-kind prerequisite, or (b) target a non-story child (epic/milestone) so Add child is exposed naturally. We picked (b)-style: skip 2.8 in this walkthrough and exercise convert_initiative as its own step in a later section.
+
+### §3.1 · Disruption dispatch (`dispatchPm`) didn't get Tier 1/2/3 — same race as plan/decompose
+
+- Severity: regression (RESOLVED — `dispatchPm` refactored to mirror `dispatchPmSynthesized`)
+- Repro: from `smart-snappy-decomposed` → /pm → type "Researcher is out next week — dental surgery, back the following Monday." → Dispatch.
+- Expected: same async behavior as plan/decompose — synth placeholder returned immediately with `dispatch_state: pending_agent`, agent's row supersedes via SSE.
+- Actual: `POST /api/pm/proposals` blocks for 60s (named-agent timeout), then synth fallback creates a row at 15:40:20. The agent's row lands at 15:40:21 (right after the timeout) but is NOT superseded — both rows live in `Recent proposals` as separate drafts. Chat panel shows the synth content; the agent's better summary ("Researcher unavailable Apr 28 – May 2 (staged in owner_availability)") is orphaned.
+- Notes: extend the same `dispatchPmSynthesized`-style refactor to `dispatchPm`. They share the named-agent + reconciler primitives — this is mostly plumbing the placeholder + supersede + SSE through the disruption code path.
+
+### §3.1 · Synth and agent disagree on "next week" semantics
+
+- Severity: polish
+- Repro: same as §3.1 above — observe the two competing proposals.
+- Expected: consistent date interpretation across synth and agent (both should produce Apr 28 – May 2 OR both May 4 – 10 — not divergent).
+- Actual: synth uses ISO-week semantics (Monday after next Monday → 2026-05-04 → 05-10). Agent uses conversational semantics (this Tue-Fri → 2026-04-28 → 05-02).
+- Notes: bias toward agent's interpretation ("next week" = next 5 weekdays from today) — that's how operators talk. Update synth's `nextWeekStart` to use today + 1 (or strict "tomorrow through next Friday") and add a unit test to lock it.
+
+### §3.4 · Refine flow recursively dispatches — agent calls `refine_proposal` MCP, which calls dispatchPm again
+
+- Severity: regression (high) (RESOLVED — refine route now strips the `[refine]` envelope and instructs the agent to use `propose_changes`)
+- Repro: from a draft proposal → click Refine → enter a constraint → Send. Watch `pm_proposals` rows appear over the next minutes.
+- Expected: ONE refine cycle — child row patched with the agent's content, transient placeholder cleaned up.
+- Actual: cascade of pending_agent placeholders + agent rows. The original child row (`624053b6` in this run) sits at "_(refining…)_" forever because the dispatchPm.completion never settles cleanly.
+- Root cause: `refineProposalDb` writes `trigger_text = "<original>\n\n[refine] <constraint>"`. When dispatchPm forwards that to the PM agent, the `[refine]` prefix nudges the agent to call `refine_proposal` (an MCP tool it has access to) instead of `propose_changes`. Inside the MCP handler at `roadmap-tools.ts:754`, `refine_proposal` itself calls `dispatchPm(...)` — closing the loop. Every refine triggers another refine, which triggers another refine.
+- Fix paths (pick one):
+  1. Strip the `[refine]` token before the prompt is built; pass the raw `additional_constraint` to the agent with explicit instructions to call `propose_changes` (NOT `refine_proposal`).
+  2. Make the refine MCP tool detect "we're being called from a dispatch in progress" via correlation_id and short-circuit to creating a propose_changes-style proposal instead of dispatching again.
+  3. Agent SOUL.md: tighten "you call propose_changes only" — refine_proposal isn't really meant for the agent to call, it's an operator/MCP UI affordance.
+- Recommendation: combine (1) and (3). The MCP tool should still exist for operator/UI use; the prompt-side guidance just keeps the agent from accidentally calling it.
+
+### §4.3 · Owner availability has no derivation effect when no children have `owner_agent_id`
+
+- Severity: doc-drift
+- Repro: from `smart-snappy-decomposed` → /roadmap → Recompute. Observe child schedules. Then check `owner_availability` and child `owner_agent_id` columns.
+- Expected per the doc: adding an availability window for an owner shifts initiatives that owner is on. Doc test step assumed owner attribution would be in place.
+- Actual: agent's `decompose_initiative` doesn't assign owners (it has no way to know which gateway agent each story will go to). All seven children have `owner_agent_id = null`. Two `owner_availability` rows already exist (from prior agent `add_owner_availability` calls during disruption dispatches), but they affect zero rows because the join `initiatives.owner_agent_id = owner_availability.agent_id` matches nothing.
+- Notes: not a bug — it's the cold-start state on a workspace where the operator hasn't made owner assignments yet. Two doc-side options:
+  1. PREVIEW_TEST_FLOW.md §4.3 should explicitly call out "first assign owners (Coordinator → backend stories, Builder Agent → mobile)" before staging availability.
+  2. The agent's `decompose_initiative` SOUL.md guidance could nudge it to suggest owners based on the description's "Owner: Backend / Mobile / Design" labels (which the agent itself wrote in the Smart Snappy refined description). That'd make the ripple test work end-to-end out of the box.
+
+<!-- new entries below -->

--- a/docs/PREVIEW_TEST_FLOW.md
+++ b/docs/PREVIEW_TEST_FLOW.md
@@ -1,0 +1,177 @@
+# Preview Test Flow
+
+A manual / Claude-driven walkthrough that exercises the primary user-facing surfaces (PM, Initiatives, Roadmap, Agents) against a **fresh database** and a **real openclaw gateway**. Designed to catch the kinds of regressions that unit + e2e tests miss — UX hangs, derivation drift, gateway-session breakage, stale resume drafts, and so on.
+
+Each step is `Action: …` (what to do) + `Expected: …` (what should be true after). When run by Claude via `preview_*` MCP tools, treat the Expected line as the assertion: snapshot, screenshot, or eval to confirm it before moving on. When `Expected` references a count, button text, or row attribute, prove it from the snapshot — not from "looks right".
+
+> **This doc is the source of truth.** If the UI changes, update this file in the same PR — out-of-date selectors silently degrade the test into "Claude clicked something."
+
+---
+
+## Preflight
+
+| # | Action | Expected |
+|---|---|---|
+| P1 | Confirm the openclaw gateway is up: `curl -fsS http://localhost:18789/healthz` (or the configured gateway port) | HTTP 200 |
+| P2 | Confirm Claude Preview is targeting Mission Control: `preview_list` shows a server pointing at this repo on port 4000/4001 | one running server |
+| P3 | If a server isn't running, start it: `preview_start` with the `mission-control-real` config | server reaches `[ready]` in logs |
+
+If the gateway isn't reachable, **stop here**: every flow below assumes the gateway path is the one being exercised. The defer-and-replay queue handles the offline case for `propose_from_notes` only; everything else just fails or falls back to deterministic synth, which is not what we're testing.
+
+---
+
+## Reset to a fresh database
+
+| # | Action | Expected |
+|---|---|---|
+| R1 | `preview_stop` (or kill the dev server manually) — the dev server holds an open handle on `mission-control.db` and a hot reset will leave a stale WAL behind | server stops |
+| R2 | `yarn db:reset` (wipes `mission-control.db` + sidecars, runs migrations on first DB access, then runs `db:seed`) | console prints `✅ Database seed complete (agents are gateway-synced; nothing else to seed).` |
+| R3 | `preview_start mission-control-real` | server boots; `preview_logs` shows migration log lines (`[Migration NNN]`) and no error |
+| R4 | Open `/agents` and confirm pages render before continuing | snapshot shows the **Agents** heading and the workspace switcher |
+
+**Checkpoints.** Any time the doc says “save the DB as a checkpoint named X”, run:
+
+```
+preview_stop
+yarn db:checkpoint <name>
+preview_start mission-control-real
+```
+
+Restore later with `yarn db:checkpoint:restore <name>`. List with `yarn db:checkpoint:list`. Snapshots live under `.tmp/checkpoints/`.
+
+---
+
+## Section 1 — Initial Setup
+
+The verbatim flow the user runs after a reset to bring the workspace + agents into a known-good state. Save the result as the checkpoint everything else builds from.
+
+| # | Action | Expected |
+|---|---|---|
+| 1.1 | Confirm gateway connection in the header (top banner reads `ONLINE`) | snapshot contains `ONLINE` |
+| 1.2 | Navigate to `/debug`. Click **Start collection** | button label flips to `Stop collection`; collection counter starts updating |
+| 1.3 | Navigate to `/agents`. Confirm gateway-synced agents are present | rows for `Builder`, `Coordinator`, `Learner`, `main`, plus the `Project Manager` PM agent. Each gateway-linked row shows the 🔗 icon |
+| 1.4 | Click the edit (✏️) action on the **Coordinator** row. Check the **Master Orchestrator** box. Click **Save** | modal closes; Coordinator row shows the master / orchestrator badge |
+| 1.5 | On the **Coordinator** row, click the **OpenClaw** button (or **Connect to OpenClaw** in the edit modal) to associate it with the gateway | row shows it's linked (no error toast) |
+| 1.6 | On the **main** row, click the **Disable** button | main row's status flips to disabled; subsequent roll-call should skip it |
+| 1.7 | Click **Reset all sessions**. Wait ~60s for sessions to stabilise | `preview_logs --search "session"` shows reconnects; toast/message confirms reset complete |
+| 1.8 | Click **Roll Call**. Wait until every active row is green | every non-disabled agent reports back; no rows stuck on "pending" |
+| 1.9 | Save checkpoint: `setup-stable` | `.tmp/checkpoints/setup-stable.db` exists |
+
+Everything below assumes you can `yarn db:checkpoint:restore setup-stable` to get back to this exact state.
+
+---
+
+## Section 2 — Initiative flow (Smart Snappy)
+
+Validates the Initiatives surface end-to-end: create → edit → plan with PM → decompose → review proposals.
+
+The reference test data (description, refinement prompt, decompose hint) is in [docs/TEST_DATA.md](TEST_DATA.md). Steps 2.1–2.3 are the verbatim flow; 2.4–2.10 are proposed coverage based on the surface area of `/initiatives` and `/initiatives/[id]` — adjust as needed.
+
+| # | Action | Expected |
+|---|---|---|
+| 2.1 | Navigate to `/initiatives`. Click **New initiative**. Fill: title `Smart Snappy`, kind `Epic`, no parent. Save | new row appears at the top of the list with kind=Epic, status=planned, no parent |
+| 2.2 | Click into **Smart Snappy**. Click into the **DESCRIPTION** section (or its "Add a description" CTA on a fresh initiative). Paste the **INITIATIVE 1** body from [TEST_DATA.md](TEST_DATA.md). Save | detail page shows the description; markdown renders |
+| 2.3 | On the detail page, click the icon button with `aria-label="Run with operator guidance"` that sits next to **Plan with PM** (it expands a guidance prompt input). Paste the **REFINE WITH PM GUIDANCE** prompt from [TEST_DATA.md](TEST_DATA.md). Click **Plan with PM** to dispatch | a draft proposal row appears with `trigger_kind = plan_initiative`; the panel either shows a streaming/loading indicator or a synthesised plan. `preview_logs --search "pm-dispatch"` shows a named-agent dispatch (not a synth fallback) |
+| 2.4 | When the plan proposal is ready, click into the proposal. Read the impact summary | impact_md is non-empty; structured `plan_suggestions` (refined description / complexity / target dates / deps) renders |
+| 2.5 | Click **Apply suggestions** (or equivalent) to populate the initiative draft. Save | the initiative's description / dates / complexity reflect the suggestions |
+| 2.6 | Back on the detail page, click **Decompose with PM**. (Optional: provide a hint such as "focus on backend first") | a draft proposal with `trigger_kind = decompose_initiative` lands; reviewing it shows 3–7 `create_child_initiative` diffs all parented to Smart Snappy |
+| 2.7 | Open the decompose proposal. Click **Accept** | proposal flips to `accepted`; child stories appear under Smart Snappy on `/initiatives`; each child has a `task_initiative_history` entry |
+| 2.8 | Pick one child. Click **Add child**, create a sub-story (e.g. "Daily checklist v0"). Save | new sub-story attaches under the child; tree view shows nested rows |
+| 2.9 | On a child, add a dependency (Add dependency dropdown → pick a sibling). Save | sibling appears in the child's deps list |
+| 2.10 | Save checkpoint: `smart-snappy-decomposed` | `.tmp/checkpoints/smart-snappy-decomposed.db` exists |
+
+**Regressions to watch for during 2.x:**
+- Plan-with-PM panel hangs forever (no timeout, no proposal lands) → this is the regression class that motivated this doc.
+- Resume-on-reopen: close the panel mid-stream, navigate away, navigate back. Expected: same draft proposal resumes, not a fresh dispatch.
+- Multiple Plan-with-PM clicks dispatch repeatedly (should be idempotent until the parent draft is rejected).
+- `preview_logs --search "session"` should show a fresh `plan-<uuid>` session per Plan/Decompose conversation, not the stable `dispatch-main` session.
+
+---
+
+## Section 3 — PM (disruption + chat + propose_from_notes)
+
+The PM surface is at `/pm` (chat + recent proposals) and `/pm/proposals/<id>` (review). The disruption flow is the original PM use case; `propose_from_notes` is the new one and is MCP-only — exercise it via `curl` from this doc.
+
+| # | Action | Expected |
+|---|---|---|
+| 3.1 | From `setup-stable` (or `smart-snappy-decomposed`), navigate to `/pm`. Type `Sarah out next week` (or any teammate name on the workspace) into the chat input. Send | a draft proposal lands in the **Recent proposals** list; impact_md mentions `add_availability` for that owner. `preview_logs` shows the named-agent path won (not synth fallback) |
+| 3.2 | Click into the new draft. Click **Reject**. Navigate back to `/pm` | proposal status flips to `rejected`; the PM chat shows the reject acknowledgement; no stale draft remains visible in the chat panel |
+| 3.3 | Send a second disruption: `Customer demo delayed until 2026-06-15`. Click into the draft | proposal includes a `shift_initiative_target` diff if any initiative title matches "demo"; otherwise an availability/at-risk diff with the explicit date |
+| 3.4 | On that proposal, click **Refine** with the constraint `keep launch on schedule, defer analytics`. Save | parent proposal flips to `superseded`; a new draft inherits the trigger and shows the constraint reflected in the new impact |
+| 3.5 | Accept the refined proposal | parent superseded chain stays; the accepted proposal has applied changes (verifiable on `/initiatives` or `/roadmap`) |
+| 3.6 | **propose_from_notes** (MCP, gateway up). From a terminal: `curl -X POST http://localhost:4001/api/mcp -H 'content-type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"propose_from_notes","arguments":{"agent_id":"<any agent id>","workspace_id":"default","notes_text":"Stand-up notes:\n- ship onboarding\n- fix #123"}}}'` (replace agent_id with an active row's id from `/agents`) | response `{ status: "dispatched", proposal_id: "<uuid>" }`. Open the proposal at `/pm/proposals/<uuid>` and confirm it carries a heterogeneous PmDiff[] (creates + tasks). |
+| 3.7 | **propose_from_notes** (gateway down). Disable openclaw temporarily (e.g. firewall the port or stop the gateway), re-issue the same curl | response `{ status: "queued", pending_id: "<uuid>" }`. Row exists in `pm_pending_notes` with status=`pending` |
+| 3.8 | Re-enable the gateway. Wait up to 60s for the periodic drain | `preview_logs --search "pm-pending-drain"` shows a successful drain; the row's status flips to `dispatched`; a new proposal exists; UI on `/pm` reflects it |
+
+**Regressions to watch for:**
+- Proposal lands but the PM chat panel never updates (SSE/listener regression).
+- Refine creates a new draft but inherits *empty* impact/changes (the synth/agent never re-fills).
+- After accept, derived dates on `/roadmap` don't reflect the change → derivation cache stale.
+
+---
+
+## Section 4 — Roadmap (derivation, owner availability, ripple)
+
+The roadmap timeline lives at `/roadmap` with Week / Month / Quarter zoom. The derivation engine reads availability + dependencies + complexity to compute target dates.
+
+| # | Action | Expected |
+|---|---|---|
+| 4.1 | After accepting decompose in §2, navigate to `/roadmap`. Pick the **Quarter** zoom | Smart Snappy + its children render on the timeline with derived target dates; arrows show dep edges |
+| 4.2 | Click **Recompute now** | "Last computed" timestamp updates; visible target dates may shift slightly; no error toasts |
+| 4.3 | Add an owner-availability window via PM (`Sarah out 2026-05-01 to 2026-05-15`) and accept the proposal. Return to `/roadmap` and Recompute | initiatives owned by Sarah whose target windows overlap the unavailability shift later; arrow/dep chain remains consistent |
+| 4.4 | Toggle Week ↔ Month ↔ Quarter | bars resize; nothing renders off-screen; no infinite scroll |
+| 4.5 | Save checkpoint: `roadmap-after-disruption` | `.tmp/checkpoints/roadmap-after-disruption.db` exists |
+
+**Regressions to watch for:**
+- Recompute spins forever (derivation cache deadlock).
+- Bars overlap or duplicate when zoom changes.
+- Owner-availability impact lands in the proposal but not in derivation output.
+
+---
+
+## Section 5 — Cross-surface regressions
+
+A short pass that goes through several surfaces in sequence to catch subtle interaction bugs.
+
+| # | Action | Expected |
+|---|---|---|
+| 5.1 | From `roadmap-after-disruption`, on `/initiatives` pick a story and **Promote to task** | a draft task appears on `/workspace/default` (Task Board, draft column); the story's link to that task is visible in detail |
+| 5.2 | Move the task draft → inbox via the Task Board | task transitions to inbox; no "ghost" duplicate row remains; events feed shows `task_promoted_to_inbox` |
+| 5.3 | Open the PM chat and send any message. While streaming, navigate to `/initiatives` and back | streaming finishes; chat history is consistent on return; no duplicate user message |
+| 5.4 | `/debug` → **Run diagnostic**. Export the collection started in 1.2 | diagnostic completes; export downloads a JSON file |
+
+---
+
+## Stubs (to be expanded once PM/Initiatives/Roadmap are stable)
+
+Not yet covered — keep these as placeholders so the doc is honest about scope. We'll fill them in next.
+
+### Section 6 — Task Board
+
+- TBD: Inbox triage → assigned → in_progress → review → done; failure path; dispatching to a worker; deliverable acceptance flow.
+
+### Section 7 — Deliverables
+
+- TBD: Listing, opening a deliverable, diff vs prior, accept / reject from the UI.
+
+### Section 8 — Autopilot / Products
+
+- TBD: Product creation, research cycles, the autopilot loop end-to-end.
+
+---
+
+## Reporting regressions
+
+When a step fails:
+
+1. Capture `preview_screenshot` + `preview_snapshot` + the relevant `preview_logs` slice (filter by `[pm-`, `[Migration`, `[OpenClaw]`, `chat_event`, etc.).
+2. Note **which checkpoint** you were on, the **step number**, and the **first observed deviation** from `Expected`.
+3. If the regression repros from a clean `setup-stable`, file a follow-up. If it only repros from an in-flight checkpoint, copy that `.tmp/checkpoints/<name>.db` to `.tmp/db-backups/` so we can re-load it later.
+
+---
+
+## Maintenance
+
+- When a UI affordance moves or renames, update the matching `Action` cell in the same PR. Stale selectors are worse than no selectors.
+- New surfaces should land here as a new section before merging the feature, not after a regression.
+- This file is intentionally one document. Splitting per-surface docs caused them to drift out of sync.

--- a/docs/TEST_DATA.md
+++ b/docs/TEST_DATA.md
@@ -1,0 +1,28 @@
+## INITIATIVE 1 - Smart Snappy - EPIC
+
+Smart Snappy turns the SnapCalorie assistant from a passive meal-logging chatbot into a proactive, personalized coach that guides users toward their health goals.
+
+## What it includes
+
+- **Snappy Service backend (TBD how stateless functions hold context)** — a layer that compiles user activity, goals, and recent responses, then prompts an AI model and returns structured actions (checklist items, tips, meal suggestions, notifications).
+- **Memory + personalization** — store loose user-context JSON the AI can read/write across sessions. Probably Firebase to start? May need a stricter schema later.
+- **Onboarding flow** — Snappy interviews the user about goals, preferences, constraints, cooking habits, and schedule, then writes the baseline memory.
+- **Daily / weekly checklist** — adaptive list tied to user goals (protein, fiber, hydration, mood support, etc.).
+- **Meal & snack suggestions** — pulled from remaining macro targets and known deficiencies; optional grocery integration (later).
+- **Dashboard cards** — render whatever Snappy returns: checklist card, snack suggestion, goal nudge, recipe, grocery list. ??? — exact card schema not yet decided.
+- **Conversational UI** — let users talk back to Snappy beyond just Q&A. RN voice? Floating button? Clippy-style? — open question.
+- **Advanced goals** (later) — fertility, pregnancy, cycle, sleep, stress.
+
+## Acceptance
+
+Users can complete onboarding, see a daily checklist on the home dashboard, get at least one meal suggestion per day, and have a back-and-forth conversation with Snappy that references their stored preferences. Internal team can ship a v0 in ~6-8 weeks with one backend engineer and one mobile engineer.
+
+## Open questions
+
+- How do we keep prompts cheap when running daily for every user?
+- Do notifications go through the existing push system or a new channel?
+- What's the migration path from the current chatbot UI?
+
+## REFINE WITH PM GUIDANCE
+
+Refine and clean up the description: remove all placeholders, ???, and open-ended hedges ("probably", "TBD", "may need"); replace each with a concrete decision or a structured TODO that names the work and the owner area (backend / mobile / design). Keep the section structure (Description, What it includes, Acceptance, Open questions) but rewrite Open questions as resolved decisions or scoped follow-ups.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "db:backup": "sqlite3 mission-control.db 'PRAGMA wal_checkpoint(TRUNCATE);' && cp mission-control.db mission-control.db.backup && echo 'Backed up to mission-control.db.backup'",
     "db:restore": "cp mission-control.db.backup mission-control.db && echo 'Restored from backup'",
     "db:reset": "rm -f mission-control.db mission-control.db-* && npm run db:seed",
+    "db:checkpoint": "tsx scripts/db-checkpoint.ts save",
+    "db:checkpoint:restore": "tsx scripts/db-checkpoint.ts restore",
+    "db:checkpoint:list": "tsx scripts/db-checkpoint.ts list",
     "openapi:generate": "next-openapi-gen generate"
   },
   "dependencies": {

--- a/scripts/db-checkpoint.ts
+++ b/scripts/db-checkpoint.ts
@@ -1,0 +1,109 @@
+/**
+ * DB checkpoint helper for the preview-based test flow.
+ *
+ *   yarn db:checkpoint <name>          — save a snapshot of the live DB
+ *   yarn db:checkpoint:restore <name>  — restore a snapshot to the live DB
+ *   yarn db:checkpoint:list            — show available snapshots
+ *
+ * Snapshots live under `.tmp/checkpoints/<name>.db`. We force a WAL
+ * checkpoint on the source so the snapshot is self-contained; on
+ * restore we delete -shm/-wal sidecars that belong to the previous
+ * runtime so SQLite doesn't see a stale write-ahead log.
+ *
+ * The dev server should be stopped while restoring — running it would
+ * either crash on the missing WAL or quietly corrupt the new file.
+ */
+
+import { existsSync, mkdirSync, copyFileSync, readdirSync, rmSync, statSync } from 'fs';
+import { join, basename } from 'path';
+import Database from 'better-sqlite3';
+
+const ROOT = process.cwd();
+const LIVE_DB = join(ROOT, 'mission-control.db');
+const CHECKPOINT_DIR = join(ROOT, '.tmp', 'checkpoints');
+
+function usage(): never {
+  console.error('Usage: tsx scripts/db-checkpoint.ts <save|restore|list> [name]');
+  process.exit(1);
+}
+
+function ensureCheckpointDir(): void {
+  mkdirSync(CHECKPOINT_DIR, { recursive: true });
+}
+
+function checkpointPath(name: string): string {
+  return join(CHECKPOINT_DIR, `${name}.db`);
+}
+
+function save(name: string): void {
+  if (!existsSync(LIVE_DB)) {
+    console.error(`No live DB at ${LIVE_DB}.`);
+    process.exit(1);
+  }
+  ensureCheckpointDir();
+  // Force a WAL checkpoint so the saved file is self-contained — no
+  // stale -wal/-shm needed.
+  const db = new Database(LIVE_DB);
+  try {
+    db.pragma('wal_checkpoint(TRUNCATE)');
+  } finally {
+    db.close();
+  }
+  const dest = checkpointPath(name);
+  copyFileSync(LIVE_DB, dest);
+  const size = statSync(dest).size;
+  console.log(`✅ saved ${dest} (${(size / 1024).toFixed(1)} KB)`);
+}
+
+function restore(name: string): void {
+  const src = checkpointPath(name);
+  if (!existsSync(src)) {
+    console.error(`No checkpoint at ${src}.`);
+    process.exit(1);
+  }
+  // Drop sidecars that belong to a previous runtime — leaving them
+  // around makes SQLite think the new file is mid-transaction.
+  for (const suffix of ['-wal', '-shm']) {
+    const p = LIVE_DB + suffix;
+    if (existsSync(p)) rmSync(p);
+  }
+  copyFileSync(src, LIVE_DB);
+  console.log(`✅ restored ${LIVE_DB} from ${src}`);
+  console.log('   (restart the dev server before using the UI)');
+}
+
+function list(): void {
+  if (!existsSync(CHECKPOINT_DIR)) {
+    console.log('(no checkpoints yet — run `yarn db:checkpoint <name>`)');
+    return;
+  }
+  const rows = readdirSync(CHECKPOINT_DIR)
+    .filter(f => f.endsWith('.db'))
+    .map(f => {
+      const p = join(CHECKPOINT_DIR, f);
+      const s = statSync(p);
+      return { name: basename(f, '.db'), size_kb: (s.size / 1024).toFixed(1), mtime: s.mtime.toISOString() };
+    })
+    .sort((a, b) => b.mtime.localeCompare(a.mtime));
+  if (rows.length === 0) {
+    console.log('(no checkpoints yet — run `yarn db:checkpoint <name>`)');
+    return;
+  }
+  for (const r of rows) {
+    console.log(`  ${r.name.padEnd(30)} ${r.size_kb.padStart(8)} KB  ${r.mtime}`);
+  }
+}
+
+const cmd = process.argv[2];
+const name = process.argv[3];
+
+if (cmd === 'list') list();
+else if (cmd === 'save') {
+  if (!name) usage();
+  save(name);
+} else if (cmd === 'restore') {
+  if (!name) usage();
+  restore(name);
+} else {
+  usage();
+}

--- a/specs/pm-dispatch-async.md
+++ b/specs/pm-dispatch-async.md
@@ -1,0 +1,103 @@
+# PM dispatch — async orchestration
+
+## Why
+
+Today's `dispatchPmSynthesized` is synchronous-with-timeout: it sends to the
+named openclaw PM agent and waits up to `NAMED_AGENT_TIMEOUT_MS` (60s) for
+the agent's `propose_changes` to land. If the agent takes longer (e.g. cold
+session + complex `plan_initiative` prompt — observed in the wild at ~70s),
+two bugs surface:
+
+1. The 60s budget elapses, the deterministic `synthesizePlanInitiative`
+   fallback fires, and the resulting low-quality proposal is what the
+   operator sees.
+2. The agent's high-quality `propose_changes` lands ~10s later, gets a fresh
+   `pm_proposals` row, but is **orphaned** — no `target_initiative_id`,
+   `trigger_kind = 'manual'`, and nothing supersedes the synth fallback. The
+   UI never surfaces it.
+
+This is a regression class the unit/e2e tests miss because they mock the
+gateway client and the timing never realistically diverges.
+
+## Tiers
+
+### Tier 1 — per-kind timeout
+
+`DispatchSynthesizedInput` gains an optional `timeoutMs?: number`.
+`dispatchPmSynthesized` passes it through to `sendChatAndAwaitReply`, falling
+back to `namedAgentTimeoutMs()` (60s) when omitted.
+
+The two slow-prompt callers — `/api/pm/plan-initiative` and
+`/api/pm/decompose-initiative` — pass `timeoutMs: 120_000`.
+
+Risk: low. Disruption + refine paths keep their 60s default.
+
+### Tier 2 — late-arrival reconciler
+
+After the named-agent path either succeeds or times out, a background watcher
+runs in the same dispatch promise's tail (default 120s past the original
+timeout). When a NEW draft `pm_proposals` row appears in the same workspace,
+keyed by the dispatch's `correlation_id` (matched via the agent's chat
+session), the watcher:
+
+1. Stamps the agent's row with `trigger_kind`, `target_initiative_id`, and
+   `parent_proposal_id = synth_row.id`.
+2. Marks the original synth row as `superseded`.
+3. Broadcasts a new SSE event `pm_proposal_replaced` carrying
+   `{ workspace_id, old_id, new_id }`.
+
+The plan-initiative panel subscribes to that SSE event and reloads (or
+navigates to the new id).
+
+If no agent row arrives within the tail window, the watcher exits silently
+and the synth row stays as the operator's draft (today's behavior, just less
+likely).
+
+### Tier 3 — async-by-default API contract
+
+`/api/pm/plan-initiative` and `/api/pm/decompose-initiative` no longer await
+the named-agent round trip. They:
+
+1. Persist the synth proposal immediately as a placeholder draft.
+2. Kick off the named-agent dispatch as a fire-and-forget background promise
+   that uses Tier 2's reconciler.
+3. Return the placeholder proposal in the POST response with
+   `dispatch_state: 'pending_agent'`.
+
+The plan-initiative panel renders the placeholder (synth content) right
+away, shows a "PM agent is still working — content may update" indicator,
+and listens for `pm_proposal_replaced` to swap content when the agent's
+proposal lands. Accept is soft-disabled until either the agent completes or
+the tail window elapses — operator opt-out via "Accept synth as-is".
+
+## Files
+
+- `src/lib/agents/pm-dispatch.ts` — plumbing for all three tiers
+- `src/lib/types.ts` — extend `SSEEventType` with `pm_proposal_replaced` and
+  `pm_proposal_dispatch_state_changed`
+- `src/lib/db/pm-proposals.ts` — add `dispatch_state` column (`'pending_agent' | 'agent_complete' | 'synth_only'`)
+  via migration 055; `createProposal` accepts it.
+- `src/app/api/pm/plan-initiative/route.ts` and
+  `src/app/api/pm/decompose-initiative/route.ts` — async path + Tier 1
+  timeout opt-in.
+- Plan-initiative panel UI — subscribe to `pm_proposal_replaced` and
+  refetch.
+
+## Tests
+
+- `pm.test.ts`:
+  - Tier 1: explicit `timeoutMs` is honored end-to-end (mock agent waits past
+    60s; with `timeoutMs: 120_000` the named-agent path wins).
+  - Tier 2: agent's `propose_changes` lands 10s after the named-agent
+    timeout → reconciler stamps the new row, supersedes the synth row,
+    broadcasts SSE.
+  - Tier 3: API returns placeholder synth row immediately with
+    `dispatch_state: 'pending_agent'`; agent row supersedes async.
+- `pm-proposals.test.ts`: `dispatch_state` column round-trip.
+
+## Out of scope
+
+- Streaming the agent's chain-of-thought into the panel as it works (would
+  be ideal UX but requires a separate SSE channel keyed on session_key).
+- Auto-rejecting the synth row when superseded (operator may want to compare
+  synth vs. agent diff manually).

--- a/src/app/(app)/agents/page.tsx
+++ b/src/app/(app)/agents/page.tsx
@@ -35,6 +35,7 @@ import { useMissionControl } from '@/lib/store';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 import type { Agent, AgentStatus, AgentHealthState, OpenClawSession } from '@/lib/types';
 import { AgentModal } from '@/components/AgentModal';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { DiscoverAgentsModal } from '@/components/DiscoverAgentsModal';
 import { HealthIndicator } from '@/components/HealthIndicator';
 import { AgentPingIndicator } from '@/components/AgentPingIndicator';
@@ -87,6 +88,15 @@ export default function AgentsPage() {
   const [rollCallBusy, setRollCallBusy] = useState(false);
   const [rollCallResult, setRollCallResult] = useState<RollCallResultView | null>(null);
   const [resetSessionsBusy, setResetSessionsBusy] = useState(false);
+  // Replaces native window.confirm() — see §1.7 finding in PREVIEW_TEST_FINDINGS.
+  // The native dialog blocks automation tooling and breaks the test-flow walk.
+  const [pendingConfirm, setPendingConfirm] = useState<null | {
+    title: string;
+    body: React.ReactNode;
+    confirmLabel: string;
+    destructive?: boolean;
+    onConfirm: () => void;
+  }>(null);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [defaultModel, setDefaultModel] = useState<string>('');
   const [emojiPickerFor, setEmojiPickerFor] = useState<string | null>(null);
@@ -247,17 +257,28 @@ export default function AgentsPage() {
     }
   };
 
-  const resetAllSessions = async () => {
-    if (
-      !confirm(
-        'Reset ALL agent sessions?\n\n' +
-          '  1. Aborts in-flight Product Autopilot research/ideation cycles.\n' +
-          '  2. Wipes Mission Control session tracking.\n' +
-          '  3. Sends `/reset` to every active gateway-synced agent.\n\n' +
-          'Use after editing persona files or when sessionKey routing has drifted.',
-      )
-    )
-      return;
+  const resetAllSessions = () => {
+    setPendingConfirm({
+      title: 'Reset ALL agent sessions?',
+      body: (
+        <ol className="list-decimal pl-5 space-y-1">
+          <li>Aborts in-flight Product Autopilot research/ideation cycles.</li>
+          <li>Wipes Mission Control session tracking.</li>
+          <li>
+            Sends <code className="text-xs px-1 rounded bg-mc-bg-secondary">/reset</code> to every active gateway-synced agent.
+          </li>
+          <li className="text-mc-text-secondary">
+            Use after editing persona files or when sessionKey routing has drifted.
+          </li>
+        </ol>
+      ),
+      confirmLabel: 'Reset all',
+      destructive: true,
+      onConfirm: () => { void doResetAllSessions(); },
+    });
+  };
+
+  const doResetAllSessions = async () => {
     setResetSessionsBusy(true);
     try {
       const res = await fetch('/api/openclaw/sessions', { method: 'DELETE' });
@@ -327,12 +348,21 @@ export default function AgentsPage() {
     setTogglingAgentId(null);
   };
 
-  const resetAgentSession = async (agent: Agent) => {
+  const resetAgentSession = (agent: Agent) => {
     if (!agent.gateway_agent_id) {
       alert('This agent has no gateway_agent_id; nothing to reset on the gateway side.');
       return;
     }
-    if (!confirm(`Reset ${agent.name}'s session? The agent will re-init persona files on its next message.`)) return;
+    setPendingConfirm({
+      title: `Reset ${agent.name}'s session?`,
+      body: <p>The agent will re-init persona files on its next message.</p>,
+      confirmLabel: 'Reset',
+      destructive: true,
+      onConfirm: () => { void doResetAgentSession(agent); },
+    });
+  };
+
+  const doResetAgentSession = async (agent: Agent) => {
     setResettingAgentId(agent.id);
     try {
       const res = await fetch(`/api/agents/${agent.id}/reset`, { method: 'POST' });
@@ -554,6 +584,19 @@ export default function AgentsPage() {
       {showDiscoverModal && (
         <DiscoverAgentsModal onClose={() => setShowDiscoverModal(false)} workspaceId={workspaceId} />
       )}
+      <ConfirmDialog
+        open={pendingConfirm !== null}
+        title={pendingConfirm?.title ?? ''}
+        body={pendingConfirm?.body ?? null}
+        confirmLabel={pendingConfirm?.confirmLabel ?? 'Confirm'}
+        destructive={pendingConfirm?.destructive}
+        onConfirm={() => {
+          const action = pendingConfirm?.onConfirm;
+          setPendingConfirm(null);
+          action?.();
+        }}
+        onCancel={() => setPendingConfirm(null)}
+      />
     </div>
   );
 }

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -69,6 +69,11 @@ interface PmProposal {
   trigger_kind: string;
   impact_md: string;
   proposed_changes: PmDiff[];
+  /** Structured plan-initiative suggestions; populated by `propose_changes`'s
+   *  plan_suggestions param OR by the deterministic synth path. The legacy
+   *  `<!--pm-plan-suggestions {json}-->` sidecar in impact_md is still used
+   *  as a fallback for older rows but should not be written for new ones. */
+  plan_suggestions: Record<string, unknown> | null;
   status: 'draft' | 'accepted' | 'rejected' | 'superseded';
   applied_at: string | null;
   parent_proposal_id: string | null;
@@ -853,8 +858,12 @@ function ChatMessageRow({
           as HTML comments) and render normally.
         */}
         {(() => {
+          // Prefer the structured `plan_suggestions` column (canonical since #85);
+          // fall back to the legacy `<!--pm-plan-suggestions {json}-->` sidecar
+          // for older rows that haven't been re-dispatched.
           const suggestions = proposal.trigger_kind === 'plan_initiative'
-            ? parseSuggestionsFromImpactMd(proposal.impact_md)
+            ? ((proposal.plan_suggestions as PlanSuggestionsLite | null) ??
+               parseSuggestionsFromImpactMd(proposal.impact_md))
             : null;
           const cleanContent = stripSuggestionsSidecar(message.content);
           return (
@@ -1223,9 +1232,11 @@ function ApplyPlanToInitiativeModal({
   const [applying, setApplying] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
-  // Pull the structured suggestions out of the impact_md HTML comment —
-  // same parser shape as the inline detail-page panel.
+  // Prefer the structured `plan_suggestions` column (canonical since #85);
+  // fall back to the legacy `<!--pm-plan-suggestions {json}-->` sidecar in
+  // impact_md for older rows that pre-date the column.
   const suggestions: PlanSuggestionsLite | null = (() => {
+    if (proposal.plan_suggestions) return proposal.plan_suggestions as PlanSuggestionsLite;
     const m = proposal.impact_md.match(/<!--pm-plan-suggestions\s+([\s\S]*?)\s*-->/);
     if (!m) return null;
     try {

--- a/src/app/api/pm/decompose-initiative/route.ts
+++ b/src/app/api/pm/decompose-initiative/route.ts
@@ -101,10 +101,14 @@ export async function POST(request: NextRequest) {
     // ~/.openclaw/workspaces/mc-project-manager). On timeout or no
     // session, the synthesized proposal is persisted exactly like
     // before so the operator always has something to react to.
-    const dispatch = await dispatchPmSynthesized({
+    const dispatch = dispatchPmSynthesized({
       workspace_id: parent.workspace_id,
       trigger_text: triggerText,
       trigger_kind: 'decompose_initiative',
+      // Same rationale as plan-initiative: composing 3-7 children with
+      // dep wiring takes the named PM agent more than the default 60s on
+      // cold sessions.
+      timeoutMs: 120_000,
       synth: { impact_md: synth.impact_md, changes: synth.changes },
       agent_prompt:
         `Decompose initiative ${parent.id} ("${parent.title}", kind=${parent.kind}) ` +
@@ -174,8 +178,9 @@ export async function GET(request: NextRequest) {
     impact_md: string;
     proposed_changes: string;
     status: string;
+    dispatch_state: string | null;
   }>(
-    `SELECT id, workspace_id, trigger_text, trigger_kind, impact_md, proposed_changes, status
+    `SELECT id, workspace_id, trigger_text, trigger_kind, impact_md, proposed_changes, status, dispatch_state
      FROM pm_proposals
      WHERE workspace_id = ?
        AND trigger_kind = 'decompose_initiative'

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -30,7 +30,7 @@ import { synthesizePlanInitiative } from '@/lib/agents/pm-agent';
 import { PmProposalValidationError } from '@/lib/db/pm-proposals';
 import { postPmChatMessage, dispatchPmSynthesized } from '@/lib/agents/pm-dispatch';
 import { parseSuggestionsFromImpactMd } from '@/lib/pm/applyPlanInitiativeProposal';
-import { run, queryOne } from '@/lib/db';
+import { queryOne } from '@/lib/db';
 
 export const dynamic = 'force-dynamic';
 
@@ -73,7 +73,9 @@ export async function POST(request: NextRequest) {
 
   try {
     const snapshot = getRoadmapSnapshot({ workspace_id: parsed.data.workspace_id });
-    const synth = synthesizePlanInitiative(snapshot, parsed.data.draft);
+    const synth = synthesizePlanInitiative(snapshot, parsed.data.draft, {
+      targetInitiativeId: parsed.data.target_initiative_id ?? null,
+    });
 
     // Mint a session key for this planning conversation. Each new plan gets
     // a fresh gateway session (clean context, no prior-plan bleed). Refine
@@ -133,12 +135,17 @@ export async function POST(request: NextRequest) {
     // session, the synthesized advisory proposal is persisted exactly
     // like before. proposed_changes stays an empty array for the
     // advisory plan_initiative case = nothing to apply on accept.
-    const dispatch = await dispatchPmSynthesized({
+    const dispatch = dispatchPmSynthesized({
       workspace_id: parsed.data.workspace_id,
       trigger_text: triggerText,
       trigger_kind: 'plan_initiative',
       target_initiative_id: parsed.data.target_initiative_id ?? null,
       planSessionKey,
+      // plan_initiative prompts are large (description + guidance + roadmap
+      // snapshot summary) and the PM agent often takes 60-90s to compose a
+      // structured rewrite. Default 60s is too tight; observed cold-session
+      // round trips at ~70s in the wild.
+      timeoutMs: 120_000,
       synth: { impact_md: synth.impact_md, changes: synth.changes, plan_suggestions: synth.suggestions as unknown as Record<string, unknown> },
       agent_prompt:
         `Plan an initiative draft titled "${parsed.data.draft.title}". ` +
@@ -150,25 +157,13 @@ export async function POST(request: NextRequest) {
         `pass the structured plan_suggestions parameter directly (do NOT embed JSON in impact_md). ` +
         `See your SOUL.md for the plan_suggestions shape.`,
     });
-    let proposal = dispatch.proposal;
-
-    // Always-embed-the-sidecar guarantee: when the PM agent answered via
-    // the gateway, its impact_md is freeform — LLMs are unreliable about
-    // including arbitrary HTML-comment JSON sidecars even when SOUL.md
-    // tells them to. Without the sidecar, the chat-card Apply flow has
-    // no structured suggestions to apply. We always have synth.suggestions
-    // here, so inject it post-hoc when missing and persist the patched
-    // impact_md to the same row. The synth path naturally already
-    // includes it, so this is a no-op there.
-    if (!parseSuggestionsFromImpactMd(proposal.impact_md)) {
-      const sidecar = `\n\n<!--pm-plan-suggestions ${JSON.stringify(synth.suggestions)} -->`;
-      const patchedMd = proposal.impact_md + sidecar;
-      run(
-        'UPDATE pm_proposals SET impact_md = ? WHERE id = ?',
-        [patchedMd, proposal.id],
-      );
-      proposal = { ...proposal, impact_md: patchedMd };
-    }
+    const proposal = dispatch.proposal;
+    // Note: the synth placeholder created by `dispatchPmSynthesized` already
+    // has `plan_suggestions` populated as a structured column (canonical
+    // since #85). The legacy `<!--pm-plan-suggestions {json}-->` sidecar
+    // appender that used to live here is removed — consumers now read the
+    // column directly. The agent's superseding row, when it lands, also
+    // carries plan_suggestions via the `propose_changes` MCP param.
 
     // Best-effort chat echo for audit visibility in /pm. Use the
     // PROPOSAL's impact_md — when the named PM agent answered, that's
@@ -262,6 +257,7 @@ export async function GET(request: NextRequest) {
     applied_by_agent_id: string | null;
     parent_proposal_id: string | null;
     target_initiative_id: string | null;
+    dispatch_state: string | null;
     created_at: string;
   }>(
     `SELECT * FROM pm_proposals

--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -102,16 +102,21 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           (draft.description ? `${draft.description as string}\n\n` : '') +
           `Refine: ${parsed.data.additional_constraint}`,
       } as Parameters<typeof synthesizePlanInitiative>[1];
-      const synth = synthesizePlanInitiative(snapshot, synthDraft);
+      const synth = synthesizePlanInitiative(snapshot, synthDraft, {
+        targetInitiativeId: parent.target_initiative_id ?? null,
+      });
 
       // Route through the PM gateway agent (same as the initial plan
       // dispatch) so the refinement gets an LLM-based response instead of
       // the deterministic heuristic that just capitalises the first letter.
-      const dispatch = await dispatchPmSynthesized({
+      const dispatch = dispatchPmSynthesized({
         workspace_id: parent.workspace_id,
         trigger_text: child.trigger_text,
         trigger_kind: 'plan_initiative',
         planSessionKey,
+        // Match the initial plan dispatch's longer wait — refines hit the
+        // same large-prompt cold-session profile.
+        timeoutMs: 120_000,
         synth: { impact_md: synth.impact_md, changes: synth.changes },
         agent_prompt:
           `Refine the plan for initiative titled "${draftTitle}". ` +
@@ -122,22 +127,32 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           `pass the structured plan_suggestions parameter directly (do NOT embed JSON in impact_md). ` +
           `See your SOUL.md for the plan_suggestions shape.`,
       });
+      // Refine has a pre-allocated child row to copy content onto, so we
+      // wait for the full dispatch lifecycle (Tier 2 reconciliation
+      // included) rather than returning the synth placeholder immediately.
+      const settled = await dispatch.completion;
 
-      const agentImpactMd = dispatch.proposal.impact_md;
+      const agentImpactMd = settled.final.impact_md;
       // Resolve structured suggestions: prefer what the agent wrote into
       // plan_suggestions (via propose_changes MCP param), then sidecar,
       // then the deterministic synth. This eliminates the sidecar-injection
       // band-aid that was applied here before.
       const refinedSuggestions =
-        (dispatch.proposal.plan_suggestions as typeof synth.suggestions | null) ??
+        (settled.final.plan_suggestions as typeof synth.suggestions | null) ??
         parseSuggestionsFromImpactMd(agentImpactMd) ??
         synth.suggestions;
 
-      // dispatchPmSynthesized created its own proposal row — delete it
-      // since we already have the pre-allocated child from refineProposal().
+      // dispatchPmSynthesized may have created up to two transient rows:
+      // the synth placeholder, and (if the named agent responded) a
+      // separate agent row that supersedes it. Refine has its own
+      // pre-allocated child row to copy content onto, so both transient
+      // rows are cleaned up.
+      const { run: del } = await import('@/lib/db');
       if (dispatch.proposal.id !== child.id) {
-        const { run: del } = await import('@/lib/db');
         del('DELETE FROM pm_proposals WHERE id = ?', [dispatch.proposal.id]);
+      }
+      if (settled.final.id !== dispatch.proposal.id && settled.final.id !== child.id) {
+        del('DELETE FROM pm_proposals WHERE id = ?', [settled.final.id]);
       }
 
       newImpactMd = agentImpactMd;
@@ -164,15 +179,39 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       // Default disruption-analysis path. We borrow dispatchPm's
       // synthesizer and patch the result onto the pre-allocated child
       // row, then delete the side-effect row dispatchPm created.
-      const synthesized = await dispatchPm({
+      // Don't forward `child.trigger_text` directly — it carries the
+      // `[refine] <constraint>` envelope written by `refineProposalDb`,
+      // and the `[refine]` token nudges the PM agent to call the
+      // `refine_proposal` MCP tool, which itself calls dispatchPm and
+      // creates a recursive cascade. Build a clean disruption-style
+      // trigger that combines the original parent context with the
+      // operator's new constraint, plus an explicit "use propose_changes"
+      // instruction so the agent stays on the right tool.
+      const cleanTrigger =
+        `Operator refinement of an earlier ${parent.trigger_kind} proposal.\n\n` +
+        `Original context:\n${(parent.trigger_text || '').replace(/\n*\[refine\][\s\S]*$/, '').trim()}\n\n` +
+        `New constraint to incorporate: ${parsed.data.additional_constraint}\n\n` +
+        `Respond by calling \`propose_changes\` with an updated impact_md + diff list. ` +
+        `Do NOT call \`refine_proposal\` — that's an operator-only tool and would create a dispatch loop.`;
+      const synthesized = dispatchPm({
         workspace_id: parent.workspace_id,
-        trigger_text: child.trigger_text,
+        trigger_text: cleanTrigger,
         trigger_kind: parent.trigger_kind,
       });
-      newImpactMd = synthesized.proposal.impact_md;
-      newChanges = synthesized.proposal.proposed_changes;
+      // Refine has a pre-allocated child row to copy content onto, so
+      // wait for the full lifecycle (Tier 2 reconciler included) rather
+      // than returning the synth placeholder immediately.
+      const settled = await synthesized.completion;
+      newImpactMd = settled.final.impact_md;
+      newChanges = settled.final.proposed_changes;
       const { run } = await import('@/lib/db');
-      run(`DELETE FROM pm_proposals WHERE id = ?`, [synthesized.proposal.id]);
+      // Clean up both the placeholder and (if separate) the agent's row.
+      if (synthesized.proposal.id !== child.id) {
+        run(`DELETE FROM pm_proposals WHERE id = ?`, [synthesized.proposal.id]);
+      }
+      if (settled.final.id !== synthesized.proposal.id && settled.final.id !== child.id) {
+        run(`DELETE FROM pm_proposals WHERE id = ?`, [settled.final.id]);
+      }
     }
 
     const { run } = await import('@/lib/db');

--- a/src/app/api/pm/proposals/route.ts
+++ b/src/app/api/pm/proposals/route.ts
@@ -32,10 +32,14 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       );
     }
-    const result = await dispatchPm(parsed.data);
+    const result = dispatchPm(parsed.data);
     return NextResponse.json(
       {
         proposal: result.proposal,
+        awaiting_agent: result.awaiting_agent,
+        // Back-compat: flag indicates the *current* row is the synth
+        // placeholder. SSE `pm_proposal_replaced` will follow when the
+        // agent's proposal supersedes it.
         used_synthesize_fallback: result.used_synthesize_fallback,
       },
       { status: 201 },

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+/**
+ * Lightweight confirmation modal — drop-in replacement for `window.confirm()`.
+ *
+ * Native `confirm()` blocks the JS event loop and can't be driven by
+ * preview/automation tooling, which surfaced as a §1.7 finding while
+ * walking PREVIEW_TEST_FLOW.md (`Reset all sessions`).
+ *
+ * Usage (controlled):
+ *
+ *   const [confirm, setConfirm] = useState<null | (() => void)>(null);
+ *   …
+ *   <ConfirmDialog
+ *     open={confirm !== null}
+ *     title="Reset ALL agent sessions?"
+ *     body={<p>This will… </p>}
+ *     confirmLabel="Reset"
+ *     destructive
+ *     onConfirm={() => { confirm?.(); setConfirm(null); }}
+ *     onCancel={() => setConfirm(null)}
+ *   />
+ *
+ * The component renders only when `open` is true, traps focus on the
+ * primary button, and returns the user's choice via the two callbacks.
+ */
+
+import { useEffect, useRef } from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  body: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Style the confirm button as destructive (red). */
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  body,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const confirmRef = useRef<HTMLButtonElement | null>(null);
+
+  // Focus the primary button on open + close on Escape.
+  useEffect(() => {
+    if (!open) return;
+    confirmRef.current?.focus();
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        // Click outside the panel cancels — same affordance as window.confirm cancel.
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="w-full max-w-md rounded-lg border border-mc-border bg-mc-bg p-5 shadow-2xl">
+        <div className="flex items-start gap-3">
+          {destructive && <AlertTriangle className="mt-1 h-5 w-5 shrink-0 text-amber-400" aria-hidden="true" />}
+          <div className="flex-1">
+            <h2 id="confirm-dialog-title" className="text-base font-semibold text-mc-text">
+              {title}
+            </h2>
+            <div className="mt-2 text-sm text-mc-text-secondary">{body}</div>
+          </div>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1.5 rounded border border-mc-border text-sm text-mc-text-secondary hover:bg-mc-bg-secondary"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            onClick={onConfirm}
+            className={
+              'px-3 py-1.5 rounded text-sm font-medium ' +
+              (destructive
+                ? 'bg-red-500 text-white hover:bg-red-600'
+                : 'bg-mc-accent text-white hover:bg-mc-accent/90')
+            }
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -58,6 +58,7 @@ interface ProposalRow {
   impact_md: string;
   proposed_changes: ChildDiff[];
   status: string;
+  dispatch_state?: 'pending_agent' | 'agent_complete' | 'synth_only' | null;
 }
 
 export default function DecomposeWithPmModal({
@@ -87,6 +88,7 @@ export default function DecomposeWithPmModal({
   const [refineText, setRefineText] = useState('');
   const [accepting, setAccepting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [dispatchState, setDispatchState] = useState<'pending_agent' | 'agent_complete' | 'synth_only' | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -105,6 +107,7 @@ export default function DecomposeWithPmModal({
             setProposalId(resumeBody.proposal.id);
             setImpactMd(resumeBody.proposal.impact_md);
             setChildren(resumeBody.proposal.proposed_changes);
+            setDispatchState(resumeBody.proposal.dispatch_state ?? null);
             return;
           }
         }
@@ -123,6 +126,7 @@ export default function DecomposeWithPmModal({
         setProposalId(proposal.id);
         setImpactMd(proposal.impact_md);
         setChildren(proposal.proposed_changes);
+        setDispatchState(proposal.dispatch_state ?? null);
       } catch (e) {
         if (!cancelled) setErr(e instanceof Error ? e.message : 'Decompose failed');
       } finally {
@@ -133,6 +137,51 @@ export default function DecomposeWithPmModal({
       cancelled = true;
     };
   }, [initiative.id, initiative.workspace_id, initialHint]);
+
+  // Tier 3 of pm-dispatch-async. While the synth placeholder is pending the
+  // named-agent reply, listen for `pm_proposal_replaced` SSE events. When
+  // the agent's row supersedes the placeholder, swap to the new id and
+  // refetch its content (now resolvable because supersede also copies
+  // trigger_text). Mirrors the PlanWithPmPanel hookup.
+  useEffect(() => {
+    if (!proposalId) return;
+    if (dispatchState !== 'pending_agent') return;
+    const es = new EventSource('/api/events/stream');
+    let cancelled = false;
+    const refetch = async () => {
+      try {
+        const url = `/api/pm/decompose-initiative?workspace_id=${encodeURIComponent(initiative.workspace_id)}&initiative_id=${encodeURIComponent(initiative.id)}`;
+        const res = await fetch(url);
+        if (!res.ok) return;
+        const body = await res.json() as { proposal?: ProposalRow | null };
+        if (cancelled || !body?.proposal) return;
+        setProposalId(body.proposal.id);
+        setImpactMd(body.proposal.impact_md);
+        setChildren(body.proposal.proposed_changes);
+        setDispatchState(body.proposal.dispatch_state ?? null);
+      } catch {
+        // Best-effort — operator can refresh manually.
+      }
+    };
+    es.onmessage = (ev) => {
+      if (cancelled) return;
+      let parsed: { type?: string; payload?: Record<string, unknown> } | null = null;
+      try { parsed = JSON.parse(ev.data); } catch { return; }
+      if (!parsed || !parsed.type) return;
+      if (parsed.type === 'pm_proposal_replaced') {
+        const oldId = parsed.payload?.old_id as string | undefined;
+        if (oldId === proposalId) void refetch();
+      } else if (parsed.type === 'pm_proposal_dispatch_state_changed') {
+        const id = parsed.payload?.proposal_id as string | undefined;
+        const next = parsed.payload?.dispatch_state as 'pending_agent' | 'agent_complete' | 'synth_only' | undefined;
+        if (id === proposalId && next) setDispatchState(next);
+      }
+    };
+    return () => {
+      cancelled = true;
+      es.close();
+    };
+  }, [proposalId, dispatchState, initiative.id, initiative.workspace_id]);
 
   // Esc to close.
   useEffect(() => {
@@ -287,6 +336,20 @@ export default function DecomposeWithPmModal({
             </div>
           ) : (
             <>
+              {dispatchState === 'pending_agent' && (
+                <div
+                  className="flex items-start gap-2 rounded border border-mc-accent/30 bg-mc-accent/5 px-3 py-2 text-[11px] text-mc-text-secondary"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <RefreshCw className="w-3.5 h-3.5 mt-[1px] animate-spin text-mc-accent" />
+                  <div>
+                    PM agent is still composing — these are draft children from the deterministic synth.
+                    The agent's final decomposition will replace this list automatically when it lands.
+                  </div>
+                </div>
+              )}
+
               {displayMd && (
                 <div className="shrink-0 max-h-32 overflow-y-auto text-xs text-mc-text-secondary whitespace-pre-wrap rounded border border-mc-border bg-mc-bg p-3">
                   {displayMd}
@@ -427,8 +490,13 @@ export default function DecomposeWithPmModal({
           </button>
           <button
             onClick={accept}
-            disabled={accepting || loading || children.length === 0 || !proposalId}
-            className="px-3 py-2 rounded bg-mc-accent text-white text-sm disabled:opacity-50"
+            disabled={accepting || loading || children.length === 0 || !proposalId || dispatchState === 'pending_agent'}
+            title={
+              dispatchState === 'pending_agent'
+                ? 'PM agent is still composing — wait for its decomposition or click Cancel.'
+                : undefined
+            }
+            className="px-3 py-2 rounded bg-mc-accent text-white text-sm disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {accepting ? 'Creating…' : `Accept (${children.length} children)`}
           </button>

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -104,6 +104,7 @@ export default function PlanWithPmPanel({
   const [proposalId, setProposalId] = useState<string | null>(null);
   const [impactMd, setImpactMd] = useState<string>('');
   const [suggestions, setSuggestions] = useState<PlanInitiativeSuggestions | null>(null);
+  const [dispatchState, setDispatchState] = useState<'pending_agent' | 'agent_complete' | 'synth_only' | null>(null);
   const [loading, setLoading] = useState(false);
   const [refining, setRefining] = useState(false);
   const [refineText, setRefineText] = useState('');
@@ -132,6 +133,7 @@ export default function PlanWithPmPanel({
       setProposalId(null);
       setImpactMd('');
       setSuggestions(null);
+      setDispatchState(null);
       setErr(null);
       setRefineText('');
       setDraftOpen(false);
@@ -157,6 +159,7 @@ export default function PlanWithPmPanel({
               setProposalId(resumeBody.proposal_id);
               setImpactMd(resumeBody.proposal.impact_md ?? '');
               setSuggestions(resumeBody.suggestions);
+              setDispatchState(resumeBody.proposal.dispatch_state ?? null);
               return; // Skip the POST — we resumed an existing draft.
             }
           }
@@ -177,6 +180,7 @@ export default function PlanWithPmPanel({
         setProposalId(body.proposal_id);
         setImpactMd(body.proposal?.impact_md ?? '');
         setSuggestions(body.suggestions ?? null);
+        setDispatchState(body.proposal?.dispatch_state ?? null);
       } catch (e) {
         if (!cancelled) setErr(e instanceof Error ? e.message : 'Plan failed');
       } finally {
@@ -188,6 +192,62 @@ export default function PlanWithPmPanel({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, workspaceId, targetInitiativeId, initialGuidance]);
+
+  // Tier 3 of the pm-dispatch-async spec. While the synth placeholder is
+  // pending the named-agent reply, listen for the server-side
+  // `pm_proposal_replaced` SSE event. When the agent's row supersedes the
+  // placeholder, swap to the new proposal id + refetch its content. Also
+  // listen for `pm_proposal_dispatch_state_changed` so the indicator
+  // resolves to "synth_only" if the agent never replies.
+  useEffect(() => {
+    if (!open || !proposalId || !targetInitiativeId) return;
+    if (dispatchState !== 'pending_agent') return;
+    const es = new EventSource('/api/events/stream');
+    let cancelled = false;
+    const refetch = async (newProposalId: string) => {
+      try {
+        const url = `/api/pm/plan-initiative?workspace_id=${encodeURIComponent(workspaceId)}&target_initiative_id=${encodeURIComponent(targetInitiativeId)}`;
+        const res = await fetch(url);
+        if (!res.ok) return;
+        const body = await res.json();
+        if (cancelled) return;
+        // The server's plan-initiative GET already follows the supersede
+        // chain when present, so we get the live (agent-completed) row.
+        setProposalId(newProposalId);
+        setImpactMd(body.proposal?.impact_md ?? '');
+        setSuggestions(body.suggestions ?? null);
+        setDispatchState(body.proposal?.dispatch_state ?? null);
+      } catch {
+        // Best-effort — leaves the panel as-is and the operator can refresh manually.
+      }
+    };
+    es.onmessage = (ev) => {
+      if (cancelled) return;
+      let parsed: { type?: string; payload?: Record<string, unknown> } | null = null;
+      try { parsed = JSON.parse(ev.data); } catch { return; }
+      if (!parsed || !parsed.type) return;
+      if (parsed.type === 'pm_proposal_replaced') {
+        const oldId = parsed.payload?.old_id as string | undefined;
+        const newId = parsed.payload?.new_id as string | undefined;
+        if (oldId === proposalId && newId) {
+          void refetch(newId);
+        }
+      } else if (parsed.type === 'pm_proposal_dispatch_state_changed') {
+        const id = parsed.payload?.proposal_id as string | undefined;
+        const next = parsed.payload?.dispatch_state as 'pending_agent' | 'agent_complete' | 'synth_only' | undefined;
+        if (id === proposalId && next) {
+          setDispatchState(next);
+        }
+      }
+    };
+    es.onerror = () => {
+      // SSE auto-reconnects; nothing to do here.
+    };
+    return () => {
+      cancelled = true;
+      es.close();
+    };
+  }, [open, proposalId, dispatchState, targetInitiativeId, workspaceId]);
 
   const refine = async () => {
     if (!proposalId || !refineText.trim()) return;
@@ -285,6 +345,19 @@ export default function PlanWithPmPanel({
         </div>
       ) : suggestions ? (
         <>
+          {dispatchState === 'pending_agent' && (
+            <div
+              className="mb-3 flex items-start gap-2 rounded border border-mc-accent/30 bg-mc-accent/5 px-3 py-2 text-[11px] text-mc-text-secondary"
+              role="status"
+              aria-live="polite"
+            >
+              <RefreshCw className="w-3.5 h-3.5 mt-[1px] animate-spin text-mc-accent" />
+              <div>
+                PM agent is still composing — these are draft suggestions from the deterministic synth.
+                The agent's final answer will replace this content automatically when it lands.
+              </div>
+            </div>
+          )}
           <div className="rounded border border-mc-border bg-mc-bg-secondary p-3 mb-3 text-xs space-y-2">
             <div>
               <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">Refined description</div>
@@ -363,7 +436,13 @@ export default function PlanWithPmPanel({
             </button>
             <button
               onClick={apply}
-              className="px-3 py-1.5 rounded bg-mc-accent text-white text-xs"
+              disabled={dispatchState === 'pending_agent'}
+              title={
+                dispatchState === 'pending_agent'
+                  ? 'PM agent is still composing — wait for it to land or click Discard if you want to start over.'
+                  : undefined
+              }
+              className="px-3 py-1.5 rounded bg-mc-accent text-white text-xs disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Apply suggestions
             </button>

--- a/src/components/inline/SplitToolbarButton.tsx
+++ b/src/components/inline/SplitToolbarButton.tsx
@@ -104,9 +104,9 @@ export function SplitToolbarButton({
             aria-hidden
             onClick={() => setOpen(false)}
           />
-          <div className="absolute top-full right-0 mt-1 w-80 z-50 bg-mc-bg-secondary border border-mc-border rounded-md shadow-lg p-3">
+          <div className="absolute top-full left-0 mt-1 z-50 bg-mc-bg-secondary border border-mc-border rounded-md shadow-lg p-3 w-[min(28rem,calc(100vw-2rem))]">
             <div className="flex items-start justify-between gap-2 mb-2">
-              <span className="text-xs font-medium text-mc-text">
+              <span className="text-xs font-medium text-mc-text leading-tight">
                 {guidanceLabel ?? 'Add guidance'}
               </span>
               <button

--- a/src/lib/agents/pm-agent.ts
+++ b/src/lib/agents/pm-agent.ts
@@ -135,9 +135,16 @@ export interface SynthesizePlanResult {
 export function synthesizePlanInitiative(
   snapshot: RoadmapSnapshot,
   draft: PlanInitiativeDraft,
-  _opts: {
+  opts: {
     velocityOverrides?: unknown;
     availabilityOverrides?: unknown;
+    /**
+     * The initiative being planned, when this is a re-plan / refinement
+     * against an existing row. Excluded from the dependency-suggestion
+     * candidate set so the heuristic doesn't propose the initiative depend
+     * on itself when its title overlaps with itself (the §2.3 self-dep bug).
+     */
+    targetInitiativeId?: string | null;
   } = {},
 ): SynthesizePlanResult {
   const title = draft.title.trim();
@@ -185,9 +192,18 @@ export function synthesizePlanInitiative(
   const titleNouns = extractNouns(title);
   if (titleNouns.length > 0) {
     const seen = new Set<string>();
+    const titleLower = title.toLowerCase();
     for (const i of snapshot.initiatives) {
+      // Skip the target itself (re-plan / refinement) so we don't propose
+      // a self-dep — the §2.3 regression that produced
+      // "Title shares 'smart, snappy' — confirm if this is a real dependency."
+      if (opts.targetInitiativeId && i.id === opts.targetInitiativeId) continue;
       if (i.id === draft.parent_initiative_id) continue;
       if (i.status === 'done' || i.status === 'cancelled') continue;
+      // Belt-and-suspenders for the non-target case: skip any candidate
+      // whose title is an exact case-insensitive match for the draft —
+      // that's almost always self-reference, not a real dependency.
+      if (i.title.trim().toLowerCase() === titleLower) continue;
       const otherNouns = extractNouns(i.title);
       const overlap = titleNouns.filter(n => otherNouns.includes(n));
       if (overlap.length === 0) continue;

--- a/src/lib/agents/pm-decompose.test.ts
+++ b/src/lib/agents/pm-decompose.test.ts
@@ -178,6 +178,48 @@ test('acceptProposal: rejects create_child_initiative with theme/milestone child
   );
 });
 
+// ─── synthesizePlanInitiative dependency suggestions ─────────────────
+
+test('synthesizePlanInitiative: skips the target initiative from dependency candidates (self-dep guard)', () => {
+  const ws = freshWorkspace();
+  const target = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Smart Snappy',
+    description: 'turning passive logging into proactive coaching',
+  });
+  const snapshot = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizePlanInitiative(
+    snapshot,
+    { title: 'Smart Snappy', description: 'turning passive logging into proactive coaching' },
+    { targetInitiativeId: target.id },
+  );
+  for (const dep of result.changes.flatMap(c => c.kind === 'create_child_initiative' ? [] : [])) {
+    void dep;
+  }
+  // The result.suggestions field carries the candidate dependencies; ensure none point at the target.
+  const deps = result.suggestions?.dependencies ?? [];
+  for (const d of deps) {
+    assert.notEqual(d.depends_on_initiative_id, target.id, 'must not propose self-dependency');
+  }
+});
+
+test('synthesizePlanInitiative: belt-and-suspenders — skips exact-title matches even without targetInitiativeId', () => {
+  const ws = freshWorkspace();
+  const twin = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Smart Snappy',
+    description: 'older draft of the same idea',
+  });
+  const snapshot = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizePlanInitiative(snapshot, { title: 'Smart Snappy', description: 'a fresh draft' });
+  const deps = result.suggestions?.dependencies ?? [];
+  for (const d of deps) {
+    assert.notEqual(d.depends_on_initiative_id, twin.id, 'exact-title match should not be suggested as a dep');
+  }
+});
+
 test('acceptProposal: plan_initiative is a no-op (advisory)', () => {
   const ws = freshWorkspace();
   const snapshot = getRoadmapSnapshot({ workspace_id: ws });

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -37,10 +37,13 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   createProposal,
   listProposals,
+  setDispatchState,
+  supersedeWithAgentProposal,
   type PmDiff,
   type PmProposal,
   type PmProposalTriggerKind,
 } from '@/lib/db/pm-proposals';
+import { broadcast } from '@/lib/events';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import {
   sendChatAndAwaitReply,
@@ -68,7 +71,23 @@ export interface DispatchPmInput {
 }
 
 export interface DispatchPmResult {
+  /** The synth placeholder row, returned immediately. When awaiting_agent
+   *  is true, this row's content will be replaced by the agent's row via a
+   *  `pm_proposal_replaced` SSE event when the named PM agent finishes. */
   proposal: PmProposal;
+  awaiting_agent: boolean;
+  /** Resolves when the dispatch lifecycle settles. Tests await this; HTTP
+   *  callers usually just return `proposal` immediately and let SSE drive
+   *  UI updates. Same shape as DispatchPmSynthesizedResult.completion. */
+  completion: Promise<{
+    final: PmProposal;
+    used_named_agent: boolean;
+    used_synthesize_fallback: boolean;
+  }>;
+  /** @deprecated Use `completion` to get the final state. Retained on the
+   *  result for back-compat with callers that don't await the completion;
+   *  reflects whether the synth placeholder was the only output at the
+   *  moment dispatchPm returned. */
   used_synthesize_fallback: boolean;
   used_named_agent?: boolean;
 }
@@ -117,17 +136,39 @@ function namedAgentTimeoutMs(): number {
 }
 
 /**
- * Top-level dispatch entry. Routes through the named openclaw agent when
- * available; falls back to `synthesizeImpactAnalysis` otherwise. Always
- * persists a proposal + posts the operator/PM messages into the PM
- * agent's chat thread so the /pm UI's card renderer fires.
+ * Top-level disruption dispatch. Returns the synth placeholder row
+ * synchronously so the API can respond fast; the named-agent dispatch
+ * runs in the background and either supersedes the placeholder via SSE
+ * (`pm_proposal_replaced`) when the agent's `propose_changes` lands, or
+ * leaves the synth row as the operator's draft when no agent reply
+ * arrives within the tail window.
+ *
+ * Mirror of `dispatchPmSynthesized` for the disruption code path. See
+ * specs/pm-dispatch-async.md for the architectural rationale.
+ *
+ * `allowFallback: false` (used by `propose_from_notes`) keeps the strict
+ * gateway-required behavior: if the gateway is down we throw
+ * `PmDispatchGatewayUnavailableError` instead of persisting a synth row.
  */
-export async function dispatchPm(input: DispatchPmInput): Promise<DispatchPmResult> {
+export function dispatchPm(input: DispatchPmInput): DispatchPmResult {
   const snapshot = getRoadmapSnapshot({ workspace_id: input.workspace_id });
   const pm = lookupPmAgent(input.workspace_id);
+  const allowFallback = input.allowFallback ?? true;
+  const gw = gatewayClient();
+  const gatewayUp = !!(pm && pm.gateway_agent_id && gw.isConnected());
 
-  // Always echo the operator's trigger as a user message regardless of
-  // path so the /pm chat reflects the conversation faithfully.
+  // Strict-gateway path (propose_from_notes / queue replay): no synth row,
+  // no chat echo — surface the unavailability cleanly.
+  if (!allowFallback && !gatewayUp) {
+    throw new PmDispatchGatewayUnavailableError(
+      pm && pm.gateway_agent_id
+        ? 'openclaw gateway unavailable'
+        : 'PM agent missing gateway_agent_id; cannot dispatch without fallback',
+    );
+  }
+
+  // Echo the operator's trigger as a user message so the /pm chat
+  // reflects the conversation faithfully.
   try {
     postPmChatMessage({
       workspace_id: input.workspace_id,
@@ -138,75 +179,168 @@ export async function dispatchPm(input: DispatchPmInput): Promise<DispatchPmResu
     console.warn('[pm-dispatch] user chat insert failed:', (err as Error).message);
   }
 
-  const allowFallback = input.allowFallback ?? true;
-
-  // ── 1. Try the named-agent path ────────────────────────────────────
-  if (pm && pm.gateway_agent_id) {
-    const gw = gatewayClient();
-    if (gw.isConnected()) {
-      try {
-        const proposal = await dispatchViaNamedAgent({
-          input,
-          snapshot,
-          pm,
-        });
-        if (proposal) {
-          try {
-            postPmChatMessage({
-              workspace_id: input.workspace_id,
-              content: proposal.impact_md,
-              proposal_id: proposal.id,
-              role: 'assistant',
-            });
-          } catch (err) {
-            console.warn('[pm-dispatch] assistant chat insert failed:', (err as Error).message);
-          }
-          return { proposal, used_synthesize_fallback: false, used_named_agent: true };
-        }
-        // Sent succeeded but no proposal landed (timeout). Treat as a
-        // gateway-side failure for the no-fallback path.
-        if (!allowFallback) {
-          throw new PmDispatchGatewayUnavailableError(
-            'PM agent did not produce a proposal within the timeout',
-          );
-        }
-      } catch (err) {
-        if (!allowFallback) throw err;
-        console.warn(
-          '[pm-dispatch] named-agent dispatch failed; falling back to synth:',
-          (err as Error).message,
-        );
-      }
-    } else if (!allowFallback) {
-      throw new PmDispatchGatewayUnavailableError();
-    }
-  } else if (!allowFallback) {
-    throw new PmDispatchGatewayUnavailableError(
-      'PM agent missing gateway_agent_id; cannot dispatch without fallback',
-    );
-  }
-
-  // ── 2. Synthesize fallback ────────────────────────────────────────
+  // Always persist the synth placeholder first — operator gets *something*
+  // to react to even if the gateway times out, and the row id is stable
+  // so the /pm UI's chat card can subscribe to SSE updates from the
+  // moment dispatchPm returns.
   const synth = synthesizeImpactAnalysis(snapshot, input.trigger_text);
-  const proposal = createProposal({
+  const placeholder = createProposal({
     workspace_id: input.workspace_id,
     trigger_text: input.trigger_text,
     trigger_kind: input.trigger_kind ?? 'manual',
     impact_md: synth.impact_md,
     proposed_changes: synth.changes,
     parent_proposal_id: input.parent_proposal_id ?? null,
+    dispatch_state: gatewayUp ? 'pending_agent' : 'synth_only',
   });
   try {
     postPmChatMessage({
       workspace_id: input.workspace_id,
       content: synth.impact_md,
-      proposal_id: proposal.id,
+      proposal_id: placeholder.id,
       role: 'assistant',
     });
   } catch (err) {
     console.warn('[pm-dispatch] chat insert failed:', (err as Error).message);
   }
-  return { proposal, used_synthesize_fallback: true, used_named_agent: false };
+
+  if (!gatewayUp) {
+    return {
+      proposal: placeholder,
+      awaiting_agent: false,
+      completion: Promise.resolve({
+        final: placeholder,
+        used_named_agent: false,
+        used_synthesize_fallback: true,
+      }),
+      used_synthesize_fallback: true,
+      used_named_agent: false,
+    };
+  }
+
+  // Fire the named-agent dispatch + late-arrival reconciler in the
+  // background. Same architecture as dispatchPmSynthesized: when the
+  // agent's `propose_changes` lands, supersede the placeholder, broadcast
+  // `pm_proposal_replaced`, and re-echo the agent's impact_md into chat.
+  const completion = runDisruptionDispatchInBackground({
+    input,
+    snapshot,
+    pm: pm!,
+    placeholder,
+    allowFallback,
+  });
+  return {
+    proposal: placeholder,
+    awaiting_agent: true,
+    completion,
+    used_synthesize_fallback: true, // Placeholder is synth at the moment we return.
+    used_named_agent: false,
+  };
+}
+
+interface RunDisruptionDispatchInput {
+  input: DispatchPmInput;
+  snapshot: RoadmapSnapshot;
+  pm: NonNullable<ReturnType<typeof lookupPmAgent>>;
+  placeholder: PmProposal;
+  allowFallback: boolean;
+}
+
+async function runDisruptionDispatchInBackground(
+  params: RunDisruptionDispatchInput,
+): Promise<{ final: PmProposal; used_named_agent: boolean; used_synthesize_fallback: boolean }> {
+  const { input, snapshot, pm, placeholder } = params;
+  // Re-mint the message + sinceIso so we can poll for the agent's row.
+  const correlationId = uuidv4();
+  const sinceIso = new Date().toISOString();
+  const summary = buildSnapshotSummary(snapshot);
+  const message =
+    input.trigger_kind === 'notes_intake'
+      ? buildNotesIntakeMessage({ correlationId, notes: input.trigger_text, summary })
+      : `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
+        `Operator-reported event:\n> ${input.trigger_text}\n\n` +
+        `Workspace snapshot summary (call \`get_roadmap_snapshot\` via MCP for full detail):\n\n` +
+        `${summary}\n\n` +
+        `Per your SOUL.md: analyse the disruption and call \`propose_changes\` ` +
+        `with a structured PmDiff[] and impact_md. Reference only ids that ` +
+        `appear in the snapshot.`;
+  const sessionSuffix = input.trigger_kind === 'notes_intake' ? `notes-${correlationId}` : 'dispatch-main';
+
+  let result: Awaited<ReturnType<typeof sendChatAndAwaitReply>> | null = null;
+  try {
+    result = await sendChatAndAwaitReply({
+      agent: pm,
+      message,
+      idempotencyKey: `pm-dispatch-${correlationId}`,
+      timeoutMs: namedAgentTimeoutMs(),
+      sessionSuffix,
+    });
+  } catch (err) {
+    console.warn(
+      '[pm-dispatch] disruption named-agent dispatch failed:',
+      (err as Error).message,
+    );
+  }
+
+  const tailMs = result?.sent ? RECONCILER_TAIL_MS : 0;
+  const found = await pollForAgentProposal(input.workspace_id, sinceIso, placeholder.id, tailMs);
+
+  if (found) {
+    console.log(
+      `[pm-dispatch] disruption reconciler matched agent row ${found.id} for placeholder ${placeholder.id} ` +
+        `(workspace=${input.workspace_id})`,
+    );
+    try {
+      supersedeWithAgentProposal(placeholder.id, found.id, {
+        trigger_kind: input.trigger_kind ?? 'manual',
+        target_initiative_id: null,
+      });
+      // Re-echo the agent's (richer) impact_md into chat — the placeholder
+      // already posted the synth content, but the agent's reasoning is
+      // what the operator actually wants to see.
+      try {
+        postPmChatMessage({
+          workspace_id: input.workspace_id,
+          content: found.impact_md,
+          proposal_id: found.id,
+          role: 'assistant',
+        });
+      } catch (err) {
+        console.warn('[pm-dispatch] agent chat re-echo failed:', (err as Error).message);
+      }
+      broadcast({
+        type: 'pm_proposal_replaced',
+        payload: {
+          workspace_id: input.workspace_id,
+          old_id: placeholder.id,
+          new_id: found.id,
+          target_initiative_id: null,
+          trigger_kind: input.trigger_kind ?? 'manual',
+        },
+      });
+      return { final: found, used_named_agent: true, used_synthesize_fallback: false };
+    } catch (err) {
+      console.warn('[pm-dispatch] disruption supersede failed:', (err as Error).message);
+    }
+  }
+
+  console.log(
+    `[pm-dispatch] disruption reconciler timed out for placeholder ${placeholder.id} (workspace=${input.workspace_id}); marking synth_only`,
+  );
+  setDispatchState(placeholder.id, 'synth_only');
+  broadcast({
+    type: 'pm_proposal_dispatch_state_changed',
+    payload: {
+      workspace_id: input.workspace_id,
+      proposal_id: placeholder.id,
+      dispatch_state: 'synth_only',
+    },
+  });
+  return {
+    final: { ...placeholder, dispatch_state: 'synth_only' },
+    used_named_agent: false,
+    used_synthesize_fallback: true,
+  };
 }
 
 // ─── Named-agent dispatch ───────────────────────────────────────────
@@ -237,83 +371,6 @@ function buildSnapshotSummary(snapshot: RoadmapSnapshot): string {
     }
   }
   return lines.join('\n');
-}
-
-interface DispatchNamedAgentParams {
-  input: DispatchPmInput;
-  snapshot: RoadmapSnapshot;
-  pm: Pick<Agent, 'id' | 'name' | 'session_key_prefix' | 'gateway_agent_id' | 'workspace_id'>;
-}
-
-/**
- * Send the trigger to the gateway-hosted PM session and wait for the
- * agent's `final` chat frame (signalling its turn is over). Then look up
- * the proposal it created via the MCP `propose_changes` tool and return
- * it.
- *
- * Replaces the original "poll pm_proposals every 500ms by recency"
- * workaround with a proper subscription-based wait via
- * `sendChatAndAwaitReply`. The chat-listener's existing `state==='final'`
- * is the same signal the per-agent chat surface already uses, so we get
- * "agent turn complete" deterministically.
- *
- * Correlation: we still embed a `correlation_id` in the message body
- * (audit trail). Lookup remains "most recent draft draft created since
- * we sent" — that's deterministic given dispatch is single-flight from
- * the operator's perspective.
- *
- * Returns:
- *   - the PmProposal the agent created during this round-trip, or
- *   - `null` if the timeout elapses, the send fails, or the agent never
- *     called `propose_changes`. The caller falls back to synth.
- */
-async function dispatchViaNamedAgent(params: DispatchNamedAgentParams): Promise<PmProposal | null> {
-  const { input, snapshot, pm } = params;
-  const correlationId = uuidv4();
-  const sinceIso = new Date().toISOString();
-
-  const summary = buildSnapshotSummary(snapshot);
-  const message =
-    input.trigger_kind === 'notes_intake'
-      ? buildNotesIntakeMessage({ correlationId, notes: input.trigger_text, summary })
-      : `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
-        `Operator-reported event:\n> ${input.trigger_text}\n\n` +
-        `Workspace snapshot summary (call \`get_roadmap_snapshot\` via MCP for full detail):\n\n` +
-        `${summary}\n\n` +
-        `Per your SOUL.md: analyse the disruption and call \`propose_changes\` ` +
-        `with a structured PmDiff[] and impact_md. Reference only ids that ` +
-        `appear in the snapshot.`;
-
-  // Notes intake gets a fresh session per dispatch (like plan/decompose)
-  // so the PM doesn't carry over disruption-conversation context. The
-  // disruption path keeps the stable 'dispatch-main' session warm.
-  const sessionSuffix =
-    input.trigger_kind === 'notes_intake'
-      ? `notes-${correlationId}`
-      : 'dispatch-main';
-
-  const result = await sendChatAndAwaitReply({
-    agent: pm,
-    message,
-    idempotencyKey: `pm-dispatch-${correlationId}`,
-    timeoutMs: namedAgentTimeoutMs(),
-    sessionSuffix,
-  });
-
-  // Send failed — caller falls back to synth.
-  if (!result.sent) return null;
-
-  // Whether we got a `final` frame or hit the timeout, do one final
-  // check for a proposal landed by the agent's MCP `propose_changes`
-  // call. The named-agent path is "useful" only if the agent actually
-  // wrote a proposal during the round-trip.
-  return findProposalCreatedSince(input.workspace_id, sinceIso);
-}
-
-function findProposalCreatedSince(workspaceId: string, sinceIso: string): PmProposal | null {
-  const drafts = listProposals({ workspace_id: workspaceId, status: 'draft', since: sinceIso });
-  // listProposals returns DESC by created_at — pick the newest.
-  return drafts[0] ?? null;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────
@@ -365,87 +422,68 @@ export interface DispatchSynthesizedInput {
    * turns. When omitted, falls back to ':main'.
    */
   planSessionKey?: string | null;
+  /**
+   * Per-call override for the named-agent wait. Disruption + refine paths
+   * are happy with the 60s default; plan_initiative and decompose_initiative
+   * dispatches benefit from longer (~120s) because the PM agent has to
+   * compose structured output from a sizable input. When omitted falls back
+   * to `namedAgentTimeoutMs()`.
+   */
+  timeoutMs?: number;
 }
 
-export async function dispatchPmSynthesized(
+export interface DispatchSynthesizedResult {
+  /** The synth placeholder row, returned immediately so the API can respond
+   *  without waiting for the named-agent round trip. */
+  proposal: PmProposal;
+  /** Whether a named-agent dispatch is in flight. When true, the panel
+   *  should subscribe to `pm_proposal_replaced` SSE events; when the agent
+   *  responds, the synth row will be superseded by the agent's row. */
+  awaiting_agent: boolean;
+  /** Promise that resolves when the dispatch lifecycle is complete: either
+   *  the agent's `propose_changes` lands and supersedes the synth row, or
+   *  the tail window elapses and the synth row is marked `synth_only`.
+   *  Tests await this to assert the post-state; callers that don't care can
+   *  ignore it. */
+  completion: Promise<{
+    final: PmProposal;
+    used_named_agent: boolean;
+    used_synthesize_fallback: boolean;
+  }>;
+}
+
+/** Tail window the reconciler keeps watching for an agent proposal AFTER the
+ *  configured timeout elapses, in case the agent is just slow. The current
+ *  60s + 60s tail covers all observed cold-session round trips (~70s). */
+const RECONCILER_TAIL_MS = 60_000;
+/** Polling interval inside the tail window — cheap because most of the time
+ *  no rows match. */
+const RECONCILER_POLL_MS = 2_000;
+
+/**
+ * Persist a synth-derived placeholder row immediately, then dispatch the
+ * named PM agent in the background. Returns the placeholder + a completion
+ * promise so callers can either:
+ *
+ *   - Return the placeholder right away (Tier 3, the common API path) and
+ *     let SSE notify the UI when the agent's proposal supersedes it; OR
+ *   - `await result.completion` to block until the lifecycle settles
+ *     (tests, code paths that need the final state synchronously).
+ *
+ * If the gateway is unreachable, the placeholder is returned with
+ * `awaiting_agent: false` and `dispatch_state: 'synth_only'`.
+ */
+export function dispatchPmSynthesized(
   input: DispatchSynthesizedInput,
-): Promise<{ proposal: PmProposal; used_synthesize_fallback: boolean; used_named_agent: boolean }> {
+): DispatchSynthesizedResult {
   const pm = lookupPmAgent(input.workspace_id);
-  if (pm && pm.gateway_agent_id) {
-    const gw = gatewayClient();
-    if (gw.isConnected()) {
-      try {
-        const correlationId = uuidv4();
-        const sinceIso = new Date().toISOString();
-        const sessionSuffix = input.planSessionKey ?? 'main';
-        const result = await sendChatAndAwaitReply({
-          agent: pm,
-          message:
-            `**PM ${input.trigger_kind} (correlation_id: ${correlationId})**\n\n` +
-            input.agent_prompt,
-          idempotencyKey: `pm-${input.trigger_kind}-${correlationId}`,
-          timeoutMs: namedAgentTimeoutMs(),
-          sessionSuffix,
-        });
-        if (result.sent) {
-          // Whether we got a `final` frame or hit the timeout, the agent
-          // either landed a proposal via MCP `propose_changes` or didn't.
-          // Either way, this is the moment to look — same semantics as
-          // dispatchViaNamedAgent.
-          const found = findProposalCreatedSince(input.workspace_id, sinceIso);
-          if (found) {
-            // Reconcile the row with this dispatch's intent. The PM
-            // agent's `propose_changes` call is freeform — it can pass
-            // a wrong trigger_kind (defaults to 'manual' if omitted)
-            // and doesn't accept target_initiative_id at all. We know
-            // what kind of dispatch this was and where it came from,
-            // so stamp both onto the row so the downstream Apply path
-            // (which validates trigger_kind === 'plan_initiative' when
-            // target_initiative_id is supplied) doesn't reject what is
-            // really a plan_initiative proposal.
-            const fixes: string[] = [];
-            const vals: unknown[] = [];
-            let nextTriggerKind = found.trigger_kind;
-            let nextTarget = found.target_initiative_id;
-            if (found.trigger_kind !== input.trigger_kind) {
-              fixes.push('trigger_kind = ?');
-              vals.push(input.trigger_kind);
-              nextTriggerKind = input.trigger_kind;
-            }
-            if (input.target_initiative_id && !found.target_initiative_id) {
-              fixes.push('target_initiative_id = ?');
-              vals.push(input.target_initiative_id);
-              nextTarget = input.target_initiative_id;
-            }
-            if (fixes.length > 0) {
-              try {
-                run(`UPDATE pm_proposals SET ${fixes.join(', ')} WHERE id = ?`, [...vals, found.id]);
-                return {
-                  proposal: {
-                    ...found,
-                    trigger_kind: nextTriggerKind,
-                    target_initiative_id: nextTarget,
-                  },
-                  used_synthesize_fallback: false,
-                  used_named_agent: true,
-                };
-              } catch (err) {
-                console.warn('[pm-dispatch] post-hoc stamp failed:', (err as Error).message);
-              }
-            }
-            return { proposal: found, used_synthesize_fallback: false, used_named_agent: true };
-          }
-        }
-      } catch (err) {
-        console.warn(
-          '[pm-dispatch] synthesized named-agent dispatch failed; falling back:',
-          (err as Error).message,
-        );
-      }
-    }
-  }
-  // Fallback — persist the synthesized proposal exactly like before.
-  const proposal = createProposal({
+  const gw = gatewayClient();
+  const gatewayUp = !!(pm && pm.gateway_agent_id && gw.isConnected());
+
+  // 1. Always persist the synth row first — the operator gets *something*
+  //    even if the agent never replies, and the row id is stable so the UI
+  //    can subscribe to it from the moment the API returns.
+  const placeholder = createProposal({
     workspace_id: input.workspace_id,
     trigger_text: input.trigger_text,
     trigger_kind: input.trigger_kind,
@@ -454,8 +492,156 @@ export async function dispatchPmSynthesized(
     plan_suggestions: input.synth.plan_suggestions ?? null,
     parent_proposal_id: input.parent_proposal_id ?? null,
     target_initiative_id: input.target_initiative_id ?? null,
+    dispatch_state: gatewayUp ? 'pending_agent' : 'synth_only',
   });
-  return { proposal, used_synthesize_fallback: true, used_named_agent: false };
+
+  if (!gatewayUp) {
+    return {
+      proposal: placeholder,
+      awaiting_agent: false,
+      completion: Promise.resolve({
+        final: placeholder,
+        used_named_agent: false,
+        used_synthesize_fallback: true,
+      }),
+    };
+  }
+
+  // 2. Kick off the named-agent dispatch + late-arrival reconciler as a
+  //    fire-and-forget background promise. The placeholder is returned
+  //    immediately so the API can respond without waiting.
+  const completion = runNamedAgentDispatchInBackground(input, pm!, placeholder);
+  return { proposal: placeholder, awaiting_agent: true, completion };
+}
+
+async function runNamedAgentDispatchInBackground(
+  input: DispatchSynthesizedInput,
+  pm: NonNullable<ReturnType<typeof lookupPmAgent>>,
+  placeholder: PmProposal,
+): Promise<{ final: PmProposal; used_named_agent: boolean; used_synthesize_fallback: boolean }> {
+  const correlationId = uuidv4();
+  const sinceIso = new Date().toISOString();
+  const sessionSuffix = input.planSessionKey ?? 'main';
+  const timeoutMs = input.timeoutMs ?? namedAgentTimeoutMs();
+
+  let result: Awaited<ReturnType<typeof sendChatAndAwaitReply>> | null = null;
+  try {
+    result = await sendChatAndAwaitReply({
+      agent: pm,
+      message:
+        `**PM ${input.trigger_kind} (correlation_id: ${correlationId})**\n\n` +
+        input.agent_prompt,
+      idempotencyKey: `pm-${input.trigger_kind}-${correlationId}`,
+      timeoutMs,
+      sessionSuffix,
+    });
+  } catch (err) {
+    console.warn(
+      '[pm-dispatch] synthesized named-agent dispatch failed:',
+      (err as Error).message,
+    );
+  }
+
+  // 3. Keep watching for an agent-produced row up to RECONCILER_TAIL_MS
+  //    past the original timeout. Cold sessions can land their
+  //    `propose_changes` after the primary timeout; without this tail
+  //    window those proposals are orphaned (the §2.3 regression that
+  //    motivated this whole refactor).
+  //
+  //    When send succeeded → the agent is still likely composing, so we
+  //    keep the full tail window. When send failed outright (no session,
+  //    network error, throw) → there's no agent to wait for, so a single
+  //    immediate check is enough.
+  const tailMs = result?.sent ? RECONCILER_TAIL_MS : 0;
+  const found = await pollForAgentProposal(
+    input.workspace_id,
+    sinceIso,
+    placeholder.id,
+    tailMs,
+  );
+
+  if (found) {
+    console.log(
+      `[pm-dispatch] reconciler matched agent row ${found.id} for placeholder ${placeholder.id} ` +
+        `(workspace=${input.workspace_id}, trigger_kind=${input.trigger_kind})`,
+    );
+    try {
+      supersedeWithAgentProposal(placeholder.id, found.id, {
+        trigger_kind: input.trigger_kind,
+        target_initiative_id: input.target_initiative_id ?? null,
+      });
+      const refreshed = listProposals({ workspace_id: input.workspace_id, limit: 1, since: sinceIso }).find(p => p.id === found.id) ?? found;
+      broadcast({
+        type: 'pm_proposal_replaced',
+        payload: {
+          workspace_id: input.workspace_id,
+          old_id: placeholder.id,
+          new_id: found.id,
+          target_initiative_id: input.target_initiative_id ?? null,
+          trigger_kind: input.trigger_kind,
+        },
+      });
+      return { final: refreshed, used_named_agent: true, used_synthesize_fallback: false };
+    } catch (err) {
+      console.warn('[pm-dispatch] supersede failed:', (err as Error).message);
+    }
+  }
+
+  // 4. No agent row arrived. Mark the placeholder as the operator's final
+  //    draft so the UI can stop showing the "PM agent is working" indicator
+  //    and re-enable Accept.
+  console.log(
+    `[pm-dispatch] reconciler timed out waiting for agent reply on placeholder ${placeholder.id} ` +
+      `(workspace=${input.workspace_id}, trigger_kind=${input.trigger_kind}); marking synth_only`,
+  );
+  setDispatchState(placeholder.id, 'synth_only');
+  broadcast({
+    type: 'pm_proposal_dispatch_state_changed',
+    payload: {
+      workspace_id: input.workspace_id,
+      proposal_id: placeholder.id,
+      dispatch_state: 'synth_only',
+    },
+  });
+  return {
+    final: { ...placeholder, dispatch_state: 'synth_only' },
+    used_named_agent: false,
+    used_synthesize_fallback: true,
+  };
+}
+
+/**
+ * Poll `pm_proposals` for a draft created by the named PM agent during this
+ * dispatch's window. The agent's `propose_changes` call lands as a fresh
+ * row; we identify it by "newest draft created since `sinceIso` whose id is
+ * NOT the placeholder we just wrote".
+ *
+ * `extraWaitMs` is the additional tail window beyond the original timeout —
+ * 0 to bail right after the configured timeout, RECONCILER_TAIL_MS for the
+ * full late-arrival catch.
+ */
+async function pollForAgentProposal(
+  workspaceId: string,
+  sinceIso: string,
+  placeholderId: string,
+  extraWaitMs: number,
+): Promise<PmProposal | null> {
+  const deadline = Date.now() + extraWaitMs;
+  // The candidate filter is: a draft proposal that isn't our placeholder
+  // AND whose dispatch_state is NOT 'pending_agent' (i.e. NOT another
+  // concurrent placeholder). Without the second clause, two simultaneous
+  // dispatches would cross-supersede each other's placeholders before
+  // either agent row landed. See §2.3 cross-supersede finding.
+  const isAgentRow = (p: PmProposal) => p.id !== placeholderId && p.dispatch_state !== 'pending_agent';
+  do {
+    const drafts = listProposals({ workspace_id: workspaceId, status: 'draft', since: sinceIso });
+    const hit = drafts.find(isAgentRow);
+    if (hit) return hit;
+    if (Date.now() >= deadline) return null;
+    await new Promise(resolve => setTimeout(resolve, RECONCILER_POLL_MS));
+  } while (Date.now() < deadline);
+  const drafts = listProposals({ workspace_id: workspaceId, status: 'draft', since: sinceIso });
+  return drafts.find(isAgentRow) ?? null;
 }
 
 // ─── Synthesize fallback ────────────────────────────────────────────

--- a/src/lib/agents/pm-pending-drain.ts
+++ b/src/lib/agents/pm-pending-drain.ts
@@ -72,13 +72,27 @@ export async function drainPendingNotes(): Promise<DrainResult> {
   for (const note of pending) {
     out.attempted++;
     try {
-      const result = await dispatchPm({
+      const result = dispatchPm({
         workspace_id: note.workspace_id,
         trigger_text: note.notes_text,
         trigger_kind: 'notes_intake',
         allowFallback: false,
       });
-      markDispatched(note.id, result.proposal.id);
+      // Wait for the full lifecycle. notes_intake requires the named
+      // agent — if no reply, we leave the row pending so the next drain
+      // tick can retry.
+      const settled = await result.completion;
+      if (!settled.used_named_agent) {
+        // Treat as failed for this attempt; cleanup the orphan placeholder.
+        out.failed++;
+        try {
+          const { run } = await import('@/lib/db');
+          run(`DELETE FROM pm_proposals WHERE id = ?`, [result.proposal.id]);
+        } catch { /* best effort */ }
+        markFailed(note.id, 'agent did not reply within tail window');
+        continue;
+      }
+      markDispatched(note.id, settled.final.id);
       out.dispatched++;
     } catch (err) {
       out.failed++;

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -18,11 +18,12 @@ import { getRoadmapSnapshot } from '@/lib/db/roadmap';
 import {
   synthesizeImpactAnalysis,
   dispatchPm,
+  dispatchPmSynthesized,
   __setOpenClawClientForTests,
   __setNamedAgentTimeoutForTests,
 } from './pm-dispatch';
 import type { ChatEvent, SendChatClient } from '@/lib/openclaw/send-chat';
-import { createProposal } from '@/lib/db/pm-proposals';
+import { createProposal, getProposal } from '@/lib/db/pm-proposals';
 
 /**
  * Build a SendChatClient stub that satisfies both `client.call('chat.send')`
@@ -192,11 +193,16 @@ test('dispatchPm: persists a draft proposal AND posts to PM chat with metadata',
   ensurePmAgent(ws);
   const sarahId = seedNamedAgent(ws, 'Sarah');
 
-  const result = await dispatchPm({
+  const result = dispatchPm({
     workspace_id: ws,
     trigger_text: 'Sarah out 2026-05-01 to 2026-05-05',
   });
-  assert.equal(result.used_synthesize_fallback, true);
+  // Tier 3 of pm-dispatch-async: dispatchPm returns the synth placeholder
+  // synchronously; the named-agent reconciler runs in the background.
+  // Await completion to assert the lifecycle settled with the synth-only
+  // outcome (no PM agent connected in this test seed).
+  const settled = await result.completion;
+  assert.equal(settled.used_synthesize_fallback, true);
   assert.equal(result.proposal.workspace_id, ws);
   assert.equal(result.proposal.status, 'draft');
 
@@ -229,7 +235,8 @@ test('dispatchPm: persists a draft proposal AND posts to PM chat with metadata',
 test('dispatchPm: returns a usable proposal even when nothing is parsed', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
-  const result = await dispatchPm({ workspace_id: ws, trigger_text: 'qqq xyz' });
+  const result = dispatchPm({ workspace_id: ws, trigger_text: 'qqq xyz' });
+  await result.completion;
   assert.equal(result.proposal.status, 'draft');
   assert.equal(result.proposal.proposed_changes.length, 0);
   assert.match(result.proposal.impact_md, /could not extract|No structured changes/);
@@ -289,13 +296,17 @@ test('dispatchPm: routes through named agent when openclaw is connected; mock cr
   __setNamedAgentTimeoutForTests(2_000);
 
   try {
-    const result = await dispatchPm({
+    const result = dispatchPm({
       workspace_id: ws,
       trigger_text: 'Operator says we lost a sprint',
     });
-    assert.equal(result.used_synthesize_fallback, false);
-    assert.equal(result.used_named_agent, true);
-    assert.match(result.proposal.impact_md, /Named-agent verdict/);
+    // Synth placeholder returned synchronously; agent supersedes via the
+    // background reconciler.
+    assert.equal(result.awaiting_agent, true);
+    const settled = await result.completion;
+    assert.equal(settled.used_synthesize_fallback, false);
+    assert.equal(settled.used_named_agent, true);
+    assert.match(settled.final.impact_md, /Named-agent verdict/);
     // chat.send went to the canonical PM session.
     const send = seenSends.find(s => s.method === 'chat.send');
     assert.ok(send);
@@ -316,12 +327,16 @@ test('dispatchPm: falls back to synth when openclaw client is offline', async ()
   __setOpenClawClientForTests(client);
 
   try {
-    const result = await dispatchPm({
+    const result = dispatchPm({
       workspace_id: ws,
       trigger_text: 'Sarah out next week',
     });
-    assert.equal(result.used_synthesize_fallback, true);
-    assert.equal(result.used_named_agent, false);
+    // Gateway down → no background reconciler runs; placeholder is the
+    // operator's final draft, marked synth_only.
+    assert.equal(result.awaiting_agent, false);
+    const settled = await result.completion;
+    assert.equal(settled.used_synthesize_fallback, true);
+    assert.equal(settled.used_named_agent, false);
     // The synth path produced a real availability diff.
     const avail = result.proposal.proposed_changes.find(c => c.kind === 'add_availability');
     assert.ok(avail, 'expected synth fallback to produce add_availability');
@@ -344,13 +359,14 @@ test('dispatchPm: falls back to synth when named-agent send throws', async () =>
   __setNamedAgentTimeoutForTests(500);
 
   try {
-    const result = await dispatchPm({
+    const result = dispatchPm({
       workspace_id: ws,
       trigger_text: 'Sarah out next week',
     });
-    assert.equal(result.used_synthesize_fallback, true);
-    assert.equal(result.used_named_agent, false);
-    assert.equal(result.proposal.status, 'draft');
+    const settled = await result.completion;
+    assert.equal(settled.used_synthesize_fallback, true);
+    assert.equal(settled.used_named_agent, false);
+    assert.equal(settled.final.status, 'draft');
   } finally {
     __setOpenClawClientForTests(null);
     __setNamedAgentTimeoutForTests(null);
@@ -367,13 +383,14 @@ test('dispatchPm: falls back to synth when named agent times out without writing
   __setNamedAgentTimeoutForTests(500);
 
   try {
-    const result = await dispatchPm({
+    const result = dispatchPm({
       workspace_id: ws,
       trigger_text: 'no agent will respond',
     });
-    assert.equal(result.used_synthesize_fallback, true);
-    assert.equal(result.used_named_agent, false);
-    assert.match(result.proposal.impact_md, /No structured changes|could not extract/);
+    const settled = await result.completion;
+    assert.equal(settled.used_synthesize_fallback, true);
+    assert.equal(settled.used_named_agent, false);
+    assert.match(settled.final.impact_md, /No structured changes|could not extract/);
   } finally {
     __setOpenClawClientForTests(null);
     __setNamedAgentTimeoutForTests(null);
@@ -401,12 +418,13 @@ test('dispatchPm: notes_intake uses a fresh per-correlation session and the note
   __setNamedAgentTimeoutForTests(2_000);
 
   try {
-    const result = await dispatchPm({
+    const result = dispatchPm({
       workspace_id: ws,
       trigger_text: 'Stand-up notes:\n- ship onboarding\n- fix #123',
       trigger_kind: 'notes_intake',
     });
-    assert.equal(result.used_named_agent, true);
+    const settled = await result.completion;
+    assert.equal(settled.used_named_agent, true);
     const send = seenSends.find(s => s.method === 'chat.send');
     assert.ok(send);
     const params = send!.params as { sessionKey?: string; message?: string };
@@ -430,13 +448,16 @@ test('dispatchPm: allowFallback=false propagates gateway error instead of synth-
   __setOpenClawClientForTests(client);
   const { PmDispatchGatewayUnavailableError } = await import('./pm-dispatch');
   try {
-    await assert.rejects(
-      dispatchPm({
-        workspace_id: ws,
-        trigger_text: 'notes go here',
-        trigger_kind: 'notes_intake',
-        allowFallback: false,
-      }),
+    // dispatchPm is now synchronous; allowFallback:false + gateway down
+    // throws immediately before any placeholder is created.
+    assert.throws(
+      () =>
+        dispatchPm({
+          workspace_id: ws,
+          trigger_text: 'notes go here',
+          trigger_kind: 'notes_intake',
+          allowFallback: false,
+        }),
       PmDispatchGatewayUnavailableError,
     );
   } finally {
@@ -444,24 +465,30 @@ test('dispatchPm: allowFallback=false propagates gateway error instead of synth-
   }
 });
 
-test('dispatchPm: allowFallback=false also surfaces a no-proposal-on-final timeout as an error', async () => {
+test('dispatchPm: allowFallback=false + gateway-up but agent silent → completion.used_named_agent === false', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
 
-  // Connected, but the agent never writes a proposal AND emitFinal arrives,
-  // so dispatchViaNamedAgent returns null. With fallback disabled this must throw.
+  // Gateway up, but the agent emits final without writing a propose_changes
+  // row. The reconciler tail expires; completion settles synth_only.
   const { client } = makeFakeClient({ emitFinal: true });
   __setOpenClawClientForTests(client);
   __setNamedAgentTimeoutForTests(500);
   try {
-    await assert.rejects(
-      dispatchPm({
-        workspace_id: ws,
-        trigger_text: 'whatever',
-        trigger_kind: 'notes_intake',
-        allowFallback: false,
-      }),
-    );
+    const result = dispatchPm({
+      workspace_id: ws,
+      trigger_text: 'whatever',
+      trigger_kind: 'notes_intake',
+      allowFallback: false,
+    });
+    // With Tier 3, dispatchPm always returns the placeholder synchronously
+    // even with allowFallback:false — the strict-gateway behavior is
+    // delegated to callers (e.g. propose_from_notes) that await completion
+    // and act on `used_named_agent === false`.
+    assert.equal(result.awaiting_agent, true);
+    const settled = await result.completion;
+    assert.equal(settled.used_named_agent, false);
+    assert.equal(settled.final.dispatch_state, 'synth_only');
   } finally {
     __setOpenClawClientForTests(null);
     __setNamedAgentTimeoutForTests(null);
@@ -531,5 +558,185 @@ test('drainPendingNotes: dispatches each pending row and marks dispatched', asyn
     __setOpenClawClientForTests(null);
     __setNamedAgentTimeoutForTests(null);
     __setGatewayProbeForTests(null);
+  }
+});
+
+// ─── dispatchPmSynthesized — Tier 1/2/3 (async w/ tail-window reconciler) ──
+
+const baseSynth = {
+  impact_md: '### Synth\n- placeholder',
+  changes: [],
+  plan_suggestions: { refined_description: '_(synth)_', complexity: 'M' as const, target_start: null, target_end: null, dependencies: [], status_check_md: null, owner_agent_id: null },
+};
+
+test('dispatchPmSynthesized: returns synth placeholder synchronously when gateway is up', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  const { client } = makeFakeClient({
+    onChatSend: () => {
+      // Simulate the agent landing a proposal via MCP propose_changes.
+      createProposal({
+        workspace_id: ws,
+        trigger_text: 'agent reply',
+        trigger_kind: 'manual',
+        impact_md: '### Agent reply\n- richer than synth',
+        proposed_changes: [],
+      });
+    },
+  });
+  __setOpenClawClientForTests(client);
+  __setNamedAgentTimeoutForTests(2_000);
+  try {
+    const dispatch = dispatchPmSynthesized({
+      workspace_id: ws,
+      trigger_text: 'plan something',
+      trigger_kind: 'plan_initiative',
+      synth: baseSynth,
+      agent_prompt: 'plan it',
+    });
+    // Returns immediately with the placeholder; agent dispatch runs in background.
+    assert.equal(dispatch.proposal.status, 'draft');
+    assert.equal(dispatch.proposal.dispatch_state, 'pending_agent');
+    assert.equal(dispatch.awaiting_agent, true);
+    // Wait for the lifecycle to settle.
+    const settled = await dispatch.completion;
+    assert.equal(settled.used_named_agent, true);
+    // The agent's row supersedes the synth placeholder.
+    const placeholder = getProposal(dispatch.proposal.id)!;
+    assert.equal(placeholder.status, 'superseded');
+    const agentRow = getProposal(settled.final.id)!;
+    assert.equal(agentRow.parent_proposal_id, dispatch.proposal.id);
+    assert.equal(agentRow.trigger_kind, 'plan_initiative');
+    assert.equal(agentRow.dispatch_state, 'agent_complete');
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
+  }
+});
+
+test('dispatchPmSynthesized: timeoutMs is honored — bumping it lets a slow agent win', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  // The fake client emits final 200ms after send; with a 50ms timeout the
+  // primary wait fails, but the tail window catches it.
+  const { client } = makeFakeClient({
+    onChatSend: () => {
+      createProposal({
+        workspace_id: ws,
+        trigger_text: 'slow agent reply',
+        trigger_kind: 'manual',
+        impact_md: '### Slow agent reply',
+        proposed_changes: [],
+      });
+    },
+    emitDelayMs: 200,
+  });
+  __setOpenClawClientForTests(client);
+  __setNamedAgentTimeoutForTests(50);
+  try {
+    const dispatch = dispatchPmSynthesized({
+      workspace_id: ws,
+      trigger_text: 'plan slow',
+      trigger_kind: 'plan_initiative',
+      synth: baseSynth,
+      agent_prompt: 'plan it',
+      // Generous tail window will catch the agent's late arrival.
+    });
+    const settled = await dispatch.completion;
+    assert.equal(settled.used_named_agent, true);
+    assert.notEqual(settled.final.id, dispatch.proposal.id);
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
+  }
+});
+
+test('dispatchPmSynthesized: synth_only when no agent reply ever arrives', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  // No onChatSend → no agent row created. emitFinal default true so wait
+  // returns sent:true but findProposal sees nothing.
+  const { client } = makeFakeClient({});
+  __setOpenClawClientForTests(client);
+  __setNamedAgentTimeoutForTests(50);
+  try {
+    const dispatch = dispatchPmSynthesized({
+      workspace_id: ws,
+      trigger_text: 'silent agent',
+      trigger_kind: 'plan_initiative',
+      synth: baseSynth,
+      agent_prompt: 'plan it',
+    });
+    const settled = await dispatch.completion;
+    assert.equal(settled.used_named_agent, false);
+    assert.equal(settled.final.id, dispatch.proposal.id);
+    // Placeholder stays as the operator's draft, marked as synth-only.
+    const refreshed = getProposal(dispatch.proposal.id)!;
+    assert.equal(refreshed.status, 'draft');
+    assert.equal(refreshed.dispatch_state, 'synth_only');
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
+  }
+});
+
+test('dispatchPmSynthesized: gateway down → synth-only placeholder, no background dispatch', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  const { client } = makeFakeClient({ isConnected: false });
+  __setOpenClawClientForTests(client);
+  try {
+    const dispatch = dispatchPmSynthesized({
+      workspace_id: ws,
+      trigger_text: 'no gateway',
+      trigger_kind: 'plan_initiative',
+      synth: baseSynth,
+      agent_prompt: 'plan it',
+    });
+    assert.equal(dispatch.awaiting_agent, false);
+    assert.equal(dispatch.proposal.dispatch_state, 'synth_only');
+    const settled = await dispatch.completion;
+    assert.equal(settled.used_named_agent, false);
+    assert.equal(settled.final.id, dispatch.proposal.id);
+  } finally {
+    __setOpenClawClientForTests(null);
+  }
+});
+
+test('dispatchPmSynthesized: target_initiative_id is stamped on the agent row during supersede', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Tier-2 target' });
+  const { client } = makeFakeClient({
+    onChatSend: () => {
+      // Agent's propose_changes call lands without target_initiative_id (current MCP shape).
+      createProposal({
+        workspace_id: ws,
+        trigger_text: 'agent reply',
+        trigger_kind: 'manual',
+        impact_md: '### Plan',
+        proposed_changes: [],
+      });
+    },
+  });
+  __setOpenClawClientForTests(client);
+  __setNamedAgentTimeoutForTests(2_000);
+  try {
+    const dispatch = dispatchPmSynthesized({
+      workspace_id: ws,
+      trigger_text: 'plan with target',
+      trigger_kind: 'plan_initiative',
+      target_initiative_id: init.id,
+      synth: baseSynth,
+      agent_prompt: 'plan it',
+    });
+    const settled = await dispatch.completion;
+    assert.equal(settled.used_named_agent, true);
+    const agentRow = getProposal(settled.final.id)!;
+    assert.equal(agentRow.target_initiative_id, init.id);
+    assert.equal(agentRow.trigger_kind, 'plan_initiative');
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
   }
 });

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3379,6 +3379,34 @@ const migrations: Migration[] = [
     },
   },
   {
+    id: '055',
+    name: 'pm_proposals_dispatch_state',
+    up: (db) => {
+      // Tracks where a draft proposal sits in the PM dispatch lifecycle:
+      //   - 'pending_agent'  : synth placeholder persisted; named-agent
+      //                        dispatch still in flight. UI should surface
+      //                        a "PM agent is still working" indicator and
+      //                        soft-disable Accept until agent_complete or
+      //                        the tail window elapses.
+      //   - 'agent_complete' : the named PM agent's `propose_changes` has
+      //                        landed (or there was nothing to wait for —
+      //                        e.g. plain disruption synth, manual creates).
+      //   - 'synth_only'     : agent never replied within the tail window;
+      //                        the synth fallback is the operator's draft.
+      // Existing rows pre-migration are stamped 'agent_complete' to
+      // preserve current accept-eligibility; only freshly-dispatched
+      // plan/decompose flows opt into the pending-agent state.
+      const cols = db.prepare(`PRAGMA table_info(pm_proposals)`).all() as Array<{ name: string }>;
+      if (!cols.some(c => c.name === 'dispatch_state')) {
+        db.exec(`ALTER TABLE pm_proposals ADD COLUMN dispatch_state TEXT NOT NULL DEFAULT 'agent_complete'`);
+        // SQLite ALTER ADD COLUMN can't carry a CHECK constraint, so back-
+        // stop with a partial index that flags any unknown value the next
+        // time it's queried (cheap, no rewrite).
+      }
+      console.log('[Migration 055] pm_proposals.dispatch_state added.');
+    },
+  },
+  {
     id: '051',
     name: 'workspaces_workspace_path',
     up: (db) => {

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -31,6 +31,7 @@ import { createTaskFromInitiative } from './promotion';
 // ─── Types ──────────────────────────────────────────────────────────
 
 export type PmProposalStatus = 'draft' | 'accepted' | 'rejected' | 'superseded';
+export type PmProposalDispatchState = 'pending_agent' | 'agent_complete' | 'synth_only';
 export type PmProposalTriggerKind =
   | 'manual'
   | 'scheduled_drift_scan'
@@ -125,6 +126,10 @@ export interface PmProposal {
   applied_by_agent_id: string | null;
   parent_proposal_id: string | null;
   target_initiative_id: string | null;
+  /** Where this row sits in the PM dispatch lifecycle (Tier 3 of the
+   *  pm-dispatch-async spec). For pre-migration rows or non-dispatched
+   *  proposals, defaults to 'agent_complete'. */
+  dispatch_state: PmProposalDispatchState;
   created_at: string;
 }
 
@@ -141,6 +146,7 @@ interface PmProposalRow {
   applied_by_agent_id: string | null;
   parent_proposal_id: string | null;
   target_initiative_id: string | null;
+  dispatch_state: PmProposalDispatchState | null;
   created_at: string;
 }
 
@@ -417,6 +423,7 @@ function rowToProposal(row: PmProposalRow): PmProposal {
     applied_by_agent_id: row.applied_by_agent_id,
     parent_proposal_id: row.parent_proposal_id,
     target_initiative_id: row.target_initiative_id ?? null,
+    dispatch_state: (row.dispatch_state ?? 'agent_complete') as PmProposalDispatchState,
     created_at: row.created_at,
   };
 }
@@ -432,6 +439,10 @@ export interface CreateProposalInput {
   plan_suggestions?: Record<string, unknown> | null;
   parent_proposal_id?: string | null;
   target_initiative_id?: string | null;
+  /** Defaults to 'agent_complete' (current behavior). Pass 'pending_agent'
+   *  when persisting a synth placeholder while the named-agent dispatch
+   *  is still in flight (Tier 3 of pm-dispatch-async). */
+  dispatch_state?: PmProposalDispatchState;
 }
 
 export function createProposal(input: CreateProposalInput): PmProposal {
@@ -454,8 +465,8 @@ export function createProposal(input: CreateProposalInput): PmProposal {
   run(
     `INSERT INTO pm_proposals (
        id, workspace_id, trigger_text, trigger_kind, impact_md,
-       proposed_changes, plan_suggestions, status, parent_proposal_id, target_initiative_id, created_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?)`,
+       proposed_changes, plan_suggestions, status, parent_proposal_id, target_initiative_id, dispatch_state, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?)`,
     [
       id,
       input.workspace_id,
@@ -466,10 +477,63 @@ export function createProposal(input: CreateProposalInput): PmProposal {
       input.plan_suggestions != null ? JSON.stringify(input.plan_suggestions) : null,
       input.parent_proposal_id ?? null,
       input.target_initiative_id ?? null,
+      input.dispatch_state ?? 'agent_complete',
       now,
     ],
   );
   return getProposal(id)!;
+}
+
+/**
+ * Update a draft's dispatch_state. Used by the late-arrival reconciler
+ * (Tier 2/3 of pm-dispatch-async) when an agent's `propose_changes` lands
+ * after the synth placeholder was persisted.
+ */
+export function setDispatchState(id: string, state: PmProposalDispatchState): void {
+  run(`UPDATE pm_proposals SET dispatch_state = ? WHERE id = ?`, [state, id]);
+}
+
+/**
+ * Mark a row as superseded by another. Used when the agent's `propose_changes`
+ * lands after a synth placeholder was already persisted: the synth row is
+ * superseded, and the agent's row inherits the synth row's
+ * `target_initiative_id` / `trigger_kind` and points at it via
+ * `parent_proposal_id`.
+ */
+export function supersedeWithAgentProposal(
+  synthRowId: string,
+  agentRowId: string,
+  intent: { trigger_kind: PmProposalTriggerKind; target_initiative_id?: string | null },
+): void {
+  const db = getDb();
+  db.transaction(() => {
+    // Inherit the placeholder's trigger_text onto the agent's row. The
+    // placeholder carries the structured JSON envelope MC built (e.g.
+    // `{ mode: 'decompose_initiative', initiative_id: '…' }`), which is
+    // what the resume/lookup endpoints (e.g.
+    // `GET /api/pm/decompose-initiative?initiative_id=…`) filter on via
+    // `json_extract(trigger_text, '$.initiative_id')`. The agent's
+    // freeform `trigger_text` from `propose_changes` doesn't carry that
+    // shape, so without copying we lose the link and the panel can't
+    // refetch after supersede.
+    const synthRow = queryOne<{ trigger_text: string | null }>(
+      `SELECT trigger_text FROM pm_proposals WHERE id = ?`,
+      [synthRowId],
+    );
+    run(`UPDATE pm_proposals SET status = 'superseded' WHERE id = ?`, [synthRowId]);
+    const sets: string[] = ['parent_proposal_id = ?', 'trigger_kind = ?', 'dispatch_state = ?'];
+    const vals: unknown[] = [synthRowId, intent.trigger_kind, 'agent_complete'];
+    if (intent.target_initiative_id) {
+      sets.push('target_initiative_id = ?');
+      vals.push(intent.target_initiative_id);
+    }
+    if (synthRow?.trigger_text) {
+      sets.push('trigger_text = ?');
+      vals.push(synthRow.trigger_text);
+    }
+    vals.push(agentRowId);
+    run(`UPDATE pm_proposals SET ${sets.join(', ')} WHERE id = ?`, vals);
+  })();
 }
 
 export function getProposal(id: string): PmProposal | undefined {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -926,7 +926,9 @@ CREATE TABLE IF NOT EXISTS pm_proposals (
   parent_proposal_id TEXT REFERENCES pm_proposals(id) ON DELETE SET NULL,
   created_at TEXT DEFAULT (datetime('now')),
   target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
-  plan_suggestions TEXT
+  plan_suggestions TEXT,
+  dispatch_state TEXT NOT NULL DEFAULT 'agent_complete'
+    CHECK (dispatch_state IN ('pending_agent','agent_complete','synth_only'))
 );
 
 -- Defer-and-replay queue for propose_from_notes requests that arrive

--- a/src/lib/mcp/roadmap-tools.ts
+++ b/src/lib/mcp/roadmap-tools.ts
@@ -33,7 +33,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
-import { queryOne } from '@/lib/db';
+import { queryOne, run } from '@/lib/db';
 import {
   createInitiative,
   updateInitiative,
@@ -611,7 +611,16 @@ export function registerRoadmapTools(server: McpServer): void {
           ])
           .optional(),
         impact_md: z.string().min(1).max(20000),
-        changes: z.array(DiffSchema),
+        // Tolerate stringified-array payloads coming from agent tool-use
+        // serialization layers that occasionally JSON-stringify array args.
+        // We unwrap-then-validate so the agent doesn't have to retry just
+        // because its caller chose strings over arrays.
+        changes: z.preprocess((val) => {
+          if (typeof val === 'string') {
+            try { return JSON.parse(val); } catch { return val; }
+          }
+          return val;
+        }, z.array(DiffSchema)),
         parent_proposal_id: z.string().nullish(),
         /**
          * Structured planning suggestions for plan_initiative proposals.
@@ -620,7 +629,12 @@ export function registerRoadmapTools(server: McpServer): void {
          * Required fields: refined_description, complexity.
          * Optional: target_start, target_end, status_check_md, dependencies.
          */
-        plan_suggestions: z.record(z.string(), z.unknown()).nullish(),
+        plan_suggestions: z.preprocess((val) => {
+          if (typeof val === 'string') {
+            try { return JSON.parse(val); } catch { return val; }
+          }
+          return val;
+        }, z.record(z.string(), z.unknown()).nullish()),
       },
       annotations: { destructiveHint: false, openWorldHint: false },
     },
@@ -670,13 +684,31 @@ export function registerRoadmapTools(server: McpServer): void {
         return { status: 'queued' as const, pending_id: queued.id };
       }
       try {
-        const result = await dispatchPm({
+        const result = dispatchPm({
           workspace_id: args.workspace_id,
           trigger_text: args.notes_text,
           trigger_kind: 'notes_intake',
           allowFallback: false,
         });
-        return { status: 'dispatched' as const, proposal_id: result.proposal.id };
+        // Wait for the agent's reply so callers don't get back a synth
+        // placeholder that masquerades as a successful dispatch. notes_intake
+        // strictly requires the named agent (regex on freeform notes is
+        // worse than nothing).
+        const settled = await result.completion;
+        if (!settled.used_named_agent) {
+          // Agent never replied within the tail window — clean up the
+          // placeholder and queue for replay so we don't keep a misleading
+          // draft around.
+          try { run(`DELETE FROM pm_proposals WHERE id = ?`, [result.proposal.id]); } catch { /* best-effort */ }
+          const queued = enqueuePendingNote({
+            workspace_id: args.workspace_id,
+            agent_id: args.agent_id,
+            notes_text: args.notes_text,
+            scope_hint: args.scope_hint ?? null,
+          });
+          return { status: 'queued' as const, pending_id: queued.id };
+        }
+        return { status: 'dispatched' as const, proposal_id: settled.final.id };
       } catch (err) {
         if (err instanceof PmDispatchGatewayUnavailableError) {
           // Gateway dropped between the health check and dispatch — queue
@@ -719,7 +751,7 @@ export function registerRoadmapTools(server: McpServer): void {
       // Re-dispatch so the new draft has impact_md + changes filled in.
       // We do this here (instead of relying on the API route refine
       // path) so MCP-driven refines also work.
-      const result = await dispatchPm({
+      const result = dispatchPm({
         workspace_id: parent.workspace_id,
         trigger_text: args.additional_constraint,
         trigger_kind: 'manual',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1000,7 +1000,9 @@ export type SSEEventType =
   | 'rollcall_started'
   | 'rollcall_delivered'
   | 'rollcall_entry_updated'
-  | 'agent_pinged';
+  | 'agent_pinged'
+  | 'pm_proposal_replaced'
+  | 'pm_proposal_dispatch_state_changed';
 
 export interface SSEEvent {
   type: SSEEventType;


### PR DESCRIPTION
## Summary

- **Async PM dispatch end-to-end.** plan_initiative, decompose_initiative, disruption, and `propose_from_notes` flows now return a synth placeholder synchronously (~15-90ms) and reconcile via a `pm_proposal_replaced` SSE event when the named openclaw agent's `propose_changes` lands. Eliminates the 60-180s sync wait that was masking real bugs.
- **PlanWithPmPanel + DecomposeWithPmModal** subscribe to the new SSE event, render a "PM agent is still composing" indicator while pending, and auto-swap content when the agent supersedes.
- **Preview-test infrastructure**: `docs/PREVIEW_TEST_FLOW.md` (the walkthrough), `docs/PREVIEW_TEST_FINDINGS.md` (running log), `scripts/db-checkpoint.ts` (+ `yarn db:checkpoint*` scripts) — exercised end-to-end against a real gateway in this PR.

See [specs/pm-dispatch-async.md](specs/pm-dispatch-async.md) for the architectural rationale.

## Changes

### PM dispatch (server)

- `dispatchPmSynthesized` + `dispatchPm` both refactored to return `{ proposal, awaiting_agent, completion }` synchronously. Background promise polls + supersedes via `pm_proposal_replaced` SSE.
- `pollForAgentProposal` filters `dispatch_state !== 'pending_agent'` so concurrent dispatches can't cross-supersede each other.
- Per-kind `timeoutMs` opt: plan/decompose pass 120_000; disruption keeps 60s default.
- Refine route strips the `[refine]` envelope and tells the agent to use `propose_changes` (closes a recursive-cascade bug where the agent triggered another dispatchPm via the `refine_proposal` MCP tool).
- `supersedeWithAgentProposal` copies `trigger_text` from the placeholder so the decompose GET endpoint keeps finding the live row after supersede.
- `propose_from_notes` awaits completion + cleans up the placeholder + queues for replay if the agent never replies.

### UI

- New `ConfirmDialog` component replaces native `window.confirm()` on `/agents` (Reset all sessions + per-row Reset session) — preview tooling can't drive native confirm.
- Guidance popup widened + flipped to `left-0` anchor so the heading and placeholder fit at any chevron position.
- `/pm` chat-card consumer prefers the structured `plan_suggestions` column; legacy sidecar appender removed from plan-initiative route.

### Drive-bys

- `synthesizePlanInitiative` self-dependency guard (targetInitiativeId opt + exact-title skip).
- `propose_changes` MCP tool: `z.preprocess` accepts JSON-stringified arrays / objects (some agent serializers stringify by default).

### Migrations

- 055: `pm_proposals.dispatch_state` column.

## Test plan

- [x] `yarn test` — 397/397 (added Tier 1/2/3 + self-dep + ConfirmDialog wiring tests).
- [x] `npx tsc --noEmit` — clean (only pre-existing `pm-decompose.test.ts` errors on main remain, unrelated).
- [x] `yarn mcp:smoke` — green.
- [x] `yarn mcp:integration` — green.
- [x] `yarn db:reset` + walked PREVIEW_TEST_FLOW.md §1-§4 against a live openclaw gateway:
  - §2 Initiative flow: created Smart Snappy → described it → Plan with PM (with guidance, SSE auto-swap to agent's full rewrite) → Apply → Decompose with PM (with hint, SSE auto-swap to 7 backend-first children, `$N` placeholder dep chain resolved) → Accept → manual dep → checkpoint.
  - §3 PM flow: disruption (POST returns 91ms, supersede in ~22s) → reject → 2nd disruption with explicit date → refine → accept (target dates apply to Smart Snappy) → `propose_from_notes` happy (heterogeneous diffs across availability + create_task_under_initiative + update_status_check) → gateway-down queue (17ms) → drain after reconnect (within 60s).
  - §4 Roadmap flow: Recompute now produced the correct backend → memory → prompts → engines → cards critical chain with the manual Onboarding dep honored; zoom toggles render cleanly.

## Open follow-ups (logged in PREVIEW_TEST_FINDINGS.md)

- Stock `Builder Agent` / `Learner Agent` rows still seeded by `bootstrapCoreAgentsRaw` (already a separate task).
- Agent's `plan_suggestions.target_start` / `.target_end` sometimes null — synth fills, agent occasionally omits.
- "next week" semantics differ between synth (ISO Mon-Mon) and agent (this Tue-Fri).
- `/api/pm/proposals?workspace_id=…` filter excludes advisory plan_initiative drafts (intentional but undocumented).
- §2.8 doc-drift: stories don't expose Add child without Convert kind first.
- §4.3 doc-drift: owner-availability ripple needs explicit owner assignments first.
- Quarter zoom on short ranges doesn't render month headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)