### PR TITLE
fix(pm): re-echo chat message after agent supersedes synth placeholder

### DIFF
--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -571,6 +571,22 @@ async function runNamedAgentDispatchInBackground(
         trigger_kind: input.trigger_kind,
         target_initiative_id: input.target_initiative_id ?? null,
       });
+      // Re-echo the agent's impact_md as a fresh chat message anchored
+      // to the new (agent-generated) proposal id. Without this the chat
+      // thread keeps pointing at the placeholder — which is now
+      // `superseded` — and the operator never sees the richer agent
+      // breakdown in the inline thread (only in the Recent proposals
+      // rail). Mirrors the disruption path's behavior.
+      try {
+        postPmChatMessage({
+          workspace_id: input.workspace_id,
+          content: found.impact_md,
+          proposal_id: found.id,
+          role: 'assistant',
+        });
+      } catch (err) {
+        console.warn('[pm-dispatch] agent chat re-echo failed:', (err as Error).message);
+      }
       // plan_initiative-specific backfill: if the agent omitted dates in
       // its plan_suggestions, fill from the synth's (always populated)
       // target window so the operator's Apply form has dates to apply.

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -635,6 +635,73 @@ test('dispatchPmSynthesized: returns synth placeholder synchronously when gatewa
   }
 });
 
+test('dispatchPmSynthesized: agent supersede re-echoes a chat message anchored to the new proposal id', async () => {
+  // Without this re-echo the chat thread keeps anchoring to the
+  // (now superseded) synth placeholder and the operator never sees
+  // the agent's richer breakdown inline. The right-rail proposals
+  // list still surfaces the new row; the chat does not. Mirrors the
+  // disruption-path behavior in dispatchPm.
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  const agentImpactMd = '### Agent reply\n- 8-story decomposition with deps';
+  const { client } = makeFakeClient({
+    onChatSend: () => {
+      createProposal({
+        workspace_id: ws,
+        trigger_text: 'agent reply',
+        trigger_kind: 'decompose_initiative',
+        impact_md: agentImpactMd,
+        proposed_changes: [],
+      });
+    },
+  });
+  __setOpenClawClientForTests(client);
+  __setNamedAgentTimeoutForTests(2_000);
+  try {
+    const dispatch = dispatchPmSynthesized({
+      workspace_id: ws,
+      trigger_text: JSON.stringify({ mode: 'decompose_initiative' }),
+      trigger_kind: 'decompose_initiative',
+      synth: baseSynth,
+      agent_prompt: 'decompose it',
+    });
+    const settled = await dispatch.completion;
+    assert.equal(settled.used_named_agent, true);
+    const agentRowId = settled.final.id;
+    assert.notEqual(agentRowId, dispatch.proposal.id);
+
+    // Note: dispatchPmSynthesized doesn't post the placeholder chat
+    // anchor itself — that's the API route caller's job (see e.g.
+    // /api/pm/decompose-initiative). What this test asserts is that
+    // dispatchPmSynthesized DOES post a re-echo anchored to the
+    // agent's superseding row, mirroring dispatchPm's behavior.
+    const pm = queryOne<{ id: string }>(
+      `SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm'`,
+      [ws],
+    );
+    assert.ok(pm);
+    const messages = queryAll<{ role: string; metadata: string | null; content: string }>(
+      `SELECT role, metadata, content FROM agent_chat_messages WHERE agent_id = ? ORDER BY created_at`,
+      [pm!.id],
+    );
+    const reEcho = messages.find(m => {
+      if (m.role !== 'assistant' || !m.metadata) return false;
+      try {
+        const meta = JSON.parse(m.metadata) as { proposal_id?: string };
+        return meta.proposal_id === agentRowId;
+      } catch { return false; }
+    });
+    assert.ok(
+      reEcho,
+      `expected a chat message anchored to agent row ${agentRowId}; messages: ${JSON.stringify(messages)}`,
+    );
+    assert.equal(reEcho!.content, agentImpactMd);
+  } finally {
+    __setOpenClawClientForTests(null);
+    __setNamedAgentTimeoutForTests(null);
+  }
+});
+
 test('dispatchPmSynthesized: timeoutMs is honored — bumping it lets a slow agent win', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);


### PR DESCRIPTION
## Symptom

After running a decompose, the latest proposal (the agent's superseding row) shows up in the **Recent proposals** rail but not in the **PM chat** thread. The chat thread continues to display the synth placeholder card with a \`superseded\` status badge — operator can't accept/refine the actual agent breakdown from chat, only from the rail or the standalone detail page.

## Root cause

The chat thread joins \`agent_chat_messages\` to \`pm_proposals\` via \`metadata.proposal_id\`. \`dispatchPm\`'s disruption-path supersede already posts a fresh chat message anchored to the agent's row (lines 302-310 of pm-dispatch.ts). \`dispatchPmSynthesized\` (used by \`plan_initiative\` and \`decompose_initiative\`) does the supersede but not the re-echo, so the chat thread is permanently stuck on the placeholder anchor.

## Fix

Mirror the disruption path: after \`supersedeWithAgentProposal\` succeeds, post a new assistant chat message with \`proposal_id\` = agent row id and \`content\` = the agent's \`impact_md\`. Inline thread now shows the synth message (with \`superseded\` badge, useful for audit) and the agent's response (with \`draft\` badge — the one the operator actually accepts).

## Files

- \`src/lib/agents/pm-dispatch.ts\` — added the re-echo after the supersede in the synthesized path.
- \`src/lib/agents/pm.test.ts\` — new case asserting the re-echo behavior. Note: the placeholder anchor is posted by the API route caller (e.g. \`/api/pm/decompose-initiative\`), not by \`dispatchPmSynthesized\`, so the test only checks the new agent-row anchor.

## Test plan

- [x] \`yarn test\` slice for pm: 25/25 pass.
- [x] Targeted run of the new test: pass.
- [x] Dev preview server clean — no compile errors after HMR pulled the change.
- [ ] Operator: rebuild prod, fire a fresh decompose, expect the agent's row to appear inline in /pm.

## Existing memory-layer proposal

The current prod proposal \`6e0ef176\` was created before this fix and won't have a chat anchor. Operator can accept it from the right rail or the detail page; subsequent decomposes will work correctly inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)