### PR TITLE
feat(workspace): context_md — v0 dispatch grounding precursor to memory-layer

### DIFF
--- a/src/app/(app)/workspace/[slug]/settings/page.tsx
+++ b/src/app/(app)/workspace/[slug]/settings/page.tsx
@@ -43,6 +43,10 @@ interface WorkspaceWithDefault {
   description?: string | null;
   icon: string;
   workspace_path?: string | null;
+  /** Markdown rules-of-the-road prepended to every dispatched task's prompt.
+   *  v0 of org-scope memory grounding — see docs/specs and the
+   *  Ground-agents theme on the roadmap. */
+  context_md?: string | null;
   /** Server-resolved default the override falls back to. */
   default_workspace_path: string;
   created_at: string;
@@ -268,6 +272,37 @@ export default function WorkspaceSettingsPage({
                 </span>
               )}
             </p>
+          </Field>
+        </Section>
+
+        {/* Workspace conventions — rules-of-the-road prepended to every
+            dispatched agent's task prompt. v0 of org-scope memory
+            grounding (precursor to the memory-layer epic). Operator
+            writes once and every dispatched mc-builder / mc-coordinator
+            inherits the workspace's testing / git / package-manager /
+            push rules without having to rediscover them per task. */}
+        <Section
+          title="Workspace conventions"
+          description={
+            <>
+              Markdown that gets prepended to every dispatched task&apos;s
+              prompt as a <code className="text-mc-text">## Workspace conventions</code>
+              {' '}block. Use this for repo URLs, testing patterns, push/PR rules,
+              package manager — whatever a fresh agent needs to ground its
+              work. Leave blank to skip the block entirely.
+            </>
+          }
+        >
+          <Field label="Conventions (markdown)">
+            <InlineTextarea
+              value={workspace.context_md ?? ''}
+              onSave={next =>
+                patch({ context_md: next.length > 0 ? next : null })
+              }
+              placeholder={`# Repos\n- ...\n\n# Testing\n- yarn test\n\n# Git rules\n- Never push to main\n- ...`}
+              minRows={8}
+              label="Edit workspace conventions"
+            />
           </Field>
         </Section>
 

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -719,7 +719,29 @@ ${criteria.length > 0 ? criteria.map(c => `  - ${c}`).join('\n') : '  - (none de
       }
     }
 
-    const taskMessage = `${priorityEmoji} **${headline}**
+    // Workspace conventions block — markdown the operator wrote on the
+    // workspace settings page (workspaces.context_md), prepended to
+    // every dispatch so the agent has rules-of-the-road grounding it
+    // can't get from the task row alone (repo URLs, testing patterns,
+    // git/PR rules, package manager, etc). v0 of org-scope memory
+    // grounding (precursor to the memory-layer epic). Empty / null →
+    // no block at all so we don't render an empty placeholder.
+    let workspaceConventionsSection = '';
+    try {
+      const wsRow = queryOne<{ context_md: string | null }>(
+        `SELECT context_md FROM workspaces WHERE id = ?`,
+        [task.workspace_id],
+      );
+      const ctx = wsRow?.context_md;
+      if (typeof ctx === 'string' && ctx.trim().length > 0) {
+        workspaceConventionsSection =
+          `## Workspace conventions\n\n${ctx.trim()}\n\n---\n\n`;
+      }
+    } catch (err) {
+      console.warn('[Dispatch] workspace context lookup failed:', (err as Error).message);
+    }
+
+    const taskMessage = `${workspaceConventionsSection}${priorityEmoji} **${headline}**
 
 **Title:** ${task.title}
 ${task.description ? `**Description:** ${task.description}\n` : ''}

--- a/src/app/api/workspaces/[id]/route.ts
+++ b/src/app/api/workspaces/[id]/route.ts
@@ -56,7 +56,7 @@ export async function PATCH(
 
   try {
     const body = await request.json();
-    const { name, description, icon, workspace_path } = body;
+    const { name, description, icon, workspace_path, context_md } = body;
 
     const db = getDb();
 
@@ -87,6 +87,14 @@ export async function PATCH(
       // any other value persists as the explicit path.
       updates.push('workspace_path = ?');
       const trimmed = typeof workspace_path === 'string' ? workspace_path.trim() : null;
+      values.push(trimmed && trimmed.length > 0 ? trimmed : null);
+    }
+    if (context_md !== undefined) {
+      // Markdown blob holding the operator's "rules of the road" for
+      // dispatched agents. Read at task dispatch time and prepended as
+      // a "## Workspace conventions" block. Empty string clears it.
+      updates.push('context_md = ?');
+      const trimmed = typeof context_md === 'string' ? context_md : null;
       values.push(trimmed && trimmed.length > 0 ? trimmed : null);
     }
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3422,6 +3422,29 @@ const migrations: Migration[] = [
       console.log('[Migration 051] workspaces.workspace_path added.');
     },
   },
+  {
+    id: '056',
+    name: 'workspaces_context_md',
+    up: (db) => {
+      // Per-workspace markdown blob holding the operator's "rules of
+      // the road" for dispatched agents — repo URLs, testing
+      // conventions, push/PR rules, package manager, etc. Read at task
+      // dispatch time and prepended as a "## Workspace conventions"
+      // block before the task description so workers have grounding
+      // context they can't get from the task row alone.
+      //
+      // v0 of org-scope memory grounding — precursor to the memory-layer
+      // epic. When that epic lands, this column gets absorbed: the
+      // value migrates into a synthetic org-scope memory entry and the
+      // dispatch-injection point swaps from `read column` to
+      // `getRelevantMemory()`. The column itself stays for back-compat.
+      const cols = db.prepare(`PRAGMA table_info(workspaces)`).all() as Array<{ name: string }>;
+      if (!cols.some(c => c.name === 'context_md')) {
+        db.exec(`ALTER TABLE workspaces ADD COLUMN context_md TEXT`);
+      }
+      console.log('[Migration 056] workspaces.context_md added.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -21,6 +21,11 @@ CREATE TABLE IF NOT EXISTS workspaces (
   -- env-derived default" (see resolveWorkspacePath()). Stored as a raw
   -- string with optional ~ that the server expands at access time.
   workspace_path TEXT,
+  -- Markdown rules-of-the-road prepended to every dispatched task's
+  -- prompt as a "## Workspace conventions" block. v0 of org-scope
+  -- memory grounding (precursor to the memory-layer epic). NULL → no
+  -- block prepended. See migration 056.
+  context_md TEXT,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -190,6 +190,54 @@ export function registerAllTools(server: McpServer): void {
     }),
   );
 
+  // get_workspace_context ─────────────────────────────────────────
+  // Lets an in-flight agent re-read the workspace's "rules of the road"
+  // markdown without re-dispatch. The same blob is prepended to every
+  // task dispatch as a "## Workspace conventions" section, so this tool
+  // is mostly useful when an agent forks a subtask and wants to keep
+  // the conventions in scope, or for debugging what the operator wrote.
+  server.registerTool(
+    'get_workspace_context',
+    {
+      title: 'Get workspace conventions',
+      description:
+        "Returns the markdown 'rules of the road' the operator wrote for this workspace (repos, testing, git/PR rules, package manager, etc). Same content prepended to every task dispatch's prompt; call this when you need to re-read it mid-session or surface it to a delegated subagent.",
+      inputSchema: {
+        agent_id: z
+          .string()
+          .min(1)
+          .describe(
+            "Your MC agent_id (UUID) or gateway_agent_id. Either form works — looked up the same way as whoami.",
+          ),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    trace('get_workspace_context', async ({ agent_id }) => {
+      const me = queryOne<{ workspace_id: string }>(
+        `SELECT workspace_id FROM agents WHERE id = ? OR gateway_agent_id = ? LIMIT 1`,
+        [agent_id, agent_id],
+      );
+      if (!me) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `agent ${agent_id} not found` }],
+          structuredContent: { error: 'agent_not_found', agent_id },
+        };
+      }
+      const ws = queryOne<{ id: string; name: string; context_md: string | null }>(
+        `SELECT id, name, context_md FROM workspaces WHERE id = ?`,
+        [me.workspace_id],
+      );
+      const payload = {
+        workspace_id: me.workspace_id,
+        workspace_name: ws?.name ?? null,
+        context_md: ws?.context_md ?? null,
+        present: typeof ws?.context_md === 'string' && ws.context_md.trim().length > 0,
+      };
+      return textResult(JSON.stringify(payload, null, 2), payload);
+    }),
+  );
+
   // list_peers ────────────────────────────────────────────────────
   server.registerTool(
     'list_peers',


### PR DESCRIPTION
## Why

Dispatching real implementation work to MC's worker agents needs grounding context (repo URLs, testing patterns, push/PR rules, package manager, etc.) BEFORE the full memory-layer epic ships. That epic is 8 stories of substrate + retrieval + UI; this PR delivers the minimum surface to unblock task dispatching today, in a shape that absorbs cleanly into memory-layer when it lands.

## What

A single markdown blob per workspace, edited on \`/workspace/[slug]/settings\`, prepended to every task dispatch's prompt as a \`## Workspace conventions\` block.

- **Migration 056** — \`workspaces.context_md TEXT\` column.
- **Settings UI** — new section between \"Project root\" and \"Export\" with an InlineTextarea (8-row min) and a starter-content placeholder.
- **PATCH route** — accepts \`context_md\`. Empty string clears.
- **Dispatch prompt** — \`/api/tasks/[id]/dispatch\` reads the column, prepends the conventions block before the priority/headline. Empty/null → no block.
- **MCP tool** — \`get_workspace_context(agent_id)\` lets in-flight agents re-read without re-dispatch.

## How it absorbs into memory-layer

When the memory-layer epic lands:
- The \`context_md\` value migrates into a synthetic org-scope memory entry.
- The dispatch-injection point swaps from \`read column → prepend block\` to \`getRelevantMemory({workspace_id, query: task.description}) → prepend block\`.
- The settings UI gets folded into \`/memory\` (workspace memory page).
- The \`context_md\` column itself stays as back-compat.

Nothing in this PR gets thrown away.

## Migration numbering note

The existing memory-layer story description (filed earlier) references migration 056 for \`memory_entries\`. This PR claims 056 first; that story will need its description updated to use the next-available number (057 currently free) when picked up. Story descriptions are inline-editable; small fix.

## Test plan

- [x] \`yarn test\` — 418/418.
- [x] \`yarn mcp:smoke\` — clean.
- [x] Dev preview boot logs migration 056 ran.
- [x] /workspace/default/settings renders new section. PATCH round-trips via UI inline-edit.
- [ ] Operator: rebuild prod, fill in conventions, promote a small QoL story to a task, dispatch, verify the conventions block appears in the openclaw chat for the dispatched session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)