### PR TITLE
docs(followups): promote gantt-preview to new Planning UX theme

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -45,21 +45,11 @@ These were raised here but their scope is genuinely larger than QoL.
 Holding them for a future dedicated theme rather than dumping into
 the QoL bucket.
 
-- [ ] **Roadmap-style preview on proposal review cards.** Today the
-  `create_child_initiative` diff list (PR #101) shows a structured
-  per-row view with $N + complexity badge + dep arrow. That's good
-  for triage. What it doesn't show is the *shape* of the resulting
-  work: critical-path depth, parallelism opportunities, where an XL
-  decomposition is going to bottleneck. A speculative Gantt view
-  that forecasts story duration from complexity (M = N days, L = M
-  days, etc.) and chains via `depends_on_initiative_ids` would
-  catch "this is too sequential" or "you XL'd everything" before
-  accept. Plugs into the same derivation engine that drives real
-  initiatives (`derived_*` fields). **Epic-sized** — naive forecast
-  is one PR, velocity-driven (per agent/role/availability) is
-  several. Surfaced during the dogfood theme decompose review.
-  Anchor for a future "Planning UX" theme rather than a story under
-  QoL.
+- ~~Roadmap-style preview on proposal review cards~~ → promoted
+  2026-04-29 to **Planning UX** theme (`4aa571cd`), epic 2
+  (Speculative shape preview on proposal cards). Pairs with epic 1
+  (Bottom-up subtree scheduling) which delivers the duration +
+  critical-path primitives the preview reuses.
 
 - [ ] **`import-workspace` to reload from JSON export.** Out of scope
   on PR #93 (export-only). Output is INSERT-shaped, so an importer


### PR DESCRIPTION
## Summary

Created **Planning UX** theme (\`4aa571cd\`) on prod MC with two paired epics:

1. **Bottom-up subtree scheduling** (L) — plan a subtree's shape via durations + deps without committing to absolute dates. Subtree's total span propagates to parent's \`derived_*\`. Anchoring the parent later (drag, refine, status transition) walks the shape and assigns dates to descendants. Removes the chicken-and-egg of \"can't plan stories until I know when the epic starts.\"

2. **Speculative shape preview on proposal cards** (M, blocked on epic 1) — apply the same critical-path math to *unaccepted* proposals so reviewers see total span / parallelism / critical-path depth before accepting. Lives above the existing structured diff list (PR #101).

Both share a v1 duration-from-complexity helper: S=1d, M=3d, L=5d, XL=10d. Velocity-driven refinement (per role / per agent) is a gardener follow-up.

## What's not blocking shipping

Per the user's framing — \"unknown unknowns are expected in any kind of project management; the tool needs to be flexible enough to replan.\" Replan is first-class throughout: durations / deps adjust, the engine re-derives, operator-set anchors are sticky. We're not waiting for velocity calibration or cross-theme constraints to start.

## Doc-only change in this PR

Just FOLLOWUPS.md — strikes through the gantt-preview item with a breadcrumb to the new theme. Theme + epics created via API direct-create on prod (same pattern as the QoL theme).

## Test plan

- [x] Theme + 2 epics created on prod, parent_initiative_id wired.
- [ ] Operator review of the epic descriptions before decomposing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)