### PR TITLE
fix(pm): tighten output discipline — tool call first, single-line reply

### DIFF
--- a/src/app/api/pm/decompose-initiative/route.ts
+++ b/src/app/api/pm/decompose-initiative/route.ts
@@ -116,7 +116,9 @@ export async function POST(request: NextRequest) {
         (parsed.data.hint ? ` Operator hint: ${parsed.data.hint}.` : '') +
         ` Call \`propose_changes\` (trigger_kind='decompose_initiative') with one ` +
         `\`create_child_initiative\` diff per child. Pre-wire each child to depend on the ` +
-        `prior sibling using placeholder ids \`$0\`, \`$1\`, etc. See your SOUL.md.`,
+        `prior sibling using placeholder ids \`$0\`, \`$1\`, etc. See your SOUL.md. ` +
+        `Output discipline: tool call FIRST, then a single-line \`Proposal {id}.\` reply — ` +
+        `no freeform summary (the operator UI discards it).`,
     });
     const proposal = dispatch.proposal;
 

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -155,7 +155,9 @@ export async function POST(request: NextRequest) {
           : '') +
         `Call \`propose_changes\` (trigger_kind='plan_initiative') with proposed_changes=[] and ` +
         `pass the structured plan_suggestions parameter directly (do NOT embed JSON in impact_md). ` +
-        `See your SOUL.md for the plan_suggestions shape.`,
+        `See your SOUL.md for the plan_suggestions shape. ` +
+        `Output discipline: tool call FIRST, then a single-line \`Proposal {id}.\` reply — ` +
+        `no freeform summary (the operator UI discards it).`,
     });
     const proposal = dispatch.proposal;
     // Note: the synth placeholder created by `dispatchPmSynthesized` already

--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -125,7 +125,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           `Produce an updated refined_description that addresses the operator's request. ` +
           `Call \`propose_changes\` (trigger_kind='plan_initiative') with proposed_changes=[] and ` +
           `pass the structured plan_suggestions parameter directly (do NOT embed JSON in impact_md). ` +
-          `See your SOUL.md for the plan_suggestions shape.`,
+          `See your SOUL.md for the plan_suggestions shape. ` +
+          `Output discipline: tool call FIRST, then a single-line \`Proposal {id}.\` reply — ` +
+          `no freeform summary (the operator UI discards it).`,
       });
       // Refine has a pre-allocated child row to copy content onto, so we
       // wait for the full dispatch lifecycle (Tier 2 reconciliation

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -263,7 +263,8 @@ async function runDisruptionDispatchInBackground(
         `${summary}\n\n` +
         `Per your SOUL.md: analyse the disruption and call \`propose_changes\` ` +
         `with a structured PmDiff[] and impact_md. Reference only ids that ` +
-        `appear in the snapshot.`;
+        `appear in the snapshot. Output discipline: tool call FIRST, then a single-line ` +
+        `\`Proposal {id}.\` reply — no freeform summary (it's discarded).`;
   const sessionSuffix = input.trigger_kind === 'notes_intake' ? `notes-${correlationId}` : 'dispatch-main';
 
   let result: Awaited<ReturnType<typeof sendChatAndAwaitReply>> | null = null;

--- a/src/lib/agents/pm-prompts/notes-intake.ts
+++ b/src/lib/agents/pm-prompts/notes-intake.ts
@@ -44,5 +44,7 @@ export function buildNotesIntakeMessage(input: BuildNotesIntakeMessageInput): st
     '- Cap proposals at ~15 diffs. Prefer the highest-signal items if the notes are long.',
     '- If the notes contain nothing actionable for the roadmap, return an empty `changes` array and explain in `impact_md`.',
     '- Never fabricate agent ids, dates, or initiative titles.',
+    '',
+    'Output discipline: call `propose_changes` FIRST. After the tool returns, your reply MUST be a single line: `Proposal {id}.` — no freeform summary. The operator UI renders only `impact_md` + structured fields; anything you say in chat after the tool call is discarded.',
   ].join('\n');
 }

--- a/src/lib/agents/pm-soul.md
+++ b/src/lib/agents/pm-soul.md
@@ -69,10 +69,28 @@ rejects / refines.
 
 ## Output discipline
 
-When the operator messages you, respond with a brief markdown summary
-followed immediately by the `propose_changes` tool call. Do **not** ask
-permission to call the tool — the operator approves at the proposal level
-(Accept / Reject / Refine).
+**Call `propose_changes` FIRST. Don't write a freeform summary before or
+after the tool call.** The operator never sees your conversational reply
+— the UI renders only the proposal's `impact_md` + structured fields.
+Anything you write in the chat after the tool call is wasted tokens and
+latency.
+
+After the tool returns, your reply MUST be a single line of the form:
+
+```
+Proposal {proposal_id}.
+```
+
+Examples:
+- `Proposal 8b2f3c10-…`
+- `Proposal 4e9d-… (refined).`
+
+That's it. Put all the substance into `impact_md` and (for plan_initiative)
+`plan_suggestions`. The `impact_md` is what shows up in the operator's
+chat card; the freeform reply is discarded.
+
+Do **not** ask permission to call the tool — the operator approves at
+the proposal level (Accept / Reject / Refine).
 
 ## Diff kinds (proposed_changes JSON)
 


### PR DESCRIPTION
## Summary

The PM agent was producing a wordy markdown summary after every `propose_changes` call. MC's UI discards that freeform reply — the chat card renders only `impact_md` + structured fields. The text was wasted tokens + latency on every dispatch.

Change the contract: agent calls `propose_changes` FIRST, then replies \`Proposal {id}.\` — single line, no summary. All substance goes into `impact_md` (and `plan_suggestions` for plan_initiative), which is what actually surfaces.

## Changes

- `src/lib/agents/pm-soul.md` and the live `~/.openclaw/workspaces/mc-project-manager/SOUL.md` — Output Discipline section rewritten.
- Reminder appended to every dispatch prompt (disruption / plan_initiative / decompose / refine / notes_intake) so the rule is reinforced even when the agent session drifts.
- Existing agents need a `/reset` to pick up the new SOUL.md; the dispatch-side reminder works immediately.

## Test plan

- [x] `yarn test` — 400/400 pass; existing notes-intake prompt assertions still hold.
- [x] `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)