### PR TITLE
fix(pm): triage open preview-test-flow findings

### DIFF
--- a/docs/PREVIEW_TEST_FINDINGS.md
+++ b/docs/PREVIEW_TEST_FINDINGS.md
@@ -20,7 +20,7 @@ A running log of regressions, UX issues, and doc-drift items surfaced by walking
 
 ### §1.3 · Stock `Builder Agent` / `Learner Agent` rows seeded alongside gateway-synced agents
 
-- Severity: regression
+- Severity: regression (RESOLVED — `bootstrapCoreAgents` / `bootstrapCoreAgentsRaw` are now no-ops; worker roster is gateway-only, PM is the one MC-side agent created by `ensurePmAgent`)
 - Repro: from a wiped DB → `yarn db:reset` → `preview_start` → open `/agents`
 - Expected: only gateway-synced rows (`Builder`, `Coordinator`, `Learner`, `main`, `Project Manager`) plus any workspace-local PM. Total ≈ 5–6 agents.
 - Actual: 13 rows. Duplicates appear because the local-source rows `Builder Agent` (role=builder) and `Learner Agent` (role=learner) are seeded next to the gateway-linked `Builder` / `Learner` rows.
@@ -87,7 +87,7 @@ A running log of regressions, UX issues, and doc-drift items surfaced by walking
 
 ### §2.3 · `/api/pm/proposals?workspace_id=default` returns empty list while plan_initiative draft exists
 
-- Severity: polish (data inconsistency)
+- Severity: polish (NOT REPRODUCIBLE — false alarm from eval response-shape parsing; endpoint returns the array correctly)
 - Repro: after a plan_initiative dispatch lands a draft, GET `/api/pm/proposals?workspace_id=default`.
 - Expected: at least the new draft proposal in the response.
 - Actual: `[]`. The proposal IS reachable via `/api/pm/plan-initiative?…&target_initiative_id=…` and `/pm/proposals/<id>`, just not in the workspace-wide list.
@@ -103,7 +103,7 @@ A running log of regressions, UX issues, and doc-drift items surfaced by walking
 
 ### §2.4-2.5 · Agent's plan_suggestions occasionally omits target_start / target_end
 
-- Severity: polish
+- Severity: polish (RESOLVED — reconciler now backfills `target_start` / `target_end` from synth's `plan_suggestions` when the agent's row leaves them null)
 - Repro: from `setup-stable` → /initiatives → Smart Snappy → Plan with PM with the standard refinement guidance; inspect the resulting `plan_suggestions` and the post-Apply initiative row.
 - Expected: target window populated (synth fallback always proposes today + N weeks based on complexity).
 - Actual: agent's `plan_suggestions.target_start` / `.target_end` are both `null`; Apply leaves them null on the initiative row.
@@ -152,7 +152,7 @@ A running log of regressions, UX issues, and doc-drift items surfaced by walking
 
 ### §3.1 · Synth and agent disagree on "next week" semantics
 
-- Severity: polish
+- Severity: polish (RESOLVED — synth's `nextWeekStart` now uses conversational "tomorrow / next Monday on weekends" semantics, with a unit test pinning the behavior)
 - Repro: same as §3.1 above — observe the two competing proposals.
 - Expected: consistent date interpretation across synth and agent (both should produce Apr 28 – May 2 OR both May 4 – 10 — not divergent).
 - Actual: synth uses ISO-week semantics (Monday after next Monday → 2026-05-04 → 05-10). Agent uses conversational semantics (this Tue-Fri → 2026-04-28 → 05-02).
@@ -180,5 +180,11 @@ A running log of regressions, UX issues, and doc-drift items surfaced by walking
 - Notes: not a bug — it's the cold-start state on a workspace where the operator hasn't made owner assignments yet. Two doc-side options:
   1. PREVIEW_TEST_FLOW.md §4.3 should explicitly call out "first assign owners (Coordinator → backend stories, Builder Agent → mobile)" before staging availability.
   2. The agent's `decompose_initiative` SOUL.md guidance could nudge it to suggest owners based on the description's "Owner: Backend / Mobile / Design" labels (which the agent itself wrote in the Smart Snappy refined description). That'd make the ripple test work end-to-end out of the box.
+
+### §4.4 · Quarter zoom doesn't render month/quarter headers on short ranges
+
+- Severity: polish (RESOLVED — `axisTicks` includes the boundary at-or-before windowStart so the leftmost edge always carries a label; canvas renderer clamps negative-x labels to render at the left edge instead of off-screen)
+- Repro: from `roadmap-after-disruption` → /roadmap → Quarter zoom on a window that doesn't span Apr→Jul (or any quarter boundary).
+- Notes: live confirmed — Quarter zoom on the Smart Snappy Apr-May window now shows `Q2 2026` anchor label.
 
 <!-- new entries below -->

--- a/docs/PREVIEW_TEST_FLOW.md
+++ b/docs/PREVIEW_TEST_FLOW.md
@@ -76,7 +76,7 @@ The reference test data (description, refinement prompt, decompose hint) is in [
 | 2.5 | Click **Apply suggestions** (or equivalent) to populate the initiative draft. Save | the initiative's description / dates / complexity reflect the suggestions |
 | 2.6 | Back on the detail page, click **Decompose with PM**. (Optional: provide a hint such as "focus on backend first") | a draft proposal with `trigger_kind = decompose_initiative` lands; reviewing it shows 3–7 `create_child_initiative` diffs all parented to Smart Snappy |
 | 2.7 | Open the decompose proposal. Click **Accept** | proposal flips to `accepted`; child stories appear under Smart Snappy on `/initiatives`; each child has a `task_initiative_history` entry |
-| 2.8 | Pick one child. Click **Add child**, create a sub-story (e.g. "Daily checklist v0"). Save | new sub-story attaches under the child; tree view shows nested rows |
+| 2.8 | Pick one of the agent's child stories. **First** click **Convert kind** to bump it from `story` → `epic` (stories are roadmap leaves and don't expose `Add child`). Then click **Add child**, create a sub-story (e.g. "Daily checklist v0"). Save | new sub-story attaches under the converted parent; tree view shows nested rows. Skip this step if you don't want to mutate the agent's structure. |
 | 2.9 | On a child, add a dependency (Add dependency dropdown → pick a sibling). Save | sibling appears in the child's deps list |
 | 2.10 | Save checkpoint: `smart-snappy-decomposed` | `.tmp/checkpoints/smart-snappy-decomposed.db` exists |
 
@@ -118,7 +118,7 @@ The roadmap timeline lives at `/roadmap` with Week / Month / Quarter zoom. The d
 |---|---|---|
 | 4.1 | After accepting decompose in §2, navigate to `/roadmap`. Pick the **Quarter** zoom | Smart Snappy + its children render on the timeline with derived target dates; arrows show dep edges |
 | 4.2 | Click **Recompute now** | "Last computed" timestamp updates; visible target dates may shift slightly; no error toasts |
-| 4.3 | Add an owner-availability window via PM (`Sarah out 2026-05-01 to 2026-05-15`) and accept the proposal. Return to `/roadmap` and Recompute | initiatives owned by Sarah whose target windows overlap the unavailability shift later; arrow/dep chain remains consistent |
+| 4.3 | **Prerequisite**: assign owners to a few children (e.g. on `Snappy Service Architecture` → click into the OWNER column → pick a gateway agent like `mc-builder`). The agent's decompose doesn't assign owners, so cold-start workspaces have all `owner_agent_id = null` and any availability window has nothing to ripple through. Then add an owner-availability window via PM (`Researcher out 2026-05-01 to 2026-05-15` if you assigned mc-researcher), accept it, return to `/roadmap` and Recompute | initiatives owned by the unavailable agent whose target windows overlap the unavailability shift later; arrow/dep chain remains consistent. If no children have owners assigned, expect zero ripple — the test is content-dependent. |
 | 4.4 | Toggle Week ↔ Month ↔ Quarter | bars resize; nothing renders off-screen; no infinite scroll |
 | 4.5 | Save checkpoint: `roadmap-after-disruption` | `.tmp/checkpoints/roadmap-after-disruption.db` exists |
 

--- a/src/components/roadmap/RoadmapCanvas.tsx
+++ b/src/components/roadmap/RoadmapCanvas.tsx
@@ -93,18 +93,26 @@ export function RoadmapCanvas({
             <svg width={totalWidth} height={48} style={{ display: 'block' }}>
               {ticks.map((t, i) => {
                 const x = dateToPx(t, windowStart, pxPerDay);
+                // Ticks placed at-or-before windowStart keep the leftmost
+                // edge labelled even on short ranges (e.g. a Quarter-zoom
+                // view that spans <90 days). Clamp the visible label to
+                // x=4 so it doesn't render in negative space.
+                const labelX = Math.max(x + 4, 4);
+                const lineVisible = x >= 0;
                 return (
                   <g key={i}>
-                    <line
-                      x1={x}
-                      x2={x}
-                      y1={0}
-                      y2={48}
-                      stroke="currentColor"
-                      className="text-mc-border"
-                    />
+                    {lineVisible && (
+                      <line
+                        x1={x}
+                        x2={x}
+                        y1={0}
+                        y2={48}
+                        stroke="currentColor"
+                        className="text-mc-border"
+                      />
+                    )}
                     <text
-                      x={x + 4}
+                      x={labelX}
                       y={30}
                       className="fill-mc-text-secondary"
                       fontSize={11}

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -570,6 +570,45 @@ async function runNamedAgentDispatchInBackground(
         trigger_kind: input.trigger_kind,
         target_initiative_id: input.target_initiative_id ?? null,
       });
+      // plan_initiative-specific backfill: if the agent omitted dates in
+      // its plan_suggestions, fill from the synth's (always populated)
+      // target window so the operator's Apply form has dates to apply.
+      // Observed in the wild: the agent sometimes returns
+      // `target_start: null, target_end: null` and the operator gets a
+      // suggestion card with empty date fields.
+      if (input.trigger_kind === 'plan_initiative') {
+        try {
+          const agentSuggestions = (found.plan_suggestions ?? null) as
+            | { target_start?: string | null; target_end?: string | null }
+            | null;
+          const synthSuggestions = (input.synth.plan_suggestions ?? null) as
+            | { target_start?: string | null; target_end?: string | null }
+            | null;
+          if (agentSuggestions && synthSuggestions) {
+            const merged = { ...agentSuggestions };
+            let dirty = false;
+            if (!merged.target_start && synthSuggestions.target_start) {
+              merged.target_start = synthSuggestions.target_start;
+              dirty = true;
+            }
+            if (!merged.target_end && synthSuggestions.target_end) {
+              merged.target_end = synthSuggestions.target_end;
+              dirty = true;
+            }
+            if (dirty) {
+              run(
+                `UPDATE pm_proposals SET plan_suggestions = ? WHERE id = ?`,
+                [JSON.stringify(merged), found.id],
+              );
+              console.log(
+                `[pm-dispatch] backfilled plan_suggestions dates from synth for agent row ${found.id}`,
+              );
+            }
+          }
+        } catch (err) {
+          console.warn('[pm-dispatch] plan_suggestions backfill failed:', (err as Error).message);
+        }
+      }
       const refreshed = listProposals({ workspace_id: input.workspace_id, limit: 1, since: sinceIso }).find(p => p.id === found.id) ?? found;
       broadcast({
         type: 'pm_proposal_replaced',
@@ -960,8 +999,23 @@ function thisWeekStart(d: Date): Date {
   return addDays(d, offset);
 }
 
+/**
+ * Conversational "next week" semantics: tomorrow through the Friday of
+ * the following workweek. This matches how operators (and the named PM
+ * agent) talk about the phrase — "Sarah out next week" said on a
+ * Monday means Tue-Fri-and-Mon-Fri, not the ISO-week-after-next which
+ * is what `thisWeekStart(d) + 7` would have produced.
+ *
+ * The window is anchored to "the Monday after today (or today, if today
+ * is a Sunday)". Saturdays/Sundays roll forward to the next Monday so
+ * a weekend operator saying "out next week" still means the upcoming
+ * Mon-Fri.
+ */
 function nextWeekStart(d: Date): Date {
-  return addDays(thisWeekStart(d), 7);
+  const day = d.getUTCDay(); // 0=Sun, 6=Sat
+  if (day === 0) return addDays(d, 1); // Sunday → tomorrow (Monday)
+  if (day === 6) return addDays(d, 2); // Saturday → Monday after
+  return addDays(d, 1); // Mon-Fri → tomorrow
 }
 
 function escapeRe(s: string): string {

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -145,6 +145,27 @@ test('synthesizeImpactAnalysis: "Sarah out next week" → add_availability for S
   }
 });
 
+test('synthesizeImpactAnalysis: "next week" starts tomorrow (or next Monday on weekends), matching how operators talk', () => {
+  // Today's date is fixed by the test harness; we just assert that the
+  // start date is no more than 2 days after today (Sat/Sun → Monday).
+  // The pre-fix behavior would land on the Monday of the FOLLOWING ISO
+  // week, which can be 8+ days after today.
+  const ws = freshWorkspace();
+  seedNamedAgent(ws, 'Sarah');
+  const snap = getRoadmapSnapshot({ workspace_id: ws });
+  const result = synthesizeImpactAnalysis(snap, 'Sarah out next week');
+  const window = result.parsed.date_windows[0];
+  assert.ok(window, 'expected a parsed date_window');
+  const today = new Date();
+  const todayIso = today.toISOString().slice(0, 10);
+  // start should be within [today, today+2] depending on weekday.
+  const dayDiff = Math.round((Date.parse(window.start + 'T00:00:00Z') - Date.parse(todayIso + 'T00:00:00Z')) / 86400000);
+  assert.ok(dayDiff >= 0 && dayDiff <= 2, `expected next-week start within 0-2 days of today, got ${dayDiff} (start=${window.start}, today=${todayIso})`);
+  // end is start + 6 → conversational "Mon through Fri of that week" in practice.
+  const endDayDiff = Math.round((Date.parse(window.end + 'T00:00:00Z') - Date.parse(window.start + 'T00:00:00Z')) / 86400000);
+  assert.equal(endDayDiff, 6);
+});
+
 test('synthesizeImpactAnalysis: never references unknown initiative_ids', () => {
   const ws = freshWorkspace();
   const initA = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Build big feature' });
@@ -735,6 +756,71 @@ test('dispatchPmSynthesized: target_initiative_id is stamped on the agent row du
     const agentRow = getProposal(settled.final.id)!;
     assert.equal(agentRow.target_initiative_id, init.id);
     assert.equal(agentRow.trigger_kind, 'plan_initiative');
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
+  }
+});
+
+test('dispatchPmSynthesized: plan_initiative — agent omits target dates → reconciler backfills from synth', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  // Build a synth that has populated dates (always true in production —
+  // synthesizePlanInitiative inserts derived target_start / _end based on
+  // complexity).
+  const synthWithDates = {
+    impact_md: '### Synth\n- placeholder',
+    changes: [],
+    plan_suggestions: {
+      refined_description: '_(synth)_',
+      complexity: 'L' as const,
+      target_start: '2026-05-01',
+      target_end: '2026-06-15',
+      dependencies: [],
+      status_check_md: null,
+      owner_agent_id: null,
+    },
+  };
+  const { client } = makeFakeClient({
+    onChatSend: () => {
+      // Agent lands its propose_changes call with NULL dates — the
+      // observed wild behavior we're fixing.
+      createProposal({
+        workspace_id: ws,
+        trigger_text: 'agent reply',
+        trigger_kind: 'manual',
+        impact_md: '### Plan\n- something',
+        proposed_changes: [],
+        plan_suggestions: {
+          refined_description: 'agent rewrite',
+          complexity: 'L',
+          target_start: null,
+          target_end: null,
+          dependencies: [],
+          status_check_md: null,
+          owner_agent_id: null,
+        },
+      });
+    },
+  });
+  __setOpenClawClientForTests(client);
+  __setNamedAgentTimeoutForTests(2_000);
+  try {
+    const dispatch = dispatchPmSynthesized({
+      workspace_id: ws,
+      trigger_text: 'plan',
+      trigger_kind: 'plan_initiative',
+      synth: synthWithDates,
+      agent_prompt: 'plan it',
+    });
+    const settled = await dispatch.completion;
+    assert.equal(settled.used_named_agent, true);
+    const refreshed = getProposal(settled.final.id)!;
+    const ps = refreshed.plan_suggestions as { target_start?: string | null; target_end?: string | null; refined_description?: string };
+    // Dates filled from synth, but the agent's refined_description is preserved.
+    assert.equal(ps.target_start, '2026-05-01');
+    assert.equal(ps.target_end, '2026-06-15');
+    assert.equal(ps.refined_description, 'agent rewrite');
   } finally {
     __setOpenClawClientForTests(null);
     __setNamedAgentTimeoutForTests(null);

--- a/src/lib/bootstrap-agents.ts
+++ b/src/lib/bootstrap-agents.ts
@@ -1,232 +1,54 @@
 /**
- * Bootstrap Core Agents
+ * Workspace bootstrap helpers.
  *
- * Creates the 4 core agents (Builder, Tester, Reviewer, Learner)
- * for a workspace if it has zero agents. Also clones workflow
- * templates from the default workspace to new workspaces.
+ * Worker agents (Builder, Tester, Reviewer, Learner, Researcher, Writer,
+ * main) are gateway-synced from openclaw and arrive via
+ * `agent-catalog-sync.ts` once the gateway is connected. The PM agent is
+ * MC-side and is created/linked by `ensurePmAgent` (further down in this
+ * file).
+ *
+ * The legacy `bootstrapCoreAgents` / `bootstrapCoreAgentsRaw` previously
+ * inserted four hardcoded `source='local'` rows (Builder Agent /
+ * Tester Agent / Reviewer Agent / Learner Agent) for any new workspace.
+ * That ran before gateway sync had a chance to populate the same roles,
+ * leaving the operator with duplicate rows on `/agents` (one local, one
+ * gateway-linked) on every fresh DB.
+ *
+ * The functions are kept as no-ops so existing call sites and migration
+ * 013 don't need to be patched. The new architectural rule:
+ *
+ *   - Worker roster: gateway sync only (mc-builder / mc-coordinator /
+ *     mc-learner / mc-researcher / mc-reviewer / mc-tester / mc-writer /
+ *     main).
+ *   - PM agent: `ensurePmAgent(workspaceId)` (called from
+ *     `POST /api/workspaces` and migration 049).
+ *   - Workflow templates: `cloneWorkflowTemplates` (still active).
  */
 
 import Database from 'better-sqlite3';
 import { getDb } from '@/lib/db';
-import { getMissionControlUrl } from '@/lib/config';
-
-// ── Agent Definitions ──────────────────────────────────────────────
-
-function sharedUserMd(missionControlUrl: string): string {
-  return `# User Context
-
-## Operating Environment
-- Platform: Autensa multi-agent task orchestration
-- API Base: ${missionControlUrl}
-- Tasks are dispatched automatically by the workflow engine
-- Communication via OpenClaw Gateway
-
-## The Human
-Manages overall system, sets priorities, defines tasks. Follow specifications precisely.
-
-## Communication Style
-- Be concise and action-oriented
-- Report results with evidence
-- Ask for clarification only when truly needed`;
-}
-
-const SHARED_AGENTS_MD = `# Team Roster
-
-## Builder Agent (🛠️)
-Creates deliverables from specs. Writes code, creates files, builds projects. When work comes back from failed QA, fixes all reported issues.
-
-## Tester Agent (🧪) — Front-End QA
-Tests the app from the user's perspective. Clicks elements, checks rendering, verifies images/links, tests forms. This is FRONT-END testing — does the app work when you use it?
-
-## Reviewer Agent (🔍) — Code QC
-Final quality gate. Reviews code quality, best practices, correctness, completeness. This is BACK-END/CODE review — is the code good? Works in the Verification column.
-
-## Learner Agent (📚)
-Observes all transitions. Captures patterns and lessons learned. Feeds knowledge back to improve future work.
-
-## How We Work Together
-Builder → Tester (front-end QA) → Review Queue → Reviewer (code QC) → Done
-If Testing fails: back to Builder with front-end issues.
-If Verification fails: back to Builder with code issues.
-Learner watches all transitions and records lessons.
-Review is a queue — tasks wait there until the Reviewer is free.
-Only one task in Verification at a time.`;
-
-interface AgentDef {
-  name: string;
-  role: string;
-  emoji: string;
-  soulMd: string;
-}
-
-const CORE_AGENTS: AgentDef[] = [
-  {
-    name: 'Builder Agent',
-    role: 'builder',
-    emoji: '🛠️',
-    soulMd: `# Builder Agent
-
-Expert builder. Follows specs exactly. Creates output in the designated project directory.
-
-## Core Responsibilities
-- Read the spec carefully before writing any code
-- Create all deliverables in the designated output directory
-- Register every deliverable via the API (POST .../deliverables)
-- Log activity when done (POST .../activities)
-- Update status to move the task forward (PATCH .../tasks/{id})
-
-## Fail-Loopback
-When tasks come back from failed QA (testing or verification), read the failure reason carefully and fix ALL issues mentioned. Do not partially fix — address every single point.
-
-## Quality Standards
-- Clean, well-structured code
-- Follow project conventions
-- No placeholder or stub code — everything must be functional
-- Test your work before marking complete`,
-  },
-  {
-    name: 'Tester Agent',
-    role: 'tester',
-    emoji: '🧪',
-    soulMd: `# Tester Agent — Front-End QA
-
-Front-end QA specialist. Tests the app/project from the user's perspective.
-
-## What You Test
-- Click on UI elements — do they respond correctly?
-- Visual rendering — does it look right? Layout, spacing, colors?
-- Images — do they load? Are they the right ones?
-- Links — do they navigate to the right places?
-- Forms — do they submit? Validation messages?
-- Responsiveness — does it work on different screen sizes?
-- Basically: does it WORK when you USE it?
-
-## Decision Criteria
-- PASS only if everything works when you use it
-- FAIL with specific details: which element, what happened, what was expected
-
-## Rules
-- Never fix issues yourself — that's the Builder's job
-- Be thorough — check every visible element and interaction
-- Report failures with evidence (what you clicked, what happened, what should have happened)`,
-  },
-  {
-    name: 'Reviewer Agent',
-    role: 'reviewer',
-    emoji: '🔍',
-    soulMd: `# Reviewer Agent — Code Quality Gatekeeper
-
-Reviews code structure, best practices, patterns, completeness, correctness, and security.
-
-## What You Review
-- Code quality — clean, well-structured, maintainable
-- Best practices — proper patterns, no anti-patterns
-- Completeness — does the code address ALL requirements in the spec?
-- Correctness — logic errors, edge cases, security issues
-- Standards — follows project conventions
-
-## Critical Rule
-You MUST fail tasks that have real code issues. A false pass wastes far more time than a false fail — the Builder gets re-dispatched with your notes, which is fast. But if bad code ships to Done, the whole pipeline failed.
-
-Never rubber-stamp. If the code is genuinely good, pass it. If there are real issues, fail it.
-
-## Failure Reports
-Explain every issue with:
-- File name and line number
-- What's wrong
-- What the fix should be
-
-Be specific. "Code quality could be better" is useless. "src/utils.ts:42 — missing null check on user input before database query" is actionable.`,
-  },
-  {
-    name: 'Learner Agent',
-    role: 'learner',
-    emoji: '📚',
-    soulMd: `# Learner Agent
-
-Observes all task transitions — both passes and failures. Captures lessons learned and writes them to the knowledge base.
-
-## What You Capture
-- Failure patterns — what went wrong and why
-- Fix patterns — what the Builder did to fix failures
-- Checklists — recurring items that should be checked every time
-- Best practices — patterns that consistently lead to passes
-
-## How to Record
-POST /api/workspaces/{workspace_id}/knowledge
-Body: {
-  "task_id": "the task id",
-  "category": "failure" | "fix" | "pattern" | "checklist",
-  "title": "Brief, searchable title",
-  "content": "Detailed description",
-  "tags": ["relevant", "tags"],
-  "confidence": 0.0-1.0
-}
-
-## Guidelines
-- Focus on actionable insights that help the team avoid repeating mistakes
-- Higher confidence for patterns seen multiple times
-- Lower confidence for first-time observations
-- Tag entries so they can be found and injected into future dispatches`,
-  },
-];
 
 // ── Public API ──────────────────────────────────────────────────────
 
 /**
- * Bootstrap core agents for a workspace using the normal getDb() accessor.
- * Safe to call from API routes (NOT from migrations — use bootstrapCoreAgentsRaw).
+ * No-op kept for back-compat with `POST /api/workspaces`. Worker agents
+ * arrive via gateway sync; the PM is created by `ensurePmAgent`.
  */
-export function bootstrapCoreAgents(workspaceId: string): void {
-  const db = getDb();
-  const missionControlUrl = getMissionControlUrl();
-  bootstrapCoreAgentsRaw(db, workspaceId, missionControlUrl);
+export function bootstrapCoreAgents(_workspaceId: string): void {
+  // Intentional no-op. See the file header for the rationale.
 }
 
 /**
- * Bootstrap core agents using a raw db handle.
- * Use this inside migrations to avoid getDb() recursion.
+ * No-op kept for back-compat with migration 013. The original behavior
+ * (inserting four hardcoded local-source agent rows) caused duplicate
+ * rows once gateway sync layered the real roles on top.
  */
 export function bootstrapCoreAgentsRaw(
-  db: Database.Database,
-  workspaceId: string,
-  missionControlUrl: string,
+  _db: Database.Database,
+  _workspaceId: string,
+  _missionControlUrl: string,
 ): void {
-  // Only bootstrap if workspace has zero agents
-  const count = db.prepare(
-    'SELECT COUNT(*) as cnt FROM agents WHERE workspace_id = ?'
-  ).get(workspaceId) as { cnt: number };
-
-  if (count.cnt > 0) {
-    console.log(`[Bootstrap] Workspace ${workspaceId} already has ${count.cnt} agent(s) — skipping`);
-    return;
-  }
-
-  const userMd = sharedUserMd(missionControlUrl);
-  const now = new Date().toISOString();
-
-  const insert = db.prepare(`
-    INSERT INTO agents (id, name, role, description, avatar_emoji, status, is_master, workspace_id, soul_md, user_md, agents_md, source, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, 'standby', 0, ?, ?, ?, ?, 'local', ?, ?)
-  `);
-
-  for (const agent of CORE_AGENTS) {
-    const id = crypto.randomUUID();
-    insert.run(
-      id,
-      agent.name,
-      agent.role,
-      `${agent.name} — core team member`,
-      agent.emoji,
-      workspaceId,
-      agent.soulMd,
-      userMd,
-      SHARED_AGENTS_MD,
-      now,
-      now,
-    );
-    console.log(`[Bootstrap] Created ${agent.name} (${agent.role}) for workspace ${workspaceId}`);
-  }
+  // Intentional no-op.
 }
 
 /**

--- a/src/lib/roadmap/date-math.test.ts
+++ b/src/lib/roadmap/date-math.test.ts
@@ -166,15 +166,27 @@ test('defaultWindow ignores nulls', () => {
 
 // ─── axisTicks / formatTick ────────────────────────────────────────
 
-test('axisTicks: month zoom returns month boundaries', () => {
+test('axisTicks: month zoom returns month boundaries (incl. leftmost-anchor)', () => {
+  // Includes Apr 1 (at-or-before window start) so the leftmost edge always
+  // gets a label — important on short windows that don't span a boundary.
   const t = axisTicks('2026-04-10', '2026-07-15', 'month');
-  // First-of-May, June, July.
-  assert.deepEqual(t.map(toIsoDay), ['2026-05-01', '2026-06-01', '2026-07-01']);
+  assert.deepEqual(t.map(toIsoDay), ['2026-04-01', '2026-05-01', '2026-06-01', '2026-07-01']);
 });
 
-test('axisTicks: quarter zoom returns quarter starts', () => {
+test('axisTicks: quarter zoom returns quarter starts (incl. leftmost-anchor)', () => {
+  // Q1 boundary (Jan 1) is at-or-before window start (Feb 1), so it's the
+  // leftmost anchor.
   const t = axisTicks('2026-02-01', '2026-12-31', 'quarter');
-  assert.deepEqual(t.map(toIsoDay), ['2026-04-01', '2026-07-01', '2026-10-01']);
+  assert.deepEqual(t.map(toIsoDay), ['2026-01-01', '2026-04-01', '2026-07-01', '2026-10-01']);
+});
+
+test('axisTicks: quarter zoom on a short range still produces an anchor tick', () => {
+  // Short Apr 27 – Jun 11 window — doesn't span Apr→Jul boundary, but we
+  // still want a Q2 anchor at Apr 1 for the canvas to clamp + display.
+  // Without the fix this returned [] and the timeline rendered with no
+  // headers at all (§4.4 finding).
+  const t = axisTicks('2026-04-27', '2026-06-11', 'quarter');
+  assert.deepEqual(t.map(toIsoDay), ['2026-04-01']);
 });
 
 test('axisTicks: week zoom returns Mondays', () => {

--- a/src/lib/roadmap/date-math.ts
+++ b/src/lib/roadmap/date-math.ts
@@ -201,8 +201,10 @@ export function axisTicks(
       cursor.setUTCDate(cursor.getUTCDate() + 7);
     }
   } else if (zoom === 'month') {
+    // Include the month boundary at-or-before window start so the leftmost
+    // visible region always has a label, even when the window doesn't span
+    // a month boundary cleanly.
     const cursor = new Date(Date.UTC(s.getUTCFullYear(), s.getUTCMonth(), 1));
-    if (cursor < s) cursor.setUTCMonth(cursor.getUTCMonth() + 1);
     while (cursor <= e) {
       ticks.push(new Date(cursor));
       cursor.setUTCMonth(cursor.getUTCMonth() + 1);
@@ -211,8 +213,11 @@ export function axisTicks(
     // quarter
     const month = s.getUTCMonth();
     const qStart = month - (month % 3);
+    // Include the quarter boundary at-or-before window start (e.g. Apr 1
+    // for an Apr 27 – Jun 11 window) so we always have at least one tick
+    // to render. The canvas renderer clamps negative x values to 0 so the
+    // label lands at the leftmost edge.
     const cursor = new Date(Date.UTC(s.getUTCFullYear(), qStart, 1));
-    if (cursor < s) cursor.setUTCMonth(cursor.getUTCMonth() + 3);
     while (cursor <= e) {
       ticks.push(new Date(cursor));
       cursor.setUTCMonth(cursor.getUTCMonth() + 3);


### PR DESCRIPTION
## Summary

Sweep of the polish + correctness findings logged in [docs/PREVIEW_TEST_FINDINGS.md](docs/PREVIEW_TEST_FINDINGS.md) during the live walkthrough on #88. All six open items addressed in this PR; one (`/api/pm/proposals` filter) was a false alarm in my test eval.

## Changes

- **Synth \"next week\" matches the agent's conversational semantics** — tomorrow / next Monday on weekends, not ISO-week-after-next. Unit test pins it.
- **Plan-initiative reconciler backfills empty agent dates from synth** so the operator's Apply form has dates to apply when the agent omits `target_start` / `target_end`.
- **`bootstrapCoreAgents` is a no-op now.** Worker roster is gateway-synced; PM is the only MC-side agent, owned by `ensurePmAgent`. Eliminates the duplicate `Builder Agent` / `Learner Agent` rows that appeared on every fresh DB.
- **Roadmap Quarter zoom always renders a header anchor** — `axisTicks` includes the boundary at-or-before windowStart so short ranges (e.g. Apr 27 – Jun 11) don't render headerless. Canvas clamps off-screen labels to the left edge.
- **PREVIEW_TEST_FLOW.md doc-drift** — §2.8 calls out the Convert kind prerequisite; §4.3 explains owner-availability ripple needs explicit assignments first.
- **§2.3 `/api/pm/proposals` filter** finding closed as NOT REPRODUCIBLE (eval shape-detection bug, not a server-side filter).

## Test plan

- [x] `yarn test` — 400/400 (3 new tests).
- [x] `npx tsc --noEmit` — clean (pre-existing `pm-decompose.test.ts` errors only).
- [x] Live preview confirmed Quarter zoom on a short range now shows the `Q2 2026` anchor label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)