### PR TITLE
docs: dogfood playbook + openclaw sync tooling, dev port 4010

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,14 @@ Watch for **loopback URL drift**: services inside Docker can't reach `localhost`
 
 The user often browses the dev server from a different machine on the LAN. Next 15+ requires those origins to be listed in `next.config.mjs` under `allowedDevOrigins` (already configured for `192.168.50.95` and `*.local`) — without it, HMR/fonts return 403 and hydration hangs. If a new LAN host needs access, extend that array rather than chasing HMR or browser-cache theories.
 
-Default dev port is `4000` (`yarn dev` honors `$PORT`).
+**Ports.** Default dev port is `4010` (`yarn dev` honors `$PORT`).
+Docker stable runs on `4001`. Port `4000` is reserved for the local
+LiteLLM gateway — don't bind MC to it. Older docs may still reference
+`4000` for dev; treat those as stale until scrubbed.
+
+See [docs/DOGFOOD_PLAYBOOK.md](docs/DOGFOOD_PLAYBOOK.md) for how the
+stable (`:4001`) and dev (`:4010`) instances coexist with separate
+openclaw agent rosters.
 
 ## Verification (MCP Preview)
 

--- a/docs/DOGFOOD_PLAYBOOK.md
+++ b/docs/DOGFOOD_PLAYBOOK.md
@@ -1,0 +1,255 @@
+# Dogfood Playbook — iterating on Mission Control with Mission Control
+
+This is the operator playbook for running two MC instances side by
+side: a **stable** instance you actually plan against, and a **dev**
+instance you iterate on. The split lets you use MC's PM/roadmap
+surface to drive the evolution of MC itself without a half-baked dev
+change taking out the planning surface you're using to plan the change.
+
+## TL;DR
+
+| | Stable | Dev |
+|---|---|---|
+| Run via | `docker compose up` | `yarn dev` |
+| Port | `4001` | `4010` |
+| Database | persisted volume | `mission-control.db` in repo |
+| Agent roster | `mc-pm`, `mc-builder`, … | `mc-pm-dev`, `mc-builder-dev`, … |
+| MCP server | `sc-mission-control` | `sc-mission-control-dev` |
+| Workspace dirs | `~/.openclaw/workspaces/<agent>` | `~/.openclaw/workspaces/<agent>-dev` |
+| Updated when | a tested PR merges + image rebuilds | every save (HMR) |
+
+> Port `4000` is the local LiteLLM gateway and stays put. Don't bind MC
+> to it.
+
+## Why two instances
+
+- **Stable is durable.** It runs the last code you tested + merged. The
+  PM, the operator UI, the SSE channel, the roadmap — all of it stays
+  up while you break things in dev.
+- **Dev is throwaway.** Migrations, prompt edits, MCP-tool refactors all
+  land in dev first. Its DB is `git`-adjacent and frequently reset.
+- **They never share a database.** A new migration on a feature branch
+  must not touch stable's data. A new MCP tool shape on a dev branch
+  must not be visible to stable's agents.
+- **Their agent rosters are isolated.** Same agent IDs across both
+  rosters would mean one MCP server registration silently routes to
+  whichever MC instance won the race — exactly the cross-contamination
+  this playbook prevents.
+
+## How the isolation works
+
+`~/.openclaw/openclaw.json` is global, but two things in it are
+independently-keyed:
+
+1. **`mcp.servers.<name>`** — each entry spawns its own launcher process
+   and points at its own URL + token. We add a parallel
+   `sc-mission-control-dev` entry pointing at `http://localhost:4010/api/mcp`.
+2. **`agents.list[].id`** — each agent has a unique ID and its own
+   `workspace` dir + `tools.alsoAllow` list. We duplicate each MC agent
+   block (`mc-pm`, `mc-coordinator`, …) under a `-dev`-suffixed ID, swap
+   its `alsoAllow` to reference `sc-mission-control-dev__*`, and point
+   its `workspace` at a copied directory.
+
+When you chat in openclaw, the agent ID you pick determines which MC
+you talk to. Picking `mc-project-manager-dev` drives dev; picking
+`mc-project-manager` drives stable.
+
+## One-time setup
+
+### 1. Copy the agent workspace directories
+
+Each MC agent has a workspace dir under `~/.openclaw/workspaces/` holding
+SOUL.md, MEMORY.md, and session caches. Copy them to `-dev`-suffixed
+counterparts:
+
+```bash
+cd ~/.openclaw/workspaces
+for d in mc-builder mc-coordinator mc-learner mc-project-manager \
+         mc-researcher mc-reviewer mc-tester mc-writer; do
+  [ -d "$d" ] && [ ! -d "$d-dev" ] && cp -r "$d" "$d-dev"
+done
+```
+
+The `-dev` dirs start as exact copies; their SOUL.md and MEMORY.md
+diverge naturally as you iterate. Stable's dirs stay untouched.
+
+### 2. Generate a dev MC API token
+
+The dev MC instance needs its own bearer token (don't share with
+stable — that defeats the isolation). Whatever process you use to mint
+stable's token, repeat for dev. Stash the dev token; you'll wire it
+into the openclaw config below.
+
+### 3. Sync the openclaw agent roster
+
+Run the sync script. It will:
+
+- add `mcp.servers.sc-mission-control-dev` to `openclaw.json` (with a
+  placeholder for the API token),
+- duplicate every `mc-*` agent block as `mc-*-dev` with the workspace
+  path and `tools.alsoAllow` rewritten,
+- back up your existing config to `openclaw.json.bak.<timestamp>`.
+
+```bash
+yarn openclaw:sync:check   # dry-run, exits non-zero if drift found
+yarn openclaw:sync         # apply
+```
+
+The script is **idempotent**: re-running mirrors any subsequent edits
+to a stable agent block back to its `-dev` counterpart. Run it after
+any change to a stable agent (new skill, tool change, model swap) to
+keep the dev block aligned.
+
+### 4. Replace the API token placeholder
+
+Open `~/.openclaw/openclaw.json`, find:
+
+```json
+"sc-mission-control-dev": {
+  "command": "node",
+  "args": ["/.../mcp-launcher/launcher.mjs"],
+  "env": {
+    "MC_URL": "http://localhost:4010/api/mcp",
+    "MC_API_TOKEN": "__SET_DEV_MC_API_TOKEN__"
+  }
+}
+```
+
+Replace `__SET_DEV_MC_API_TOKEN__` with your dev MC token from step 2.
+Match `MC_URL` to wherever your dev MC actually listens (default
+`4010`; override via `PORT=…` in the dev MC's env).
+
+### 5. Restart openclaw
+
+Openclaw reads `openclaw.json` once at start. After the sync, restart
+the gateway so the new agent roster and MCP server are picked up.
+
+### 6. Smoke test
+
+Pick `mc-project-manager-dev` in the openclaw chat surface. Ask it
+something simple ("call `whoami`"). The reply should report
+`agent_id: mc-project-manager-dev` and the dev MC's workspace details.
+Then pick `mc-project-manager` and confirm it reports stable's.
+
+If the dev agent gets MCP errors or routes to stable's data, double-check:
+
+- Dev MC is running on `4010` (`curl http://localhost:4010/api/health`).
+- The token in `sc-mission-control-dev` matches the dev MC's expected token.
+- The dev agent's `tools.alsoAllow` contains `sc-mission-control-dev__*`,
+  not `sc-mission-control__*`.
+
+## Daily workflow
+
+### Plan in stable
+
+Open `http://localhost:4001/pm` (or wherever the docker stable lives
+in your environment). Decompose specs into epics, accept proposals,
+track work. **This is where the durable roadmap of MC's evolution
+lives.** It survives container restarts, prompt iterations, and dev
+breakage.
+
+### Build in dev
+
+Branch, code, `yarn test`, run the preview-test flow against
+`http://localhost:4010`. Drive interactive testing through the
+`-dev`-suffixed agents — they reach into dev's DB and exercise dev's
+MCP-tool shape.
+
+### Validate before merge
+
+For changes that touch the agent prompts (`src/lib/agents/*-soul.md`)
+or the MCP tool surface, walk the relevant section of
+`docs/PREVIEW_TEST_FLOW.md` against dev. Reset the dev agent's session
+on `/agents` after a SOUL.md change so it picks up the new prompt.
+
+### Merge → rebuild stable
+
+PR merges to main → CI rebuilds the stable docker image → restart
+the stable container. The persisted volume keeps stable's planning
+state across restarts; only the code changes.
+
+### Optional: hydrate dev with realism
+
+To test against non-trivial data, snapshot stable's DB into dev:
+
+```bash
+yarn db:checkpoint save stable-realistic --source=/path/to/stable.db
+yarn db:checkpoint:restore stable-realistic
+```
+
+Treat the copy as throwaway — dev's DB is reset frequently.
+
+## Maintenance
+
+### When a stable agent block changes
+
+Run `yarn openclaw:sync` after editing any `mc-*` agent in
+`openclaw.json`. The script re-mirrors the change to the matching
+`-dev` block. Forgetting this means dev silently drifts behind stable
+on tools/skills until the next sync.
+
+### When a SOUL.md changes
+
+Live SOUL.md lives at `~/.openclaw/workspaces/<agent>/SOUL.md`. The
+canonical copy is in the MC repo at `src/lib/agents/<agent>-soul.md`.
+After editing the repo copy:
+
+1. Copy to dev: `cp src/lib/agents/pm-soul.md ~/.openclaw/workspaces/mc-project-manager-dev/SOUL.md`
+2. Test in dev. Reset the agent's session.
+3. On merge, copy to stable: `cp src/lib/agents/pm-soul.md ~/.openclaw/workspaces/mc-project-manager/SOUL.md`
+4. Reset stable's agent session.
+
+There's no automatic sync between the repo and the live workspace
+dirs — that's intentional, because stable should stay on the
+last-known-good prompt until you choose to update it.
+
+### When a new MC agent is added
+
+If a new agent ID matching `^mc-[a-z-]+$` appears in `openclaw.json`,
+the next `yarn openclaw:sync` will create the `-dev` counterpart
+automatically. You still need to manually `cp -r` the workspace dir
+(step 1 above).
+
+### When you remove an MC agent
+
+The sync script doesn't currently prune `-dev` agents whose stable
+counterpart was deleted. Remove the `-dev` block by hand and delete
+its workspace dir.
+
+## Risks and gotchas
+
+- **Stable can't pick up MCP-tool changes without rebuilding.** Fine
+  in steady state; just don't expect mid-session hot-reload.
+- **Dev's PM may give different recommendations than stable's** because
+  it's running in-progress prompts. That's correct, but watch for
+  "I refined this in dev's PM" → "doesn't repro in stable" — they're
+  different agents now.
+- **Schema drift between branches.** A long-lived feature branch with
+  migrations should checkpoint dev frequently; rolling back is easier
+  than untangling a polluted DB.
+- **Agent session caching.** Both stable and dev cache openclaw
+  sessions per agent. After a SOUL.md change, hit `/agents` Reset
+  session — same as in production, just more frequent.
+- **Token leakage.** Don't commit `~/.openclaw/openclaw.json`
+  anywhere. The dev token belongs to the operator's machine, not the
+  repo.
+
+## Why not the alternatives
+
+- **One MCP server, route by `agent_id` inside the launcher.** Hacky;
+  breaks isolation: a typo in agent_id could cross workspaces. The
+  proxy is the wrong place for routing.
+- **Per-workspace openclaw config.** Doesn't exist; openclaw.json is
+  global.
+- **Run dev with stable's MCP server and a different token.** Tempting,
+  but stable's agents would reach into dev's DB whenever they call MCP
+  — exactly the cross-contamination this split prevents.
+
+## Future tightening (out of scope here)
+
+- Lifecycle hooks: when MC's repo bumps a SOUL.md, automate the
+  workspace-dir copy with `--target=stable|dev` so steps 1/3 of the
+  SOUL.md flow above collapse.
+- Sync-script prune: detect `-dev` agents whose stable counterpart
+  was deleted and remove them (with a confirm prompt).
+- A `yarn dev:fresh` script that resets dev's DB + reseeds + restarts.

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "2.5.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p ${PORT:-4000}",
+    "dev": "next dev -p ${PORT:-4010}",
     "build": "next build",
-    "start": "next start -p ${PORT:-4000}",
+    "start": "next start -p ${PORT:-4010}",
     "lint": "eslint .",
     "test": "npm run test:setup && find src -name '*.test.ts' -print0 | NODE_ENV=test xargs -0 tsx --test",
     "test:setup": "mkdir -p .tmp/test-dbs && rm -rf .tmp/test-dbs/* && rm -f .tmp/test-template.db .tmp/test-template.db-shm .tmp/test-template.db-wal .tmp/mission-control-test.db .tmp/mission-control-test.db-shm .tmp/mission-control-test.db-wal && NODE_ENV=test tsx scripts/build-test-template.ts",
@@ -19,7 +19,9 @@
     "db:checkpoint": "tsx scripts/db-checkpoint.ts save",
     "db:checkpoint:restore": "tsx scripts/db-checkpoint.ts restore",
     "db:checkpoint:list": "tsx scripts/db-checkpoint.ts list",
-    "openapi:generate": "next-openapi-gen generate"
+    "openapi:generate": "next-openapi-gen generate",
+    "openclaw:sync": "node scripts/sync-openclaw-agents.mjs",
+    "openclaw:sync:check": "node scripts/sync-openclaw-agents.mjs --dry-run"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1032.0",

--- a/scripts/sync-openclaw-agents.mjs
+++ b/scripts/sync-openclaw-agents.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * sync-openclaw-agents.mjs
+ *
+ * Mirrors stable MC agent definitions in ~/.openclaw/openclaw.json under
+ * a parallel `-dev` roster pointing at the dev MC instance. Lets the
+ * operator iterate on MC by running stable + dev side by side without
+ * cross-contaminating their agent rosters.
+ *
+ * What it does:
+ *   1. Ensures `mcp.servers.sc-mission-control-dev` exists pointing at
+ *      MC dev (default http://localhost:4010/api/mcp). The token is left
+ *      alone if already set; otherwise a placeholder is written and the
+ *      operator is prompted to fill it in.
+ *   2. For every agent matching ^mc-[a-z-]+$ (i.e. a stable MC agent),
+ *      ensures a parallel `<id>-dev` agent exists with:
+ *        - workspace path suffixed `-dev`
+ *        - tools.alsoAllow rewritten so `sc-mission-control__*` becomes
+ *          `sc-mission-control-dev__*`
+ *        - all other fields copied from the stable block (model, skills,
+ *          heartbeat, etc.)
+ *   3. Writes openclaw.json back, formatted, after taking a backup.
+ *
+ * Idempotent: re-running re-syncs the dev blocks to whatever the stable
+ * blocks currently look like. Use it after editing a stable agent block
+ * (new skill, tool change, etc.) to keep the dev block aligned.
+ *
+ * Does NOT:
+ *   - Create or copy agent workspace directories. Run the one-time
+ *     workspace-copy step in docs/DOGFOOD_PLAYBOOK.md manually.
+ *   - Touch any agent that already exists with `-dev` suffix and an
+ *     `id` not corresponding to a stable counterpart (custom agents
+ *     are preserved untouched).
+ *   - Generate API tokens. The operator wires the dev token in by
+ *     hand the first time.
+ *
+ * Usage:
+ *   node scripts/sync-openclaw-agents.mjs               # sync, write back
+ *   node scripts/sync-openclaw-agents.mjs --dry-run     # report only
+ *   node scripts/sync-openclaw-agents.mjs --config=PATH # alt openclaw.json
+ *
+ * Exits non-zero on parse errors or when --dry-run finds drift (useful
+ * in CI / pre-commit if the dev roster is ever committed).
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const DEV_SERVER_NAME = 'sc-mission-control-dev';
+const STABLE_SERVER_NAME = 'sc-mission-control';
+const DEV_MC_URL_DEFAULT = 'http://localhost:4010/api/mcp';
+const STABLE_AGENT_ID_RE = /^mc-[a-z-]+$/;
+
+function isStableMcAgentId(id) {
+  return typeof id === 'string' && STABLE_AGENT_ID_RE.test(id) && !id.endsWith('-dev');
+}
+
+function devIdFor(stableId) {
+  return `${stableId}-dev`;
+}
+
+function devWorkspaceFor(stableWorkspace) {
+  if (typeof stableWorkspace !== 'string' || !stableWorkspace) return stableWorkspace;
+  const base = path.basename(stableWorkspace);
+  const parent = path.dirname(stableWorkspace);
+  return path.join(parent, `${base}-dev`);
+}
+
+function rewriteAlsoAllow(alsoAllow) {
+  if (!Array.isArray(alsoAllow)) return alsoAllow;
+  return alsoAllow.map((entry) =>
+    typeof entry === 'string' && entry.startsWith(`${STABLE_SERVER_NAME}__`)
+      ? entry.replace(`${STABLE_SERVER_NAME}__`, `${DEV_SERVER_NAME}__`)
+      : entry,
+  );
+}
+
+function buildDevBlock(stableBlock) {
+  // Deep clone so we don't mutate the stable block.
+  const dev = JSON.parse(JSON.stringify(stableBlock));
+  dev.id = devIdFor(stableBlock.id);
+  if (dev.workspace) dev.workspace = devWorkspaceFor(stableBlock.workspace);
+  if (dev.tools && Array.isArray(dev.tools.alsoAllow)) {
+    dev.tools = { ...dev.tools, alsoAllow: rewriteAlsoAllow(dev.tools.alsoAllow) };
+  }
+  return dev;
+}
+
+function shallowEqualBlocks(a, b) {
+  // Stringify with stable key ordering for a structural compare.
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function ensureDevMcpServer(config, { dryRun }) {
+  config.mcp ??= { servers: {} };
+  config.mcp.servers ??= {};
+  const stable = config.mcp.servers[STABLE_SERVER_NAME];
+  const existing = config.mcp.servers[DEV_SERVER_NAME];
+
+  if (existing) {
+    return { changed: false, message: `mcp.servers.${DEV_SERVER_NAME} already configured` };
+  }
+
+  if (!stable) {
+    throw new Error(
+      `mcp.servers.${STABLE_SERVER_NAME} not found in openclaw.json — set up stable first.`,
+    );
+  }
+
+  const placeholder = {
+    command: stable.command,
+    args: [...(stable.args ?? [])],
+    env: {
+      MC_URL: DEV_MC_URL_DEFAULT,
+      MC_API_TOKEN: '__SET_DEV_MC_API_TOKEN__',
+    },
+  };
+
+  if (!dryRun) {
+    config.mcp.servers[DEV_SERVER_NAME] = placeholder;
+  }
+  return {
+    changed: true,
+    message:
+      `Added mcp.servers.${DEV_SERVER_NAME} pointing at ${DEV_MC_URL_DEFAULT}. ` +
+      `Replace MC_API_TOKEN placeholder with the dev MC's token before starting agents.`,
+  };
+}
+
+function syncAgents(config, { dryRun }) {
+  const list = config.agents?.list;
+  if (!Array.isArray(list)) {
+    throw new Error('Expected agents.list array in openclaw.json');
+  }
+
+  const byId = new Map(list.map((a, i) => [a.id, { agent: a, index: i }]));
+  const changes = [];
+
+  for (const agent of list) {
+    if (!isStableMcAgentId(agent.id)) continue;
+    const expected = buildDevBlock(agent);
+    const existing = byId.get(expected.id);
+
+    if (!existing) {
+      changes.push({ kind: 'add', id: expected.id, block: expected });
+      continue;
+    }
+    if (!shallowEqualBlocks(existing.agent, expected)) {
+      changes.push({ kind: 'update', id: expected.id, index: existing.index, block: expected });
+    }
+  }
+
+  if (!dryRun) {
+    // Apply additions (append) and updates (in place).
+    for (const change of changes) {
+      if (change.kind === 'add') {
+        list.push(change.block);
+      } else if (change.kind === 'update') {
+        list[change.index] = change.block;
+      }
+    }
+  }
+
+  return changes;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const configFlag = args.find((a) => a.startsWith('--config='));
+  const configPath = configFlag
+    ? configFlag.slice('--config='.length).replace(/^~/, os.homedir())
+    : path.join(os.homedir(), '.openclaw', 'openclaw.json');
+
+  const raw = await fs.readFile(configPath, 'utf8');
+  const config = JSON.parse(raw);
+
+  const mcpResult = ensureDevMcpServer(config, { dryRun });
+  const agentChanges = syncAgents(config, { dryRun });
+
+  console.log(`[sync-openclaw-agents] config: ${configPath}`);
+  console.log(`[sync-openclaw-agents] mode: ${dryRun ? 'dry-run' : 'write'}`);
+  console.log(`[sync-openclaw-agents] mcp: ${mcpResult.message}`);
+  if (agentChanges.length === 0) {
+    console.log('[sync-openclaw-agents] agents: in sync (no changes)');
+  } else {
+    for (const c of agentChanges) {
+      console.log(`[sync-openclaw-agents] agents: ${c.kind} ${c.id}`);
+    }
+  }
+
+  if (dryRun) {
+    if (mcpResult.changed || agentChanges.length > 0) {
+      process.exitCode = 2;
+    }
+    return;
+  }
+
+  if (!mcpResult.changed && agentChanges.length === 0) {
+    return;
+  }
+
+  const backupPath = `${configPath}.bak.${Date.now()}`;
+  await fs.copyFile(configPath, backupPath);
+  await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+  console.log(`[sync-openclaw-agents] wrote ${configPath} (backup: ${path.basename(backupPath)})`);
+  console.log('[sync-openclaw-agents] restart openclaw to load the new agent roster.');
+}
+
+main().catch((err) => {
+  console.error(`[sync-openclaw-agents] ERROR: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- New [docs/DOGFOOD_PLAYBOOK.md](docs/DOGFOOD_PLAYBOOK.md) — operator playbook for running stable (docker, `:4001`) and dev (`yarn dev`, `:4010`) MC instances side by side. Stable drives durable roadmap planning; dev is throwaway. The two have separate databases AND separate openclaw agent rosters (`mc-*` vs `mc-*-dev`) wired to separate MCP server registrations (`sc-mission-control` vs `sc-mission-control-dev`). Picking the suffixed agent in openclaw is the only operator gesture needed to switch instances.
- New [scripts/sync-openclaw-agents.mjs](scripts/sync-openclaw-agents.mjs) — idempotent script that mirrors every `mc-*` agent block in `~/.openclaw/openclaw.json` under a `-dev`-suffixed counterpart with the workspace path and `tools.alsoAllow` rewritten. Also ensures `mcp.servers.sc-mission-control-dev` is registered. Backs up `openclaw.json` before writing. Exposed as `yarn openclaw:sync` and `yarn openclaw:sync:check` (dry-run, exits non-zero on drift).
- Dev port moved from `4000` → `4010` in `package.json` scripts and `CLAUDE.md`, freeing `4000` for the local LiteLLM gateway. Older docs still reference `4000` for dev — flagged as stale; scrub is a follow-up.

## Why

We want to use MC's PM/roadmap surface to plan the evolution of MC itself. The constraint: openclaw's MCP server registrations are global, so naively running stable + dev would cross-contaminate (one agent roster reaching into either DB depending on which MC won the race). The playbook + sync script give a clean split with no openclaw changes required.

## Changes

- `CLAUDE.md` — Ports section updated; refers operators to the new playbook.
- `package.json` — `dev` and `start` script defaults `4000` → `4010`; new `openclaw:sync` and `openclaw:sync:check` aliases.
- `scripts/sync-openclaw-agents.mjs` — new (270 lines).
- `docs/DOGFOOD_PLAYBOOK.md` — new.

## Test plan

- [x] Dry-run sync against the live `~/.openclaw/openclaw.json` exits with the expected drift report (8 `mc-*-dev` adds + the new MCP server entry).
- [ ] Operator one-time setup walkthrough (manual, per the playbook): copy workspace dirs, run sync, replace token placeholder, restart openclaw, confirm `mc-project-manager-dev` reports the dev workspace via `whoami`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)