### PR TITLE
docs(followups): promote 8 items to QoL theme on prod MC

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -1,62 +1,49 @@
 # Followups
 
-Small tasks flagged inline during sessions that don't yet warrant their
-own initiative. Promote any of these to a real MC initiative once the
-scope clarifies; otherwise grab one when there's a quiet moment between
-larger work.
+Small tasks flagged inline during sessions. **Most of the items that
+used to live here have been promoted to the [Quality of life & minor
+bugs](#) theme on prod MC** (theme `ee3c4dbe`). Once that theme exists
+on the live roadmap, this doc shrinks to:
 
-Format: each item names the trigger session / PR, the concrete fix, and
-why it was descoped at the time. Strike through and date-mark when done
-rather than deleting — the trail is useful retrospectively.
+1. Items that haven't been triaged into the theme yet (drop them here
+   first, decide later).
+2. Items whose scope is genuinely larger than QoL but haven't earned
+   their own theme — flagged "may graduate."
 
-## UI / preview interaction
+When you do triage an item to MC, leave a one-line breadcrumb here so
+the trail is greppable.
 
-- [ ] **Refactor browser-style alerts to a custom modal so preview can
-  drive them.** ~30 native `alert()` calls remain across `/agents`,
-  `/initiatives`, `/debug`, and `AgentsSidebar`. Native `window.alert`
-  blocks JS execution and is invisible to `preview_*` tools, so any
-  flow that hits one (e.g. error path on agent update, "Reset sent"
-  confirmation, delete failures) can't be exercised via the preview
-  test flow. `src/components/ConfirmDialog.tsx` already exists and
-  replaced the native `window.confirm()` calls per PREVIEW_TEST_FINDINGS
-  §1.7 — extend the same pattern with an `AlertDialog` (single-action
-  modal) plus a small `useAlert()` hook so the call sites stay terse.
-  Triage: error/success toasts probably want a different surface
-  entirely (transient, non-blocking) — split this followup into
-  "blocking confirm-style alerts → modal" vs "non-blocking notifications
-  → toast" before starting.
+## Promoted to MC initiatives (theme: Quality of life & minor bugs)
 
-## Docs hygiene
+These have been moved from this doc to live initiatives under theme
+`ee3c4dbe-55f2-481e-87c4-630e4eb02173` on prod. Edit / track them
+there, not here.
 
-- [ ] **Scrub stale `localhost:4000` references.** Older docs still
-  point dev at port 4000 (the LiteLLM gateway port now). Touched files:
-  `docs/ORCHESTRATION_WORKFLOW.md`, `docs/ISSUE-01-LOCAL-GUIDE.md`,
-  `docs/TESTING_REALTIME.md`. CLAUDE.md flags them as stale; this
-  followup actually fixes them.
+- ~~Refactor browser-style alerts to a custom modal~~ → epic 1
+  (Operator UX polish)
+- ~~Add 'Hide offline gateway agents' toggle on /agents~~ → epic 1
+- ~~`yarn openclaw:sync` prune for orphaned `-dev` agents~~ → epic 2
+  (Dogfood-loop tooling)
+- ~~`yarn agents:resync` CLI + 'Resync now' button~~ → epic 2
+- ~~`refine_proposal` LLM-less for decompose_initiative~~ → epic 3
+  (PM correctness)
+- ~~Verify proposal review handles unknown diff kinds gracefully~~ →
+  epic 3
+- ~~Retire `synthesizeImpactAnalysis` fallback~~ → epic 3
+- ~~Scrub stale `localhost:4000` references in older docs~~ → epic 4
+  (Docs hygiene)
 
-## Tooling — dogfood loop
+Plus, born straight as a story under epic 1 (UX polish):
 
-- [ ] **`yarn openclaw:sync` prune.** Today the script only adds /
-  updates `-dev` agents; it doesn't detect a `-dev` block whose stable
-  counterpart was deleted in `openclaw.json`. Add a confirmation prompt
-  ("delete `mc-foo-dev`? its stable `mc-foo` was removed") so the
-  rosters stay in lockstep without manual cleanup.
+- ~~Add draggable column widths on /roadmap~~ — surfaced 2026-04-29
+  during the dogfood roadmap walkthrough; titles get truncated when
+  many initiatives are visible.
 
-- [ ] **`yarn agents:resync` (and / or a "Resync now" button on
-  `/agents`).** Catalog sync runs on startup + every 60s, so today
-  changing `MC_AGENT_SYNC_INCLUDE` / `MC_AGENT_SYNC_EXCLUDE` requires
-  either a restart (env-var reload) or waiting up to 60s after a
-  PATCH. A button/CLI that calls `syncGatewayAgentsToCatalog({force:
-  true})` would shorten the env-tuning loop. Skipped on
-  PR #94 because the 60s cadence + restart-on-env-change covered the
-  immediate dogfood need.
+## May-graduate items (not in QoL theme)
 
-- [ ] **"Hide offline gateway agents" toggle on `/agents` All tab.**
-  Operators can already filter to STANDBY to hide them — this is
-  cosmetic. Worth doing only if the OFFLINE clutter starts to bug us
-  in practice.
-
-## Planning UX
+These were raised here but their scope is genuinely larger than QoL.
+Holding them for a future dedicated theme rather than dumping into
+the QoL bucket.
 
 - [ ] **Roadmap-style preview on proposal review cards.** Today the
   `create_child_initiative` diff list (PR #101) shows a structured
@@ -68,42 +55,23 @@ rather than deleting — the trail is useful retrospectively.
   days, etc.) and chains via `depends_on_initiative_ids` would
   catch "this is too sequential" or "you XL'd everything" before
   accept. Plugs into the same derivation engine that drives real
-  initiatives (\`derived_*\` fields). Epic-sized — naive forecast
+  initiatives (`derived_*` fields). **Epic-sized** — naive forecast
   is one PR, velocity-driven (per agent/role/availability) is
   several. Surfaced during the dogfood theme decompose review.
-
-## Memory / PM
-
-- [ ] **`refine_proposal` for `decompose_initiative` is LLM-less.** At
-  `src/app/api/pm/proposals/[id]/refine/route.ts:163-180`, the
-  decompose branch only calls `synthesizeDecompose(init, combinedHint)`
-  and skips the named-agent path entirely. Same shape as the
-  `plan_initiative` branch already does (lines 80-162) via
-  `dispatchPmSynthesized` + `await dispatch.completion` — that's the
-  template to mirror. Surfaced during dogfood: a refine on the
-  memory-layer epic produced 3 generic Discovery/Implementation/
-  Verification stories instead of an actual refinement of the 8
-  agent-generated stories. Promote to a real fix soon — refine is
-  load-bearing for the planning loop.
+  Anchor for a future "Planning UX" theme rather than a story under
+  QoL.
 
 - [ ] **`import-workspace` to reload from JSON export.** Out of scope
   on PR #93 (export-only). Output is INSERT-shaped, so an importer
   iterates `tables` in dependency order. Open question: workspace_id
-  collision policy (overwrite, rename, abort). Likely waits until we
-  actually need to round-trip a snapshot — until then, the export is
-  retention-only.
+  collision policy (overwrite, rename, abort). Real design space and
+  not a paper-cut — waits until the round-trip use case is concrete
+  enough to drive the collision-policy call.
 
-- [ ] **Retire the deterministic `synthesizeImpactAnalysis` fallback.**
-  The disruption / refine paths still use it. Once the queue-based
-  `notes_intake` pattern proves out, the same defer-and-replay shape
-  could replace the synth fallback for those paths too. Called out
-  in the original `propose_from_notes` plan as an explicit followup.
+## New / not yet triaged
 
-- [ ] **Verify proposal review pane handles unknown diff kinds.**
-  `propose_from_notes` introduced `create_task_under_initiative`. The
-  diff-list renderer should fall back gracefully on kinds it doesn't
-  know about rather than crashing. Confirm via preview test, fix if
-  needed. Flagged as a verification step in the original plan.
+(empty — drop new inline-flagged items here as we hit them, then
+sweep into MC during triage.)
 
 ## Promotion criteria
 
@@ -112,3 +80,6 @@ notification system with toasts + modals + Toast queue"), it graduates
 out of this doc and becomes an initiative in the prod MC roadmap with
 a real description and decomposition. The bar is rough: ≥1 day of work,
 or touches more than one subsystem, or wants a design doc — promote.
+
+The May-graduate section above is for items that have *already* hit
+that bar but want their own theme rather than slotting into QoL.


### PR DESCRIPTION
## Summary

Created a new theme on prod MC — **Quality of life & minor bugs** (\`ee3c4dbe\`) — to collect non-blocking TODOs that were accumulating in \`docs/FOLLOWUPS.md\`. Four epics under it (Operator UX polish, Dogfood-loop tooling, PM correctness, Docs hygiene), nine stories total.

Plus one new story raised today: **Add draggable column widths on /roadmap** — titles truncate when many initiatives are visible, surfaced during the dogfood walkthrough after accepting the theme + 3 epics + 22 stories from the memory/subagent/gardener decompose work.

## Why

\`FOLLOWUPS.md\` was becoming a parallel TODO list, drifting from the actual roadmap. Promoting these to MC initiatives gets them onto the same surface as the rest of the planning state, with proper status tracking, complexity, and dep relationships.

## What stays in FOLLOWUPS

Two items kept out of the QoL theme deliberately:

1. **Roadmap-style preview on proposal cards** — explicitly epic-sized; better as the anchor for a future Planning-UX theme.
2. **\`import-workspace\` to reload JSON exports** — meaningful feature with real design questions (collision policy, etc.); waits for the round-trip use case to concretize.

Both flagged in a new \"May-graduate items\" section so they don't get lost.

## Doc structure changes

\`FOLLOWUPS.md\` now functions as a small inbox + breadcrumb trail:

- **Promoted** section: strikethrough breadcrumbs pointing to the MC epic each item landed in.
- **May-graduate items**: scoped-too-big-for-QoL items waiting for their own theme.
- **New / not yet triaged**: empty bin for fresh inline-flagged items between triage sweeps.

## Files

- \`docs/FOLLOWUPS.md\` — restructured as described.

No code changes, no tests affected.

## Created on prod (not in this PR)

| Kind | Title | Complexity |
|---|---|---|
| Theme | Quality of life & minor bugs | L |
| Epic | Operator UX polish | M |
| Story | Refactor native alert() calls to a custom modal | M |
| Story | Add draggable column widths on /roadmap | M |
| Story | Add 'Hide offline gateway agents' toggle | S |
| Epic | Dogfood-loop tooling | M |
| Story | yarn openclaw:sync prune for orphaned -dev agents | S |
| Story | yarn agents:resync CLI + Resync-now button | S |
| Epic | PM correctness | M |
| Story | Make refine_proposal LLM-backed for decompose_initiative | M |
| Story | Verify proposal review handles unknown diff kinds | S |
| Story | Retire synthesizeImpactAnalysis fallback | L |
| Epic | Docs hygiene | S |
| Story | Scrub stale localhost:4000 references | S |

🤖 Generated with [Claude Code](https://claude.com/claude-code)