### PR TITLE
docs: memory layer + subagent orchestration + gardener specs

### DIFF
--- a/specs/gardener.md
+++ b/specs/gardener.md
@@ -1,0 +1,499 @@
+# Gardener — memory curation, seeding, and dissemination
+
+## Why
+
+The memory layer (see [memory-layer.md](memory-layer.md)) gives every
+agent grounded context at dispatch time. But a static store rots:
+
+- Recurring decisions stay duplicated across siblings instead of being
+  promoted to a parent or org scope where they'd inform peer work.
+- Stale claims linger ("auth lives in `backend-app/internal/auth`")
+  long after the codebase has moved on.
+- Critical findings discovered in one task ("package `foo` has a
+  CVE-2026-…") don't reach peer tasks that should know.
+- Adoption is hard from a cold start: a new workspace's memory is
+  empty until operators or agents dribble entries in over weeks.
+
+The gardener is the curation role that closes those loops. It sees
+**all** memory in a workspace (every scope, the full tree) — a
+privileged view no individual builder/coordinator gets — and uses
+that vantage to consolidate, prune, verify, seed, and disseminate.
+
+This is a **role**, not necessarily a new agent. The defining property
+is the cross-tree view; whether it lands as a dedicated `gardener`
+agent or as a mode of the existing learner is an implementation
+detail decided in the first PR.
+
+## Responsibilities
+
+Six jobs, in rough order of risk:
+
+### 1. Promote (consolidation)
+
+Detect recurring themes across siblings and lift them to the lowest
+common ancestor that covers them.
+
+Examples:
+- Three story-scoped entries under the same epic each say "we use
+  Postgres with the `pgx` driver" → promote to the epic.
+- Five entries scattered across unrelated themes mention "demo to
+  Sarah on Fridays" → promote to org.
+
+Mechanism: cluster active entries by embedding similarity (configurable
+threshold, default 0.85). For clusters of size ≥ N (default 3),
+compute lowest common ancestor of their scopes. Emit a promote
+proposal: new entry at the ancestor level, originals marked
+`superseded_by` the new id.
+
+### 2. Prune (rot management)
+
+Mark entries stale based on:
+
+- Time since `last_retrieved_at` (default >180 days never retrieved →
+  candidate).
+- Contradiction with newer entries (semantic similarity high, but
+  conflicting tags or content keywords like "no longer", "deprecated",
+  "moved").
+- Supersession by accepted proposals (e.g. an initiative status
+  change that contradicts a memory claim).
+
+Stale entries are flagged via `archived_at` (not deleted) and excluded
+from active retrieval. Operator can un-archive or delete. This is
+distinct from `quarantined_at` — pruning means "low signal," quarantine
+means "actively wrong." See job 6.
+
+### 3. Verify (ground-truth checks)
+
+Spot-check claims that name verifiable external state:
+
+- Repo paths ("auth is in `backend-app/internal/auth`") — read the
+  path against a checked-out worktree or via the GitHub read API
+  (when that lands, see open question below).
+- URLs / docs ("our brand guidelines live at notion.so/…") — HEAD
+  request or fetch.
+- Package status ("we use `foo@1.2`") — check npm/pypi/etc. for
+  current version, deprecation flags, advisories.
+
+Outcomes:
+- Match → bump `last_verified_at`.
+- Drift → emit a verify proposal with the discrepancy spelled out.
+  Operator decides to update or reject.
+
+Verification is **rate-limited and budgeted** — see "Context
+discipline" below. Not every entry gets verified every cycle; the
+gardener picks the highest-leverage K per run, weighted by retrieval
+frequency.
+
+### 4. Disseminate (cross-tree relevance)
+
+The flagship case the operator called out: when one task discovers
+something that peers need, the gardener routes it.
+
+Examples:
+- Researcher finds package `foo` is deprecated → gardener proposes an
+  org-scope memory entry tagged `#deprecation:foo` and (optionally)
+  files a `propose_changes` against the PM to slot a remediation
+  initiative if the package is in heavy use.
+- Builder learns "the staging DB has a 2GB row limit on `events`" →
+  gardener promotes to the platform epic level if multiple stories
+  underneath touch the same DB.
+
+Mechanism: high-priority entries (`priority = 'critical'` set by the
+writing agent or by gardener heuristics — security, deprecation,
+data-loss keywords) bypass the periodic cycle and trigger an immediate
+gardener pass, debounced ~30s to batch bursts.
+
+### 5. Closure pass (initiative lifecycle)
+
+When an initiative transitions to `done` or `cancelled`, the gardener
+runs a focused pass over its subtree's memory. Each entry is classified
+into one of three outcomes:
+
+- **Promote** — the lesson generalizes (e.g. "Stripe webhooks are
+  unreliable below 5min retry"). Lift to parent or org via the
+  standard promote pipeline.
+- **Archive** (`archived_at` set) — durable record, excluded from
+  active retrieval but searchable for audit. Default outcome for
+  `done` initiatives whose memory doesn't warrant promotion.
+- **Quarantine** (`quarantined_at` set) — default outcome for
+  `cancelled` initiatives. Cancellation usually means the embedded
+  assumptions proved wrong; treating that memory as ground truth for
+  unrelated future work is harmful. Operator can selectively
+  un-quarantine the bits that are still valid.
+
+The classifier is a subagent (per the context-discipline rules below):
+reads each entry, the closure context (status, status_check_md,
+recent activity), and outputs one of {promote, archive, quarantine}
+with a short justification. Output goes through proposal review — the
+operator sees a single batched proposal per closure rather than per
+entry.
+
+Trigger: a hook on `initiatives.status` transitions to `done` or
+`cancelled` enqueues a closure run for that initiative_id.
+
+### 6. Quarantine + blast-radius investigation
+
+The case operators most need a backstop for: an agent saved a flawed
+memory, peers grounded on it, downstream decisions inherited the error.
+Targeted removal isn't enough — bad memory often *symptomizes* either a
+flawed mental model from one agent in one period, or a confusing area
+that produced multiple miscalibrated entries. Fix has to look wider
+than the single entry.
+
+When an entry is quarantined (operator clicks "Report bad memory" or
+gardener heuristics flag) the gardener immediately runs a
+blast-radius pass. Four candidate sets:
+
+- **Direct downstream consumers** — query `memory_retrievals` for
+  every task or proposal that grounded on the entry. Surface them so
+  the operator can review whether the bad assumption affected the
+  outcome.
+- **Peer entries by the same author + time window** — same
+  `created_by_agent_id` within ±N days (default 14). If one of agent
+  X's entries from week Y was wrong, neighbors deserve a look.
+- **Semantic neighbors** — embedding-similar entries across the
+  workspace. A flawed mental model often produces multiple entries
+  that cluster in vector space.
+- **Downstream memories** — entries written by tasks that consumed
+  the bad one (joined via `memory_retrievals` where
+  `consumer_kind = 'memory_write'`). Inheritance of the flaw.
+
+The investigation produces a *quarantine review queue* — a single
+batched proposal listing each candidate with severity (direct vs peer
+vs neighbor vs downstream-memory), rationale, and a suggested action
+per candidate. Operator triages in one pass rather than chasing
+per-entry.
+
+This shares machinery with the closure pass — quarantine is a
+narrower, operator-driven version of cancellation's bulk-quarantine
+default. Both feed the same review-queue UX.
+
+## Two-track operator trust contract
+
+The gardener never silently rewrites operator-authored memory. Two
+classes of action:
+
+**Mechanical** (low risk) — applied directly, surfaced in a "gardener
+log" the operator can scroll:
+- Bump `last_retrieved_at`, `retrieval_count`, `last_verified_at`.
+- Mark stale (recoverable, doesn't delete).
+- Re-tag based on content (additive, not destructive).
+- Dedupe near-identical entries within the same scope.
+
+**Substantive** (needs review) — emitted as `pm_proposals` rows with
+a new `trigger_kind = 'memory_curation'`:
+- Promote (new entry + supersede chain).
+- Verify drift (proposed update to an existing entry).
+- New entry from research / seeding.
+- Cross-tree dissemination.
+- Closure classification batch (one proposal per closing initiative,
+  enumerating promote/archive/quarantine actions for each attached
+  entry).
+- Quarantine review queue (one proposal per investigation, enumerating
+  direct/peer/neighbor/downstream-memory candidates with suggested
+  actions).
+
+Reusing the proposal review pipeline gives free audit, accept/reject/
+refine, and SSE notification. Operator stays in control.
+
+## Seeding from external sources
+
+The gardener can bootstrap a cold workspace's memory from existing
+sources, on operator demand or as a periodic enrichment pass. **Never
+required** — agents work fine on an empty memory store, just without
+grounding.
+
+Source adapters (each lives at `src/lib/gardener/sources/<name>.ts`):
+
+- **Git history** — read commit messages + PR descriptions for
+  configured repos. Distill recurring patterns: "tests run via
+  `yarn test`", "we squash-merge", architectural decisions called out
+  in commits.
+- **Code structure** — read top-level READMEs, `package.json`,
+  config files. Extract: stack, scripts, conventions.
+- **Web pages** — operator-supplied URL list. Fetch + summarize.
+  Useful for vendor docs, internal wikis, brand guidelines.
+- **Email / chat exports** — operator-supplied JSON/MBOX dump.
+  Distill recurring contacts, vendor relationships, decision history.
+- **GitHub issues / PRs** — when the GitHub read path lands.
+
+### Map-reduce pipeline (load-bearing for high-volume sources)
+
+The hardest seeding cases — multi-year email archives, decade-long
+commit histories — defeat any "feed it to one prompt" approach. The
+adapter pipeline is fixed at six phases that all sources implement:
+
+1. **Cull** (no LLM cost). Heuristic filters drop structurally noisy
+   inputs: newsletters, automated notifications, "+1" replies for
+   email; merge commits, dependabot, formatting-only commits for git.
+   Eliminates 70-90% of volume before any model runs.
+2. **Identity dictionary**. Extract a people/org table from senders,
+   signatures, commit authors, GitHub handles. Built once before any
+   content is read so downstream phases can disambiguate (`Sarah Chen
+   <acme>` vs `Sarah Patel <recruiter>`). Without this, findings
+   confidently conflate identities.
+3. **Survey (map only)**. A single subagent reads a stratified sample
+   (e.g. 200 threads spread across the time range) and returns a
+   *taxonomy of recurring topics* — not findings, just an outline.
+   The full corpus stays untouched.
+4. **Targeted reduce**. For each topic in the taxonomy, dispatch a
+   fresh subagent with a tight prompt and budget cap. Each returns
+   ≤500 tokens of distilled findings + citations. Topics run in
+   parallel within the per-cycle subagent cap.
+5. **Recency + drift weighting**. Findings tagged with their evidence
+   date range. Topics heavy in older periods but absent recently are
+   flagged as likely stale, not ingested. Contradicting findings
+   resolve to the most recent, with the older retained as supersede
+   history.
+6. **Privacy + safety gate**. Heuristic filters surface candidates
+   that look personal (family domains, medical/legal-personal
+   keywords) into a separate operator-only review track, never
+   auto-ingested as memory. Conservative: false positives are far
+   cheaper than false negatives.
+
+Each adapter returns `SeedingCandidate[]`:
+
+```ts
+interface SeedingCandidate {
+  body_md: string;
+  suggested_scope: 'org' | { initiative_id: string };
+  tags: string[];
+  source_ref: string;        // citation: commit sha, URL, message-id, etc.
+  confidence: number;         // 0..1, source-adapter-specific
+  evidence_window: {          // recency context for the finding
+    earliest: string;         // ISO date
+    latest: string;
+    occurrences: number;
+  };
+  flagged_personal?: boolean; // routed to separate operator review track
+}
+```
+
+Candidates are ALL routed through proposal review, batched by topic
+(one proposal per topic, not per finding). Cap initial seeding output
+at ~30 proposals per workspace per run; second wave only after the
+first is reviewed. No silent ingestion.
+
+## Context discipline (load-bearing)
+
+This is the critical constraint. Source material can be enormous —
+tens of thousands of commits, hundreds of pages of docs, archives of
+emails. Pulling all of it into a single gardener prompt is impossible.
+
+**Strategy: scoped subagents that report distilled findings.** The
+gardener orchestrates rather than reads directly. For each job it
+identifies what it needs ("does package `foo` have a known CVE?",
+"what conventions appear in the last 200 commits to `backend-app`?"),
+spawns researcher subagents with tight prompts and budgeted tools,
+and synthesises their distilled reports into memory proposals.
+
+The orchestration contract — subagent identity, MCP-compliant
+messaging (including `send_mail` for mid-flight check-ins), persona
+gating, lifecycle, and fan-out collection — is defined in
+[subagent-orchestration.md](subagent-orchestration.md). Gardener uses
+that surface; it does not invent its own.
+
+Gardener-specific budgets layered on top of the platform defaults:
+
+- **Per-cycle subagent cap**: default 3 concurrent on local-LLM
+  workspaces, 5 nightly / 20 weekly when the openclaw gateway is
+  configured for cloud capacity. Workspace-tunable.
+- **Per-subagent caps**: default 15 tool calls, 2k output tokens,
+  120s deadline (local-LLM-friendly).
+- **Verification prioritization**: verify subagents prioritize
+  entries with high `retrieval_count` — value scales with how often
+  peers depend on the claim.
+
+## Cadence
+
+- **Mechanical pass** — nightly cron. Cheap. No subagents needed for
+  the dedup/stale/retag work.
+- **Substantive pass** — weekly cron, or operator-triggered ("garden
+  this initiative now" button on the Memory tab).
+- **Verify / fill-gap** — on-demand, triggered by either:
+  - Retrieval-time signal (`getRelevantMemory` returns thin results
+    for a load-bearing query — log the miss, gardener picks it up).
+  - Operator request ("verify all memory under epic X").
+  - Disseminate-class triggers (high-priority finding posted by an
+    in-flight builder/researcher).
+- **Seeding** — operator-triggered the first time per source. Optional
+  periodic re-runs (monthly) to catch new commits / new PRs.
+
+## Implementation outline
+
+### Storage additions
+
+The `memory_entries` columns the gardener needs (`archived_at`,
+`quarantined_at`, `quarantine_reason`, `last_verified_at`, `priority`,
+`superseded_by`) and the `memory_retrievals` provenance table are
+defined in [memory-layer.md](memory-layer.md). The gardener only adds
+the cycle log:
+
+```sql
+CREATE TABLE gardener_runs (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN
+    ('mechanical','substantive','verify','seed','disseminate','closure','quarantine')),
+  trigger_ref TEXT,                           -- initiative_id (closure) or memory_entry_id (quarantine)
+  started_at TEXT NOT NULL DEFAULT (datetime('now')),
+  finished_at TEXT,
+  status TEXT NOT NULL DEFAULT 'running' CHECK (status IN ('running','complete','failed')),
+  summary_md TEXT,                            -- distilled report for the operator
+  subagents_spawned INTEGER NOT NULL DEFAULT 0,
+  proposals_emitted INTEGER NOT NULL DEFAULT 0,
+  error TEXT
+);
+CREATE INDEX idx_gardener_runs_workspace ON gardener_runs(workspace_id, started_at DESC);
+```
+
+### Code layout
+
+```
+src/lib/gardener/
+  index.ts                  # public API: runMechanical, runSubstantive, runVerify, runSeed, runClosure, runQuarantine
+  cluster.ts                # promotion clustering
+  prune.ts                  # stale + contradiction detection (sets archived_at)
+  verify.ts                 # subagent orchestration for ground-truth checks
+  disseminate.ts            # cross-tree triggers
+  closure.ts                # closure-pass classifier (promote/archive/quarantine per entry)
+  quarantine.ts             # blast-radius investigation
+  seed.ts                   # source-adapter orchestration (six-phase pipeline)
+  sources/
+    git-history.ts
+    code-structure.ts
+    web.ts
+    email-export.ts
+  subagent.ts               # spawn + budget + collect helper
+  identity.ts               # shared identity-dictionary builder for seeding adapters
+```
+
+### Triggers
+
+- Nightly cron registered in `instrumentation.ts` next to the
+  `pm-pending-drain` worker.
+- Weekly cron likewise.
+- Operator button on `/memory` (workspace) and the initiative Memory
+  tab — POSTs to `/api/gardener/run` with `{ kind, scope }`.
+- High-priority memory write — when an agent saves a memory entry
+  with `priority: 'critical'`, the dispatch path enqueues a
+  disseminate run (debounced ~30s to batch bursts).
+- **Initiative status hook** — transitions to `done` or `cancelled`
+  enqueue a closure run for that subtree.
+- **Quarantine hook** — operator's "Report bad memory" click (or
+  gardener-driven quarantine) enqueues a blast-radius investigation
+  for that entry.
+
+### MCP surface
+
+Two new tools, both gardener-restricted:
+
+- `propose_memory_curation` — the gardener's analogue of
+  `propose_changes`. Emits a `pm_proposals` row with
+  `trigger_kind = 'memory_curation'` and a `proposed_changes` array of
+  memory diffs.
+- `record_gardener_finding` — short-circuit logging for mechanical
+  ops that don't need review (writes to `gardener_runs.summary_md`).
+
+Plus new diff kinds in `pm_proposals` for memory ops:
+`memory_promote`, `memory_supersede`, `memory_update`, `memory_create`,
+`memory_archive`, `memory_quarantine`, `memory_unquarantine`.
+`acceptProposal` applies them transactionally.
+
+### UI
+
+Two surfaces:
+
+- **Gardener log** — `/memory/gardener` lists runs (kind, status,
+  proposals emitted, summary). Click into a run to see the
+  subagent reports and resulting proposals. Closure and quarantine
+  runs render their candidate tables inline so the operator can
+  triage without leaving the page.
+- **Memory entry detail** — when viewing an entry, show its
+  provenance: source, supersede chain, last verified, retrieval
+  count, and (via the `memory_retrievals` join) the list of tasks
+  and proposals that consumed it. Operator actions: un-archive,
+  un-quarantine, trigger a one-off verify, "Report bad memory"
+  (kicks off a quarantine investigation).
+
+## Tests
+
+- `src/lib/gardener/cluster.test.ts` — promotion clustering with
+  seeded multi-scope entries; lowest-common-ancestor logic.
+- `src/lib/gardener/prune.test.ts` — staleness rules, contradiction
+  detection, archive flagging.
+- `src/lib/gardener/verify.test.ts` — fake subagent, asserts budget
+  caps + drift-proposal emission.
+- `src/lib/gardener/seed.test.ts` — fake source adapters, asserts
+  six-phase pipeline (cull → identity → survey → reduce → recency
+  → privacy gate); candidates → proposals routing (no direct writes).
+- `src/lib/gardener/disseminate.test.ts` — high-priority memory
+  write triggers a debounced run; cross-tree proposal emission.
+- `src/lib/gardener/closure.test.ts` — initiative status transitions
+  to `done` produce archive-default proposals; transitions to
+  `cancelled` produce quarantine-default proposals; promote outcomes
+  surface for entries that match cluster patterns above the closing
+  initiative.
+- `src/lib/gardener/quarantine.test.ts` — quarantining an entry
+  produces a review-queue proposal listing direct consumers (from
+  `memory_retrievals`), peer entries by author+time, semantic
+  neighbors, and downstream-memory candidates with appropriate
+  severity tags.
+- E2E: seed an org with three sibling entries that should promote;
+  run substantive pass; assert proposal exists; accept; assert the
+  promoted entry exists at the parent and originals are superseded.
+
+## Verification
+
+- `yarn typecheck && yarn test`.
+- MCP smoke: confirm `propose_memory_curation` registered.
+- Preview pass:
+  1. Seed a workspace with three sibling memory entries that should
+     cluster.
+  2. Trigger the substantive pass via `/api/gardener/run`.
+  3. Open `/memory/gardener` → confirm run summary appears.
+  4. Open the resulting proposal in the PM review pane → accept →
+     confirm promoted entry exists at the parent scope.
+- Manual: write a `priority: 'critical'` entry from a builder context;
+  observe disseminate run firing within ~30s and a proposal landing.
+- Manual closure: transition a story-level initiative to `cancelled`;
+  observe a closure proposal listing its attached entries with
+  quarantine-default classifications; accept; confirm entries become
+  excluded from active retrieval for sibling tasks.
+- Manual quarantine: from a dispatch log, click "Report bad memory"
+  on a retrieved snippet; observe quarantine proposal listing
+  downstream consumers and peer candidates within ~30s.
+
+## Open questions
+
+- **Gardener as named agent vs role on existing agents.** Naming a
+  dedicated gardener agent gives it its own openclaw session and
+  prompt — cleaner separation, but more agent roster overhead. Folding
+  into the learner reuses an existing agent at the cost of a more
+  complex prompt. Recommend: separate agent if the prompt complexity
+  warrants (it likely will once seeding is in scope), folded otherwise.
+  Decide at first-PR time.
+- **Embedding re-runs on model change.** If a workspace switches
+  embedding provider (e.g. Ollama `nomic-embed-text` → cloud
+  `voyage-3-lite`), all entries need re-embedding. Gardener owns the
+  migration pass — define the contract before adopting a second
+  provider.
+- **Cross-workspace gardening.** Out of scope for v1. A future
+  org-of-workspaces view might want a meta-gardener that promotes
+  patterns across workspaces, but that's a separate design.
+- **GitHub read path coupling.** The verify + seed jobs benefit from
+  GitHub API access (commit history, PR bodies, issue search). Spec
+  is independent — gardener works without it, just with thinner
+  source coverage. If GitHub read lands, verify/seed get richer.
+
+## Out of scope (followups)
+
+- A "memory diff" view across supersede chains (audit-grade).
+- Operator-driven "force promote" / "force prune" buttons that
+  bypass proposal review.
+- Multi-modal memory (screenshots, voice notes) — text-only for v1.
+- Per-tag retrieval boosts ("entries tagged `#critical` always
+  surface").
+- Gardener-driven initiative reorg (gardener sees patterns suggesting
+  an initiative restructure → emits PM proposals). Tempting, out of
+  scope here — current spec keeps gardener bounded to memory.

--- a/specs/memory-layer.md
+++ b/specs/memory-layer.md
@@ -1,0 +1,468 @@
+# Memory layer — grounding agents in workspace + initiative context
+
+## Why
+
+Today's MC has a knowledge surface (`knowledge_entries`) that's
+workspace-scoped and untyped beyond a small enum (`failure | fix |
+pattern | checklist`). When a builder/coordinator dispatches, it
+receives the task row plus the top-K workspace lessons by confidence.
+That's a flat retrieval that ignores where the task sits in the
+initiative tree, and it forces all knowledge into a single global pool.
+
+Two gaps follow:
+
+1. **No durable workspace context**. There's no place for an operator to
+   write down "frontend lives in `frontend-app`, backend lives in
+   `backend-app`, we use yarn, our content schedule template lives at
+   `/docs/content/template.md`." Agents have to rediscover this every
+   task.
+2. **No scoped project context**. An epic-level decision ("we rejected
+   webhooks for billing, using polling instead") cannot be attached to
+   that epic so it informs every story underneath without leaking to
+   unrelated work.
+
+The fix is a memory store that mirrors how operators and agents
+already think — markdown notes scoped to a node in the initiative tree,
+retrieved by similarity, injected into dispatch prompts.
+
+This spec covers storage, retrieval, dispatch integration, and the
+operator editor surface. The agentic curator that promotes / prunes /
+verifies / seeds memory is a separate concern — see
+[gardener.md](gardener.md).
+
+## Design summary
+
+```
+operator + learner + coordinator + builder
+        ↓ write_memory MCP / editor UI
+memory_entries (markdown + embedding, scoped to org or initiative)
+        ↑ getRelevantMemory({workspace_id, initiative_id?, query, k})
+        ↑ tree walk: org + ancestor chain entries, ranked by similarity
+dispatch prompt
+  ## Workspace context (org entries)
+  ## Initiative context (matched ancestor entries)
+```
+
+Two scopes: **org** (workspace-wide, NULL `initiative_id`) and
+**project** (attached to a specific initiative; inherited by the entire
+subtree below). Retrieval at task dispatch time pulls org entries plus
+all ancestor-chain project entries above the task's initiative, ranks
+by cosine similarity to the task description, and injects the top-K
+into the prompt.
+
+Memory entries are **untyped by topic**. Org memory can hold repo
+conventions, vendor contacts, brand guidelines, oncall rotation, legal
+SLAs, anything. The agent reads the relevant snippets and grounds its
+plan accordingly — if the task is "update checkout copy" the retrieved
+memory will mention repos; if it's "schedule next week's influencer
+outreach" it will mention vendors. The dispatch helper does not know
+the difference and does not need to.
+
+## Data model
+
+### New table `memory_entries`
+
+```sql
+CREATE TABLE memory_entries (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  initiative_id TEXT,                         -- NULL = org scope
+  body_md TEXT NOT NULL,
+  tags TEXT NOT NULL DEFAULT '[]',            -- JSON array of strings
+  embedding BLOB,                              -- Float32Array, nullable until backfilled
+  embedding_model TEXT,                        -- e.g. 'voyage-3-lite'
+  source TEXT NOT NULL DEFAULT 'manual'        -- 'manual' | 'agent' | 'gardener' | 'seeded'
+    CHECK (source IN ('manual','agent','gardener','seeded')),
+  created_by_agent_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  last_retrieved_at TEXT,                      -- gardener input (prune signal), not retrieval internals
+  retrieval_count INTEGER NOT NULL DEFAULT 0,  -- gardener input (value signal)
+  last_verified_at TEXT,                       -- gardener verify pass timestamp
+  superseded_by TEXT,                          -- id of newer entry; gardener promote/dedupe sets this
+  archived_at TEXT,                            -- set when attached initiative closes 'done'
+  quarantined_at TEXT,                         -- set when entry is flagged actively wrong
+  quarantine_reason TEXT,                      -- short operator/gardener note
+  priority TEXT NOT NULL DEFAULT 'normal'
+    CHECK (priority IN ('normal','critical')), -- 'critical' triggers disseminate run
+  FOREIGN KEY (initiative_id) REFERENCES initiatives(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_memory_workspace_org
+  ON memory_entries(workspace_id) WHERE initiative_id IS NULL;
+CREATE INDEX idx_memory_initiative
+  ON memory_entries(initiative_id) WHERE initiative_id IS NOT NULL;
+CREATE INDEX idx_memory_active
+  ON memory_entries(workspace_id)
+  WHERE superseded_by IS NULL AND archived_at IS NULL AND quarantined_at IS NULL;
+```
+
+`tags` are agent-suggested annotations (`#repo:backend-app`,
+`#vendor:acme`, `#convention:testing`) — useful for filtering and
+dedup but **not load-bearing for retrieval**. Embeddings do the work.
+
+Lifecycle columns and what they mean:
+
+- `superseded_by` — chain history. Gardener promote/dedupe writes a new
+  entry and supersedes originals rather than deleting; the operator can
+  audit the chain.
+- `archived_at` — durable record, excluded from active retrieval. Set
+  by the gardener's closure pass when an initiative transitions to
+  `done` and the attached entry doesn't warrant promotion. Still
+  searchable for audit.
+- `quarantined_at` + `quarantine_reason` — actively wrong, may have
+  caused harm. Distinct from `stale_at` / "outdated"; quarantine
+  excludes from retrieval immediately and triggers a blast-radius
+  investigation (see gardener.md).
+- `priority = 'critical'` — high-importance findings (CVE, deprecation,
+  data-loss-class facts). Bypass the periodic gardener cycle and
+  trigger an immediate disseminate run.
+- `last_retrieved_at` + `retrieval_count` — gardener inputs only.
+  Retrieval-frequency heuristics drive prune candidacy and verify
+  prioritization. Not consumed by the retrieval pipeline itself.
+- `last_verified_at` — set by gardener verify pass when a claim is
+  spot-checked against ground truth.
+
+### New table `memory_retrievals` — provenance graph
+
+Every dispatch and proposal that grounds itself in memory writes one
+row per consumed entry. Cheap, indexed, and the foundation of
+blast-radius investigation: given a quarantined memory, find every
+consumer that saw it.
+
+```sql
+CREATE TABLE memory_retrievals (
+  id TEXT PRIMARY KEY,
+  memory_entry_id TEXT NOT NULL,
+  consumer_kind TEXT NOT NULL
+    CHECK (consumer_kind IN ('task_dispatch','pm_proposal','memory_write')),
+  consumer_id TEXT NOT NULL,                   -- task_id, proposal_id, or memory_entry_id
+  rerank_score REAL NOT NULL,                  -- final ranking score after rerank step
+  retrieved_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (memory_entry_id) REFERENCES memory_entries(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_memory_retrievals_entry
+  ON memory_retrievals(memory_entry_id);
+CREATE INDEX idx_memory_retrievals_consumer
+  ON memory_retrievals(consumer_kind, consumer_id);
+```
+
+The `memory_write` kind covers the case where one memory is grounded
+in earlier memory — agent reads memory M1 while writing memory M2;
+quarantining M1 surfaces M2 as a downstream candidate.
+
+### Migration 056
+
+Add both tables. No backfill needed — `knowledge_entries` continues
+to exist for now. (Whether to merge them is a follow-up; see
+"Open questions" below.)
+
+## Retrieval
+
+Use a textbook hybrid retrieval + rerank pipeline rather than rolling
+custom ranking. The pieces are mature and well-benchmarked; what's
+MC-specific is the **scope filter** (org + ancestor chain, exclude
+archived/quarantined/superseded) — applied as metadata pre-filtering
+before the standard pipeline runs.
+
+### Pipeline
+
+```
+query
+  ↓ embed (Voyage voyage-3-lite or similar)
+  ↓ scope filter: (initiative_id IN ancestor_chain OR initiative_id IS NULL)
+                  AND superseded_by IS NULL
+                  AND archived_at IS NULL
+                  AND quarantined_at IS NULL
+  ├─ vector ANN (sqlite-vec) → top-50
+  └─ BM25 / FTS5 keyword search → top-50
+  ↓ reciprocal rank fusion → top-25
+  ↓ cross-encoder rerank (Voyage rerank-2 or Cohere rerank-3) → top-K
+  → return split as org[] + project[]
+```
+
+Concrete stack:
+
+- **Vector store**: `sqlite-vec` extension. Co-located with the main
+  DB, no new infra.
+- **Keyword search**: SQLite FTS5 virtual table mirroring `body_md +
+  tags`. Built-in, free.
+- **RRF**: ~10-line utility merging the two ranked lists.
+- **Embedding model + reranker**: pluggable providers (see below).
+  Defaults are self-hostable; cloud providers are swap-in.
+
+If the workspace ever migrates to Postgres, the same pipeline rewrites
+to `pgvector` + `tsvector` with no change to the surrounding code.
+
+### Local-first provider defaults
+
+MC is designed to be self-hostable end-to-end. Models we depend on
+directly **must** have a viable local-LLM path; cloud APIs are
+optional accelerators, never load-bearing requirements. This applies
+to embeddings, rerankers, and any future LLM call from MC's own code
+(distinct from agent reasoning, which already runs on whatever model
+the workspace's openclaw gateway is wired to).
+
+Default providers, both runnable on a developer laptop or a single
+self-hosted box:
+
+- **Embeddings (default)**: `nomic-embed-text` via Ollama (768-dim,
+  CPU-friendly, ~100MB), or `bge-base-en-v1.5` for slightly higher
+  quality. Both run inside the existing local-inference stack the
+  workspace likely already has for openclaw.
+- **Reranker (default)**: `bge-reranker-v2-m3` via a small local
+  inference server (TEI / text-embeddings-inference, or llama.cpp).
+  Cross-encoder, runs comfortably on CPU for the ~25-candidate batch
+  size the pipeline needs.
+
+Cloud providers (Voyage, Cohere, OpenAI) plug into the same
+interfaces and are workspace-config opt-in. They give better quality
+in exchange for egress + API key — useful for trial workspaces, not
+required.
+
+### `getRelevantMemory(input)` — `src/lib/memory/retrieval.ts`
+
+```ts
+interface MemoryRetrievalInput {
+  workspace_id: string;
+  initiative_id?: string | null;       // task's parent initiative
+  query: string;                        // typically the task title + description
+  k?: number;                           // default 8
+  consumer?: {                          // for provenance logging
+    kind: 'task_dispatch' | 'pm_proposal' | 'memory_write';
+    id: string;
+  };
+}
+
+interface MemoryHit {
+  entry: MemoryEntry;
+  rerank_score: number;                 // post-rerank score, the canonical ranking signal
+  scope: 'org' | 'ancestor';
+  ancestor_initiative_id?: string;     // for project hits
+}
+
+interface RelevantMemory {
+  org: MemoryHit[];
+  project: MemoryHit[];                 // sorted by rerank_score desc
+}
+```
+
+The reranker score (typically 0..1) is the only ranking signal exposed
+to callers. There is no hardcoded floor cutoff — that's a tunable on
+top of rerank, not an architectural decision. v1 default: keep
+everything from the rerank top-K; tune later if needed.
+
+When `consumer` is provided, retrieval writes one `memory_retrievals`
+row per returned hit. This is the provenance graph the gardener uses
+for blast-radius investigations; missing it makes that flow blind.
+
+### Embedding + reranker provider interfaces
+
+Both interfaces are designed for swap-in. Selection is workspace-
+config, not per-entry. Default implementations land for the local
+options listed above; cloud adapters are added incrementally.
+
+```ts
+interface EmbeddingProvider {
+  id: string;                  // 'ollama:nomic-embed-text', 'voyage:voyage-3-lite', etc.
+  model: string;
+  dimensions: number;
+  endpoint?: string;           // for HTTP-based providers (Ollama, TEI, OpenAI-compatible)
+  embed(texts: string[]): Promise<Float32Array[]>;
+}
+
+interface Reranker {
+  id: string;                  // 'tei:bge-reranker-v2-m3', 'cohere:rerank-3', etc.
+  model: string;
+  endpoint?: string;
+  rerank(
+    query: string,
+    candidates: { id: string; text: string }[],
+  ): Promise<{ id: string; score: number }[]>;
+}
+```
+
+The interfaces are deliberately thin: `endpoint` covers any
+OpenAI-compatible HTTP API (Ollama, TEI, llama.cpp's server,
+LM Studio, vLLM, OpenAI itself), and named SaaS adapters
+(Voyage, Cohere) are separate classes implementing the same shape.
+
+Provider config lives in workspace settings (`embedding_provider_id`,
+`reranker_provider_id` plus an endpoint/key map). The retrieval helper
+resolves at call time so a workspace can change providers without
+code changes — only the embedding-backfill cost (re-embed everything
+on model switch).
+
+Backfill path: a one-shot script `yarn memory:embed-backfill` walks
+entries with NULL or stale-model `embedding` and fills them in.
+Re-embedding on model change is the gardener's job (see
+[gardener.md](gardener.md)).
+
+## Dispatch integration
+
+### Builder + coordinator + decomp prompts
+
+When the master orchestrator hands off to a worker, the dispatch prompt
+gets a new section block, BEFORE the task description:
+
+```markdown
+## Workspace context
+
+> [org memory snippet 1]
+> [org memory snippet 2]
+…
+
+## Initiative context
+
+> [project memory snippet — from epic "Stripe migration"]
+> [project memory snippet — from theme "Billing"]
+…
+
+(Above context is retrieved memory. Treat as ground truth from prior
+work on this workspace. If memory is silent on something load-bearing
+for your plan, say so explicitly rather than guessing.)
+```
+
+Implementation: `buildDispatchContext(taskId)` in
+`src/lib/memory/dispatch-context.ts`, called from the existing dispatch
+prompt builder. Returns a markdown block ready to splice in. Empty
+when retrieval returns nothing — agents see no section rather than a
+"no memory found" placeholder. Always passes `consumer: { kind:
+'task_dispatch', id: taskId }` so the provenance log is populated.
+
+### PM dispatch (decompose, plan_initiative)
+
+Same hook: PM's decompose and plan-initiative prompts get the workspace
++ initiative-ancestor memory bundle. Lets the PM ground decomposition
+in prior decisions ("epic uses polling not webhooks → don't propose a
+webhook-handler story") without explicit operator restating.
+
+### Greenfield tasks
+
+If retrieval comes back empty (no org memory yet, no project memory
+above this initiative), dispatch proceeds without a context block. The
+prompt phrasing handles silence gracefully — there's no "no memory
+found" placeholder that would invite hallucination.
+
+## Write paths
+
+Three ways memory enters the store:
+
+1. **Operator (editor UI)** — primary surface for org memory.
+   Markdown editor, free-text body, optional tags. `source = 'manual'`.
+2. **Agent during work (`save_memory` MCP tool)** — replaces
+   `save_knowledge` for new writes. Tool input: `{ scope: 'org' |
+   { initiative_id }, body_md, tags? }`. `source = 'agent'`.
+3. **Gardener** — proposes promotions, supersedes stale entries,
+   inserts seeded findings. Goes through the proposal review machinery
+   (see gardener.md) for substantive changes; mechanical changes
+   (mark stale, dedupe) write directly. `source = 'gardener'` or
+   `'seeded'`.
+
+`save_memory` is persona-gated like other write tools. Builders +
+coordinators + researchers + learner can write. PM cannot (PM
+proposes; gardener applies).
+
+## Editor UX
+
+Two surfaces, both in the existing app shell:
+
+### Workspace memory page (`/memory`)
+
+Shows org-scoped entries. Operator can:
+- Create entry (markdown editor, tags input).
+- Edit / delete existing.
+- Filter by tag.
+- See `last_retrieved_at` + `retrieval_count` (signal of usefulness).
+- See `source` (manual vs agent vs seeded) so it's clear where each
+  entry came from.
+
+Pattern matches the existing workspace settings pages — no new shell.
+
+### Initiative detail panel — Memory tab
+
+On each initiative detail page, a "Memory" tab lists project-scoped
+entries for that initiative (not the subtree — only entries directly
+attached). Same CRUD affordances as the workspace page. A small "see
+inherited" toggle expands to show ancestor entries that would be
+retrieved at dispatch time, read-only. Archived and quarantined
+entries are hidden by default with a toggle to surface them for audit.
+
+### "Report bad memory" surface
+
+Every memory snippet rendered in dispatch logs or proposal review has
+a one-click "Report bad memory" action. Clicking it:
+
+1. Sets `quarantined_at` + `quarantine_reason` on the entry (excluded
+   from retrieval immediately).
+2. Triggers a gardener blast-radius investigation (see gardener.md)
+   that lands as a review proposal within ~30s.
+
+This is the bridge between operator-driven flagging and the gardener's
+investigation flow. Without it, bad memory only gets caught when
+operators manually scrub the editor pages.
+
+### What we're NOT building yet
+
+- Diff view across superseded chains.
+- Memory search UI for operators (the agents search; operators browse).
+- Bulk import flow — that's gardener territory (seeding from external
+  sources).
+
+## Migration of existing `knowledge_entries`
+
+For now, leave them in place. The retrieval helper checks both tables
+and unions results, with `knowledge_entries` mapped to the same
+`MemoryHit` shape (workspace-scoped, no embedding initially).
+
+Once the gardener is up and proves out, a one-shot migration moves
+`knowledge_entries` rows into `memory_entries` (workspace-scoped),
+generates embeddings, and drops the old table. Out of scope here.
+
+## Open questions
+
+- **`knowledge_entries` deprecation timing.** Cohabitation works but
+  doubles the surface area for retrieval. Prefer to deprecate in the
+  same PR as the gardener's first promote pass — that's also when
+  embeddings get generated for old rows.
+- **Per-tag access control?** Probably no. Memory is workspace-private
+  already; the operator decides what's safe to write.
+- **Cloud providers as optional accelerators.** Local defaults
+  (Ollama-hosted embeddings + TEI-hosted reranker) are the supported
+  path. Cloud adapters (Voyage, Cohere, OpenAI) are kept buildable
+  but not required, and CI must continue to pass with cloud keys
+  absent.
+
+## Tests
+
+- `src/lib/memory/retrieval.test.ts` — fake embedding + reranker;
+  scope filter (ancestor walk + archived/quarantined exclusion);
+  RRF merge of vector + BM25 lists; empty-result returns empty
+  struct (not error); provenance row written when `consumer` set.
+- `src/lib/memory/dispatch-context.test.ts` — block formatting with
+  org-only, project-only, both, empty.
+- `src/lib/db/memory-entries.test.ts` — CRUD + supersede + archive +
+  quarantine state transitions.
+- `src/lib/db/memory-retrievals.test.ts` — provenance log round-trip;
+  cascade delete on entry removal.
+- `src/lib/mcp/save_memory.test.ts` — persona gates; tag normalization.
+- E2E: dispatch a task under a seeded initiative, assert the prompt
+  built by the dispatcher contains the expected memory block AND the
+  provenance log has one row per included entry.
+
+## Verification
+
+- `yarn typecheck && yarn test`.
+- Migration smoke: fresh DB → seed two org entries + an initiative-
+  scoped entry → call retrieval helper → confirm both surface.
+- Preview pass: open `/memory`, write a workspace memory entry, dispatch
+  a builder task on a child initiative, screenshot the resulting agent
+  prompt logs to confirm the block lands.
+
+## Out of scope (handled in gardener.md)
+
+- Promotion (lifting recurring child entries to a parent or org scope).
+- Pruning (marking stale, contradiction detection).
+- Verification (spot-checking claims against ground truth).
+- Seeding from external sources (commit history, websites, emails).
+- Cross-tree consolidation.

--- a/specs/subagent-orchestration.md
+++ b/specs/subagent-orchestration.md
@@ -1,0 +1,446 @@
+# Subagent orchestration — MCP-compliant context offloading and fan-out
+
+## Why
+
+The primary use case is **context offloading**. A named agent has a
+limited working context that's expensive to dilute. When it knows a
+chunk of material is relevant but doesn't want to ingest the raw
+content, it hands the material plus a focused question to a subagent
+and gets back a distilled answer. The subagent burns its own context
+on the bulk material and returns ≤500 tokens of synthesis; the parent
+keeps its working context clean.
+
+Canonical example, in the named agent's voice:
+
+> "I have these 3 documents and 2 websites that I know have relevant
+> info but I don't want to ingest them into my context to avoid
+> dilution. I'm going to hand this to a subagent."
+
+Common shapes for that handoff:
+
+- **Summarization** — "give me a 200-word brief on this 50-page
+  policy doc."
+- **Synthesis** — "across these 3 docs and 2 URLs, what are the
+  recurring themes about X?"
+- **Extraction** — "pull the action items from this transcript."
+- **Classification** — "is this email candidate personal or
+  business?"
+- **Research** — "does package `foo` have a known CVE? cite sources."
+- **Verification** — "is the path `auth/internal/sessions.go` still
+  the right reference for our auth module?"
+
+All share the same shape: parent provides prompt + references to
+material; subagent reads the material; subagent returns a structured
+distilled report. The parent never reads the raw material.
+
+A secondary use case is **fan-out**: an orchestrator (gardener, PM,
+seeding pipeline) spawning N parallel subagents to cover a topic
+space. Same primitive, just used in plural.
+
+Today MC has named long-lived agents (`mc-builder`, `mc-coordinator`,
+`mc-project-manager`, etc.) registered in the openclaw gateway, plus
+the `internal-dispatch.ts` path for handing tasks to those agents.
+There is **no surface** for ephemeral, scoped subagents that:
+
+- exist only for the duration of a single offload/research task,
+- are not in the workspace's permanent agent roster,
+- have an explicit parent (the agent that spawned them),
+- speak the same MCP protocol as named agents — including
+  `send_mail` for mid-flight check-ins back to their parent.
+
+Without this surface, every offload or fan-out workflow either
+inflates the parent's context (defeating the purpose) or reinvents
+spawn/budget/collect logic and risks subagents that bypass the MCP
+toolkit (e.g. raw LLM calls), losing audit, observability, and the
+operator's ability to interrupt.
+
+This spec defines the contract.
+
+## Scope: what subagents do and don't do
+
+**Do**: read, summarize, synthesize, extract, classify, research,
+verify. Pure read-and-distill workloads.
+
+**Don't (in v1)**: write code, edit files, create initiatives, save
+memory, post proposals. Subagents *report* findings; only the
+parent agent (or operator-mediated proposal review) acts on them.
+Code-writing subagents are a plausible future extension but are not
+in scope here — adding them is a new persona variant, not a redesign.
+
+## Design summary
+
+```
+parent agent (named: builder / coordinator / PM / gardener / …)
+    ↓ spawn_subagent MCP tool
+       — prompt + material refs (urls, file paths, mail threads, …)
+       — toolkit + budget + expected report shape
+ephemeral agent (subagent_runs row + transient agent_id)
+    ↓ runs against openclaw with reduced-permission MCP toolkit
+    ↓ reads the referenced material
+    ↓ send_mail back to parent for partial check-ins
+    ↓ submit_subagent_report MCP tool when done
+parent
+    ↓ reads the structured report (small)
+    ↓ decides next action — never sees the raw material
+```
+
+Subagents are **first-class MCP agents** — same protocol, same tool
+namespaces, same audit. What makes them ephemeral is lifecycle: they
+exist for one task, expire on completion or timeout, and never enter
+the persistent agent roster.
+
+## Subagent identity
+
+Each subagent gets:
+
+- `agent_id` — fresh UUID, transient. Visible in `whoami`, mail, and
+  activity log just like any agent. Cleaned up on expiration.
+- `parent_agent_id` — the spawning orchestrator's id. The MCP layer
+  enforces that subagent mail / reports route to this parent.
+- `subagent_run_id` — links to the orchestration record (see schema).
+- `session_key` — fresh openclaw session, isolated from the parent's
+  context (subagent gets only its scoped prompt + retrieved memory,
+  never the parent's full conversation).
+
+Subagent agent_ids are namespaced (`subagent-<run_id>-<seq>`) so they
+sort together in agent lists and don't pollute the named-agent roster.
+
+## Persona + tool gate
+
+Subagents run under a new `subagent` persona with a deliberately
+narrow toolkit:
+
+**Always available:**
+- `whoami`, `log_activity`, `fetch_mail`, `send_mail` (parent-only)
+- `search_memory`, `get_relevant_memory` (read)
+- `submit_subagent_report` (new — the structured exit point)
+- `request_extension` (new — asks parent for more time/tools)
+
+**Available per subagent kind, configured at spawn time:**
+- `read_file`, `read_url`, `web_search` for research / summarization
+  / synthesis / extraction subagents
+- `read_repo`, `git_log`, `git_diff` for code-investigation subagents
+- `read_proposal`, `read_initiative`, `read_mail_thread` for
+  PM-domain or extraction-from-mail subagents
+
+**Never available (v1):**
+- Any write tool (`save_memory`, `propose_changes`, `create_*`,
+  `update_*`). Subagents *report* findings; only the parent acts.
+- Any code-mutating tool. Subagents read code, they don't edit it.
+- `spawn_subagent` itself — no recursive fan-out in v1. Parents
+  spawn flat, not trees. (Open question below.)
+
+The persona is enforced at the MCP layer the same way the existing
+PM-vs-builder gates work. Adding a future "code-writer subagent"
+persona would be a separate variant with a curated write toolkit;
+not in scope here, not blocked architecturally.
+
+## Lifecycle
+
+### Spawn
+
+```ts
+interface SpawnSubagentInput {
+  workspace_id: string;
+  parent_agent_id: string;
+  parent_run_id?: string;             // gardener_runs.id, etc; null for direct named-agent spawns
+  kind:                                // shapes the persona toolkit + report expectations
+    | 'summarize' | 'synthesize' | 'extract' | 'classify'
+    | 'research' | 'verify' | 'reduce-topic';
+  prompt: string;                     // self-contained task description
+  material_refs?: MaterialRef[];      // see below — what the subagent should read
+  toolkit: SubagentToolkit;           // which optional tools to enable
+  budget: {
+    max_tool_calls: number;
+    max_output_tokens: number;
+    deadline_ms: number;              // wall-clock cap
+  };
+  expected_report_shape?: JSONSchema; // structure the parent expects back
+}
+
+type MaterialRef =
+  | { kind: 'url'; url: string; note?: string }
+  | { kind: 'file'; path: string; note?: string }
+  | { kind: 'repo_object'; repo: string; ref: string; path?: string; note?: string }
+  | { kind: 'mail_thread'; thread_id: string; note?: string }
+  | { kind: 'memory_entry'; entry_id: string; note?: string }
+  | { kind: 'proposal'; proposal_id: string; note?: string }
+  | { kind: 'initiative'; initiative_id: string; note?: string };
+
+interface SpawnSubagentResult {
+  subagent_run_id: string;
+  agent_id: string;
+  status: 'spawned';
+}
+```
+
+`material_refs` is the heart of the context-offload pattern: the
+parent names what to read, the subagent reads it. The MCP layer
+validates that the subagent's toolkit covers the ref kinds attached
+(e.g. `url` ref requires `read_url` in the toolkit).
+
+Spawn is exposed two ways:
+
+1. **MCP tool `spawn_subagent`** — callable by named agents
+   (builder, coordinator, PM, gardener) under their existing personas.
+   This is how a working agent offloads context mid-task. Persona
+   gate restricts which agent kinds may spawn (in v1: any named
+   agent; subagents themselves cannot).
+2. **Internal API `spawnSubagent()`** — same underlying
+   implementation, callable from privileged MC code (cron-driven
+   gardener cycles, post-merge automation) without going through MCP.
+
+Both paths:
+
+1. Insert a `subagent_runs` row.
+2. Mint the transient `agent_id` and register it with openclaw for
+   the duration.
+3. Post the prompt + materialized material refs to a fresh openclaw
+   session keyed by `subagent_run_id`.
+4. Return immediately — the parent awaits via the report channel,
+   not a synchronous wait on the chat reply.
+
+### Run
+
+The subagent runs against openclaw exactly like a named agent:
+receives its prompt, calls MCP tools, optionally `send_mail`s the
+parent for partial findings or clarification asks, ultimately calls
+`submit_subagent_report` with the structured output.
+
+Mid-flight check-ins via `send_mail` are first-class. Examples:
+
+- "Halfway through the commit history; here are the top 3 patterns
+  so far. Should I continue or wrap up?"
+- "I'm hitting a paywall on this URL — skip or surface as a partial?"
+- "Found a contradiction with org memory entry #abc — flagging."
+
+The orchestrator can read its mail mid-run and either reply (the
+subagent reads it via `fetch_mail`), or let the subagent run to
+completion. Two-way mail keeps the orchestration interactive without
+forcing every subagent to be one-shot.
+
+### Report
+
+`submit_subagent_report` is the canonical exit:
+
+```ts
+interface SubagentReport {
+  status: 'complete' | 'partial' | 'failed';
+  summary_md: string;                 // ≤ configured token cap
+  findings: Array<{                   // structured, machine-consumable
+    body_md: string;
+    confidence: number;               // 0..1
+    citations: string[];              // URLs, file:line, commit shas, message-ids
+  }>;
+  unable_to_answer?: string[];        // questions the subagent could not resolve
+  recommended_followups?: string[];   // hooks for the orchestrator
+}
+```
+
+Calling this tool marks the subagent_runs row complete and signals
+the orchestrator's await. The subagent's openclaw session is closed
+shortly after (small grace window for the orchestrator to mail
+"thanks, here's a follow-up" if it wants — but no recursion).
+
+### Expire / timeout
+
+If `deadline_ms` elapses without a report, the orchestration layer:
+
+1. Sends a "wrap up now" mail to the subagent (final 30s grace).
+2. If still no report, marks the row `status = 'timed_out'` and reaps
+   the openclaw session.
+3. Surfaces whatever partial check-ins were mailed back as a
+   `partial` finding for the orchestrator's collection step.
+
+Hard caps prevent runaway: any subagent hitting `max_tool_calls` or
+`max_output_tokens` must report what it has so far via
+`submit_subagent_report` with `status: 'partial'`.
+
+## Fan-out collection
+
+The orchestrator spawns N subagents (concurrent, bounded by the
+per-cycle subagent cap), then awaits via:
+
+```ts
+const results = await collectSubagentReports({
+  parent_run_id,
+  expected_count: N,
+  deadline_ms,
+});
+// results: SubagentReport[] (one per spawned, including partials and timeouts)
+```
+
+`collectSubagentReports` polls the `subagent_runs` table (or
+subscribes via the same SSE channel pm_proposal events use). Returns
+when all are complete OR `deadline_ms` elapses, whichever comes first.
+
+Failure handling:
+- Crashed subagent (openclaw error, MCP exception) → `status =
+  'failed'` with `error` populated; orchestrator decides whether one
+  failure aborts the cycle or it proceeds with remaining successes.
+- Timed-out subagent → reported as `partial` if any mail was mailed
+  back, else as a stub with `unable_to_answer = [<original prompt>]`.
+- Mid-flight mail bounce (orchestrator unreachable) → not possible
+  for in-process orchestrators; for cross-service orchestration,
+  subagents queue mail to be delivered when parent reconnects (same
+  pattern as `pm_pending_notes`).
+
+## Storage
+
+```sql
+CREATE TABLE subagent_runs (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  parent_agent_id TEXT NOT NULL,
+  parent_run_kind TEXT NOT NULL,             -- 'gardener' | 'pm' | 'builder' | …
+  parent_run_id TEXT NOT NULL,                -- gardener_runs.id, etc.
+  agent_id TEXT NOT NULL,                     -- transient id assigned to subagent
+  kind TEXT NOT NULL,                         -- 'research', 'verify', 'classify', ...
+  prompt TEXT NOT NULL,
+  toolkit_json TEXT NOT NULL,                 -- which tools enabled
+  budget_json TEXT NOT NULL,                  -- caps
+  status TEXT NOT NULL DEFAULT 'spawned'
+    CHECK (status IN ('spawned','running','complete','partial','failed','timed_out')),
+  report_json TEXT,                           -- SubagentReport when status final
+  spawned_at TEXT NOT NULL DEFAULT (datetime('now')),
+  finished_at TEXT,
+  error TEXT
+);
+CREATE INDEX idx_subagent_runs_parent
+  ON subagent_runs(parent_run_kind, parent_run_id, status);
+CREATE INDEX idx_subagent_runs_agent
+  ON subagent_runs(agent_id);
+```
+
+Mid-flight mail uses the existing mail table (subagents are MCP
+agents; their mail is normal mail). The MCP layer enforces that
+subagent `send_mail` only addresses `parent_agent_id`.
+
+## Local-LLM-first considerations
+
+Subagents reach LLM capacity via openclaw, same as named agents.
+The model behind a subagent is whichever model the workspace's
+openclaw gateway is configured for — local (Ollama, llama.cpp,
+vLLM) or remote. No new direct LLM calls from MC code.
+
+What MC's spawn layer must NOT do:
+- Bake in a specific model or provider.
+- Assume cloud-only round-trip latencies (subagents on local models
+  may take 30-90s per check-in; budget defaults reflect that).
+- Hardcode parallelism that overwhelms a single-GPU local setup.
+  Per-cycle subagent cap is workspace-config (default 3 concurrent
+  on a typical local box, configurable up to 20+ for cloud-backed
+  workspaces).
+
+## MCP surface
+
+Three new tools registered in `src/lib/mcp/`:
+
+- `spawn_subagent` — callable by named-agent personas (builder,
+  coordinator, PM, gardener, learner). Not callable by the
+  `subagent` persona (no recursion in v1). Wraps the internal
+  spawn API; enforces caller-identity = `parent_agent_id`.
+- `submit_subagent_report` — only callable by `subagent` persona.
+  Validates against `expected_report_shape` if provided. Marks the
+  run complete.
+- `request_extension` — only callable by `subagent` persona. Opens
+  a mail thread to the parent asking for more time or tools; parent
+  replies via `send_mail` with a yes/no + new budget if applicable.
+
+Plus internal API (not MCP-exposed) for privileged orchestrators:
+- `spawnSubagent(input)` — the underlying spawn used by the MCP tool
+  AND by cron-driven orchestrators (gardener cycles).
+- `collectSubagentReports({ parent_run_id, deadline_ms })`
+- `reapTimedOutSubagents()` — periodic cleanup, mirrors the existing
+  drain workers in `instrumentation.ts`.
+
+## Code layout
+
+```
+src/lib/subagents/
+  index.ts                  # public API: spawnSubagent, collectSubagentReports
+  persona.ts                # tool-gate definition for the 'subagent' persona
+  lifecycle.ts              # spawn / monitor / reap
+  reports.ts                # report validation + storage
+  mail-gate.ts              # enforces parent-only send_mail
+src/lib/mcp/
+  spawn_subagent.ts         # new MCP tool (named-agent personas)
+  submit_subagent_report.ts # new MCP tool (subagent persona)
+  request_extension.ts      # new MCP tool (subagent persona)
+```
+
+## Backwards compatibility
+
+Existing named agents are unaffected. The subagent persona is
+purely additive. Orchestrators that don't fan out (most existing
+flows) ignore the new surface entirely.
+
+## Tests
+
+- `src/lib/subagents/lifecycle.test.ts` — spawn → run → report
+  round-trip with a fake openclaw client; material_refs are
+  materialized into the subagent prompt; budget caps enforced;
+  timeout produces `timed_out` status with mailed-partial findings
+  surfaced.
+- `src/lib/subagents/persona.test.ts` — write tools rejected;
+  `send_mail` to non-parent rejected; `spawn_subagent` rejected
+  when called by a subagent.
+- `src/lib/subagents/spawn-mcp.test.ts` — named-agent persona can
+  call `spawn_subagent`; toolkit validation rejects spawn when
+  attached `material_refs` aren't covered by the toolkit.
+- `src/lib/subagents/collect.test.ts` — fan-out of N subagents with
+  mixed outcomes (success / partial / timeout / fail); deadline
+  semantics; cancellation via parent.
+- E2E (context offload): a builder agent calls `spawn_subagent`
+  with kind=`synthesize` and 3 url + 1 file refs; observes the
+  report return; asserts the builder's openclaw context never
+  contains the raw material bodies.
+- E2E (fan-out): gardener's verify pass spawns 3 verification
+  subagents, two succeed, one times out → orchestrator emits a
+  partial verify proposal noting the third was skipped.
+
+## Open questions
+
+- **Recursive fan-out.** A subagent that wants to spawn its own
+  subagents would be a tree, not a flat fan-out. v1 forbids it
+  (`spawn_subagent` not in the subagent persona) to keep the
+  lifecycle simple. If a real workload needs it, the lifecycle
+  reaper has to walk the tree.
+- **Code-writing subagents.** Out of scope here. The architecture
+  doesn't preclude a future `writer` persona variant with a curated
+  write toolkit (e.g. `propose_diff` against a repo), but the v1
+  use case is read-and-distill only. Adding writers later is a new
+  persona class, not a redesign.
+- **Cross-orchestrator subagents.** A subagent reporting to a
+  non-MC orchestrator (e.g. an external tool driving MC via the
+  MCP server) is not in scope. Parent must be an in-workspace agent.
+- **Subagent observability.** A future operator UI for "what
+  subagents are running right now" is useful but out of scope here.
+  The `subagent_runs` table is the source of truth; UI is a
+  follow-up.
+- **Reuse of openclaw sessions.** Each subagent currently mints a
+  fresh session. For workloads spawning hundreds of subagents in
+  quick succession, session pool reuse may be worth adding —
+  measure first.
+
+## Verification
+
+- `yarn typecheck && yarn test`.
+- MCP smoke: `submit_subagent_report` and `request_extension`
+  registered under the subagent persona only.
+- Preview pass:
+  1. Trigger a gardener verify run.
+  2. Observe 3 subagent_runs rows appear with `status = 'running'`.
+  3. Watch mid-flight mail land in the orchestrator's inbox.
+  4. Confirm reports land, status flips to `complete`.
+  5. `preview_logs` confirms no MCP write-tool calls from any
+     subagent.
+
+## Out of scope (followups)
+
+- Subagent observability UI.
+- Recursive fan-out (subagents spawning subagents).
+- Cross-workspace subagents.
+- Subagent session pooling / reuse.
+- Parallel-subagent rate limiting beyond the per-cycle cap (e.g.
+  per-tool, per-domain quotas for web research).


### PR DESCRIPTION
## Summary

Three new design docs under `specs/` outlining the next architectural slice. Reference-only; no code changes.

- **[specs/memory-layer.md](specs/memory-layer.md)** — markdown memory entries scoped to org or any initiative subtree, retrieved via a textbook hybrid pipeline (`sqlite-vec` ANN + FTS5 BM25 → reciprocal rank fusion → cross-encoder rerank) and injected into builder/coordinator/PM dispatch prompts. **Local-first** by default (Ollama `nomic-embed-text` for embeddings, TEI `bge-reranker-v2-m3` for rerank); cloud adapters (Voyage, Cohere, OpenAI) plug into the same interfaces and are workspace-config opt-in. Lifecycle states (`archived_at`, `quarantined_at`, `superseded_by`) and a `memory_retrievals` provenance log underpin the gardener's blast-radius and closure flows.

- **[specs/subagent-orchestration.md](specs/subagent-orchestration.md)** — MCP-compliant ephemeral worker primitive. Primary use case is **context offloading**: a named agent that has 3 docs and 2 URLs of relevant material doesn't ingest them — it spawns a subagent with `MaterialRef[]` and gets back a ≤500-token distilled report. Subagents are first-class MCP agents with parent-only `send_mail`, narrow tool gates, and a structured `submit_subagent_report` exit. Read-and-distill only in v1; code-writing subagents are a future persona variant. Fan-out (gardener spawning N parallel verifiers) is a secondary mode of the same primitive.

- **[specs/gardener.md](specs/gardener.md)** — curation role on top of the memory layer. Six jobs: promote, prune, verify, disseminate, closure-pass, quarantine-investigation. Closure on `cancelled` initiatives defaults attached memory to quarantine (not archive) since cancellation usually means the embedded assumptions proved wrong. Quarantine investigations run a blast-radius pass over four candidate sets (direct consumers, peers by author+time, semantic neighbors, downstream memories) using the provenance log. Seeding pipeline is a six-phase map-reduce (cull → identity dictionary → survey → targeted reduce → recency weighting → privacy gate) sized for high-volume sources like multi-year email archives.

Cross-cutting design choices baked in:
- **Standard RAG, not custom retrieval.** Hybrid + rerank pipeline rather than hand-rolled cosine. Scope hierarchy (org + ancestor walk) is a metadata pre-filter on the standard retriever, not bespoke logic.
- **Local-LLM-first.** All MC-direct model calls (embed, rerank, future synth) are pluggable behind `EmbeddingProvider` / `Reranker` / openclaw interfaces with self-hostable defaults. CI must pass without cloud keys.
- **MCP compliance everywhere.** No raw LLM calls bypass the toolkit; subagents speak the same protocol as named agents and respect the same audit/persona machinery.

## Changes

- New: `specs/memory-layer.md` (storage, retrieval, dispatch integration, editor UX).
- New: `specs/subagent-orchestration.md` (lifecycle, persona, fan-out collection, MCP surface).
- New: `specs/gardener.md` (six jobs, two-track trust contract, seeding pipeline, code layout).

## Implementation order (not in this PR)

1. memory-layer — table + retrieval + dispatch hook (foundation; everything else depends on it).
2. subagent-orchestration — MCP surface + lifecycle reaper (independent foundation; gardener depends on it).
3. gardener — mechanical pass + proposal pipeline first; seeding + verify + closure + quarantine in follow-ups once the curation loop has proven out.

## Test plan

- [ ] Reviewer confirms specs are internally consistent and cross-references resolve.
- [ ] No code changes — `yarn typecheck` / `yarn test` not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)