### PR TITLE
fix(docker): serialize yarn cache mount to prevent concurrent corruption

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY package.json yarn.lock ./
 # BuildKit cache mount: a warm yarn cache survives across rebuilds, so
 # even when this layer is invalidated by a package.json change yarn
 # pulls from cache instead of re-downloading every dep.
-RUN --mount=type=cache,target=/root/.cache/yarn \
+RUN --mount=type=cache,target=/root/.cache/yarn,sharing=locked \
     yarn install --frozen-lockfile
 
 FROM base AS prod-deps
@@ -22,7 +22,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 make g++ \
   && rm -rf /var/lib/apt/lists/*
 COPY package.json yarn.lock ./
-RUN --mount=type=cache,target=/root/.cache/yarn \
+RUN --mount=type=cache,target=/root/.cache/yarn,sharing=locked \
     yarn install --frozen-lockfile --production
 
 FROM base AS builder


### PR DESCRIPTION
## Why

#98 introduced parallel cache-mount access that corrupts itself. BuildKit ran `build-deps 3/3` and `prod-deps 3/3` concurrently, both writing into the same \`/root/.cache/yarn\`. A read from one stage interleaved with a partial write from the other and left a 0-byte tarball. Yarn then computed the integrity of empty bytes (\`sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=\`, the well-known SHA-1 of the empty string), tripped its frozen-lockfile check, and failed:

```
error https://registry.yarnpkg.com/@aws-sdk/middleware-location-constraint/...
Integrity check failed: got \"sha512-z4PhNX7vuL3...== sha1-2jmj7l5...\"
```

## Fix

Add \`sharing=locked\` to both cache mounts. The second stage now waits for the first to release the lock, then runs against the warmed cache. Better than \`sharing=private\` (which would give each stage its own cache and lose cross-stage reuse) and better than the unspecified default (which produced today's race).

## Operator action

The corrupted cache mount needs a one-time prune before the next build:

\`\`\`bash
docker builder prune --filter type=exec.cachemount
\`\`\`

After that, \`docker compose build mission-control\` should complete cleanly. Subsequent rebuilds get the warm-cache speedup #98 was supposed to deliver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)