### PR TITLE
perf(docker): cache yarn install + drop backups/ from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,7 @@ coverage
 .tmp
 .claude
 data
-db-backups
+backups
 openclaw-workspaces
 presentation
 .cursor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,29 @@
+# syntax=docker/dockerfile:1.7
 FROM node:22-bookworm-slim AS base
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
+# Pin the yarn cache path so the BuildKit cache mounts in the install
+# stages below land somewhere predictable and survive across rebuilds.
+ENV YARN_CACHE_FOLDER=/root/.cache/yarn
 
 FROM base AS build-deps
 RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 make g++ \
   && rm -rf /var/lib/apt/lists/*
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+# BuildKit cache mount: a warm yarn cache survives across rebuilds, so
+# even when this layer is invalidated by a package.json change yarn
+# pulls from cache instead of re-downloading every dep.
+RUN --mount=type=cache,target=/root/.cache/yarn \
+    yarn install --frozen-lockfile
 
 FROM base AS prod-deps
 RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 make g++ \
   && rm -rf /var/lib/apt/lists/*
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --production && yarn cache clean
+RUN --mount=type=cache,target=/root/.cache/yarn \
+    yarn install --frozen-lockfile --production
 
 FROM base AS builder
 COPY --from=build-deps /app/node_modules ./node_modules


### PR DESCRIPTION
## Summary

Two prod-build wins after #96 (auto-backups) landed:

1. **`.dockerignore`** — replace the stale `db-backups` entry (which never matched any actual path) with `backups/`, the path the new scheduled backup writes to. Without this, every `docker compose build` was sending the dev DB's most recent ~141 MB snapshot through the COPY context for nothing. The runtime image is unaffected (it only consumes its own `/app/data` volume).

2. **`Dockerfile`** — enable BuildKit `--mount=type=cache` on both yarn install layers (`build-deps` + `prod-deps`). Pin `YARN_CACHE_FOLDER` for predictability. Drop the now-redundant `yarn cache clean` from `prod-deps` (cache lives in the mount, not the image layer, so the layer stays slim either way). Add `# syntax=docker/dockerfile:1.7` to lock the parser version.

## Expected impact

- **Cold first build**: slightly faster (smaller COPY context).
- **Warm rebuilds**: 30–50% faster — when `package.json` changes invalidate the install layer, yarn now pulls from the persistent cache volume instead of re-fetching every dep from npm.

Type-check stays in the build (we just got bit by skipping it), and ESLint stays in the build pending a CI lint step. Standalone-output is a separate followup.

## Test plan

- [x] File-only changes; CI / repo tests unaffected.
- [ ] Operator measures `time docker compose build mission-control` against the same warm state, before vs. after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)