### PR TITLE
fix(roadmap): tree-walk row ordering so children render under their parent

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -56,6 +56,22 @@ rather than deleting — the trail is useful retrospectively.
   cosmetic. Worth doing only if the OFFLINE clutter starts to bug us
   in practice.
 
+## Planning UX
+
+- [ ] **Roadmap-style preview on proposal review cards.** Today the
+  `create_child_initiative` diff list (PR #101) shows a structured
+  per-row view with $N + complexity badge + dep arrow. That's good
+  for triage. What it doesn't show is the *shape* of the resulting
+  work: critical-path depth, parallelism opportunities, where an XL
+  decomposition is going to bottleneck. A speculative Gantt view
+  that forecasts story duration from complexity (M = N days, L = M
+  days, etc.) and chains via `depends_on_initiative_ids` would
+  catch "this is too sequential" or "you XL'd everything" before
+  accept. Plugs into the same derivation engine that drives real
+  initiatives (\`derived_*\` fields). Epic-sized — naive forecast
+  is one PR, velocity-driven (per agent/role/availability) is
+  several. Surfaced during the dogfood theme decompose review.
+
 ## Memory / PM
 
 - [ ] **`refine_proposal` for `decompose_initiative` is LLM-less.** At

--- a/src/lib/db/roadmap.test.ts
+++ b/src/lib/db/roadmap.test.ts
@@ -159,6 +159,35 @@ function buildFixture(): Fixture {
   };
 }
 
+test('snapshot orders rows by tree-walk (parent then its children) — not by kind', () => {
+  // Regression: before the tree-walk fix, the snapshot returned rows
+  // ordered by sort_order + created_at flat, so accepting a
+  // decompose proposal that creates N stories under one epic
+  // interleaved every story below all epics, severing the visual
+  // hierarchy on /roadmap. The fix: emit parent → children DFS so
+  // each child appears immediately after its parent.
+  const f = buildFixture();
+  const snap = getRoadmapSnapshot({ workspace_id: f.workspace });
+  const order = snap.initiatives.map(i => i.id);
+
+  function indexOf(id: string): number {
+    const idx = order.indexOf(id);
+    assert.ok(idx >= 0, `expected ${id} in order`);
+    return idx;
+  }
+  // milestone → epicA → storyA → epicB → storyB. storyOrphan is a root
+  // (its parent is unknown / missing) so it appears at the top level.
+  // Each child must come immediately after its parent; siblings (epicA,
+  // epicB) preserve sort_order/created_at among themselves.
+  assert.equal(indexOf(f.epicAId), indexOf(f.milestoneId) + 1);
+  assert.equal(indexOf(f.storyAId), indexOf(f.epicAId) + 1);
+  assert.equal(indexOf(f.epicBId), indexOf(f.storyAId) + 1);
+  assert.equal(indexOf(f.storyBId), indexOf(f.epicBId) + 1);
+  // storyA sits between its parent (epicA) and its uncle (epicB) —
+  // i.e. children flow before sibling subtrees.
+  assert.ok(indexOf(f.storyAId) < indexOf(f.epicBId));
+});
+
 test('snapshot returns all initiatives in workspace with correct depth', () => {
   const f = buildFixture();
   const snap = getRoadmapSnapshot({ workspace_id: f.workspace });

--- a/src/lib/db/roadmap.ts
+++ b/src/lib/db/roadmap.ts
@@ -258,7 +258,45 @@ export function getRoadmapSnapshot(filters: RoadmapFilters): RoadmapSnapshot {
     else if (ACTIVE_STATUSES.has(t.status)) c.active += 1;
   }
 
-  const initiatives: RoadmapInitiative[] = visibleRows.map(r => ({
+  // Tree-walk ordering: parent → its children → next parent, depth-first,
+  // so the timeline grid renders nested under the correct parent rather
+  // than as flat kind-buckets. Without this, accepting a decompose
+  // proposal that creates 8 stories under one epic interleaves all 22
+  // stories below their three epic rows, severing the visual hierarchy.
+  //
+  // The SQL ORDER BY i.sort_order, i.created_at gives within-sibling
+  // order; we just need to walk the parent→children tree to emit rows
+  // in tree-DFS order. Children of an unknown / filtered-out parent are
+  // treated as roots (their .depth=0 already reflects this).
+  const childrenByParent = new Map<string | null, RawInitiativeRow[]>();
+  for (const r of visibleRows) {
+    const parentKey = r.parent_initiative_id && byId.has(r.parent_initiative_id)
+      ? r.parent_initiative_id
+      : null; // Treat orphans as roots.
+    const bucket = childrenByParent.get(parentKey) ?? [];
+    bucket.push(r);
+    childrenByParent.set(parentKey, bucket);
+  }
+  // Children inherit the SQL ORDER BY (sort_order, created_at) since the
+  // bucket is filled in row order. No re-sort needed.
+  const orderedRows: RawInitiativeRow[] = [];
+  function emit(parentKey: string | null) {
+    const kids = childrenByParent.get(parentKey);
+    if (!kids) return;
+    for (const k of kids) {
+      orderedRows.push(k);
+      emit(k.id);
+    }
+  }
+  emit(null);
+  // Safety net: if anything was somehow missed (cycle, dropped lookup),
+  // append it at the end. A bad ordering is better than a missing row.
+  if (orderedRows.length !== visibleRows.length) {
+    const seen = new Set(orderedRows.map(r => r.id));
+    for (const r of visibleRows) if (!seen.has(r.id)) orderedRows.push(r);
+  }
+
+  const initiatives: RoadmapInitiative[] = orderedRows.map(r => ({
     id: r.id,
     parent_initiative_id: r.parent_initiative_id,
     product_id: r.product_id,


### PR DESCRIPTION
## Symptom

After accepting decompose proposals that created 22 stories under three epics, /roadmap rendered: theme → all 3 epics → 22 stories interleaved by created_at order. Children no longer appeared under their parent epic; the visual hierarchy was severed.

## Root cause

\`getRoadmapSnapshot\` returns rows ordered by \`i.sort_order, i.created_at\` flat. \`depth\` is computed correctly, but the array order doesn't reflect tree structure — siblings of an epic and grandchildren are intermingled by their global sort key, not nested under their parent.

## Fix

After fetching + depth computation, do a parent→children DFS to reorder. The SQL ORDER BY still gives within-sibling ordering; the DFS gives parent-first, children-then emission. Orphans (parent unknown / filtered out) become top-level roots, preserving their visibility. Safety net: any row missed by the walk is appended at the end (defensive against cycles / lookup oddities — bad order is better than missing rows).

## Files

- \`src/lib/db/roadmap.ts\` — tree-walk DFS over \`visibleRows\` before mapping to \`RoadmapInitiative[]\`.
- \`src/lib/db/roadmap.test.ts\` — regression test asserting \`milestone → epicA → storyA → epicB → storyB\` ordering against the existing fixture.
- \`docs/FOLLOWUPS.md\` — separately captured a planning-UX idea surfaced during dogfood review: speculative Gantt-style preview on proposal cards (forecast story duration from complexity + dep graph, show critical path before accepting). Epic-sized; logged as a followup not started here.

## Test plan

- [x] \`yarn test\` — 420/420 (was 418; +1 tree-walk regression test).
- [x] \`npx tsc --noEmit\` — no errors in changed files.
- [x] Dev preview: navigated to \`/roadmap\` against an existing Smart Snappy epic with 7 stories. Now renders: epic row, then 7 stories nested directly underneath with the expected indent. Screenshot in PR #101's vein — chevron + indented children.
- [ ] Operator: rebuild prod, verify the theme/epic/story tree under \"Ground agents in durable workspace context\" renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)