### PR TITLE
fix(openclaw-sync): bidirectional deny rules to stop cross-roster MCP calls

### DIFF
--- a/docs/DOGFOOD_PLAYBOOK.md
+++ b/docs/DOGFOOD_PLAYBOOK.md
@@ -96,10 +96,18 @@ yarn openclaw:sync:check   # dry-run, exits non-zero if drift found
 yarn openclaw:sync         # apply
 ```
 
-The script is **idempotent**: re-running mirrors any subsequent edits
-to a stable agent block back to its `-dev` counterpart. Run it after
-any change to a stable agent (new skill, tool change, model swap) to
-keep the dev block aligned.
+The script is **idempotent and bidirectional**: re-running mirrors any
+subsequent edits to a stable agent block back to its `-dev` counterpart,
+AND additively writes a `tools.deny` rule into each stable block to
+block calls into the dev MCP server (the inverse rule lands on dev
+blocks). Without that deny, prod agents see `sc-mission-control-dev__*`
+in their tool catalog (openclaw lists every registered MCP server's
+tools to every agent — `alsoAllow` only gates *calls*, not *visibility*)
+and occasionally try to use them, producing blocked-state lifecycle
+errors during roll calls.
+
+Run after any change to a stable agent (new skill, tool change, model
+swap) to keep both sides aligned.
 
 ### 4. Replace the API token placeholder
 

--- a/scripts/sync-openclaw-agents.mjs
+++ b/scripts/sync-openclaw-agents.mjs
@@ -12,18 +12,27 @@
  *      MC dev (default http://localhost:4010/api/mcp). The token is left
  *      alone if already set; otherwise a placeholder is written and the
  *      operator is prompted to fill it in.
- *   2. For every agent matching ^mc-[a-z-]+$ (i.e. a stable MC agent),
- *      ensures a parallel `<id>-dev` agent exists with:
- *        - workspace path suffixed `-dev`
- *        - tools.alsoAllow rewritten so `sc-mission-control__*` becomes
- *          `sc-mission-control-dev__*`
- *        - all other fields copied from the stable block (model, skills,
- *          heartbeat, etc.)
+ *   2. For every agent matching ^mc-[a-z-]+$ (i.e. a stable MC agent):
+ *        - Ensures the stable block's `tools.deny` includes
+ *          `sc-mission-control-dev__*` so the prod agent can't even SEE
+ *          the dev MCP tool catalog (alsoAllow only gates calls, not
+ *          visibility — without deny, prod agents call dev tools by
+ *          accident and produce blocked-state errors during roll calls).
+ *        - Ensures a parallel `<id>-dev` agent exists with:
+ *            - workspace path suffixed `-dev`
+ *            - tools.alsoAllow rewritten so `sc-mission-control__*`
+ *              becomes `sc-mission-control-dev__*`
+ *            - tools.deny rewritten so it denies `sc-mission-control__*`
+ *              (the inverse of stable's deny rule)
+ *            - all other fields copied from the stable block (model,
+ *              skills, heartbeat, etc.)
  *   3. Writes openclaw.json back, formatted, after taking a backup.
  *
- * Idempotent: re-running re-syncs the dev blocks to whatever the stable
- * blocks currently look like. Use it after editing a stable agent block
- * (new skill, tool change, etc.) to keep the dev block aligned.
+ * Idempotent: re-running re-syncs both stable and dev blocks. Use it
+ * after editing a stable agent block (new skill, tool change, etc.) to
+ * keep the dev block aligned. The script only touches stable blocks
+ * additively — it adds the dev-server deny rule if missing; it never
+ * removes anything from a stable block.
  *
  * Does NOT:
  *   - Create or copy agent workspace directories. Run the one-time
@@ -67,6 +76,16 @@ function devWorkspaceFor(stableWorkspace) {
   return path.join(parent, `${base}-dev`);
 }
 
+// Tool patterns each side denies. The deny rules are belt-and-suspenders
+// to alsoAllow: openclaw still lists every registered MCP server's tool
+// catalog to every agent, so without an explicit deny the LLM in a prod
+// agent will see (and try to call) `sc-mission-control-dev__send_mail`
+// even though alsoAllow doesn't authorize it. deny is checked before
+// tool resolution and removes the cross-side tools from the catalog
+// entirely.
+const STABLE_DENY_DEV_PATTERN = `${DEV_SERVER_NAME}__*`;     // sc-mission-control-dev__*
+const DEV_DENY_STABLE_PATTERN = `${STABLE_SERVER_NAME}__*`;  // sc-mission-control__*
+
 function rewriteAlsoAllow(alsoAllow) {
   if (!Array.isArray(alsoAllow)) return alsoAllow;
   return alsoAllow.map((entry) =>
@@ -76,13 +95,46 @@ function rewriteAlsoAllow(alsoAllow) {
   );
 }
 
+/**
+ * Stable-side: deep-add `sc-mission-control-dev__*` to deny[]. Returns
+ * the original block untouched if the rule is already present so the
+ * change-detector can report a no-op.
+ */
+function ensureStableDeny(stableBlock) {
+  if (!stableBlock.tools || typeof stableBlock.tools !== 'object') return stableBlock;
+  const existing = Array.isArray(stableBlock.tools.deny) ? stableBlock.tools.deny : [];
+  if (existing.includes(STABLE_DENY_DEV_PATTERN)) return stableBlock;
+  return {
+    ...stableBlock,
+    tools: { ...stableBlock.tools, deny: [...existing, STABLE_DENY_DEV_PATTERN] },
+  };
+}
+
+/**
+ * Dev-side: rebuild deny[] so it has `sc-mission-control__*` (the
+ * inverse of stable's deny rule) and does NOT carry over the
+ * dev-server deny pattern that exists in stable. Idempotent.
+ */
+function rewriteDeny(deny) {
+  const existing = Array.isArray(deny) ? deny : [];
+  // Drop the stable-side deny rule (irrelevant on the dev block).
+  const filtered = existing.filter((e) => e !== STABLE_DENY_DEV_PATTERN);
+  if (!filtered.includes(DEV_DENY_STABLE_PATTERN)) {
+    filtered.push(DEV_DENY_STABLE_PATTERN);
+  }
+  return filtered;
+}
+
 function buildDevBlock(stableBlock) {
   // Deep clone so we don't mutate the stable block.
   const dev = JSON.parse(JSON.stringify(stableBlock));
   dev.id = devIdFor(stableBlock.id);
   if (dev.workspace) dev.workspace = devWorkspaceFor(stableBlock.workspace);
-  if (dev.tools && Array.isArray(dev.tools.alsoAllow)) {
-    dev.tools = { ...dev.tools, alsoAllow: rewriteAlsoAllow(dev.tools.alsoAllow) };
+  if (dev.tools && typeof dev.tools === 'object') {
+    if (Array.isArray(dev.tools.alsoAllow)) {
+      dev.tools = { ...dev.tools, alsoAllow: rewriteAlsoAllow(dev.tools.alsoAllow) };
+    }
+    dev.tools = { ...dev.tools, deny: rewriteDeny(dev.tools.deny) };
   }
   return dev;
 }
@@ -137,9 +189,28 @@ function syncAgents(config, { dryRun }) {
   const byId = new Map(list.map((a, i) => [a.id, { agent: a, index: i }]));
   const changes = [];
 
-  for (const agent of list) {
+  for (let i = 0; i < list.length; i++) {
+    const agent = list[i];
     if (!isStableMcAgentId(agent.id)) continue;
-    const expected = buildDevBlock(agent);
+
+    // Step 1: ensure the stable block denies the dev MCP server. Only
+    // additive — we never remove anything from operator-authored stable
+    // blocks. Same change-detection pattern as the dev-side build.
+    const updatedStable = ensureStableDeny(agent);
+    if (!shallowEqualBlocks(agent, updatedStable)) {
+      changes.push({
+        kind: 'update',
+        id: agent.id,
+        index: i,
+        block: updatedStable,
+        reason: 'add deny rule for dev MCP server',
+      });
+    }
+
+    // Step 2: ensure the dev counterpart exists and is in sync. Build
+    // dev from the (possibly updated) stable so deny inversion sees a
+    // consistent baseline.
+    const expected = buildDevBlock(updatedStable);
     const existing = byId.get(expected.id);
 
     if (!existing) {
@@ -152,7 +223,6 @@ function syncAgents(config, { dryRun }) {
   }
 
   if (!dryRun) {
-    // Apply additions (append) and updates (in place).
     for (const change of changes) {
       if (change.kind === 'add') {
         list.push(change.block);
@@ -186,7 +256,8 @@ async function main() {
     console.log('[sync-openclaw-agents] agents: in sync (no changes)');
   } else {
     for (const c of agentChanges) {
-      console.log(`[sync-openclaw-agents] agents: ${c.kind} ${c.id}`);
+      const suffix = c.reason ? ` (${c.reason})` : '';
+      console.log(`[sync-openclaw-agents] agents: ${c.kind} ${c.id}${suffix}`);
     }
   }
 


### PR DESCRIPTION
## Why

Roll-call traffic in prod produced **40 lifecycle events ending in `phase=error livenessState=blocked`**. The failing tool calls came from a prod agent (`mc-builder`, no `-dev` suffix) firing `sc-mission-control-dev__whoami` and `sc-mission-control-dev__send_mail` — the dev MCP server. The persona gate rejected, but the noise made the gateway look unhealthy and made roll-call output unreliable.

**Root cause:** openclaw lists every registered MCP server's tool catalog to every agent. `tools.alsoAllow` only gates *calls*, not *visibility*. So a prod agent allowed only `sc-mission-control__*` still **sees** `sc-mission-control-dev__*` in its toolkit, and the LLM sometimes picks the wrong server (especially for `send_mail`, which exists on both — common during a roll call).

## Fix

`sync-openclaw-agents.mjs` becomes bidirectional and additively writes `tools.deny` rules:

```
prod agents:  tools.deny += "sc-mission-control-dev__*"
dev agents:   tools.deny += "sc-mission-control__*"
```

`deny` is checked before tool resolution — the cross-side tools never make it into the LLM's catalog at all.

## Implementation

- `ensureStableDeny` — appends `sc-mission-control-dev__*` to each stable block's `tools.deny`. **Additive only**; preserves operator-authored entries (`image_generate`, `music_generate`, `video_generate`).
- `rewriteDeny` — for the dev clone, drops the stable-side deny pattern and ensures `sc-mission-control__*` is present.
- `syncAgents` runs both passes per stable agent and reports the reason in the change log so dry-runs are clear about what's changing.
- Idempotent: re-running after the fix is a no-op.

## Test plan

- [x] `yarn openclaw:sync:check` against the live config produced 16 expected changes (8 stable updates, 8 dev updates).
- [x] `yarn openclaw:sync` applied them; backup written to `openclaw.json.bak.<ts>`.
- [x] `jq` inspection confirmed `mc-builder.tools.deny` includes `sc-mission-control-dev__*` alongside the existing image/music/video entries; `mc-builder-dev.tools.deny` includes `sc-mission-control__*`.
- [x] Re-running `yarn openclaw:sync:check` exits 0 with \"in sync\".
- [ ] Operator restarts openclaw, runs another roll call, expects zero `livenessState=blocked` cross-roster events.

## docs

`docs/DOGFOOD_PLAYBOOK.md` updated with the bidirectional behavior + the openclaw visibility-vs-calls distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)