### PR TITLE
feat(pm): structured per-row diff rendering on proposal cards

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -20,6 +20,7 @@ import {
   stripSuggestionsSidecar,
   type PlanInitiativeSuggestionsBlob,
 } from '@/lib/pm/planSuggestionsSidecar';
+import { ProposalDiffsList, type PmDiff } from '@/components/pm/ProposalDiffsList';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -42,24 +43,6 @@ interface AgentChatMessage {
   status: 'pending' | 'delivered';
   metadata?: string;
   created_at: string;
-}
-
-interface PmDiff {
-  kind: string;
-  initiative_id?: string;
-  agent_id?: string;
-  status?: string;
-  target_start?: string;
-  target_end?: string;
-  start?: string;
-  end?: string;
-  reason?: string;
-  status_check_md?: string;
-  depends_on_initiative_id?: string;
-  dependency_id?: string;
-  parent_id?: string | null;
-  child_ids_in_order?: string[];
-  note?: string;
 }
 
 interface PmProposal {
@@ -879,18 +862,7 @@ function ChatMessageRow({
             </>
           );
         })()}
-        {proposal.proposed_changes.length > 0 && (
-          <div className="px-3 pb-3 space-y-1 text-xs text-mc-text-secondary">
-            {proposal.proposed_changes.slice(0, 6).map((c, idx) => (
-              <div key={idx} className="font-mono">
-                · {summarizeDiff(c)}
-              </div>
-            ))}
-            {proposal.proposed_changes.length > 6 && (
-              <div className="font-mono">…and {proposal.proposed_changes.length - 6} more</div>
-            )}
-          </div>
-        )}
+        <ProposalDiffsList diffs={proposal.proposed_changes} />
         {proposal.status === 'draft' && (
           <div className="px-3 py-2 border-t border-amber-500/30 bg-amber-500/5 flex items-center gap-2">
             {refining === proposal.id ? (
@@ -950,26 +922,9 @@ function ChatMessageRow({
   );
 }
 
-function summarizeDiff(c: PmDiff): string {
-  switch (c.kind) {
-    case 'shift_initiative_target':
-      return `shift ${shortId(c.initiative_id)}: ${c.target_start ?? '∅'} → ${c.target_end ?? '∅'}`;
-    case 'add_availability':
-      return `availability ${shortId(c.agent_id)}: ${c.start} – ${c.end}`;
-    case 'set_initiative_status':
-      return `${shortId(c.initiative_id)} → ${c.status}`;
-    case 'add_dependency':
-      return `dep ${shortId(c.initiative_id)} blocks on ${shortId(c.depends_on_initiative_id)}`;
-    case 'remove_dependency':
-      return `remove dep ${shortId(c.dependency_id)}`;
-    case 'reorder_initiatives':
-      return `reorder under ${shortId(c.parent_id ?? null) || 'root'} (${c.child_ids_in_order?.length ?? 0})`;
-    case 'update_status_check':
-      return `status_check ${shortId(c.initiative_id)}`;
-    default:
-      return c.kind ?? '?';
-  }
-}
+// Diff rendering (DiffRow, ProposalDiffsList, summarizeDiff, complexity
+// badges) moved to @/components/pm/ProposalDiffsList so the standalone
+// /pm/proposals/[id] detail page renders identically.
 
 function shortId(id: string | null | undefined): string {
   if (!id) return '∅';
@@ -1029,20 +984,7 @@ function PinnedStandupCard({
       <div className="p-3">
         <ChatMarkdown content={stripSuggestionsSidecar(proposal.impact_md)} />
       </div>
-      {proposal.proposed_changes.length > 0 && (
-        <div className="px-3 pb-3 space-y-1 text-xs text-mc-text-secondary">
-          {proposal.proposed_changes.slice(0, 6).map((c, idx) => (
-            <div key={idx} className="font-mono">
-              · {summarizeDiff(c)}
-            </div>
-          ))}
-          {proposal.proposed_changes.length > 6 && (
-            <div className="font-mono">
-              …and {proposal.proposed_changes.length - 6} more
-            </div>
-          )}
-        </div>
-      )}
+      <ProposalDiffsList diffs={proposal.proposed_changes} />
       <div className="px-3 py-2 border-t border-violet-500/30 bg-violet-500/5 flex items-center gap-2">
         <button
           type="button"

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -10,22 +10,7 @@ import {
   stripSuggestionsSidecar,
   parseSuggestionsFromImpactMd,
 } from '@/lib/pm/planSuggestionsSidecar';
-
-interface PmDiff {
-  kind: string;
-  initiative_id?: string;
-  agent_id?: string;
-  status?: string;
-  target_start?: string;
-  target_end?: string;
-  start?: string;
-  end?: string;
-  reason?: string;
-  depends_on_initiative_id?: string;
-  dependency_id?: string;
-  parent_id?: string | null;
-  child_ids_in_order?: string[];
-}
+import { ProposalDiffsList, type PmDiff } from '@/components/pm/ProposalDiffsList';
 
 interface PmProposal {
   id: string;
@@ -58,30 +43,8 @@ const TRIGGER_BADGE: Record<string, { label: string; cls: string }> = {
   decompose_initiative: { label: 'decompose', cls: 'bg-pink-500/15 text-pink-300 border-pink-500/30' },
 };
 
-function summarizeDiff(c: PmDiff): string {
-  switch (c.kind) {
-    case 'shift_initiative_target':
-      return `shift ${short(c.initiative_id)}: ${c.target_start ?? '∅'} → ${c.target_end ?? '∅'}`;
-    case 'add_availability':
-      return `availability ${short(c.agent_id)}: ${c.start} – ${c.end}`;
-    case 'set_initiative_status':
-      return `${short(c.initiative_id)} → ${c.status}`;
-    case 'add_dependency':
-      return `dep ${short(c.initiative_id)} blocks on ${short(c.depends_on_initiative_id)}`;
-    case 'remove_dependency':
-      return `remove dep ${short(c.dependency_id)}`;
-    case 'reorder_initiatives':
-      return `reorder under ${short(c.parent_id) || 'root'} (${c.child_ids_in_order?.length ?? 0})`;
-    case 'update_status_check':
-      return `status_check ${short(c.initiative_id)}`;
-    default:
-      return c.kind ?? '?';
-  }
-}
-
-function short(id: string | null | undefined): string {
-  return id ? id.slice(0, 8) : '∅';
-}
+// summarizeDiff lives in @/components/pm/ProposalDiffsList — both
+// /pm and the standalone detail page render through the same component.
 
 export default function ProposalDetailPage({
   params,
@@ -257,13 +220,15 @@ export default function ProposalDetailPage({
                 </div>
               )}
 
-              {/* Proposed changes */}
+              {/* Proposed changes — shared component with /pm. The
+                  detail page has more vertical room than the inline
+                  chat card, so we ask for the full list (no fold). */}
               {proposal.proposed_changes.length > 0 && (
-                <div className="px-4 py-3 border-b border-amber-500/20 space-y-1 text-xs text-mc-text-secondary font-mono">
-                  {proposal.proposed_changes.map((c, i) => (
-                    <div key={i}>· {summarizeDiff(c)}</div>
-                  ))}
-                </div>
+                <ProposalDiffsList
+                  diffs={proposal.proposed_changes}
+                  showAll
+                  className="px-4 py-3 border-b border-amber-500/20 space-y-1"
+                />
               )}
 
               {/* Actions */}

--- a/src/components/pm/ProposalDiffsList.tsx
+++ b/src/components/pm/ProposalDiffsList.tsx
@@ -1,0 +1,172 @@
+/**
+ * Structured renderer for the `proposed_changes` array on a PM
+ * proposal card. Used by both the inline /pm chat card and the
+ * standalone /pm/proposals/[id] detail page so the rendering stays
+ * consistent across surfaces.
+ *
+ * The previous flat one-liner (`· create_child_initiative` × 8) hid
+ * everything an operator actually needs to triage a decompose
+ * proposal — title, complexity, dependency graph. This component
+ * surfaces those for the create kinds (`create_child_initiative`,
+ * `create_task_under_initiative`) and falls back to the existing
+ * terse text summary for other diff kinds.
+ *
+ * Kept presentation-only: no fetching, no state. Caller passes the
+ * `proposed_changes` array; we render. That keeps it equally usable
+ * inside an SSR page, a chat card, or a future preview component.
+ */
+
+import * as React from 'react';
+
+export interface PmDiff {
+  kind: string;
+  initiative_id?: string;
+  agent_id?: string;
+  status?: string;
+  target_start?: string;
+  target_end?: string;
+  start?: string;
+  end?: string;
+  reason?: string;
+  status_check_md?: string;
+  depends_on_initiative_id?: string;
+  dependency_id?: string;
+  parent_id?: string | null;
+  child_ids_in_order?: string[];
+  note?: string;
+  // create_child_initiative + create_task_under_initiative payload fields
+  parent_initiative_id?: string;
+  title?: string;
+  description?: string;
+  child_kind?: 'epic' | 'story' | 'milestone' | 'theme';
+  complexity?: 'S' | 'M' | 'L' | 'XL';
+  depends_on_initiative_ids?: string[];
+  // create_task_under_initiative-only
+  assigned_agent_id?: string | null;
+  priority?: 'low' | 'normal' | 'high';
+}
+
+export const COMPLEXITY_BADGE: Record<NonNullable<PmDiff['complexity']>, string> = {
+  S: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+  M: 'bg-sky-500/15 text-sky-300 border-sky-500/30',
+  L: 'bg-amber-500/15 text-amber-200 border-amber-500/30',
+  XL: 'bg-rose-500/15 text-rose-300 border-rose-500/30',
+};
+
+function shortId(id: string | null | undefined): string {
+  if (!id) return '∅';
+  return id.slice(0, 8);
+}
+
+/**
+ * Format an initiative-id reference. `$0`-style placeholders (used by
+ * create_*_initiative diffs to reference siblings created in the same
+ * proposal) render verbatim so the dependency graph reads as
+ * "$2 ← $0, $1" at a glance. Real ids get short-hashed.
+ */
+function formatInitiativeRef(ref: string | null | undefined): string {
+  if (!ref) return '∅';
+  if (/^\$\d+$/.test(ref)) return ref;
+  return shortId(ref);
+}
+
+export function summarizeDiff(c: PmDiff): string {
+  switch (c.kind) {
+    case 'shift_initiative_target':
+      return `shift ${shortId(c.initiative_id)}: ${c.target_start ?? '∅'} → ${c.target_end ?? '∅'}`;
+    case 'add_availability':
+      return `availability ${shortId(c.agent_id)}: ${c.start} – ${c.end}`;
+    case 'set_initiative_status':
+      return `${shortId(c.initiative_id)} → ${c.status}`;
+    case 'add_dependency':
+      return `dep ${shortId(c.initiative_id)} blocks on ${shortId(c.depends_on_initiative_id)}`;
+    case 'remove_dependency':
+      return `remove dep ${shortId(c.dependency_id)}`;
+    case 'reorder_initiatives':
+      return `reorder under ${shortId(c.parent_id ?? null) || 'root'} (${c.child_ids_in_order?.length ?? 0})`;
+    case 'update_status_check':
+      return `status_check ${shortId(c.initiative_id)}`;
+    default:
+      return c.kind ?? '?';
+  }
+}
+
+/**
+ * Single-row renderer. `index` is the position in the proposal's
+ * `proposed_changes` array — for create kinds it doubles as the `$N`
+ * placeholder id agents use to reference this row from a sibling's
+ * `depends_on_initiative_ids`.
+ */
+export function DiffRow({ diff, index }: { diff: PmDiff; index: number }) {
+  if (diff.kind === 'create_child_initiative' || diff.kind === 'create_task_under_initiative') {
+    const complexity = diff.complexity;
+    const deps = diff.depends_on_initiative_ids ?? [];
+    const isTask = diff.kind === 'create_task_under_initiative';
+    return (
+      <div className="flex items-baseline gap-2 text-xs leading-relaxed">
+        <span className="font-mono text-mc-text-secondary/60 shrink-0 w-6 text-right">${index}</span>
+        {complexity && (
+          <span
+            className={`shrink-0 px-1.5 py-0.5 rounded-sm border text-[10px] font-mono ${COMPLEXITY_BADGE[complexity]}`}
+            title={`complexity: ${complexity}`}
+          >
+            {complexity}
+          </span>
+        )}
+        {isTask && (
+          <span className="shrink-0 px-1.5 py-0.5 rounded-sm border border-violet-500/30 bg-violet-500/15 text-violet-200 text-[10px] font-mono uppercase tracking-wide">
+            task
+          </span>
+        )}
+        <span className="text-mc-text">{diff.title || <em className="text-mc-text-secondary">(untitled)</em>}</span>
+        {deps.length > 0 && (
+          <span className="text-mc-text-secondary/70 font-mono shrink-0 ml-auto">
+            ← {deps.map(formatInitiativeRef).join(', ')}
+          </span>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div className="font-mono text-xs text-mc-text-secondary">
+      · {summarizeDiff(diff)}
+    </div>
+  );
+}
+
+const DEFAULT_PREVIEW_CAP = 10;
+
+interface ProposalDiffsListProps {
+  diffs: PmDiff[];
+  /** Show all diffs without the "and N more" fold. Used on the
+   *  detail page where vertical real-estate is plentiful. */
+  showAll?: boolean;
+  /** Override the preview cap for the inline chat-card view. */
+  previewCap?: number;
+  /** Wrapping container className override. */
+  className?: string;
+}
+
+export function ProposalDiffsList({
+  diffs,
+  showAll = false,
+  previewCap = DEFAULT_PREVIEW_CAP,
+  className = 'px-3 pb-3 space-y-1',
+}: ProposalDiffsListProps) {
+  if (diffs.length === 0) return null;
+  const cap = showAll ? diffs.length : previewCap;
+  const visible = diffs.slice(0, cap);
+  const overflow = diffs.length - visible.length;
+  return (
+    <div className={className}>
+      {visible.map((c, idx) => (
+        <DiffRow key={idx} diff={c} index={idx} />
+      ))}
+      {overflow > 0 && (
+        <div className="font-mono text-xs text-mc-text-secondary">
+          …and {overflow} more
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

Decompose proposals rendered as N identical \`create_child_initiative\` lines with no detail. Operators had to read the impact_md and mentally cross-reference to triage. Same on the standalone detail page. The new memory-layer epic decompose surfaced this — a clean 8-story breakdown was unreadable as a flat list.

## What

- **Per-row structured rendering for create kinds** (\`create_child_initiative\`, \`create_task_under_initiative\`):
  - \`$N\` placeholder index (matches the dependency-graph syntax agents already use)
  - Color-coded complexity badge: S=emerald, M=sky, L=amber, XL=rose
  - Title
  - Right-aligned dependency list (\`← \$0, \$1\`); placeholder ids render verbatim, real ids get short-hashed
- Other diff kinds (shift_initiative_target, set_initiative_status, add_dependency, etc.) keep the existing terse one-liner — they're already readable.
- Inline-card preview cap bumped from 6 → 10 so an 8-story decompose lands without an \"…and 2 more\" fold.
- Detail page passes \`showAll\` so the full list renders without a fold.

## Refactor

Factored the rendering into \`src/components/pm/ProposalDiffsList.tsx\`:

- \`PmDiff\` type (replaces two ad-hoc copies in the page files)
- \`COMPLEXITY_BADGE\` lookup
- \`summarizeDiff\` (kept for non-create kinds)
- \`DiffRow\` (single-row renderer)
- \`ProposalDiffsList\` (container with cap + overflow)

Both call sites (\`/pm\` chat card, \`/pm/proposals/[id]\` detail page) import from the shared module. Removes ~70 lines of duplication.

## Test plan

- [x] \`yarn test\` — 418/418.
- [x] \`npx tsc --noEmit\` — no errors in changed files.
- [x] Dev preview: navigated to an existing 7-story decompose proposal at \`/pm/proposals/<id>\`. Rows render as \`\$0 L Snappy Service Architecture\`, \`\$1 M User Memory Layer Design ← \$0\`, \`\$5 M Dashboard Card Components ← \$3, \$4\`, etc. Screenshot:

  ![structured rendering](docs/img/proposal-card-structured.png) <!-- not committed; see preview screenshot -->

## Out of scope

- A \"Show all\" expand control on the inline /pm chat card if a decompose ever produces > 10 stories (rare in practice). Easy follow-up if it shows up.
- Description preview / hover. The agent's per-story description is rich; surfacing it on hover would help further but adds complexity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)