### PR TITLE
fix(task-status): clear stale "Failed:" reason on successful recovery

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -255,8 +255,24 @@ export async function PATCH(
         return NextResponse.json({ error: 'status_reason is required when failing a stage' }, { status: 400 });
       }
 
-      if (nextStatus === 'done' && !boardOverrideAllowed && !taskCanBeDone(id)) {
+      // Self-clear stale "Failed: …" reasons on successful recovery (mirror
+      // of the same check in services/task-status.ts:transitionTaskStatus).
+      // Without this, a task that was bounced by a prior reviewer and has
+      // since been re-tested + re-reviewed successfully still has the old
+      // failure text on the row, and taskCanBeDone's substring-includes-fail
+      // check rejects the final transition.
+      const existingReason = (existing as { status_reason?: string }).status_reason ?? '';
+      const shouldClearStaleFailure =
+        !failingBackwards &&
+        validatedData.status_reason === undefined &&
+        /^failed:/i.test(existingReason.trim());
+
+      if (nextStatus === 'done' && !boardOverrideAllowed && !taskCanBeDone(id, { ignoreStaleFailureReason: shouldClearStaleFailure })) {
         return NextResponse.json({ error: 'Cannot mark done: validation/evidence requirements not met' }, { status: 400 });
+      }
+
+      if (shouldClearStaleFailure) {
+        updates.push('status_reason = NULL');
       }
 
       updates.push('status = ?');

--- a/src/lib/services/task-status.ts
+++ b/src/lib/services/task-status.ts
@@ -136,7 +136,23 @@ export function transitionTaskStatus(
     };
   }
 
-  if (newStatus === 'done' && !boardOverride && !taskCanBeDone(taskId)) {
+  // Self-clear stale failure reasons on successful recovery. handleStageFailure
+  // writes status_reason = "Failed: <text>" when bouncing a task back. If the
+  // work is later re-tested + re-reviewed and progresses forward again, that
+  // old reason is still on the row — and `taskCanBeDone` blocks the final
+  // transition to `done` because its substring check sees "fail". Clear the
+  // stale reason whenever the caller didn't explicitly set one AND we're
+  // moving forward (not failing-backwards), and only when the existing reason
+  // matches the canonical "Failed:" prefix produced by handleStageFailure —
+  // operator-set or other-source reasons (e.g. legacy "Validation failed:")
+  // are left alone.
+  const shouldClearStaleFailure =
+    !failingBackwards &&
+    statusReason === undefined &&
+    typeof existing.status_reason === 'string' &&
+    /^failed:/i.test(existing.status_reason.trim());
+
+  if (newStatus === 'done' && !boardOverride && !taskCanBeDone(taskId, { ignoreStaleFailureReason: shouldClearStaleFailure })) {
     return {
       ok: false,
       code: 'cannot_mark_done',
@@ -150,6 +166,8 @@ export function transitionTaskStatus(
   if (statusReason !== undefined) {
     updates.push('status_reason = ?');
     values.push(statusReason);
+  } else if (shouldClearStaleFailure) {
+    updates.push('status_reason = NULL');
   }
   values.push(taskId);
   run(`UPDATE tasks SET ${updates.join(', ')} WHERE id = ?`, values);

--- a/src/lib/task-governance.test.ts
+++ b/src/lib/task-governance.test.ts
@@ -57,6 +57,30 @@ test('task cannot be done when status_reason indicates failure', () => {
   assert.equal(taskCanBeDone(taskId), false);
 });
 
+test('ignoreStaleFailureReason forgives canonical "Failed:" prefix only', () => {
+  const taskId = crypto.randomUUID();
+  seedTask(taskId);
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, role, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'file', 'x.ts', 'output', datetime('now'))`,
+    [taskId]
+  );
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'completed', 'did thing', datetime('now'))`,
+    [taskId]
+  );
+
+  // Canonical handleStageFailure prefix — recovery path should forgive it.
+  run(`UPDATE tasks SET status_reason = 'Failed: CRITICAL — old reviewer finding' WHERE id = ?`, [taskId]);
+  assert.equal(taskCanBeDone(taskId), false, 'still blocks without the option');
+  assert.equal(taskCanBeDone(taskId, { ignoreStaleFailureReason: true }), true, 'option forgives canonical prefix');
+
+  // Non-canonical "fail" reason — option must NOT forgive (still blocks).
+  run(`UPDATE tasks SET status_reason = 'Validation failed: CSS broken' WHERE id = ?`, [taskId]);
+  assert.equal(taskCanBeDone(taskId, { ignoreStaleFailureReason: true }), false, 'option still rejects non-canonical failures');
+});
+
 test('ensureFixerExists creates fixer when missing', () => {
   const fixer = ensureFixerExists('default');
   assert.equal(fixer.created, true);

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -185,10 +185,20 @@ export async function recordLearnerOnTransition(taskId: string, previousStatus: 
   await notifyLearner(taskId, { previousStatus, newStatus, passed, failReason });
 }
 
-export function taskCanBeDone(taskId: string): boolean {
+export function taskCanBeDone(
+  taskId: string,
+  opts: { ignoreStaleFailureReason?: boolean } = {},
+): boolean {
   const task = queryOne<{ status: string; status_reason?: string }>('SELECT status, status_reason FROM tasks WHERE id = ?', [taskId]);
   if (!task) return false;
-  const hasValidationFailure = (task.status_reason || '').toLowerCase().includes('fail');
+  const reason = (task.status_reason || '').trim();
+  // The caller (transitionTaskStatus) detected a stale "Failed: …" reason
+  // that is about to be cleared by the same UPDATE — don't block the
+  // transition on the very reason we're erasing in the next statement.
+  // Only the canonical handleStageFailure prefix is forgiven; other
+  // failure-shaped reasons still block.
+  const isStaleAutoFailure = opts.ignoreStaleFailureReason && /^failed:/i.test(reason);
+  const hasValidationFailure = !isStaleAutoFailure && reason.toLowerCase().includes('fail');
   return !hasValidationFailure && hasStageEvidence(taskId);
 }
 


### PR DESCRIPTION
## Summary

`taskCanBeDone` rejects any task whose `status_reason` lower-cases to contain `"fail"` — a useful circuit breaker for live validation failures, but it has no self-clear. Once `handleStageFailure` writes `status_reason = "Failed: <text>"` to bounce a task back, that text stays on the row even after the task is re-tested + re-reviewed and walked back through to a healthy state. The final `update_task_status('done')` then returns the generic `cannot_mark_done` error, leaving the agent stuck and forcing operator intervention.

Caught in the wild on the AlertDialog parent task today: REVIEW FAIL → Builder fix → TEST PASS → REVIEW PASS, then `done` blocked by the original FAIL reason still on the row.

## Changes

- `src/lib/services/task-status.ts` — `transitionTaskStatus` detects when the existing `status_reason` matches the canonical `^Failed:/i` prefix (the format `handleStageFailure` writes), the caller didn't pass an explicit `status_reason`, and the transition is forward (not `failingBackwards`). When all three hold, the same UPDATE that flips status also clears `status_reason`.
- `src/lib/task-governance.ts` — `taskCanBeDone(taskId, { ignoreStaleFailureReason })` accepts an option. When the caller is about to clear the stale reason in the next statement, the gate skips the substring check for the canonical prefix only — non-canonical "fail" reasons (e.g. legacy `Validation failed:`) still block.
- `src/app/api/tasks/[id]/route.ts` — same logic in the operator-driven PATCH path so symmetry holds.
- `src/lib/task-governance.test.ts` — new regression test asserting:
  - canonical `Failed: …` reason is forgiven only when the option is passed,
  - non-canonical `Validation failed: …` is still blocked even with the option (preserves the existing test scenario).

## Why the forgiveness is narrow

- Only the canonical handleStageFailure prefix self-clears. Operator-set or other-source failure text is left alone.
- Only forward transitions trigger the clear (`failingBackwards` already requires a fresh reason).
- Caller intent always wins — passing `status_reason` explicitly skips the auto-clear entirely.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `yarn test` — 419/419 pass (was 418, new regression test).
- [ ] After merge + container restart: re-verify the stuck AlertDialog parent unsticks, and a fresh failure → fix → re-review flow ends at `done` without manual reason-clearing.