### PR TITLE
feat(agents): per-instance catalog-sync filter via env globs

### DIFF
--- a/docs/DOGFOOD_PLAYBOOK.md
+++ b/docs/DOGFOOD_PLAYBOOK.md
@@ -16,6 +16,7 @@ change taking out the planning surface you're using to plan the change.
 | Agent roster | `mc-pm`, `mc-builder`, … | `mc-pm-dev`, `mc-builder-dev`, … |
 | MCP server | `sc-mission-control` | `sc-mission-control-dev` |
 | Workspace dirs | `~/.openclaw/workspaces/<agent>` | `~/.openclaw/workspaces/<agent>-dev` |
+| Catalog-sync filter | `MC_AGENT_SYNC_EXCLUDE=*-dev` | `MC_AGENT_SYNC_INCLUDE=*-dev` |
 | Updated when | a tested PR merges + image rebuilds | every save (HMR) |
 
 > Port `4000` is the local LiteLLM gateway and stays put. Don't bind MC
@@ -119,12 +120,41 @@ Replace `__SET_DEV_MC_API_TOKEN__` with your dev MC token from step 2.
 Match `MC_URL` to wherever your dev MC actually listens (default
 `4010`; override via `PORT=…` in the dev MC's env).
 
-### 5. Restart openclaw
+### 5. Filter the catalog sync per instance
+
+The openclaw gateway is single-source-of-truth for the workspace
+agent roster, so without filtering each MC instance mirrors **every**
+agent the gateway exposes — meaning prod's `/agents` page shows the
+`-dev` roster and vice versa. Set one of the two env vars below per
+instance so each MC only mirrors its own subset:
+
+| Instance | env var |
+|---|---|
+| Prod (docker) | `MC_AGENT_SYNC_EXCLUDE=*-dev` |
+| Dev (`launch.json`) | `MC_AGENT_SYNC_INCLUDE=*-dev` |
+
+For dev, add `MC_AGENT_SYNC_INCLUDE=*-dev` to the env block of your
+`.claude/launch.json` (`mission-control-dev` config) — that file is
+gitignored so each operator wires it once locally. For prod, add
+`MC_AGENT_SYNC_EXCLUDE=*-dev` to whichever env source your
+`docker-compose.yml` uses.
+
+Both vars accept comma-separated lists with `*` wildcards
+(e.g. `mc-builder,mc-coordinator-dev`, `mc-*` ). When both are set,
+exclude wins for the same id. Default empty → no filter (current
+behavior).
+
+When a previously-synced agent stops matching the filter, the next
+catalog sync flips its `status` to `offline` (does **not** delete
+the row — task / mailbox FK references stay valid). Re-including it
+later flips status back to `idle` automatically.
+
+### 6. Restart openclaw
 
 Openclaw reads `openclaw.json` once at start. After the sync, restart
 the gateway so the new agent roster and MCP server are picked up.
 
-### 6. Smoke test
+### 7. Smoke test
 
 Pick `mc-project-manager-dev` in the openclaw chat surface. Ask it
 something simple ("call `whoami`"). The reply should report

--- a/src/lib/agent-catalog-sync.test.ts
+++ b/src/lib/agent-catalog-sync.test.ts
@@ -1,0 +1,100 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { selectGatewayAgents } from './agent-catalog-sync';
+
+const AGENTS = [
+  { id: 'main', name: 'main' },
+  { id: 'mc-builder', name: 'Builder' },
+  { id: 'mc-coordinator', name: 'Coordinator' },
+  { id: 'mc-builder-dev', name: 'Builder' },
+  { id: 'mc-coordinator-dev', name: 'Coordinator' },
+  { id: 'mc-project-manager', name: 'Project Manager' },
+  { id: 'mc-project-manager-dev', name: 'Project Manager' },
+];
+
+describe('selectGatewayAgents (env-driven filter)', () => {
+  it('default config includes everything', () => {
+    const { included, excludedGatewayIds } = selectGatewayAgents(AGENTS, {});
+    assert.equal(included.length, AGENTS.length);
+    assert.equal(excludedGatewayIds.size, 0);
+  });
+
+  it('exclude=*-dev keeps prod roster, drops dev roster', () => {
+    const { included, excludedGatewayIds } = selectGatewayAgents(AGENTS, {
+      exclude: '*-dev',
+    });
+    assert.deepEqual(
+      included.map((a) => a.id).sort(),
+      ['main', 'mc-builder', 'mc-coordinator', 'mc-project-manager'].sort(),
+    );
+    assert.deepEqual(
+      [...excludedGatewayIds].sort(),
+      ['mc-builder-dev', 'mc-coordinator-dev', 'mc-project-manager-dev'].sort(),
+    );
+  });
+
+  it('include=*-dev keeps dev roster only', () => {
+    const { included, excludedGatewayIds } = selectGatewayAgents(AGENTS, {
+      include: '*-dev',
+    });
+    assert.deepEqual(
+      included.map((a) => a.id).sort(),
+      ['mc-builder-dev', 'mc-coordinator-dev', 'mc-project-manager-dev'].sort(),
+    );
+    assert.equal(excludedGatewayIds.size, 4);
+    // Each non-matching id should land in excluded.
+    for (const id of ['main', 'mc-builder', 'mc-coordinator', 'mc-project-manager']) {
+      assert.ok(excludedGatewayIds.has(id), `${id} should be excluded`);
+    }
+  });
+
+  it('exclude takes precedence over include for the same id', () => {
+    // Operator sets a wide include and then an explicit exclude — the
+    // exclude wins.
+    const { included, excludedGatewayIds } = selectGatewayAgents(AGENTS, {
+      include: 'mc-*',
+      exclude: 'mc-coordinator,mc-coordinator-dev',
+    });
+    const ids = included.map((a) => a.id);
+    assert.ok(!ids.includes('mc-coordinator'));
+    assert.ok(!ids.includes('mc-coordinator-dev'));
+    assert.ok(ids.includes('mc-builder'));
+    assert.ok(excludedGatewayIds.has('mc-coordinator'));
+    assert.ok(excludedGatewayIds.has('mc-coordinator-dev'));
+    // Wide include matched, exclude knocked these out, and 'main'
+    // never matched the include in the first place — still excluded.
+    assert.ok(excludedGatewayIds.has('main'));
+  });
+
+  it('explicit comma-separated list works without globs', () => {
+    const { included } = selectGatewayAgents(AGENTS, {
+      include: 'main,mc-builder,mc-project-manager',
+    });
+    assert.deepEqual(
+      included.map((a) => a.id).sort(),
+      ['main', 'mc-builder', 'mc-project-manager'].sort(),
+    );
+  });
+
+  it('whitespace and empty tokens are tolerated', () => {
+    const { included } = selectGatewayAgents(AGENTS, {
+      include: ' main , , mc-builder ',
+    });
+    assert.deepEqual(
+      included.map((a) => a.id).sort(),
+      ['main', 'mc-builder'].sort(),
+    );
+  });
+
+  it('agents missing both id and name are skipped', () => {
+    const noisy = [...AGENTS, { name: undefined }] as Parameters<typeof selectGatewayAgents>[0];
+    const { included, excludedGatewayIds } = selectGatewayAgents(noisy, {});
+    assert.equal(included.length, AGENTS.length);
+    assert.equal(excludedGatewayIds.size, 0);
+  });
+
+  it('empty include string is treated as no filter (matches all)', () => {
+    const { included } = selectGatewayAgents(AGENTS, { include: '' });
+    assert.equal(included.length, AGENTS.length);
+  });
+});

--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -24,6 +24,73 @@ const SYNC_INTERVAL_MS = Number(process.env.AGENT_CATALOG_SYNC_INTERVAL_MS || 60
 let lastSyncAt = 0;
 let syncing: Promise<number> | null = null;
 
+/**
+ * Compile a comma-separated list of glob patterns into a single matcher.
+ * Patterns support `*` only (matches any sequence). Whitespace and empty
+ * tokens are ignored. Returns `null` when no patterns were configured —
+ * caller treats null as "no filter".
+ *
+ * Used by the catalog sync to honor `MC_AGENT_SYNC_INCLUDE` /
+ * `MC_AGENT_SYNC_EXCLUDE`. The dogfood layout sets one of:
+ *   prod docker:  MC_AGENT_SYNC_EXCLUDE=*-dev
+ *   dev launch:   MC_AGENT_SYNC_INCLUDE=*-dev
+ * so each MC instance only mirrors its own roster from the gateway.
+ */
+function compileGlobList(env: string | undefined): ((id: string) => boolean) | null {
+  if (!env) return null;
+  const patterns = env
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (patterns.length === 0) return null;
+  // Translate each glob to a regex anchored to the full id. `*` becomes
+  // `.*`; everything else is escaped so dots / dashes etc. match literally.
+  const regexes = patterns.map((p) => {
+    const escaped = p.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+    return new RegExp(`^${escaped}$`);
+  });
+  return (id: string) => regexes.some((re) => re.test(id));
+}
+
+/**
+ * Decide which gateway agent ids should sync into the catalog. Returns
+ * the included subset and the set of gateway ids that were filtered
+ * out, so the caller can mark previously-synced excluded rows offline.
+ *
+ * Exported for tests; production callers use it through
+ * `syncGatewayAgentsToCatalog`.
+ */
+export function selectGatewayAgents(
+  gatewayAgents: GatewayAgent[],
+  env: { include?: string; exclude?: string } = {
+    include: process.env.MC_AGENT_SYNC_INCLUDE,
+    exclude: process.env.MC_AGENT_SYNC_EXCLUDE,
+  },
+): { included: GatewayAgent[]; excludedGatewayIds: Set<string> } {
+  const includeMatch = compileGlobList(env.include);
+  const excludeMatch = compileGlobList(env.exclude);
+
+  const included: GatewayAgent[] = [];
+  const excludedGatewayIds = new Set<string>();
+
+  for (const ga of gatewayAgents) {
+    const id = ga.id || ga.name;
+    if (!id) continue;
+    // Include defaults to match-all when not configured. Exclude is then
+    // applied on top — so an id can be in the include list and still be
+    // dropped if exclude matches it.
+    const isIncluded = includeMatch ? includeMatch(id) : true;
+    const isExcluded = excludeMatch ? excludeMatch(id) : false;
+    if (isIncluded && !isExcluded) {
+      included.push(ga);
+    } else {
+      excludedGatewayIds.add(id);
+    }
+  }
+
+  return { included, excludedGatewayIds };
+}
+
 function normalizeRole(name: string): string {
   const n = name.toLowerCase();
   // Order matters: more-specific patterns first. Without the research /
@@ -78,16 +145,24 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
       });
     }
 
+    // Apply MC_AGENT_SYNC_INCLUDE / MC_AGENT_SYNC_EXCLUDE before any DB
+    // writes. The gateway is single-source-of-truth for the workspace
+    // roster; this filter is purely an MC-side mirror choice (one prod
+    // and one dev MC instance can coexist against the same gateway by
+    // mirroring disjoint subsets of agents).
+    const { included, excludedGatewayIds } = selectGatewayAgents(gatewayAgents);
+
     const existing = queryAll<{ id: string; gateway_agent_id: string | null }>(
       `SELECT id, gateway_agent_id FROM agents WHERE gateway_agent_id IS NOT NULL`
     );
     const existingByGatewayId = new Map(existing.map((a) => [a.gateway_agent_id, a.id]));
 
     let changed = 0;
+    let markedOffline = 0;
     const ts = new Date().toISOString();
 
     transaction(() => {
-      for (const ga of gatewayAgents) {
+      for (const ga of included) {
         const gatewayId = ga.id || ga.name;
         if (!gatewayId) continue;
 
@@ -96,8 +171,18 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
         const existingId = existingByGatewayId.get(gatewayId) || null;
 
         if (existingId) {
+          // Update existing row. Flip status off 'offline' if a previous
+          // sync had marked it filtered-out and the operator has now
+          // included it again (env var change → restart).
           run(
-            `UPDATE agents SET name = ?, role = CASE WHEN role IS NULL OR role = 'builder' THEN ? ELSE role END, model = COALESCE(?, model), source = 'gateway', updated_at = ? WHERE id = ?`,
+            `UPDATE agents
+                SET name = ?,
+                    role = CASE WHEN role IS NULL OR role = 'builder' THEN ? ELSE role END,
+                    model = COALESCE(?, model),
+                    source = 'gateway',
+                    status = CASE WHEN status = 'offline' THEN 'idle' ELSE status END,
+                    updated_at = ?
+              WHERE id = ?`,
             [name, role, normaliseModel(ga.model), ts, existingId]
           );
         } else {
@@ -110,12 +195,34 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
         changed += 1;
       }
 
+      // Mark previously-synced rows whose gateway id is now filtered
+      // out as `status='offline'`. Don't touch `is_active` — that's the
+      // operator's intentional disable toggle and we don't want to
+      // overwrite it. Don't delete the row either; FK references from
+      // tasks / mailbox stay valid, and a future env-var relaxation
+      // will flip status back to 'idle' automatically (above).
+      for (const gatewayId of excludedGatewayIds) {
+        const existingId = existingByGatewayId.get(gatewayId);
+        if (!existingId) continue;
+        const result = run(
+          `UPDATE agents SET status = 'offline', updated_at = ? WHERE id = ? AND status != 'offline'`,
+          [ts, existingId]
+        );
+        if (result.changes > 0) markedOffline += 1;
+      }
+
       run(
         `INSERT INTO events (id, type, message, metadata, created_at)
          VALUES (lower(hex(randomblob(16))), 'system', ?, ?, ?)`,
         [
           `Agent catalog sync completed (${options?.reason || 'automatic'})`,
-          JSON.stringify({ changed, reason: options?.reason || 'automatic' }),
+          JSON.stringify({
+            changed,
+            marked_offline: markedOffline,
+            included: included.length,
+            excluded: excludedGatewayIds.size,
+            reason: options?.reason || 'automatic',
+          }),
           ts,
         ]
       );


### PR DESCRIPTION
## Why

The openclaw gateway is single-source-of-truth for the workspace agent roster. When stable + dev MC instances coexist (per [docs/DOGFOOD_PLAYBOOK.md](docs/DOGFOOD_PLAYBOOK.md)), both ended up mirroring **each other's** `-dev` and prod agents into their own catalogs. That clutters `/agents`, makes it harder to tell what belongs where, and creates routing-confusion risk if either MC ever picks the wrong roster for a dispatch.

## What

Two new env vars on each MC instance — comma-separated globs with `*` wildcards, evaluated against gateway agent ids before any DB write:

```
MC_AGENT_SYNC_INCLUDE   default empty → match all (current behavior)
MC_AGENT_SYNC_EXCLUDE   default empty → exclude none
```

Dogfood layout:

| Instance | env |
|---|---|
| Prod (docker) | `MC_AGENT_SYNC_EXCLUDE=*-dev` |
| Dev (`launch.json`) | `MC_AGENT_SYNC_INCLUDE=*-dev` |

`exclude` wins over `include` for the same id — so an operator can write a wide include and selectively knock things out without restructuring the include list.

## Behavior on existing rows

When a previously-synced agent stops matching the filter:

- `status` flips to `'offline'` (the existing dispatch path already excludes offline agents).
- The row is **not deleted** — task / mailbox FK references stay valid.
- `is_active` is **not touched** — that's the operator's intentional disable toggle and shouldn't get overwritten by env-driven config.
- Re-including later flips status back to `'idle'` automatically on the next sync.

The sync event log now records `{ included, excluded, marked_offline, changed }` so you can audit what each tick did.

## Files

- `src/lib/agent-catalog-sync.ts` — `selectGatewayAgents()` filter helper + integration in `syncGatewayAgentsToCatalog`.
- `src/lib/agent-catalog-sync.test.ts` — 8 cases covering default, include-only, exclude-only, both with exclude precedence, whitespace tolerance, missing ids, empty include.
- `docs/DOGFOOD_PLAYBOOK.md` — new step 5 with the prod/dev one-liners; quick-ref table updated.

## Test plan

- [x] `yarn test` — 408/408 (was 400; +8 for the new filter test).
- [x] `npx tsc --noEmit` — no new errors in changed files.
- [x] Preview verified on dev (`:4010`): with `MC_AGENT_SYNC_INCLUDE=*-dev` set in `launch.json` env, `/agents` flips to **STANDBY(8)** showing only the `-dev` roster; the 9 prod-roster rows go OFFLINE; clearing the env var and restarting flips them back to `idle` on next sync.

## Out of scope

- A "Resync now" button. The 60s scheduled sync + restart-on-env-change covers the dogfood need; if env-tuning gets common, easy to add later.
- UI affordances to hide `OFFLINE` agents from the All tab. They show as offline today (visible but unrouteable). Operators who want them gone can use the existing "Pause" / delete actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)