### PR TITLE
fix(pm): factor trigger-kind badge so /pm and detail page can't drift

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -21,6 +21,7 @@ import {
   type PlanInitiativeSuggestionsBlob,
 } from '@/lib/pm/planSuggestionsSidecar';
 import { ProposalDiffsList, type PmDiff } from '@/components/pm/ProposalDiffsList';
+import { triggerBadgeFor } from '@/components/pm/triggerBadge';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -80,21 +81,9 @@ const STATUS_BADGE: Record<PmProposal['status'], string> = {
 // Trigger-kind badge palette. Distinct colors so the operator can tell at a
 // glance whether a card was operator-initiated (manual), scheduled (drift),
 // or a disruption response.
-const TRIGGER_BADGE: Record<string, { label: string; cls: string }> = {
-  manual: { label: 'manual', cls: 'bg-blue-500/15 text-blue-300 border-blue-500/30' },
-  scheduled_drift_scan: {
-    label: 'scheduled',
-    cls: 'bg-violet-500/15 text-violet-300 border-violet-500/30',
-  },
-  disruption_event: {
-    label: 'disruption',
-    cls: 'bg-orange-500/15 text-orange-300 border-orange-500/30',
-  },
-  status_check_investigation: {
-    label: 'status check',
-    cls: 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30',
-  },
-};
+// Trigger-kind badge map factored to @/components/pm/triggerBadge so
+// /pm and /pm/proposals/[id] can't drift again (this map used to be
+// missing plan/decompose/notes — all three rendered as blue "manual").
 
 export default function PmChatPage() {
   // useSearchParams() requires a Suspense boundary during static prerender
@@ -806,7 +795,7 @@ function ChatMessageRow({
   }
 
   // Proposal card
-  const trigger = TRIGGER_BADGE[proposal.trigger_kind] ?? TRIGGER_BADGE.manual;
+  const trigger = triggerBadgeFor(proposal.trigger_kind);
   return (
     <div className="mr-12">
       <div

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   parseSuggestionsFromImpactMd,
 } from '@/lib/pm/planSuggestionsSidecar';
 import { ProposalDiffsList, type PmDiff } from '@/components/pm/ProposalDiffsList';
+import { triggerBadgeFor } from '@/components/pm/triggerBadge';
 
 interface PmProposal {
   id: string;
@@ -34,17 +35,8 @@ const STATUS_BADGE: Record<PmProposal['status'], string> = {
   superseded: 'bg-zinc-500/20 text-zinc-300',
 };
 
-const TRIGGER_BADGE: Record<string, { label: string; cls: string }> = {
-  manual: { label: 'manual', cls: 'bg-blue-500/15 text-blue-300 border-blue-500/30' },
-  scheduled_drift_scan: { label: 'scheduled', cls: 'bg-violet-500/15 text-violet-300 border-violet-500/30' },
-  disruption_event: { label: 'disruption', cls: 'bg-orange-500/15 text-orange-300 border-orange-500/30' },
-  status_check_investigation: { label: 'status check', cls: 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30' },
-  plan_initiative: { label: 'plan', cls: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30' },
-  decompose_initiative: { label: 'decompose', cls: 'bg-pink-500/15 text-pink-300 border-pink-500/30' },
-};
-
-// summarizeDiff lives in @/components/pm/ProposalDiffsList — both
-// /pm and the standalone detail page render through the same component.
+// Trigger badge map + summarizeDiff both live in @/components/pm — both
+// pages render through the same components/helpers, no parallel maps.
 
 export default function ProposalDetailPage({
   params,
@@ -141,7 +133,7 @@ export default function ProposalDetailPage({
     }
   };
 
-  const trigger = proposal ? (TRIGGER_BADGE[proposal.trigger_kind] ?? TRIGGER_BADGE.manual) : null;
+  const trigger = proposal ? triggerBadgeFor(proposal.trigger_kind) : null;
   const displayMd = proposal ? stripSuggestionsSidecar(proposal.impact_md).trim() : '';
   const suggestions = proposal?.trigger_kind === 'plan_initiative'
     ? parseSuggestionsFromImpactMd(proposal.impact_md)

--- a/src/components/pm/triggerBadge.ts
+++ b/src/components/pm/triggerBadge.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared trigger-kind → badge mapping for PM proposal cards.
+ *
+ * Both /pm (inline chat card) and /pm/proposals/[id] (standalone
+ * detail page) render proposal cards with a colored pill identifying
+ * the trigger_kind. They used to keep parallel copies of this map,
+ * which drifted: the inline card's map was missing entries for
+ * plan_initiative / decompose_initiative / notes_intake, so those
+ * proposals rendered as blue "manual" until the bug was caught.
+ *
+ * Keep all consumers reading from this single source.
+ */
+
+export interface TriggerBadge {
+  label: string;
+  cls: string;
+}
+
+export const TRIGGER_BADGE: Record<string, TriggerBadge> = {
+  manual: {
+    label: 'manual',
+    cls: 'bg-blue-500/15 text-blue-300 border-blue-500/30',
+  },
+  scheduled_drift_scan: {
+    label: 'scheduled',
+    cls: 'bg-violet-500/15 text-violet-300 border-violet-500/30',
+  },
+  disruption_event: {
+    label: 'disruption',
+    cls: 'bg-orange-500/15 text-orange-300 border-orange-500/30',
+  },
+  status_check_investigation: {
+    label: 'status check',
+    cls: 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30',
+  },
+  plan_initiative: {
+    label: 'plan',
+    cls: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+  },
+  decompose_initiative: {
+    label: 'decompose',
+    cls: 'bg-pink-500/15 text-pink-300 border-pink-500/30',
+  },
+  notes_intake: {
+    label: 'notes',
+    cls: 'bg-yellow-500/15 text-yellow-300 border-yellow-500/30',
+  },
+};
+
+/**
+ * Look up a badge for a trigger_kind, falling back to the 'manual'
+ * style (with the actual kind as the label so unknown kinds are
+ * visible rather than masquerading as manual).
+ */
+export function triggerBadgeFor(kind: string): TriggerBadge {
+  return TRIGGER_BADGE[kind] ?? { label: kind || 'unknown', cls: TRIGGER_BADGE.manual.cls };
+}


### PR DESCRIPTION
## Symptom

Fresh decompose proposal renders with a blue **MANUAL** badge in the /pm chat thread despite its actual \`trigger_kind\` being \`decompose_initiative\`. (Standalone proposal detail page renders correctly.)

## Root cause

Two parallel \`TRIGGER_BADGE\` maps in /pm/page.tsx and /pm/proposals/[id]/page.tsx. The chat-page map was stale — missing entries for \`plan_initiative\`, \`decompose_initiative\`, and \`notes_intake\`. Lookups fell through to \`?? TRIGGER_BADGE.manual\` → blue manual.

## Fix

Factor the map to \`src/components/pm/triggerBadge.ts\` with a \`triggerBadgeFor(kind)\` helper. Both pages import. Same drift-prevention pattern as PR #101 (ProposalDiffsList).

While here: \`triggerBadgeFor\` default for unknown kinds now uses the actual kind string as the label (e.g. \`unknown:foo\`) instead of masquerading as manual, so the next missing entry surfaces loudly.

## Test plan

- [x] \`yarn test\` — 418/418.
- [x] \`npx tsc --noEmit\` — clean for changed files.
- [x] Dev preview clean.
- [ ] Operator: rebuild prod, confirm the existing decompose-initiative proposal renders with a pink \`decompose\` badge instead of blue \`manual\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)