### PR TITLE
fix(workflow): stage-isolate sessions, propagate roles, run convoy hooks on every transition

### DIFF
--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -127,23 +127,42 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // Get or create OpenClaw session for this agent + task combination
+    // Resolve the workflow stage that owns this dispatch. Sessions are
+    // keyed on (agent_id, task_id, stage) so the same agent landing in
+    // two stages (e.g. via fallback routing) gets two distinct gateway
+    // conversations rather than appending to a shared context. NULL =
+    // no workflow stage (planner / coordinator / legacy paths) — the
+    // lookup matches NULL-stage sessions for those callers.
+    const dispatchWorkflow = getTaskWorkflow(id);
+    const dispatchStage: string | null = dispatchWorkflow
+      ? (dispatchWorkflow.stages.find(s => s.status === task.status)?.id ?? null)
+      : null;
+
+    // Get or create OpenClaw session for this agent + task + stage. The
+    // NULL-aware predicate means a missing stage parameter only matches
+    // a row that was also written with NULL stage — so workflow
+    // dispatches and non-workflow dispatches don't cross-pollinate.
     let session = queryOne<OpenClawSession>(
-      'SELECT * FROM openclaw_sessions WHERE agent_id = ? AND task_id = ? AND status = ?',
-      [agent.id, id, 'active']
+      `SELECT * FROM openclaw_sessions
+         WHERE agent_id = ? AND task_id = ? AND status = 'active'
+           AND ((stage IS NULL AND ? IS NULL) OR stage = ?)`,
+      [agent.id, id, dispatchStage, dispatchStage]
     );
 
     const now = new Date().toISOString();
 
     if (!session) {
-      // Create session record
+      // Create session record. The session id encodes the stage so the
+      // gateway-side conversation is observably distinct in debug logs
+      // even before we look at the row.
       const sessionId = uuidv4();
-      const openclawSessionId = `mission-control-${agent.name.toLowerCase().replace(/\s+/g, '-')}-${id}`;
+      const stageSlug = dispatchStage ? `-${dispatchStage}` : '';
+      const openclawSessionId = `mission-control-${agent.name.toLowerCase().replace(/\s+/g, '-')}-${id}${stageSlug}`;
 
       run(
-        `INSERT INTO openclaw_sessions (id, agent_id, openclaw_session_id, task_id, channel, status, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-        [sessionId, agent.id, openclawSessionId, id, 'mission-control', 'active', now, now]
+        `INSERT INTO openclaw_sessions (id, agent_id, openclaw_session_id, task_id, stage, channel, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [sessionId, agent.id, openclawSessionId, id, dispatchStage, 'mission-control', 'active', now, now]
       );
 
       session = queryOne<OpenClawSession>(
@@ -256,6 +275,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     if (rawTask.planning_spec) {
       try {
         const spec = JSON.parse(rawTask.planning_spec);
+        // follow_ups are persisted alongside the spec for operator triage but
+        // must NOT bleed into the builder's brief — they describe work that
+        // is intentionally out of scope for THIS task.
+        if (spec && typeof spec === 'object' && !Array.isArray(spec)) {
+          delete (spec as Record<string, unknown>).follow_ups;
+        }
         // planning_spec may be an object with spec_markdown, or a raw string
         const specText = typeof spec === 'string' ? spec : (spec.spec_markdown || JSON.stringify(spec, null, 2));
         planningSpecSection = `\n---\n**📋 PLANNING SPECIFICATION:**\n${specText}\n`;

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -3,9 +3,9 @@ import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { internalDispatch } from '@/lib/internal-dispatch';
-import { handleStageTransition, handleStageFailure, getTaskWorkflow, drainQueue, populateTaskRolesFromAgents } from '@/lib/workflow-engine';
+import { handleStageTransition, handleStageFailure, getTaskWorkflow, populateTaskRolesFromAgents } from '@/lib/workflow-engine';
+import { runPostStatusChangeSideEffects } from '@/lib/services/task-status';
 import { hasStageEvidence, checkStageEvidence, canUseBoardOverride, auditBoardOverride, taskCanBeDone, recordLearnerOnTransition, isTerminalStatus } from '@/lib/task-governance';
-import { updateConvoyProgress, checkConvoyCompletion, dispatchReadyConvoySubtasks } from '@/lib/convoy';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
 import { UpdateTaskSchema } from '@/lib/validation';
@@ -464,24 +464,18 @@ export async function PATCH(
       );
     }
 
-    // If this is a sub-task, update convoy progress and check completion
-    if (nextStatus && nextStatus !== existing.status && existing.convoy_id) {
-      try {
-        updateConvoyProgress(existing.convoy_id);
-        if (nextStatus === 'done') {
-          const wasFinal = checkConvoyCompletion(existing.convoy_id);
-          // If the convoy still has work left, promote any sub-tasks whose
-          // dependencies just cleared. Without this the convoy stalls with
-          // dependent sub-tasks permanently stuck in inbox.
-          if (!wasFinal) {
-            dispatchReadyConvoySubtasks(existing.convoy_id).catch(err =>
-              console.error('[Convoy] auto-dispatch on subtask done failed:', err)
-            );
-          }
-        }
-      } catch (err) {
-        console.error('[Convoy] progress update failed:', err);
-      }
+    // Convoy progress + completion + drainQueue side effects. The shared
+    // helper (also called from MCP-driven transitions in transitionTaskStatus)
+    // is the single source of truth so a status change behaves the same
+    // whether it came from this route or update_task_status / accept_subtask.
+    if (nextStatus && nextStatus !== existing.status) {
+      runPostStatusChangeSideEffects({
+        taskId: id,
+        previousStatus: existing.status,
+        newStatus: nextStatus,
+        workspaceId: existing.workspace_id,
+        convoyId: existing.convoy_id ?? null,
+      });
     }
 
     // Extract skills from completed task (non-blocking, async)
@@ -493,18 +487,12 @@ export async function PATCH(
       );
     }
 
-    // Drain the review queue when a task reaches 'done' (frees the verification slot)
-    if (nextStatus === 'done') {
-      drainQueue(id, existing.workspace_id).catch(err =>
-        console.error('[Workflow] drainQueue after done failed:', err)
+    // Trigger workspace merge if task has an isolated workspace.
+    // (drainQueue is now handled by runPostStatusChangeSideEffects above.)
+    if (nextStatus === 'done' && existing.workspace_path) {
+      triggerWorkspaceMerge(id).catch(err =>
+        console.error('[Workspace] merge after done failed:', err)
       );
-
-      // Trigger workspace merge if task has an isolated workspace
-      if (existing.workspace_path) {
-        triggerWorkspaceMerge(id).catch(err =>
-          console.error('[Workspace] merge after done failed:', err)
-        );
-      }
     }
 
     return NextResponse.json(task);

--- a/src/lib/convoy.ts
+++ b/src/lib/convoy.ts
@@ -4,6 +4,7 @@ import { broadcast } from '@/lib/events';
 import { notifyLearner } from '@/lib/learner';
 import { internalDispatch } from '@/lib/internal-dispatch';
 import { pickDynamicAgent } from '@/lib/task-governance';
+import { getTaskWorkflow, populateTaskRolesFromAgents } from '@/lib/workflow-engine';
 import type { Convoy, ConvoySubtask, Task, ConvoyStatus, DecompositionStrategy } from '@/lib/types';
 
 /**
@@ -636,6 +637,64 @@ export function spawnDelegationSubtask(input: SpawnDelegationInput): SpawnDelega
       `UPDATE convoys SET total_subtasks = total_subtasks + 1, updated_at = ? WHERE id = ?`,
       [now, convoy.id]
     );
+
+    // Propagate workflow role assignments to the child. Without this the
+    // child inherits a multi-stage workflow (Build/Test/Review) but only
+    // has assigned_agent_id set to the spawned peer — every other stage
+    // role has no assignment, and the workflow engine's old fallback
+    // would silently re-dispatch the same peer as Tester/Reviewer in its
+    // own session. Now we wire the child's task_roles up front:
+    //   1. The stage role matching the spawned peer's role → the peer.
+    //   2. Every other stage role inherits from the parent's task_roles
+    //      when present (so a Tester/Reviewer the operator wired up at
+    //      the parent level cascades to spawned children).
+    //   3. populateTaskRolesFromAgents fills any remaining gaps via fuzzy
+    //      match against the workspace roster.
+    const childWorkflow = getTaskWorkflow(childTaskId);
+    if (childWorkflow) {
+      const peerRoleKey = (input.suggestedRole || '').toLowerCase();
+      const inserted = new Set<string>();
+
+      // Stage role matching the peer agent's role
+      for (const stage of childWorkflow.stages) {
+        if (!stage.role) continue;
+        if (stage.role.toLowerCase() === peerRoleKey) {
+          run(
+            `INSERT OR IGNORE INTO task_roles (id, task_id, role, agent_id, created_at)
+             VALUES (?, ?, ?, ?, datetime('now'))`,
+            [uuidv4(), childTaskId, stage.role, input.peerAgentId],
+          );
+          inserted.add(stage.role);
+        }
+      }
+
+      // Inherit remaining stage roles from the parent's task_roles
+      const parentRoles = queryAll<{ role: string; agent_id: string }>(
+        'SELECT role, agent_id FROM task_roles WHERE task_id = ?',
+        [parent.id],
+      );
+      const parentRoleMap = new Map<string, string>();
+      for (const pr of parentRoles) {
+        parentRoleMap.set(pr.role.toLowerCase(), pr.agent_id);
+      }
+      for (const stage of childWorkflow.stages) {
+        if (!stage.role || inserted.has(stage.role)) continue;
+        const parentAgentId = parentRoleMap.get(stage.role.toLowerCase());
+        if (parentAgentId) {
+          run(
+            `INSERT OR IGNORE INTO task_roles (id, task_id, role, agent_id, created_at)
+             VALUES (?, ?, ?, ?, datetime('now'))`,
+            [uuidv4(), childTaskId, stage.role, parentAgentId],
+          );
+          inserted.add(stage.role);
+        }
+      }
+
+      // Fall back to fuzzy matching for any role still unassigned. The
+      // helper is a no-op when task_roles already has rows for every
+      // stage role, so calling it after our explicit inserts is safe.
+      populateTaskRolesFromAgents(childTaskId, parent.workspace_id);
+    }
 
     return {
       subtaskId,

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3445,6 +3445,29 @@ const migrations: Migration[] = [
       console.log('[Migration 056] workspaces.context_md added.');
     },
   },
+  {
+    id: '057',
+    name: 'openclaw_sessions_stage',
+    up: (db) => {
+      // Stage-scope the session lookup so a workflow's Build/Test/Review
+      // stages each get a distinct gateway-side conversation, even when
+      // they happen to be assigned to the same agent (e.g. fallback paths
+      // that re-pick the builder for a missing tester role). Without this
+      // column the lookup keys on (agent_id, task_id) only, which causes
+      // context append-bleed when the workflow loops the same agent
+      // across stages — see the AlertDialog dispatch where the Builder
+      // ended up role-playing Tester and Reviewer in its own session.
+      const cols = db.prepare(`PRAGMA table_info(openclaw_sessions)`).all() as Array<{ name: string }>;
+      if (!cols.some(c => c.name === 'stage')) {
+        db.exec(`ALTER TABLE openclaw_sessions ADD COLUMN stage TEXT`);
+      }
+      db.exec(
+        `CREATE INDEX IF NOT EXISTS idx_openclaw_sessions_task_agent_stage
+           ON openclaw_sessions(task_id, agent_id, stage)`,
+      );
+      console.log('[Migration 057] openclaw_sessions.stage added.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -208,6 +208,12 @@ CREATE TABLE IF NOT EXISTS openclaw_sessions (
   status TEXT DEFAULT 'active',
   session_type TEXT DEFAULT 'persistent',
   task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
+  -- Workflow stage owning this session (e.g. 'in_progress', 'testing').
+  -- NULL for non-workflow dispatches (planner, coordinator). The lookup
+  -- in the dispatch route keys on (agent_id, task_id, stage) so distinct
+  -- stages get distinct gateway-side conversations even when routed to
+  -- the same agent.
+  stage TEXT,
   ended_at TEXT,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
@@ -967,6 +973,7 @@ CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
 CREATE INDEX IF NOT EXISTS idx_activities_task ON task_activities(task_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_deliverables_task ON task_deliverables(task_id);
 CREATE INDEX IF NOT EXISTS idx_openclaw_sessions_task ON openclaw_sessions(task_id);
+CREATE INDEX IF NOT EXISTS idx_openclaw_sessions_task_agent_stage ON openclaw_sessions(task_id, agent_id, stage);
 CREATE INDEX IF NOT EXISTS idx_planning_questions_task ON planning_questions(task_id, sort_order);
 CREATE INDEX IF NOT EXISTS idx_workflow_templates_workspace ON workflow_templates(workspace_id);
 CREATE INDEX IF NOT EXISTS idx_task_roles_task ON task_roles(task_id);

--- a/src/lib/planner-prompt.ts
+++ b/src/lib/planner-prompt.ts
@@ -115,6 +115,12 @@ You have three response shapes: multiple-choice, free-text, or confident.
     "needs_research": false              // or true with a rationale
   }
 
+  When you declare confidence, "understanding" must explicitly state the
+  DELIVERABLE BOUNDARY — what's in scope AND what's NOT. Example:
+  "I will build component X. I will NOT modify existing call sites of X —
+  that's a follow-up." If the user disagrees, they'll widen the scope by
+  answering. Do not assume related-but-separate work is implied.
+
   If "needs_research": true, include "research_rationale": "why web research
   would close a specific unknown" — be concrete; do not ask for research as a
   reflex.
@@ -157,6 +163,10 @@ Produce a structured, testable spec:
       "success_criteria": [
         { "id": "sc-1", "assertion": "Binary pass/fail", "how_to_test": "..." }
       ],
+      "follow_ups": [
+        { "title": "Short imperative phrase",
+          "rationale": "Why this is related but out of scope for THIS task." }
+      ],
       "constraints": {}
     },
     "agents": [
@@ -170,15 +180,42 @@ Produce a structured, testable spec:
     "execution_plan": { "approach": "...", "steps": ["...", "..."] }
   }
 
+Scope discipline (anti–scope-creep) — read this BEFORE the rules below:
+The deliverables list must be the MINIMUM set that satisfies the task title
+and description as written. Before emitting, run each deliverable against
+this test:
+
+  "Would removing this leave the task as TITLED unfinished?"
+
+If the answer is "no" — if it's a useful side quest, a follow-up integration,
+a 'while we're here' rewire, or a related cleanup — DROP IT from deliverables
+and move it to "follow_ups". Pattern that bites us repeatedly: turning
+"build component X" into "build X AND wire it up at every existing call site
+AND replace the legacy implementation." Building X is the task. Migrating
+callers is a separate task that should be its own story — surface it as a
+follow-up so the operator can triage it into a new task once X ships.
+
+When in doubt: under-scope, not over-scope. The user can widen scope in
+"confirm"; they can't easily un-do work that was never asked for.
+
 Rules for a good spec (these are the difference between shippable work and
 a broken mockup):
-- EVERY major artifact gets its own deliverables entry. An HTML app with a
-  service worker is at least four deliverables (index.html, styles.css,
-  app.js, sw.js) — not one vague "PWA module".
+- EVERY major artifact REQUIRED BY THE TITLE gets its own deliverables entry.
+  An HTML app with a service worker is at least four deliverables
+  (index.html, styles.css, app.js, sw.js) — not one vague "PWA module". But
+  this is decomposition WITHIN scope, not an excuse to expand scope.
 - kind=file REQUIRES path_pattern. Name the file — no "some CSS file".
 - kind=behavior REQUIRES a testable acceptance ("page loads from cache with
   network disabled", not "works offline").
-- success_criteria entries must each be pass/fail-able on their own.
+- success_criteria entries must each be pass/fail-able on their own AND
+  must test a property of WHAT WAS ASKED FOR. "≥3 existing call sites
+  updated" is NOT a valid success criterion for "build a new component" —
+  rewiring callers is a separate refactor. If you find yourself writing a
+  criterion that asserts something about pre-existing code, that criterion
+  belongs in a follow-up task, not this spec.
+- "follow_ups" is where related-but-out-of-scope work goes. Use it freely
+  — every entry there is one fewer item bloating the current task. The
+  operator/PM will triage these into their own stories.
 - Prefer assigning roles to agents in the roster above by including their
   "agent_id". Only propose a new agent (agent_id: null) when no listed agent
   fits, and include a "rationale" naming the specific capability gap.

--- a/src/lib/planning-envelope.ts
+++ b/src/lib/planning-envelope.ts
@@ -77,6 +77,11 @@ export interface ResearchDoneEnvelope {
  * for initial plan emission and post-tweak regeneration — the phase column on
  * the task tells the caller which it is.
  */
+export interface PlanFollowUp {
+  title: string;
+  rationale?: string;
+}
+
 export interface PlanEnvelope {
   kind: 'plan';
   spec: {
@@ -84,6 +89,10 @@ export interface PlanEnvelope {
     summary: string;
     deliverables: Array<SpecDeliverable | string>;
     success_criteria: Array<SpecSuccessCriterion | string>;
+    /** Related-but-out-of-scope work the planner spotted. Persisted with the
+     * spec so an operator/PM can triage these into new tasks, but stripped
+     * from the dispatch brief so the builder doesn't treat them as todos. */
+    follow_ups?: PlanFollowUp[];
     constraints?: Record<string, unknown>;
   };
   agents: Array<{
@@ -258,6 +267,19 @@ function tryBuildPlan(raw: Record<string, unknown>): PlanEnvelope | null {
   const success_criteria = Array.isArray(spec.success_criteria) ? spec.success_criteria : [];
   const agents = Array.isArray(raw.agents) ? raw.agents : [];
 
+  const follow_ups: PlanFollowUp[] = Array.isArray(spec.follow_ups)
+    ? spec.follow_ups.flatMap((entry): PlanFollowUp[] => {
+        if (typeof entry === 'string') {
+          return entry.trim() ? [{ title: entry }] : [];
+        }
+        if (!isRecord(entry)) return [];
+        const title = typeof entry.title === 'string' ? entry.title.trim() : '';
+        if (!title) return [];
+        const rationale = typeof entry.rationale === 'string' ? entry.rationale : undefined;
+        return [{ title, rationale }];
+      })
+    : [];
+
   return {
     kind: 'plan',
     spec: {
@@ -265,6 +287,7 @@ function tryBuildPlan(raw: Record<string, unknown>): PlanEnvelope | null {
       summary: spec.summary,
       deliverables: deliverables as Array<SpecDeliverable | string>,
       success_criteria: success_criteria as Array<SpecSuccessCriterion | string>,
+      follow_ups: follow_ups.length > 0 ? follow_ups : undefined,
       constraints: isRecord(spec.constraints) ? (spec.constraints as Record<string, unknown>) : undefined,
     },
     agents: agents.filter(isRecord).map((a) => {

--- a/src/lib/services/task-status.ts
+++ b/src/lib/services/task-status.ts
@@ -159,9 +159,74 @@ export function transitionTaskStatus(
   }
 
   const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+
+  // Convoy + workflow side effects. These used to live only in the
+  // /api/tasks/[id] PATCH route, so MCP-driven status changes
+  // (`update_task_status`, `accept_subtask`) bypassed them entirely. The
+  // Builder marking a subtask done would update the row but never bump
+  // the parent convoy's completed_subtasks, so checkConvoyCompletion
+  // never ran and the parent stayed in convoy_active until the stall
+  // scanner flagged it. Run them here so every status mutation gets
+  // consistent treatment regardless of caller.
+  runPostStatusChangeSideEffects({
+    taskId,
+    previousStatus: existing.status,
+    newStatus,
+    workspaceId: existing.workspace_id,
+    convoyId: existing.convoy_id ?? null,
+  });
+
   return {
     ok: true,
     task: task ?? existing,
     previousStatus: existing.status,
   };
+}
+
+/**
+ * Convoy + drain hooks that must fire on every status change, regardless
+ * of whether the source is an API PATCH or an MCP tool. Idempotent —
+ * safe to call from multiple call sites if a future refactor stacks them.
+ */
+export function runPostStatusChangeSideEffects(input: {
+  taskId: string;
+  previousStatus: string;
+  newStatus: string;
+  workspaceId: string;
+  convoyId: string | null;
+}): void {
+  const { taskId, previousStatus, newStatus, workspaceId, convoyId } = input;
+  if (newStatus === previousStatus) return;
+
+  // Lazy imports to avoid pulling convoy + workflow engine into modules
+  // that only import the type signatures of task-status.
+  if (convoyId) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const convoy = require('@/lib/convoy') as typeof import('@/lib/convoy');
+      convoy.updateConvoyProgress(convoyId);
+      if (newStatus === 'done') {
+        const wasFinal = convoy.checkConvoyCompletion(convoyId);
+        if (!wasFinal) {
+          convoy.dispatchReadyConvoySubtasks(convoyId).catch((err: unknown) => {
+            console.error('[Convoy] auto-dispatch on subtask done failed:', err);
+          });
+        }
+      }
+    } catch (err) {
+      console.error('[Convoy] progress update failed:', err);
+    }
+  }
+
+  if (newStatus === 'done') {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const wf = require('@/lib/workflow-engine') as typeof import('@/lib/workflow-engine');
+      wf.drainQueue(taskId, workspaceId).catch((err: unknown) => {
+        console.error('[Workflow] drainQueue after done failed:', err);
+      });
+    } catch (err) {
+      console.error('[Workflow] drainQueue failed:', err);
+    }
+  }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -286,6 +286,9 @@ export interface OpenClawSession {
   status: string;
   session_type: 'persistent' | 'subagent';
   task_id?: string;
+  /** Workflow stage that owns this session (e.g. 'in_progress', 'testing').
+   * NULL for non-workflow dispatches (planner, coordinator). */
+  stage?: string | null;
   ended_at?: string;
   created_at: string;
   updated_at: string;

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -10,6 +10,7 @@ import { pickDynamicAgent, escalateFailureIfNeeded, recordLearnerOnTransition } 
 import { internalDispatch } from '@/lib/internal-dispatch';
 import { broadcast } from '@/lib/events';
 import { saveCheckpointThrottled } from '@/lib/checkpoint';
+import { createNote } from '@/lib/task-notes';
 import type { Task, WorkflowTemplate, WorkflowStage, TaskRole } from '@/lib/types';
 
 interface StageTransitionResult {
@@ -143,24 +144,34 @@ export async function handleStageTransition(
     return { success: true, handedOff: false };
   }
 
-  // Find the agent assigned to this role (task_roles first, then fall back to assigned_agent_id)
+  // Find the agent assigned to this role. Resolution order:
+  //   1. task_roles row matching the stage role — explicit assignment wins.
+  //   2. assigned_agent_id, BUT only if its role matches the stage role.
+  //      Re-using a role-mismatched assignee (e.g. dispatching the Builder
+  //      to the Test stage because no Tester is wired up) silently breaks
+  //      Build/Test/Review isolation: the same agent picks up its own
+  //      handoff and reviews its own code. We refuse that fallback now and
+  //      let dynamic routing or a hard error surface the gap.
+  //   3. pickDynamicAgent — planner+rules pick by role over the workspace
+  //      roster.
   let roleAgent = getAgentForRole(taskId, targetStage.role);
   let resolution: 'task_role' | 'assigned_fallback' | 'dynamic' = 'task_role';
   if (!roleAgent) {
-    // Fall back to the task's directly assigned agent
     const task = queryOne<{ assigned_agent_id: string | null }>(
       'SELECT assigned_agent_id FROM tasks WHERE id = ?',
       [taskId]
     );
     if (task?.assigned_agent_id) {
-      const agent = queryOne<{ id: string; name: string }>(
-        'SELECT id, name FROM agents WHERE id = ?',
+      const agent = queryOne<{ id: string; name: string; role: string | null }>(
+        'SELECT id, name, role FROM agents WHERE id = ?',
         [task.assigned_agent_id]
       );
-      if (agent) {
-        console.log(`[Workflow] task=${taskId} no task_role for "${targetStage.role}" — using assigned agent "${agent.name}" (${agent.id})`);
-        roleAgent = agent;
+      if (agent && agent.role && agent.role.toLowerCase() === targetStage.role.toLowerCase()) {
+        console.log(`[Workflow] task=${taskId} no task_role for "${targetStage.role}" — using assigned agent "${agent.name}" (${agent.id}) (role match)`);
+        roleAgent = { id: agent.id, name: agent.name };
         resolution = 'assigned_fallback';
+      } else if (agent) {
+        console.log(`[Workflow] task=${taskId} assigned agent "${agent.name}" has role "${agent.role}" but stage requires "${targetStage.role}" — refusing role-mismatched fallback, attempting dynamic routing`);
       }
     }
   }
@@ -303,6 +314,25 @@ export async function handleStageFailure(
     [crypto.randomUUID(), taskId, `Stage failed: ${currentStatus} → ${targetStatus} (reason: ${failReason})`, now]
   );
 
+  // Compose a Prior-stage report and queue it as a pending task_note. The
+  // dispatch route picks up pending notes via getPendingNotesForDispatch
+  // and inlines them into the next agent's brief — that's the channel by
+  // which the Tester's findings reach the Builder on loopback. Just the
+  // failReason string isn't enough; include the most recent deliverables
+  // and any agent activity messages logged during the failing stage so
+  // the next agent has the actual report to act on.
+  try {
+    const reportBody = composePriorStageReport(taskId, currentStatus, targetStatus, failReason);
+    if (reportBody) {
+      createNote(taskId, reportBody, 'note', 'user');
+    }
+  } catch (err) {
+    // Non-fatal: a failed report assembly shouldn't block the loopback
+    // dispatch. The failReason still lands in status_reason and the
+    // dispatch activity log.
+    console.warn('[Workflow] composePriorStageReport failed:', err);
+  }
+
   // Update task status to the fail target
   run(
     'UPDATE tasks SET status = ?, status_reason = ?, updated_at = ? WHERE id = ?',
@@ -326,6 +356,98 @@ export async function handleStageFailure(
 }
 
 /**
+ * Build a markdown report describing what the failing stage produced and
+ * why it failed. Read by the loopback dispatch via the pending-notes
+ * mechanism. Returns null if there's nothing useful to say beyond the
+ * failReason itself (caller can skip the note in that case).
+ */
+function composePriorStageReport(
+  taskId: string,
+  failingStatus: string,
+  targetStatus: string,
+  failReason: string,
+): string | null {
+  // Find the timestamp the task entered the failing stage so we only
+  // report on what THIS stage did — not history from earlier loops.
+  const entry = queryOne<{ created_at: string }>(
+    `SELECT created_at FROM task_activities
+       WHERE task_id = ? AND activity_type = 'status_changed'
+         AND message LIKE ?
+       ORDER BY created_at DESC LIMIT 1`,
+    [taskId, `%→ ${failingStatus}%`],
+  );
+  const since = entry?.created_at ?? null;
+
+  // Deliverables produced during the failing stage. The role='output'
+  // filter excludes inputs the agent was handed.
+  const deliverables = queryAll<{ title: string; path: string | null; description: string | null; deliverable_type: string }>(
+    since
+      ? `SELECT title, path, description, deliverable_type
+           FROM task_deliverables
+          WHERE task_id = ? AND role = 'output' AND created_at >= ?
+          ORDER BY created_at ASC`
+      : `SELECT title, path, description, deliverable_type
+           FROM task_deliverables
+          WHERE task_id = ? AND role = 'output'
+          ORDER BY created_at DESC LIMIT 10`,
+    since ? [taskId, since] : [taskId],
+  );
+
+  // Activity messages from the failing stage — log_activity calls and
+  // similar narrate the agent's findings (e.g. Tester's verification
+  // notes). Cap to avoid blowing up the next agent's brief.
+  const activities = queryAll<{ message: string; activity_type: string; created_at: string }>(
+    since
+      ? `SELECT message, activity_type, created_at
+           FROM task_activities
+          WHERE task_id = ? AND created_at >= ?
+            AND activity_type IN ('agent_message', 'progress_update', 'log_activity', 'verification_failed', 'review_failed')
+          ORDER BY created_at ASC LIMIT 15`
+      : `SELECT message, activity_type, created_at
+           FROM task_activities
+          WHERE task_id = ?
+            AND activity_type IN ('agent_message', 'progress_update', 'log_activity', 'verification_failed', 'review_failed')
+          ORDER BY created_at DESC LIMIT 15`,
+    since ? [taskId, since] : [taskId],
+  );
+
+  if (deliverables.length === 0 && activities.length === 0) {
+    // Nothing concrete to add — failReason will reach the next agent via
+    // status_reason on the task row anyway.
+    return null;
+  }
+
+  const lines: string[] = [];
+  lines.push(`Prior stage report — \`${failingStatus}\` → \`${targetStatus}\``);
+  lines.push('');
+  lines.push(`**Reason for loopback:** ${failReason}`);
+
+  if (deliverables.length > 0) {
+    lines.push('');
+    lines.push(`**Deliverables registered during the failing stage (${deliverables.length}):**`);
+    for (const d of deliverables) {
+      const pathPart = d.path ? ` → \`${d.path}\`` : '';
+      const desc = d.description ? `\n      ${d.description.slice(0, 500)}` : '';
+      lines.push(`- (${d.deliverable_type}) **${d.title}**${pathPart}${desc}`);
+    }
+  }
+
+  if (activities.length > 0) {
+    lines.push('');
+    lines.push(`**Agent activity from the failing stage:**`);
+    for (const a of activities) {
+      const msg = (a.message || '').slice(0, 600);
+      lines.push(`- _${a.activity_type}_: ${msg}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('Address each finding before re-submitting. Do not rebuild from scratch — patch the existing deliverables.');
+
+  return lines.join('\n');
+}
+
+/**
  * Auto-populate task_roles from planning agents when a workflow template is assigned.
  * Maps agent roles to workflow stage roles using fuzzy matching.
  */
@@ -333,8 +455,12 @@ export function populateTaskRolesFromAgents(taskId: string, workspaceId: string)
   const workflow = getTaskWorkflow(taskId);
   if (!workflow) return;
 
-  const existingRoles = getTaskRoles(taskId);
-  if (existingRoles.length > 0) return; // Already populated
+  // Fill gaps only — preserve any explicit assignments the caller made
+  // before invoking this helper. Skip stage roles that already have an
+  // entry; previously this returned early on the first existing row,
+  // which silently blocked spawn-time role propagation from finishing
+  // the job.
+  const existingRoles = new Set(getTaskRoles(taskId).map(r => r.role.toLowerCase()));
 
   // Get all agents in the workspace
   const agents = queryAll<{ id: string; name: string; role: string }>(
@@ -345,7 +471,7 @@ export function populateTaskRolesFromAgents(taskId: string, workspaceId: string)
   // For each stage that requires a role, try to find a matching agent
   const roleMap: Record<string, string> = {};
   for (const stage of workflow.stages) {
-    if (!stage.role || roleMap[stage.role]) continue;
+    if (!stage.role || roleMap[stage.role] || existingRoles.has(stage.role.toLowerCase())) continue;
 
     // Try exact match on role name, then fuzzy match
     const match = agents.find(a =>
@@ -361,7 +487,7 @@ export function populateTaskRolesFromAgents(taskId: string, workspaceId: string)
 
   // Learner fallback: the 'learner' role isn't in any workflow stage,
   // so it won't be matched above. Find a learner agent and assign it.
-  if (!roleMap['learner']) {
+  if (!roleMap['learner'] && !existingRoles.has('learner')) {
     const learner = agents.find(a =>
       a.role.toLowerCase() === 'learner' ||
       a.name.toLowerCase().includes('learner')


### PR DESCRIPTION
## Summary

Five cuts to a single root issue: Build → Test → Review pipelines were collapsing back into the builder's own session, and convoy progress wasn't getting bumped when subtasks finished.

Reproduced on a recent AlertDialog dispatch:
- The Coordinator's spawn produced a child task with the standard Build/Test/Review template but only `assigned_agent_id = Builder` — no `task_roles` rows. When the child hit the Test stage, `getAgentForRole('tester')` returned null, and the workflow engine silently fell back to dispatching the Builder again. Same agent → same `agent:<gateway-id>:` session-key prefix → context append. Builder ended up role-playing Tester and Reviewer inside its own conversation, with the conventions block re-injected each time.
- When the Builder finally marked the subtask `done` via the MCP `update_task_status` tool, the convoy's `completed_subtasks` was never bumped (the hook lived only in the API PATCH route), so the parent stayed in `convoy_active` and got flagged `stalled_no_activity` 30 min later.

## Changes

- **`openclaw_sessions.stage` column** (migration 057). Session lookup now keys on `(agent_id, task_id, stage)` so the same agent landing in two stages gets distinct gateway-side conversations. NULL-aware predicate keeps legacy non-workflow dispatches (planner, coordinator) compatible.
- **`spawnDelegationSubtask` propagates `task_roles`** for every workflow stage: peer's role-stage → spawned peer; other roles inherit from parent's `task_roles`; `populateTaskRolesFromAgents` fills remaining gaps via fuzzy match. The helper is also tightened to fill missing roles only instead of all-or-nothing returning early on the first existing row.
- **`handleStageTransition` refuses the role-mismatched fallback.** Re-using `assigned_agent_id` as Tester when its role is `builder` is the silent bug that produces same-session re-dispatch. Now it falls through to `pickDynamicAgent`, then surfaces a `planning_dispatch_error` if nothing matches — better to stall visibly than silently re-pick the builder.
- **`handleStageFailure` assembles a Prior-stage report** (deliverables + activity messages registered since the failing stage was entered) and queues it via `createNote`, so the loopback dispatch's existing `getPendingNotesForDispatch` channel inlines the tester's findings into the builder's brief. Replaces the single-line `failReason` that the builder couldn't act on.
- **`runPostStatusChangeSideEffects`** extracted from the API PATCH route into `services/task-status.ts` and called from `transitionTaskStatus` too. `update_task_status` from MCP tools now bumps convoy progress, fires `checkConvoyCompletion`, and drains the workflow queue — closing the gap where an agent-marked-done subtask left the parent stuck in `convoy_active` indefinitely.

Also includes anti-scope-creep planner prompt updates from earlier in the same session:
- "Scope discipline" section that gates each deliverable through *"would removing it leave the title unfinished?"*
- New `spec.follow_ups[]` field for related-but-out-of-scope work, parsed by the envelope reader and stripped from the dispatch brief so it persists for operator triage but doesn't reach the builder.
- Tightened `success_criteria` rule (each criterion must test the requested artifact, not "≥3 existing call sites updated"-style smuggled rewires).

And the workspace conventions block injected at dispatch now has a per-change-type verification matrix (UI / MCP-tool / API / Docker) instead of a single generic paragraph.

## Test plan

- [x] `npx tsc --noEmit` clean for touched modules (pre-existing failures in `pm-decompose.test.ts` and `.next/types/validator.ts` only, unrelated to this PR).
- [x] `yarn test` — 418/418 pass.
- [ ] After merge + container restart, dispatch a fresh multi-stage task to a Coordinator and confirm:
  - Builder, Tester, Reviewer each open distinct sessions (`mission-control-<agent>-<task>-<stage>` visible in `/debug`).
  - Subtask `update_task_status('done')` promotes parent to `review` without operator intervention.
  - Tester-rejected work returns to the Builder with a "Prior stage report" block in the dispatch brief listing the rejected deliverables and activity log.

## Migration safety

`057_openclaw_sessions_stage` is additive (`ALTER TABLE … ADD COLUMN stage TEXT` + `CREATE INDEX IF NOT EXISTS`); existing rows get NULL `stage` and the lookup matches them. No downtime, no data backfill, idempotent.