### PR TITLE
feat(evidence): submit_evidence MCP tool + run-and-forward stage gate

### DIFF
--- a/specs/autonomous-flow-tightening-spec.md
+++ b/specs/autonomous-flow-tightening-spec.md
@@ -1,0 +1,134 @@
+# Autonomous Flow Tightening
+
+Status: draft
+Owner: smb209
+Date: 2026-04-29
+Trigger: post-mortem of first fully-autonomous AlertDialog convoy run (PR #111). Three sessions reviewed: Builder (`61f914e…`), Reviewer (`c4844a9…`), Tester (`114ec91…`).
+
+## Goal
+
+Close the failure modes surfaced by the first autonomous run so the next convoy can complete without operator mid-flight fixes. Stage isolation worked at the gateway-session layer (#110); it bled through at workspace, roll-call, ACL, status_reason, and **verification** layers. The Tester is currently the only role producing real verification evidence — Builder and Reviewer can ship `TASK_COMPLETE` with zero runtime proof.
+
+## Non-goals
+
+- Re-architecting convoy. The convoy primitive is fine.
+- Adding new roles. Builder / Tester / Reviewer / PM stay as-is.
+- Changing OpenClaw worker semantics. Changes are MC-side except role-doc updates.
+
+## Core principle: never ask an agent a yes/no question about its own work
+
+Every gate is **"run this exact command, submit raw output."** The convoy hook parses the output and decides pass/fail. The agent is the transport, not the judge. A field like `typecheck: pass` is just another self-attestation — replace it with `typecheck.stdout: <raw>` + server-side parse.
+
+## Failure modes (from post-mortem)
+
+| FM | One-line | Ground truth |
+|----|----------|--------------|
+| FM1 | Verification gate is pure self-attestation | `src/lib/task-governance.ts:30` `checkStageEvidence` only counts deliverable/activity rows |
+| FM2 | Workspace isolation skipped — Builder ran on `main` | `src/lib/workspace-isolation.ts` exists; dispatch path doesn't always invoke or doesn't enforce |
+| FM3 | Roll-call id lost across stage-isolated session boundary | `src/lib/rollcall.ts:274` `recordRollCallReplyIfMatch` — pattern match only, not propagated |
+| FM4 | `agent_not_coordinator` on first `get_task` for assigned agent | `src/lib/mcp/tools.ts:280-342` |
+| FM5 | Stale `status_reason` survives forward transitions | `src/lib/services/task-status.ts:149-153` partial fix already (`/^failed:/i` only) |
+| FM6 | `yarn test` stalls with no harness budget / fallback | `package.json:10` test script unbounded |
+| FM7 | Path-scheme drift (`/app/...` vs host paths) in deliverables | `src/lib/deliverables/storage.ts` |
+| FM8 | Builder "spray scaffolding" — no end-to-end wiring trace | role doc absent (`src/lib/agents/` has only `pm-soul.md`) |
+| FM9 | Free-text completion summaries hide verification asymmetry | `register_deliverable` `src/lib/mcp/tools.ts:366-412` |
+| FM-T | No role-scoped test budget — Builder runs full regression | role-doc + harness-side change |
+| FM-A | Self-attestation everywhere — no run-and-forward primitive | new `submit_evidence` MCP tool |
+
+## Design
+
+### A. Evidence model (FM1, FM9, FM-A)
+
+New MCP tool `submit_evidence`:
+
+```
+submit_evidence({
+  task_id: string,
+  gate: 'build_fast' | 'test_full' | 'review_static' | 'runtime_ui' | 'runtime_smoke',
+  command: string,            // exact command line agent ran
+  stdout: string,             // raw, untrimmed
+  stderr: string,
+  exit_code: number,
+  artifact_paths?: string[],  // screenshots, trace.zip, HAR
+  diff_sha?: string,          // git rev-parse HEAD at run time
+})
+```
+
+Server side:
+1. Reject if `command` doesn't match the gate's prescribed pattern (regex per gate).
+2. Reject if `diff_sha` doesn't match the task's current head SHA (stale run).
+3. For `runtime_ui`: require ≥1 `artifact_paths` entry that exists on disk and was written within session window.
+4. Parse stdout: TS errors counted from `tsc` output, ESLint error count from JSON output, test pass/fail from tap or jest summary line. Pass/fail is computed, never trusted.
+5. Persist as `task_evidence` row (new table) with hash of stdout for tamper-evidence.
+6. Update `checkStageEvidence` to require a passing `task_evidence` row of the matching gate type for a forward transition into `testing` / `review` / `done`.
+
+Free-text deliverables remain (for narrative context) but no longer satisfy the gate.
+
+### B. Role-scoped test budgets (FM-T, FM6)
+
+| Role | Required gate(s) before transitioning OUT |
+|------|------------------------------------------|
+| Builder | `build_fast`: `tsc --noEmit`, `eslint <changed>`, `jest --findRelatedTests <changed>` (or repo equivalent) — hard 60s budget |
+| Tester | `test_full`: `yarn test` — 90s harness budget; `runtime_ui` or `runtime_smoke` artifact |
+| Reviewer | `review_static`: structured diff notes referencing Tester's evidence ids — no test execution |
+
+`build_fast` command is computed from `git diff --name-only <base>...HEAD` and prescribed to the Builder via the dispatch context — Builder doesn't pick the file list.
+
+Harness budget: `submit_evidence` rejects entries with `duration_ms > budget`. The harness layer (Bash tool? gateway?) wraps long-running commands in a SIGTERM at budget+10s and emits a structured `{event: 'runner_stalled', command, budget}` payload the agent must surface.
+
+### C. Workspace isolation enforcement (FM2)
+
+Dispatch route (`src/app/api/tasks/[id]/dispatch/route.ts:33`) currently calls `determineIsolationStrategy` + `createTaskWorkspace`. Make isolation **mandatory** for any task with role ∈ {builder, tester} on a repo-backed product. Inject the resolved absolute workspace path into the agent's bootstrap context (`MC-CONTEXT.json` or session intro mail) as `workspace.path`. Agents that attempt to write outside that path through MCP tools get rejected at the MC API layer (path-prefix check).
+
+If isolation fails (no git, no rsync target), fail the dispatch — don't fall back to shared working tree.
+
+### D. Roll-call propagation (FM3)
+
+`rollcall.ts` initiates a session and broadcasts the subject. When stage-isolated session is created (`workflow-engine.ts:handleStageTransition`), copy any `rollcall_sessions` entries with `status='active'` and matching agent into the new session's bootstrap context so `recordRollCallReplyIfMatch` finds them. Specifically: include `active_rollcalls: [{id, subject_pattern, expires_at}]` in the dispatch payload.
+
+### E. ACL widening (FM4)
+
+`get_task` in `src/lib/mcp/tools.ts:280` currently requires coordinator scope. Add: assigned agent of the task (any stage's role mapping) can read the task without elevation. Implementation: check `tasks.assigned_agent_id == calling_agent_id` OR `task_roles.agent_id == calling_agent_id` before falling through to coordinator gate.
+
+### F. status_reason cleanup (FM5)
+
+Already partly done in `task-status.ts:149-153` — broaden to clear ANY `status_reason` on forward transition out of a quality stage (not just `/^failed:/i`). Keep it on backward (`testing → in_progress`) since that's the audit trail. Optional: persist cleared reason to `prior_failures[]` JSON column on tasks.
+
+### G. Path-scheme drift (FM7)
+
+`src/lib/deliverables/storage.ts:getTaskDeliverableDir` should resolve to a path that is meaningful from the agent's runtime, not from MC's. Detect agent runtime (host vs Docker) at agent-registration time, store in `agents.runtime_root`, and resolve deliverables-root by joining that root with the task-relative subpath. Agent bootstrap MUST include the resolved absolute root.
+
+### H. Builder wiring trace (FM8)
+
+Add `src/lib/agents/builder-soul.md`, `tester-soul.md`, `reviewer-soul.md`. Builder soul mandates:
+- Before transitioning to `testing`, trace one user-visible path end-to-end: call site → shim/dispatcher → component → mounted DOM. Document the trace in the deliverable.
+- The `runtime_ui` evidence (Tester gate) is what *proves* the trace; the Builder doc just makes "wire it before saying done" explicit.
+
+## Implementation slices
+
+Ordered by leverage / risk:
+
+1. **submit_evidence + checkStageEvidence rewrite** (FM1, FM9, FM-A) — biggest leverage. Schema migration + MCP tool + governance update + role-doc snippets.
+2. **Role-scoped test budgets + role souls** (FM-T, FM8, FM6) — depends on (1) for the gate definitions. New role docs, dispatch context inclusion of prescribed commands, harness budget wrapper.
+3. **Workspace isolation enforcement** (FM2) — make existing infra mandatory + inject path into bootstrap.
+4. **Roll-call propagation** (FM3) — small, isolated change in dispatch + rollcall.
+5. **ACL widening for get_task** (FM4) — one-line change, low risk.
+6. **status_reason broadening** (FM5) — single regex/predicate change.
+7. **Path-scheme drift** (FM7) — touches agent registration + bootstrap; medium risk.
+
+Each slice is its own PR on its own branch, stacked on the previous where dependencies exist.
+
+## Verification
+
+Each slice ships with:
+- Unit tests on the parser / hook logic
+- A replay test that takes the recorded session 1/2/3 transcripts and asserts the new gates would have caught the bug (e.g. the no-mount AlertDialog should fail Builder's `build_fast` runtime trace step or Tester's `runtime_ui` gate)
+- Preview-smoke run before the PR opens
+
+Final gate: re-run a tiny convoy task end-to-end through the autonomous flow and confirm zero operator interventions.
+
+## Open questions
+
+- Does the harness budget belong in MC's MCP layer or in the openclaw worker? MC-side rejection is simpler but worker-side cancellation actually frees the turn.
+- Should `task_evidence` be append-only audit, or should re-runs supersede prior entries? Append-only is safer; supersede is cleaner UI.
+- Where do we store the prescribed-command templates per repo? Repo-local `.mc/gates.json` keeps it close to the code; central in MC keeps it consistent across products. Lean toward repo-local with MC fallbacks.

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3468,6 +3468,46 @@ const migrations: Migration[] = [
       console.log('[Migration 057] openclaw_sessions.stage added.');
     },
   },
+  {
+    id: '058',
+    name: 'task_evidence',
+    up: (db) => {
+      // Run-and-forward evidence model: agents submit raw stdout from
+      // prescribed commands (typecheck/lint/tests/runtime), and the
+      // server parses pass/fail. Replaces self-attested "≥1 deliverable
+      // + ≥1 activity" as the verification bar for stage transitions
+      // on tasks that carry a prescribed gate set. See
+      // specs/autonomous-flow-tightening-spec.md.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS task_evidence (
+          id TEXT PRIMARY KEY,
+          task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+          agent_id TEXT,
+          gate TEXT NOT NULL CHECK (gate IN (
+            'build_fast', 'test_full', 'review_static', 'runtime_ui', 'runtime_smoke'
+          )),
+          command TEXT NOT NULL,
+          stdout TEXT NOT NULL DEFAULT '',
+          stderr TEXT NOT NULL DEFAULT '',
+          exit_code INTEGER NOT NULL,
+          duration_ms INTEGER,
+          diff_sha TEXT,
+          artifact_paths TEXT,
+          parsed_summary TEXT,
+          passed INTEGER NOT NULL CHECK (passed IN (0, 1)),
+          reject_reason TEXT,
+          stdout_hash TEXT NOT NULL,
+          created_at TEXT DEFAULT (datetime('now'))
+        );
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_task_evidence_task ON task_evidence(task_id)`);
+      db.exec(
+        `CREATE INDEX IF NOT EXISTS idx_task_evidence_gate
+           ON task_evidence(task_id, gate, created_at DESC)`,
+      );
+      console.log('[Migration 058] task_evidence created.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -285,6 +285,37 @@ CREATE TABLE IF NOT EXISTS task_deliverables (
   created_at TEXT DEFAULT (datetime('now'))
 );
 
+-- Task evidence: structured pass/fail records produced by running a
+-- prescribed command (typecheck / lint / tests / runtime smoke) and
+-- forwarding the raw output. The server parses stdout and computes
+-- whether the gate passed; the agent never self-reports a boolean.
+-- Replaces "at least one deliverable + at least one activity" self-
+-- attestation as the bar for forward stage transitions when a task
+-- carries a prescribed gate set.
+CREATE TABLE IF NOT EXISTS task_evidence (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  agent_id TEXT,
+  gate TEXT NOT NULL CHECK (gate IN (
+    'build_fast', 'test_full', 'review_static', 'runtime_ui', 'runtime_smoke'
+  )),
+  command TEXT NOT NULL,
+  stdout TEXT NOT NULL DEFAULT '',
+  stderr TEXT NOT NULL DEFAULT '',
+  exit_code INTEGER NOT NULL,
+  duration_ms INTEGER,
+  diff_sha TEXT,
+  artifact_paths TEXT,        -- JSON array of paths
+  parsed_summary TEXT,        -- JSON: {ts_errors, eslint_errors, tests_passed, tests_failed, ...}
+  passed INTEGER NOT NULL CHECK (passed IN (0, 1)),
+  reject_reason TEXT,
+  stdout_hash TEXT NOT NULL,  -- sha256(stdout) for tamper-evidence
+  created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_task_evidence_task ON task_evidence(task_id);
+CREATE INDEX IF NOT EXISTS idx_task_evidence_gate
+  ON task_evidence(task_id, gate, created_at DESC);
+
 -- Convoys: parallel task groups.
 -- parent_task_id is NOT unique: a task may have multiple convoys over time
 -- (e.g. an agent coordinator appends further delegation rounds). Readers

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -21,6 +21,7 @@ import { authzErrorToToolResult, internalErrorToToolResult } from './errors';
 import { logMcpToolCall } from './debug';
 
 import { registerDeliverable } from '@/lib/services/task-deliverables';
+import { submitEvidence, ALL_EVIDENCE_GATES } from '@/lib/services/task-evidence';
 import { logActivity } from '@/lib/services/task-activities';
 import { transitionTaskStatus } from '@/lib/services/task-status';
 import { failTask } from '@/lib/services/task-failure';
@@ -407,6 +408,54 @@ export function registerAllTools(server: McpServer): void {
         deliverable: result.deliverable,
         file_exists: result.fileExists,
         normalized_path: result.normalizedPath,
+      };
+      return textResult(JSON.stringify(summary, null, 2), summary);
+    }),
+  );
+
+  // submit_evidence ────────────────────────────────────────────────
+  server.registerTool(
+    'submit_evidence',
+    {
+      title: 'Submit raw command output as evidence for a stage gate',
+      description:
+        'Run-and-forward verification: paste the EXACT command you ran plus its raw stdout/stderr/exit_code. The server parses pass/fail (TS errors, ESLint counts, test totals, artifact presence). Never self-report a boolean — submit the output. Required to transition into testing/review on tasks that carry a prescribed gate set.',
+      inputSchema: {
+        agent_id: agentIdArg,
+        task_id: taskIdArg,
+        gate: z.enum(ALL_EVIDENCE_GATES as [string, ...string[]]),
+        command: z.string().min(1).describe('Exact command line you ran'),
+        stdout: z.string().default('').describe('Raw stdout, untrimmed'),
+        stderr: z.string().default(''),
+        exit_code: z.number().int(),
+        duration_ms: z.number().int().optional(),
+        diff_sha: z.string().optional().describe('git rev-parse HEAD at run time'),
+        artifact_paths: z
+          .array(z.string())
+          .optional()
+          .describe('Required for runtime_ui: screenshot/trace/HAR paths'),
+      },
+      annotations: { destructiveHint: false, openWorldHint: false },
+    },
+    trace('submit_evidence', async (args) => {
+      const result = submitEvidence({
+        taskId: args.task_id,
+        actingAgentId: args.agent_id,
+        gate: args.gate as Parameters<typeof submitEvidence>[0]['gate'],
+        command: args.command,
+        stdout: args.stdout,
+        stderr: args.stderr,
+        exitCode: args.exit_code,
+        durationMs: args.duration_ms,
+        diffSha: args.diff_sha,
+        artifactPaths: args.artifact_paths,
+      });
+      const summary = {
+        evidence_id: result.evidenceId,
+        gate: args.gate,
+        passed: result.passed,
+        parsed_summary: result.parsedSummary,
+        reject_reason: result.rejectReason,
       };
       return textResult(JSON.stringify(summary, null, 2), summary);
     }),

--- a/src/lib/services/task-evidence.test.ts
+++ b/src/lib/services/task-evidence.test.ts
@@ -1,0 +1,294 @@
+/**
+ * task-evidence service tests.
+ *
+ * Covers the parser fingerprints (so an agent can't submit garbage and
+ * call it a typecheck) and the gate-required-by-stage logic in
+ * checkStageEvidence.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { run, queryOne } from '@/lib/db';
+import { submitEvidence, getLatestEvidence, hasAnyEvidence } from './task-evidence';
+import { checkStageEvidence } from '@/lib/task-governance';
+
+function seedAgent(opts: { id?: string; workspace?: string; role?: string } = {}): string {
+  const id = opts.id ?? crypto.randomUUID();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, created_at, updated_at)
+     VALUES (?, 'A', ?, ?, 1, datetime('now'), datetime('now'))`,
+    [id, opts.role ?? 'builder', opts.workspace ?? 'default'],
+  );
+  return id;
+}
+
+function seedTask(opts: { id?: string; assigned?: string; status?: string } = {}): string {
+  const id = opts.id ?? crypto.randomUUID();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, assigned_agent_id, created_at, updated_at)
+     VALUES (?, 'T', ?, 'normal', 'default', 'default', ?, datetime('now'), datetime('now'))`,
+    [id, opts.status ?? 'in_progress', opts.assigned ?? null],
+  );
+  return id;
+}
+
+// ─── Parser fingerprints ────────────────────────────────────────────
+
+test('build_fast rejects unrecognized output (e.g. echo ok)', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  const result = submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'build_fast',
+    command: 'echo ok',
+    stdout: 'ok\n',
+    stderr: '',
+    exitCode: 0,
+  });
+  assert.equal(result.passed, false);
+  assert.match(result.rejectReason ?? '', /no recognizable.*output/i);
+});
+
+test('build_fast accepts clean tsc output (empty stdout, exit 0)', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  const result = submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'build_fast',
+    command: 'yarn tsc --noEmit',
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+  });
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.parsedSummary.fingerprints, ['tsc']);
+  assert.equal(result.parsedSummary.ts_errors, 0);
+});
+
+test('build_fast fails on tsc errors regardless of exit code claim', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  const result = submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'build_fast',
+    command: 'yarn tsc --noEmit',
+    stdout: "src/foo.ts(1,1): error TS2304: Cannot find name 'bar'.\n",
+    stderr: '',
+    exitCode: 0, // agent claims success
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.parsedSummary.ts_errors, 1);
+});
+
+test('test_full requires recognizable runner summary', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  const result = submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'test_full',
+    command: 'yarn test',
+    stdout: 'tests are fine trust me',
+    stderr: '',
+    exitCode: 0,
+  });
+  assert.equal(result.passed, false);
+  assert.match(result.rejectReason ?? '', /test-runner summary/i);
+});
+
+test('test_full accepts jest summary', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  const result = submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'test_full',
+    command: 'yarn test',
+    stdout:
+      'Test Suites: 5 passed, 5 total\nTests: 0 failed, 42 passed, 0 skipped, 42 total\n',
+    stderr: '',
+    exitCode: 0,
+  });
+  assert.equal(result.passed, true);
+  assert.equal(result.parsedSummary.tests_passed, 42);
+  assert.equal(result.parsedSummary.tests_failed, 0);
+});
+
+test('runtime_ui requires at least one artifact path', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  const result = submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'runtime_ui',
+    command: 'playwright test',
+    stdout: '1 passed (3s)\n',
+    stderr: '',
+    exitCode: 0,
+    // no artifact_paths
+  });
+  assert.equal(result.passed, false);
+  assert.match(result.rejectReason ?? '', /artifact_path/);
+});
+
+test('runtime_ui passes with artifact + exit 0', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  const result = submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'runtime_ui',
+    command: 'playwright test',
+    stdout: '1 passed (3s)\n',
+    stderr: '',
+    exitCode: 0,
+    artifactPaths: ['/tmp/screenshot.png'],
+  });
+  assert.equal(result.passed, true);
+});
+
+// ─── Persistence ─────────────────────────────────────────────────────
+
+test('rejected evidence is still persisted (audit trail)', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'build_fast',
+    command: 'echo nope',
+    stdout: 'nope\n',
+    stderr: '',
+    exitCode: 0,
+  });
+  const row = queryOne<{ passed: number; reject_reason: string }>(
+    `SELECT passed, reject_reason FROM task_evidence WHERE task_id = ?`,
+    [task],
+  );
+  assert.ok(row);
+  assert.equal(row.passed, 0);
+  assert.match(row.reject_reason, /no recognizable/i);
+});
+
+test('stdout_hash is recorded for tamper-evidence', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'build_fast',
+    command: 'yarn tsc --noEmit',
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+  });
+  const row = queryOne<{ stdout_hash: string }>(
+    `SELECT stdout_hash FROM task_evidence WHERE task_id = ?`,
+    [task],
+  );
+  assert.ok(row);
+  assert.equal(row.stdout_hash.length, 64); // sha256 hex
+});
+
+// ─── Stage gate integration ─────────────────────────────────────────
+
+test('checkStageEvidence falls back to legacy bar when no evidence rows exist', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  // Legacy bar requires deliverable + activity. With neither, gate fails
+  // — but this is the existing behavior, not the new strict path.
+  const result = checkStageEvidence(task, 'testing');
+  assert.equal(result.ok, false);
+  assert.match(result.reason ?? '', /no deliverables/);
+});
+
+test('checkStageEvidence enforces build_fast for testing once any evidence exists', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  // Submit a passing runtime_smoke (irrelevant to testing's required gate)
+  // — this puts the task on the strict path but does not satisfy build_fast.
+  submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'runtime_smoke',
+    command: 'curl -fsS http://localhost:4010/api/health',
+    stdout: '{"ok":true}\n',
+    stderr: '',
+    exitCode: 0,
+  });
+  assert.equal(hasAnyEvidence(task), true);
+  const result = checkStageEvidence(task, 'testing');
+  assert.equal(result.ok, false);
+  assert.match(result.reason ?? '', /build_fast required/);
+});
+
+test('checkStageEvidence admits transition once required gate passed', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'build_fast',
+    command: 'yarn tsc --noEmit',
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+  });
+  const result = checkStageEvidence(task, 'testing');
+  assert.equal(result.ok, true);
+});
+
+test('checkStageEvidence rejects when latest gate run failed', () => {
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  // Pass once
+  submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'build_fast',
+    command: 'yarn tsc --noEmit',
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+  });
+  // Then a later failing run supersedes
+  submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'build_fast',
+    command: 'yarn tsc --noEmit',
+    stdout: "src/x.ts(1,1): error TS2304: Cannot find name 'y'.\n",
+    stderr: '',
+    exitCode: 1,
+  });
+  const latest = getLatestEvidence(task, 'build_fast');
+  assert.ok(latest);
+  assert.equal(latest.passed, 0);
+  const result = checkStageEvidence(task, 'testing');
+  assert.equal(result.ok, false);
+  assert.match(result.reason ?? '', /did not pass/);
+});
+
+// ─── Replay test from the AlertDialog post-mortem ────────────────────
+
+test("replay: AlertDialog Builder's self-attestation would NOT pass build_fast", () => {
+  // Session 3, line 2293: Builder claimed "TS clean, dev server verified"
+  // with no command output. Their submit_evidence call would have looked
+  // like this — and the parser correctly rejects it.
+  const agent = seedAgent();
+  const task = seedTask({ assigned: agent });
+  const result = submitEvidence({
+    taskId: task,
+    actingAgentId: agent,
+    gate: 'build_fast',
+    command: 'verified manually',
+    stdout: 'TS clean, dev server verified',
+    stderr: '',
+    exitCode: 0,
+  });
+  assert.equal(result.passed, false);
+  assert.match(result.rejectReason ?? '', /no recognizable/i);
+});

--- a/src/lib/services/task-evidence.ts
+++ b/src/lib/services/task-evidence.ts
@@ -1,0 +1,478 @@
+/**
+ * Task evidence service.
+ *
+ * Implements the "run-and-forward" verification model from
+ * specs/autonomous-flow-tightening-spec.md: agents submit the raw stdout/
+ * stderr of a prescribed command and the server parses pass/fail
+ * deterministically. The agent never self-reports a boolean.
+ *
+ * Five gate kinds, each with its own parser:
+ *   - build_fast    typecheck + lint + related-tests (Builder gate)
+ *   - test_full     full regression suite (Tester gate)
+ *   - runtime_ui    Playwright/preview run with screenshot artifact
+ *   - runtime_smoke MCP smoke / curl probe (Tester / Reviewer)
+ *   - review_static structured diff notes (Reviewer gate; no execution)
+ *
+ * The parsers are intentionally strict: they look for fingerprints that
+ * a real run produces (TS error lines, ESLint JSON shape, jest summary
+ * line, "Tests:" totals). An agent that submits "echo ok" gets
+ * `unverified` because none of the parsers match, and `passed=0`.
+ */
+
+import { createHash } from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+import { assertAgentCanActOnTask } from '@/lib/authz/agent-task';
+
+export type EvidenceGate =
+  | 'build_fast'
+  | 'test_full'
+  | 'review_static'
+  | 'runtime_ui'
+  | 'runtime_smoke';
+
+export const ALL_EVIDENCE_GATES: EvidenceGate[] = [
+  'build_fast',
+  'test_full',
+  'review_static',
+  'runtime_ui',
+  'runtime_smoke',
+];
+
+export interface SubmitEvidenceInput {
+  taskId: string;
+  /** `null` for operator-initiated entries (rare; mostly tests). */
+  actingAgentId: string | null;
+  gate: EvidenceGate;
+  command: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode: number;
+  durationMs?: number;
+  diffSha?: string;
+  artifactPaths?: string[];
+}
+
+export interface SubmitEvidenceResult {
+  ok: boolean;
+  evidenceId: string;
+  passed: boolean;
+  parsedSummary: ParsedSummary;
+  rejectReason?: string;
+}
+
+export interface ParsedSummary {
+  /** Which parser fingerprints matched the output. Empty = unverified. */
+  fingerprints: string[];
+  ts_errors?: number;
+  eslint_errors?: number;
+  eslint_warnings?: number;
+  tests_passed?: number;
+  tests_failed?: number;
+  tests_skipped?: number;
+  /** Free-form notes the parser surfaces (e.g. "no recognizable runner output"). */
+  notes?: string[];
+}
+
+export interface TaskEvidenceRow {
+  id: string;
+  task_id: string;
+  agent_id: string | null;
+  gate: EvidenceGate;
+  command: string;
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  duration_ms: number | null;
+  diff_sha: string | null;
+  artifact_paths: string | null;
+  parsed_summary: string | null;
+  passed: number;
+  reject_reason: string | null;
+  stdout_hash: string;
+  created_at: string;
+}
+
+// ─── Parsers ────────────────────────────────────────────────────────
+
+/**
+ * tsc parser. Pass iff exit_code === 0 AND no `error TS\d+:` lines anywhere.
+ * Fingerprint: the output contains a TS error line, OR exit_code === 0 and
+ * the command line invokes tsc/typecheck — empty success of tsc is a real
+ * signal but only when we can confirm tsc was actually invoked.
+ */
+function parseTsc(command: string, stdout: string, stderr: string, exitCode: number): {
+  matched: boolean;
+  passed: boolean;
+  errors: number;
+} {
+  const tscFingerprint =
+    /\btsc\b|\btypecheck\b/i.test(command) ||
+    /error TS\d{4}:/.test(stdout) ||
+    /error TS\d{4}:/.test(stderr);
+  if (!tscFingerprint) return { matched: false, passed: false, errors: 0 };
+  const errors =
+    (stdout.match(/error TS\d{4}:/g)?.length ?? 0) +
+    (stderr.match(/error TS\d{4}:/g)?.length ?? 0);
+  const passed = exitCode === 0 && errors === 0;
+  return { matched: true, passed, errors };
+}
+
+/**
+ * ESLint parser. Detects `eslint` invocation OR ESLint-shaped output (JSON
+ * array of {messages: [{severity}]}) or stylish format (`X problems (Y errors,
+ * Z warnings)`).
+ */
+function parseEslint(command: string, stdout: string, stderr: string, exitCode: number): {
+  matched: boolean;
+  passed: boolean;
+  errors: number;
+  warnings: number;
+} {
+  const isEslintCmd = /\beslint\b/i.test(command) || /\blint\b/i.test(command);
+  let errors = 0;
+  let warnings = 0;
+  let parsedJson = false;
+
+  // Stylish: "1 problem (1 error, 0 warnings)" or "✖ N problems (X errors, Y warnings)"
+  const stylish = stdout.match(/(\d+)\s+errors?,\s*(\d+)\s+warnings?/i);
+  if (stylish) {
+    errors = parseInt(stylish[1]!, 10);
+    warnings = parseInt(stylish[2]!, 10);
+  } else {
+    // Try JSON formatter output
+    try {
+      const trimmed = stdout.trim();
+      if (trimmed.startsWith('[')) {
+        const arr = JSON.parse(trimmed) as Array<{ messages?: Array<{ severity?: number }> }>;
+        if (Array.isArray(arr)) {
+          parsedJson = true;
+          for (const f of arr) {
+            for (const m of f.messages ?? []) {
+              if (m.severity === 2) errors++;
+              else if (m.severity === 1) warnings++;
+            }
+          }
+        }
+      }
+    } catch {
+      // not JSON
+    }
+  }
+
+  const matched = isEslintCmd || stylish != null || parsedJson;
+  if (!matched) return { matched: false, passed: false, errors: 0, warnings: 0 };
+  // ESLint exits 0 when only warnings, 1 when errors. Use both signals.
+  const passed = exitCode === 0 && errors === 0;
+  return { matched: true, passed, errors, warnings };
+  // stderr intentionally unused — eslint writes its report to stdout
+  void stderr;
+}
+
+/**
+ * Jest / Vitest / node:test summary parser. Looks for the canonical totals
+ * line. Falls back to TAP-style `# pass N` / `# fail N` for `tsx --test`.
+ */
+function parseTestRunner(command: string, stdout: string, stderr: string, exitCode: number): {
+  matched: boolean;
+  passed: boolean;
+  passed_count: number;
+  failed_count: number;
+  skipped_count: number;
+  runner: string | null;
+} {
+  // Jest/Vitest: "Tests:       1 failed, 4 passed, 1 skipped, 6 total"
+  const jestLine = (stdout + '\n' + stderr).match(
+    /Tests?:\s*(?:(\d+)\s+failed[,\s]*)?(?:(\d+)\s+passed[,\s]*)?(?:(\d+)\s+skipped[,\s]*)?(?:(\d+)\s+total)?/i,
+  );
+  if (jestLine && (jestLine[1] || jestLine[2] || jestLine[4])) {
+    const failed = parseInt(jestLine[1] ?? '0', 10);
+    const passed = parseInt(jestLine[2] ?? '0', 10);
+    const skipped = parseInt(jestLine[3] ?? '0', 10);
+    return {
+      matched: true,
+      passed: exitCode === 0 && failed === 0 && passed > 0,
+      passed_count: passed,
+      failed_count: failed,
+      skipped_count: skipped,
+      runner: 'jest-like',
+    };
+  }
+  // node:test TAP: "# pass N", "# fail N"
+  const tapPass = (stdout + '\n' + stderr).match(/^# pass\s+(\d+)/m);
+  const tapFail = (stdout + '\n' + stderr).match(/^# fail\s+(\d+)/m);
+  const tapSkip = (stdout + '\n' + stderr).match(/^# skipped?\s+(\d+)/m);
+  if (tapPass || tapFail) {
+    const passed = parseInt(tapPass?.[1] ?? '0', 10);
+    const failed = parseInt(tapFail?.[1] ?? '0', 10);
+    const skipped = parseInt(tapSkip?.[1] ?? '0', 10);
+    return {
+      matched: true,
+      passed: exitCode === 0 && failed === 0 && passed > 0,
+      passed_count: passed,
+      failed_count: failed,
+      skipped_count: skipped,
+      runner: 'tap',
+    };
+  }
+  // Playwright: "N passed (Xs)" / "N failed"
+  const pwPass = stdout.match(/^\s*(\d+)\s+passed\b/m);
+  const pwFail = stdout.match(/^\s*(\d+)\s+failed\b/m);
+  if (pwPass || pwFail) {
+    const passed = parseInt(pwPass?.[1] ?? '0', 10);
+    const failed = parseInt(pwFail?.[1] ?? '0', 10);
+    return {
+      matched: true,
+      passed: exitCode === 0 && failed === 0 && passed > 0,
+      passed_count: passed,
+      failed_count: failed,
+      skipped_count: 0,
+      runner: 'playwright',
+    };
+  }
+  // Command names a known runner but no recognizable output → unverified.
+  void command;
+  return { matched: false, passed: false, passed_count: 0, failed_count: 0, skipped_count: 0, runner: null };
+}
+
+/**
+ * Compose parsers per gate. Returns the pass/fail decision and the
+ * structured summary persisted alongside the raw output.
+ */
+function parseEvidence(
+  gate: EvidenceGate,
+  command: string,
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  artifactPaths: string[],
+): { passed: boolean; summary: ParsedSummary; rejectReason?: string } {
+  const summary: ParsedSummary = { fingerprints: [], notes: [] };
+
+  if (gate === 'build_fast') {
+    // build_fast = the union of fast checks. Pass iff every parser that
+    // matches passes AND at least one parser matched (so an agent can't
+    // submit `echo ok` and call it a typecheck).
+    const tsc = parseTsc(command, stdout, stderr, exitCode);
+    const eslint = parseEslint(command, stdout, stderr, exitCode);
+    const tests = parseTestRunner(command, stdout, stderr, exitCode);
+    if (tsc.matched) {
+      summary.fingerprints.push('tsc');
+      summary.ts_errors = tsc.errors;
+    }
+    if (eslint.matched) {
+      summary.fingerprints.push('eslint');
+      summary.eslint_errors = eslint.errors;
+      summary.eslint_warnings = eslint.warnings;
+    }
+    if (tests.matched) {
+      summary.fingerprints.push('test-runner');
+      summary.tests_passed = tests.passed_count;
+      summary.tests_failed = tests.failed_count;
+      summary.tests_skipped = tests.skipped_count;
+    }
+    if (summary.fingerprints.length === 0) {
+      return {
+        passed: false,
+        summary,
+        rejectReason:
+          'build_fast: no recognizable typecheck/lint/test output. Run tsc, eslint, or a focused jest/node:test run and submit the raw stdout.',
+      };
+    }
+    const passed =
+      (!tsc.matched || tsc.passed) &&
+      (!eslint.matched || eslint.passed) &&
+      (!tests.matched || tests.passed);
+    return { passed, summary };
+  }
+
+  if (gate === 'test_full') {
+    const tests = parseTestRunner(command, stdout, stderr, exitCode);
+    if (!tests.matched) {
+      return {
+        passed: false,
+        summary,
+        rejectReason:
+          'test_full: no recognizable test-runner summary in output. Submit the full output of `yarn test` (or equivalent).',
+      };
+    }
+    summary.fingerprints.push('test-runner');
+    summary.tests_passed = tests.passed_count;
+    summary.tests_failed = tests.failed_count;
+    summary.tests_skipped = tests.skipped_count;
+    return { passed: tests.passed, summary };
+  }
+
+  if (gate === 'runtime_ui') {
+    // Runtime UI must have at least one artifact (screenshot, trace, HAR).
+    if (artifactPaths.length === 0) {
+      return {
+        passed: false,
+        summary,
+        rejectReason:
+          'runtime_ui: at least one artifact_path (screenshot, trace.zip, HAR) is required. The artifact is the proof.',
+      };
+    }
+    summary.fingerprints.push('artifact');
+    // If the command happens to be a Playwright run, parse its summary too.
+    const tests = parseTestRunner(command, stdout, stderr, exitCode);
+    if (tests.matched) {
+      summary.fingerprints.push('test-runner');
+      summary.tests_passed = tests.passed_count;
+      summary.tests_failed = tests.failed_count;
+    }
+    // Pass iff exit_code === 0 and any test-runner that matched also passed.
+    const passed = exitCode === 0 && (!tests.matched || tests.passed);
+    return { passed, summary };
+  }
+
+  if (gate === 'runtime_smoke') {
+    // Smoke gate: exit_code === 0 and stdout is non-empty (something actually ran).
+    if (stdout.trim().length === 0 && stderr.trim().length === 0) {
+      return {
+        passed: false,
+        summary,
+        rejectReason: 'runtime_smoke: stdout and stderr both empty — looks like nothing ran.',
+      };
+    }
+    summary.fingerprints.push('exit-code');
+    const tests = parseTestRunner(command, stdout, stderr, exitCode);
+    if (tests.matched) {
+      summary.fingerprints.push('test-runner');
+      summary.tests_passed = tests.passed_count;
+      summary.tests_failed = tests.failed_count;
+    }
+    return { passed: exitCode === 0 && (!tests.matched || tests.passed), summary };
+  }
+
+  // review_static: judgment gate. Reviewer submits structured notes; we
+  // accept any non-empty stdout (their notes) and don't try to parse pass/fail.
+  // The `passed` here is "the reviewer recorded their review" — final
+  // approval still happens via status transition.
+  if (gate === 'review_static') {
+    if (stdout.trim().length === 0) {
+      return {
+        passed: false,
+        summary,
+        rejectReason: 'review_static: notes are required (submit the review text as stdout).',
+      };
+    }
+    summary.fingerprints.push('reviewer-notes');
+    return { passed: true, summary };
+  }
+
+  // Should be unreachable thanks to TS exhaustiveness, but be explicit.
+  return { passed: false, summary, rejectReason: `unknown gate: ${String(gate)}` };
+}
+
+// ─── Submission ─────────────────────────────────────────────────────
+
+export function submitEvidence(input: SubmitEvidenceInput): SubmitEvidenceResult {
+  const {
+    taskId,
+    actingAgentId,
+    gate,
+    command,
+    stdout = '',
+    stderr = '',
+    exitCode,
+    durationMs,
+    diffSha,
+    artifactPaths = [],
+  } = input;
+
+  // Authorization: only agents on the task (or operators with no agent_id)
+  // may submit evidence. Reuses the same predicate as deliverables.
+  if (actingAgentId) {
+    assertAgentCanActOnTask(actingAgentId, taskId, 'status');
+  }
+
+  // Parse first so a hard reject (no fingerprints) still gets persisted as
+  // failed evidence the operator can audit. Persisting rejected attempts
+  // is intentional — it's a record of the agent trying to short-circuit
+  // the gate.
+  const { passed, summary, rejectReason } = parseEvidence(
+    gate,
+    command,
+    stdout,
+    stderr,
+    exitCode,
+    artifactPaths,
+  );
+
+  const id = uuidv4();
+  const stdoutHash = createHash('sha256').update(stdout).digest('hex');
+
+  run(
+    `INSERT INTO task_evidence (
+       id, task_id, agent_id, gate, command, stdout, stderr,
+       exit_code, duration_ms, diff_sha, artifact_paths, parsed_summary,
+       passed, reject_reason, stdout_hash, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+    [
+      id,
+      taskId,
+      actingAgentId,
+      gate,
+      command,
+      stdout,
+      stderr,
+      exitCode,
+      durationMs ?? null,
+      diffSha ?? null,
+      artifactPaths.length > 0 ? JSON.stringify(artifactPaths) : null,
+      JSON.stringify(summary),
+      passed ? 1 : 0,
+      rejectReason ?? null,
+      stdoutHash,
+    ],
+  );
+
+  return {
+    ok: !rejectReason,
+    evidenceId: id,
+    passed,
+    parsedSummary: summary,
+    rejectReason,
+  };
+}
+
+// ─── Lookup helpers (used by checkStageEvidence) ────────────────────
+
+/**
+ * Most-recent evidence row for a (task, gate) pair, or null if none.
+ * Stage gates check this against `passed = 1` to admit a transition.
+ */
+export function getLatestEvidence(taskId: string, gate: EvidenceGate): TaskEvidenceRow | null {
+  return (
+    queryOne<TaskEvidenceRow>(
+      `SELECT * FROM task_evidence
+        WHERE task_id = ? AND gate = ?
+        ORDER BY created_at DESC, rowid DESC LIMIT 1`,
+      [taskId, gate],
+    ) ?? null
+  );
+}
+
+/** All evidence rows for a task, newest first. */
+export function listTaskEvidence(taskId: string): TaskEvidenceRow[] {
+  return queryAll<TaskEvidenceRow>(
+    `SELECT * FROM task_evidence WHERE task_id = ? ORDER BY created_at DESC`,
+    [taskId],
+  );
+}
+
+/**
+ * Has the task accumulated *any* evidence rows? Used by the stage gate to
+ * decide whether to enforce the new strict bar or fall back to the legacy
+ * deliverable-count check. Once a task has been routed through a flow that
+ * prescribes commands (slice 2), evidence rows should be present and the
+ * legacy fallback is bypassed.
+ */
+export function hasAnyEvidence(taskId: string): boolean {
+  const row = queryOne<{ count: number }>(
+    `SELECT COUNT(*) as count FROM task_evidence WHERE task_id = ?`,
+    [taskId],
+  );
+  return Number(row?.count ?? 0) > 0;
+}

--- a/src/lib/services/task-status.ts
+++ b/src/lib/services/task-status.ts
@@ -114,7 +114,7 @@ export function transitionTaskStatus(
 
   // Evidence gate for forward moves into quality stages.
   if (QUALITY_STAGES.has(newStatus) && !boardOverride) {
-    const evidence = checkStageEvidence(taskId);
+    const evidence = checkStageEvidence(taskId, newStatus);
     if (!evidence.ok) {
       return {
         ok: false,

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -1,7 +1,12 @@
 import { queryAll, queryOne, run, transaction } from '@/lib/db';
 import { notifyLearner } from '@/lib/learner';
 import { parsePlanningSpec } from '@/lib/planning-spec';
-import type { Task } from '@/lib/types';
+import {
+  hasAnyEvidence,
+  getLatestEvidence,
+  type EvidenceGate,
+} from '@/lib/services/task-evidence';
+import type { Task, TaskStatus } from '@/lib/types';
 
 const ACTIVE_STATUSES = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification'];
 const TERMINAL_STATUSES = ['done', 'cancelled'];
@@ -27,7 +32,50 @@ export interface StageEvidenceResult {
  * task_deliverables row carrying the matching spec_deliverable_id, otherwise
  * the gate rejects and lists the missing ones.
  */
-export function checkStageEvidence(taskId: string): StageEvidenceResult {
+/**
+ * Evidence gates required when transitioning forward INTO a quality stage.
+ * Once a task carries any task_evidence rows (i.e. has been routed through
+ * the prescribed-command flow), these are required and the legacy
+ * deliverable-count check is bypassed. Tasks without any evidence rows
+ * still satisfy the legacy bar — slice 2 will inject prescribed commands
+ * at dispatch which is what populates this table.
+ */
+const STAGE_REQUIRED_EVIDENCE: Partial<Record<TaskStatus, EvidenceGate[]>> = {
+  testing: ['build_fast'],
+  review: ['test_full'],
+  // `verification` and `done` reuse `review`'s artifacts; no new gate added
+  // here so we don't break any operator-driven completions.
+};
+
+export function checkStageEvidence(
+  taskId: string,
+  newStatus?: TaskStatus,
+): StageEvidenceResult {
+  // Strict path: when the task has any evidence rows, enforce the gate
+  // map for the target stage. Falling back to the legacy bar when no
+  // evidence has been recorded keeps existing flows unbroken until the
+  // dispatch path starts prescribing commands (slice 2).
+  if (newStatus && hasAnyEvidence(taskId)) {
+    const required = STAGE_REQUIRED_EVIDENCE[newStatus] ?? [];
+    for (const gate of required) {
+      const latest = getLatestEvidence(taskId, gate);
+      if (!latest) {
+        return {
+          ok: false,
+          reason: `Evidence gate: ${gate} required to enter ${newStatus}. Submit raw command output via submit_evidence.`,
+        };
+      }
+      if (latest.passed !== 1) {
+        return {
+          ok: false,
+          reason: `Evidence gate: latest ${gate} run did not pass${latest.reject_reason ? ` (${latest.reject_reason})` : ''}. Re-run and resubmit.`,
+        };
+      }
+    }
+    // Strict path satisfied — skip legacy deliverable bar.
+    return { ok: true };
+  }
+
   // role='output' filter: operator-attached inputs on task creation don't
   // count as evidence that the agent did any work.
   const deliverableCount = Number(


### PR DESCRIPTION
## Summary

Slice 1 of the autonomous-flow tightening (stacked on [#113](https://github.com/smb209/mission-control/pull/113)).

Replaces the self-attested evidence bar (≥1 deliverable + ≥1 activity) with a parsed-stdout model: agents submit the EXACT command they ran plus raw stdout/stderr/exit_code, and the server computes pass/fail. The agent never reports a boolean.

Five gates with parser fingerprints:
- \`build_fast\` — typecheck + lint + related-tests (Builder)
- \`test_full\` — full regression (Tester)
- \`runtime_ui\` — Playwright/preview + screenshot artifact (Tester)
- \`runtime_smoke\` — MCP smoke / curl probe (Tester / Reviewer)
- \`review_static\` — reviewer notes (judgment gate)

Parsers reject unrecognized output: an agent that submits \`echo ok\` or \`verified manually\` gets \`passed=0\` because no parser fingerprint matches. **Replay test confirms the AlertDialog Builder's \"TS clean, dev server verified\" self-attestation would now be rejected.**

Rejected attempts are still persisted as audit trail, with a sha256 hash of stdout for tamper-evidence.

\`checkStageEvidence\` is enhanced — once a task has any \`task_evidence\` rows, the strict path enforces the per-stage gate map (testing requires \`build_fast\`, review requires \`test_full\`). Tasks without evidence rows fall back to the legacy bar so existing flows keep working until slice 2 wires prescribed commands into dispatch.

## Changes

- Migration 058 + \`task_evidence\` table with stdout hash
- \`src/lib/services/task-evidence.ts\` — \`submitEvidence\`, parsers, lookup helpers
- \`submit_evidence\` MCP tool in \`src/lib/mcp/tools.ts\`
- \`checkStageEvidence\` extended with \`newStatus\` parameter and gate-by-stage map
- 14 unit tests including a replay test from the AlertDialog post-mortem

## Test plan

- [x] \`yarn tsc --noEmit\` (pre-existing pm-decompose.test.ts errors unrelated, verified against \`origin/main\`)
- [x] \`yarn tsx --test src/lib/services/task-evidence.test.ts\` — 14/14 passing
- [x] \`yarn tsx --test src/lib/services/services.test.ts\` — 31/31 passing (no regression)
- [x] Replay test: AlertDialog Builder's self-attestation rejected by build_fast parser

## Notes

Two pre-existing WIP changes unrelated to this slice are stashed locally (\`tasks.is_failed\` flag work for FM5, and \`register_deliverable\` count-readback). They'll be revisited in their respective slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)