### PR TITLE
fix(db-backup): drop stale line + loosen env type for typecheck

### DIFF
--- a/src/lib/db-backup.ts
+++ b/src/lib/db-backup.ts
@@ -143,7 +143,9 @@ export async function enforceRetention(
  * Resolve effective config from env vars, with sensible defaults
  * grounded in DATABASE_PATH. Pure function — no side effects.
  */
-export function resolveBackupConfig(env: NodeJS.ProcessEnv = process.env): {
+export function resolveBackupConfig(
+  env: Record<string, string | undefined> = process.env,
+): {
   enabled: boolean;
   dbPath: string;
   backupDir: string;
@@ -211,7 +213,6 @@ export function registerBackupSchedule(getLiveDb: () => Database.Database): void
   // First backup ~30s after boot — lets migrations + any startup writes
   // settle so the first snapshot reflects a steady state, not a partial
   // one. Then every intervalHours.
-  g.__mcBootTimer = undefined;
   g.__mcBackupBoot = setTimeout(() => {
     void tick('boot');
   }, 30_000);


### PR DESCRIPTION
## Summary

Hotfix for two TypeScript errors in #96 that broke the prod docker build:

1. **Stale `g.__mcBootTimer = undefined`** in `src/lib/db-backup.ts` — leftover line referencing a key not in the typed global. Removed.
2. **`resolveBackupConfig(env: NodeJS.ProcessEnv)` rejected partial test objects** like `{ DATABASE_PATH: '...' }`. Loosened to `Record<string, string | undefined>`, which `process.env` structurally satisfies.

## Test plan

- [x] `npx tsc --noEmit` — no errors in `db-backup.ts` or `db-backup.test.ts`.
- [x] `npx tsx --test src/lib/db-backup.test.ts` — 10/10.
- [x] Dev preview restarted: `[Backup] scheduled: dir=…, every 24h, retain=14`, no server errors.

After merge: `cd /Users/snappytwo/docker && docker compose build mission-control && docker compose up -d mission-control` should now build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)