### PR TITLE
feat(workspace): JSON export from settings page + CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "db:checkpoint:list": "tsx scripts/db-checkpoint.ts list",
     "openapi:generate": "next-openapi-gen generate",
     "openclaw:sync": "node scripts/sync-openclaw-agents.mjs",
-    "openclaw:sync:check": "node scripts/sync-openclaw-agents.mjs --dry-run"
+    "openclaw:sync:check": "node scripts/sync-openclaw-agents.mjs --dry-run",
+    "workspace:export": "tsx scripts/export-workspace.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1032.0",

--- a/scripts/export-workspace.ts
+++ b/scripts/export-workspace.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env -S tsx
+/**
+ * export-workspace.ts
+ *
+ * Thin CLI wrapper around src/lib/db/workspace-export.ts. Dumps every
+ * workspace-scoped table for a given workspace_id to a JSON file.
+ *
+ * Usage:
+ *   yarn tsx scripts/export-workspace.ts \
+ *     [--workspace-id=default] \
+ *     [--out=./workspace-export.json] \
+ *     [--include-transient] \
+ *     [--db=./mission-control.db]
+ *
+ * The same export logic powers the workspace settings page download
+ * button, so the CLI and UI stay aligned on what "export everything"
+ * means.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import Database from 'better-sqlite3';
+import {
+  exportWorkspace,
+  defaultExportFilename,
+  WorkspaceNotFoundError,
+} from '../src/lib/db/workspace-export.js';
+
+interface Args {
+  workspaceId: string;
+  out?: string;
+  includeTransient: boolean;
+  dbPath: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    workspaceId: 'default',
+    includeTransient: false,
+    dbPath: process.env.DATABASE_PATH ?? './mission-control.db',
+  };
+  for (const a of argv.slice(2)) {
+    if (a.startsWith('--workspace-id=')) args.workspaceId = a.split('=', 2)[1];
+    else if (a.startsWith('--out=')) args.out = a.split('=', 2)[1];
+    else if (a === '--include-transient') args.includeTransient = true;
+    else if (a.startsWith('--db=')) args.dbPath = a.split('=', 2)[1];
+    else if (a === '--help' || a === '-h') {
+      console.log(
+        'Usage: yarn tsx scripts/export-workspace.ts [--workspace-id=ID] [--out=FILE] [--include-transient] [--db=PATH]',
+      );
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${a}`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const dbPath = path.resolve(args.dbPath);
+
+  await fs.access(dbPath).catch(() => {
+    console.error(`DB not found at ${dbPath}`);
+    process.exit(1);
+  });
+
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+
+  let result;
+  try {
+    result = exportWorkspace(db, args.workspaceId, {
+      includeTransient: args.includeTransient,
+    });
+  } catch (err) {
+    if (err instanceof WorkspaceNotFoundError) {
+      console.error(err.message);
+      const all = db.prepare('SELECT id, name FROM workspaces ORDER BY id').all() as Array<{
+        id: string;
+        name?: string;
+      }>;
+      if (all.length > 0) {
+        console.error('Available workspaces:');
+        for (const w of all) console.error(`  - ${w.id}${w.name ? `  (${w.name})` : ''}`);
+      }
+      process.exit(1);
+    }
+    throw err;
+  } finally {
+    db.close();
+  }
+
+  const outPath = path.resolve(
+    args.out ??
+      `./${defaultExportFilename(args.workspaceId, result.exported_at)}`,
+  );
+  await fs.writeFile(outPath, JSON.stringify(result, null, 2), 'utf8');
+
+  console.log(`Exported workspace "${args.workspaceId}" → ${outPath}`);
+  console.log(`Schema migration at export: ${result.schema_migration ?? '(unknown)'}`);
+  console.log(`Transient tables included: ${result.include_transient}`);
+  for (const [t, n] of Object.entries(result.table_counts)) {
+    console.log(`  ${t.padEnd(34)} ${n}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/(app)/workspace/[slug]/settings/page.tsx
+++ b/src/app/(app)/workspace/[slug]/settings/page.tsx
@@ -21,6 +21,7 @@ import Link from 'next/link';
 import {
   AlertTriangle,
   ArrowLeft,
+  Download,
   Folder,
   Loader,
   Trash2,
@@ -63,6 +64,8 @@ export default function WorkspaceSettingsPage({
   const [error, setError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [showDelete, setShowDelete] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [includeTransient, setIncludeTransient] = useState(false);
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -125,6 +128,40 @@ export default function WorkspaceSettingsPage({
   }
 
   const isDefault = workspace.id === 'default';
+
+  const exportWorkspace = async () => {
+    if (!workspace || exporting) return;
+    setExporting(true);
+    setActionError(null);
+    try {
+      const url = `/api/workspaces/${workspace.id}/export${
+        includeTransient ? '?include_transient=true' : ''
+      }`;
+      const res = await fetch(url);
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Export failed (${res.status})`);
+      }
+      // Honor the Content-Disposition filename from the server.
+      const blob = await res.blob();
+      const disp = res.headers.get('Content-Disposition') ?? '';
+      const m = disp.match(/filename="([^"]+)"/);
+      const filename =
+        m?.[1] ?? `mc-workspace-${workspace.id}-${new Date().toISOString()}.json`;
+      const a = document.createElement('a');
+      const objectUrl = URL.createObjectURL(blob);
+      a.href = objectUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(objectUrl);
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : 'Export failed');
+    } finally {
+      setExporting(false);
+    }
+  };
 
   return (
     <div className="min-h-screen bg-mc-bg text-mc-text">
@@ -232,6 +269,39 @@ export default function WorkspaceSettingsPage({
               )}
             </p>
           </Field>
+        </Section>
+
+        {/* Export — read-only snapshot of every workspace-scoped row,
+            useful for retaining state before a reset or copying a real
+            workspace into a checkpoint. Backed by the same lib the CLI
+            script uses (src/lib/db/workspace-export.ts). */}
+        <Section
+          title="Export"
+          description="Download a JSON snapshot of every initiative, task, agent, proposal, knowledge entry, and supporting row attached to this workspace. Useful for retention before a database reset or for staging an import elsewhere."
+        >
+          <div className="flex items-start justify-between gap-3">
+            <label className="flex items-center gap-2 text-xs text-mc-text-secondary">
+              <input
+                type="checkbox"
+                checked={includeTransient}
+                onChange={e => setIncludeTransient(e.target.checked)}
+                className="accent-mc-accent"
+              />
+              Include transient rows
+              <span className="text-mc-text-secondary/60">
+                (mailbox, chat, sessions — large, mostly noise)
+              </span>
+            </label>
+            <button
+              type="button"
+              onClick={exportWorkspace}
+              disabled={exporting}
+              className="px-3 py-1.5 text-sm rounded border border-mc-border text-mc-text hover:bg-mc-bg-tertiary disabled:opacity-40 inline-flex items-center gap-1.5 shrink-0"
+            >
+              <Download className="w-3.5 h-3.5" />
+              {exporting ? 'Exporting…' : 'Export workspace'}
+            </button>
+          </div>
         </Section>
 
         {/* Danger Zone — GitHub-style. Red border, destructive actions

--- a/src/app/api/workspaces/[id]/export/route.ts
+++ b/src/app/api/workspaces/[id]/export/route.ts
@@ -1,0 +1,64 @@
+/**
+ * GET /api/workspaces/[id]/export
+ *
+ *   Optional query: ?include_transient=true → include mailbox / chat /
+ *   sessions / agent health rows. Off by default (those grow large
+ *   and are mostly noise for retention/reload purposes).
+ *
+ * Returns the workspace's full content as a single JSON document with
+ * Content-Disposition set so a browser GET triggers a file download.
+ * Same shape as `scripts/export-workspace.ts` (both share the lib at
+ * src/lib/db/workspace-export.ts).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/db';
+import {
+  exportWorkspace,
+  defaultExportFilename,
+  WorkspaceNotFoundError,
+} from '@/lib/db/workspace-export';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const includeTransient =
+    request.nextUrl.searchParams.get('include_transient') === 'true';
+
+  try {
+    const db = getDb();
+
+    // Resolve slug → id so the route works for both. The export lib
+    // requires the canonical workspace_id since that's what every
+    // scoped table references.
+    const workspace = db
+      .prepare('SELECT id FROM workspaces WHERE id = ? OR slug = ?')
+      .get(id, id) as { id: string } | undefined;
+    if (!workspace) {
+      return NextResponse.json({ error: 'Workspace not found' }, { status: 404 });
+    }
+
+    const result = exportWorkspace(db, workspace.id, { includeTransient });
+    const filename = defaultExportFilename(workspace.id, result.exported_at);
+
+    return new NextResponse(JSON.stringify(result, null, 2), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (err) {
+    if (err instanceof WorkspaceNotFoundError) {
+      return NextResponse.json({ error: err.message }, { status: 404 });
+    }
+    const msg = err instanceof Error ? err.message : 'Export failed';
+    console.error('[workspace-export] error:', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/lib/db/workspace-export.ts
+++ b/src/lib/db/workspace-export.ts
@@ -1,0 +1,187 @@
+/**
+ * workspace-export — dump every workspace-scoped table for a given
+ * workspace_id to an in-memory JSON-shaped object. Shared by the
+ * settings-page download button and the `scripts/export-workspace.ts`
+ * CLI so both stay aligned on what "export everything" means.
+ *
+ * The output is INSERT-shaped: { tables: { name: [rows] } }. Rows are
+ * unmodified — JSON-serialised SQLite values. A future
+ * `import-workspace` can iterate `tables` in dependency order and
+ * INSERT row-by-row.
+ *
+ * What's included:
+ *   - Direct workspace_id-scoped tables (workspaces row, agents,
+ *     tasks, initiatives, products, knowledge, PM proposals, …).
+ *   - Tables linked to workspace via a parent (task_activities,
+ *     task_deliverables, initiative_dependencies, etc.).
+ *
+ * What's NOT included by default (transient/large):
+ *   - agent_mailbox, agent_chat_messages, agent_health
+ *   - openclaw_sessions
+ *   These are gated behind `includeTransient: true`.
+ *
+ * What's never included:
+ *   - Truly global tables (debug_events, businesses, …) — they aren't
+ *     workspace-scoped and don't belong in a workspace export.
+ */
+
+import type Database from 'better-sqlite3';
+
+export interface ExportOptions {
+  includeTransient?: boolean;
+}
+
+export interface ExportOutput {
+  version: 1;
+  workspace_id: string;
+  exported_at: string;
+  schema_migration: string | null;
+  include_transient: boolean;
+  table_counts: Record<string, number>;
+  tables: Record<string, unknown[]>;
+}
+
+/**
+ * Tables with a direct workspace_id column.
+ */
+const DIRECT_TABLES = [
+  'workspaces',           // the row itself
+  'agents',
+  'tasks',
+  'workflow_templates',
+  'knowledge_entries',
+  'rollcall_sessions',
+  'products',
+  'cost_events',
+  'cost_caps',
+  'initiatives',
+  'pm_proposals',
+  'pm_pending_notes',
+] as const;
+
+interface IndirectTable {
+  table: string;
+  joinSql: string;
+  transient?: boolean;
+}
+
+/**
+ * Tables linked to a workspace via a parent table. The query joins
+ * through the parent column to filter by workspace_id.
+ */
+const INDIRECT_TABLES: IndirectTable[] = [
+  // Task-linked
+  { table: 'task_roles',                joinSql: 'SELECT t.* FROM task_roles t JOIN tasks p ON t.task_id = p.id WHERE p.workspace_id = ?' },
+  { table: 'task_activities',           joinSql: 'SELECT t.* FROM task_activities t JOIN tasks p ON t.task_id = p.id WHERE p.workspace_id = ?' },
+  { table: 'task_deliverables',         joinSql: 'SELECT t.* FROM task_deliverables t JOIN tasks p ON t.task_id = p.id WHERE p.workspace_id = ?' },
+  { table: 'task_notes',                joinSql: 'SELECT t.* FROM task_notes t JOIN tasks p ON t.task_id = p.id WHERE p.workspace_id = ?' },
+  { table: 'task_initiative_history',   joinSql: 'SELECT t.* FROM task_initiative_history t JOIN tasks p ON t.task_id = p.id WHERE p.workspace_id = ?' },
+  { table: 'user_task_reads',           joinSql: 'SELECT t.* FROM user_task_reads t JOIN tasks p ON t.task_id = p.id WHERE p.workspace_id = ?' },
+  { table: 'work_checkpoints',          joinSql: 'SELECT t.* FROM work_checkpoints t JOIN tasks p ON t.task_id = p.id WHERE p.workspace_id = ?' },
+
+  // Initiative-linked
+  { table: 'initiative_dependencies',   joinSql: 'SELECT t.* FROM initiative_dependencies t JOIN initiatives p ON t.initiative_id = p.id WHERE p.workspace_id = ?' },
+  { table: 'initiative_parent_history', joinSql: 'SELECT t.* FROM initiative_parent_history t JOIN initiatives p ON t.initiative_id = p.id WHERE p.workspace_id = ?' },
+
+  // Rollcall-linked. FK column on rollcall_entries is rollcall_id.
+  { table: 'rollcall_entries',          joinSql: 'SELECT t.* FROM rollcall_entries t JOIN rollcall_sessions p ON t.rollcall_id = p.id WHERE p.workspace_id = ?' },
+
+  // Agent-linked
+  { table: 'owner_availability',        joinSql: 'SELECT t.* FROM owner_availability t JOIN agents p ON t.agent_id = p.id WHERE p.workspace_id = ?' },
+
+  // Convoy chains (task-rooted via parent_task_id)
+  { table: 'convoys',                   joinSql: 'SELECT t.* FROM convoys t JOIN tasks p ON t.parent_task_id = p.id WHERE p.workspace_id = ?' },
+  { table: 'convoy_subtasks',           joinSql: 'SELECT t.* FROM convoy_subtasks t JOIN convoys c ON t.convoy_id = c.id JOIN tasks p ON c.parent_task_id = p.id WHERE p.workspace_id = ?' },
+
+  // Transient: chat / mailbox / sessions. agent_mailbox has from_/to_
+  // agent ids — pick rows where either endpoint belongs to this
+  // workspace (DISTINCT in case both endpoints match).
+  { table: 'agent_mailbox',             joinSql: 'SELECT DISTINCT t.* FROM agent_mailbox t JOIN agents p ON (t.from_agent_id = p.id OR t.to_agent_id = p.id) WHERE p.workspace_id = ?', transient: true },
+  { table: 'agent_health',              joinSql: 'SELECT t.* FROM agent_health t JOIN agents p ON t.agent_id = p.id WHERE p.workspace_id = ?', transient: true },
+  { table: 'agent_chat_messages',       joinSql: 'SELECT t.* FROM agent_chat_messages t JOIN agents p ON t.agent_id = p.id WHERE p.workspace_id = ?', transient: true },
+  { table: 'openclaw_sessions',         joinSql: 'SELECT t.* FROM openclaw_sessions t JOIN agents p ON t.agent_id = p.id WHERE p.workspace_id = ?', transient: true },
+];
+
+export class WorkspaceNotFoundError extends Error {
+  constructor(public workspaceId: string) {
+    super(`No workspace with id "${workspaceId}"`);
+    this.name = 'WorkspaceNotFoundError';
+  }
+}
+
+/**
+ * Run the export against an open SQLite handle. The handle is used
+ * read-only — only `prepare().all()` is called.
+ */
+export function exportWorkspace(
+  db: Database.Database,
+  workspaceId: string,
+  opts: ExportOptions = {},
+): ExportOutput {
+  const includeTransient = opts.includeTransient ?? false;
+
+  // Sanity-check the workspace exists.
+  const workspaceRow = db
+    .prepare('SELECT id FROM workspaces WHERE id = ?')
+    .get(workspaceId) as { id: string } | undefined;
+  if (!workspaceRow) {
+    throw new WorkspaceNotFoundError(workspaceId);
+  }
+
+  // Best-effort schema version capture.
+  let migration: string | null = null;
+  try {
+    const row = db
+      .prepare('SELECT name FROM migrations ORDER BY id DESC LIMIT 1')
+      .get() as { name?: string } | undefined;
+    if (row?.name) migration = row.name;
+  } catch {
+    // migrations table may not exist or have a different schema; keep null
+  }
+
+  // Existing-tables set so optional tables don't blow up.
+  const existingTables = new Set(
+    (db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .all() as Array<{ name: string }>).map((r) => r.name),
+  );
+
+  const out: ExportOutput = {
+    version: 1,
+    workspace_id: workspaceId,
+    exported_at: new Date().toISOString(),
+    schema_migration: migration,
+    include_transient: includeTransient,
+    table_counts: {},
+    tables: {},
+  };
+
+  for (const table of DIRECT_TABLES) {
+    if (!existingTables.has(table)) continue;
+    const sql =
+      table === 'workspaces'
+        ? `SELECT * FROM workspaces WHERE id = ?`
+        : `SELECT * FROM ${table} WHERE workspace_id = ?`;
+    const rows = db.prepare(sql).all(workspaceId);
+    out.tables[table] = rows;
+    out.table_counts[table] = rows.length;
+  }
+
+  for (const def of INDIRECT_TABLES) {
+    if (!existingTables.has(def.table)) continue;
+    if (def.transient && !includeTransient) continue;
+    const rows = db.prepare(def.joinSql).all(workspaceId);
+    out.tables[def.table] = rows;
+    out.table_counts[def.table] = rows.length;
+  }
+
+  return out;
+}
+
+/**
+ * Suggested filename for a workspace export, used by both the API
+ * route's Content-Disposition header and the CLI's default `--out`.
+ */
+export function defaultExportFilename(workspaceId: string, exportedAt: string): string {
+  return `mc-workspace-${workspaceId}-${exportedAt.replace(/[:.]/g, '-')}.json`;
+}


### PR DESCRIPTION
## Summary

One-click **Export workspace** button on the per-workspace settings page that downloads a JSON snapshot of every workspace-scoped row. Useful for retaining state before a `db:reset`, copying a real workspace into a checkpoint snapshot, or staging a future `import-workspace` that reloads into a fresh DB.

The same lib backs a CLI (`yarn workspace:export`), so the UI and script stay aligned on what \"export everything\" means.

## What's included

**Direct** workspace_id-scoped tables:
`workspaces`, `agents`, `tasks`, `workflow_templates`, `knowledge_entries`, `rollcall_sessions`, `products`, `cost_events`, `cost_caps`, `initiatives`, `pm_proposals`, `pm_pending_notes`.

**Indirect** (linked via parent):
`task_roles`, `task_activities`, `task_deliverables`, `task_notes`, `task_initiative_history`, `user_task_reads`, `work_checkpoints`, `initiative_dependencies`, `initiative_parent_history`, `rollcall_entries`, `owner_availability`, `convoys`, `convoy_subtasks`.

**Transient** (opt-in via checkbox or `--include-transient`):
`agent_mailbox`, `agent_health`, `agent_chat_messages`, `openclaw_sessions`. Off by default — large and mostly noise for retention.

## Output shape

```json
{
  \"version\": 1,
  \"workspace_id\": \"default\",
  \"exported_at\": \"2026-04-28T20:30:59.243Z\",
  \"schema_migration\": null,
  \"include_transient\": false,
  \"table_counts\": { \"initiatives\": 8, \"pm_proposals\": 39, ... },
  \"tables\": { \"initiatives\": [...rows], \"tasks\": [...rows], ... }
}
```

INSERT-shaped — rows are unmodified SQLite values, so a future `import-workspace` can iterate `tables` in dependency order and INSERT row-by-row.

## Files

- `src/lib/db/workspace-export.ts` — shared lib (direct + indirect table maps, scope filter).
- `src/app/api/workspaces/[id]/export/route.ts` — `GET` with `?include_transient` query, `Content-Disposition: attachment`.
- `src/app/(app)/workspace/[slug]/settings/page.tsx` — Export section between Project root and Danger Zone with a transient-rows checkbox.
- `scripts/export-workspace.ts` — thin CLI wrapper around the lib.
- `package.json` — `yarn workspace:export` alias.

## Test plan

- [x] `yarn test` — 400/400 pass.
- [x] `npx tsc --noEmit` — no new errors in changed files (pre-existing errors in `pm-decompose.test.ts` and `.next/types/validator.ts` are unrelated).
- [x] Preview verify on dev (`:4010`):
  - Settings page renders the new Export section in the right slot.
  - `fetch('/api/workspaces/default/export')` returns 200, `Content-Type: application/json`, `Content-Disposition: attachment; filename=\"mc-workspace-default-...json\"`, 229 KB.
  - Real export contains 8 initiatives, 39 PM proposals, 17 agents, 9 dependencies, 7 parent-history rows, 7 rollcall entries, 2 owner-availability rows.

## Out of scope

- Import flow (`import-workspace` from this JSON into a fresh DB) — the output is shaped for it, but the actual reloader is a follow-up.
- Diffing two exports for change auditing.
- Compression — payloads are small enough that gzip isn't worth the complexity yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)