### PR TITLE
feat(governance): structured is_failed flag replaces status_reason substring check

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -5,7 +5,7 @@ import { broadcast } from '@/lib/events';
 import { internalDispatch } from '@/lib/internal-dispatch';
 import { handleStageTransition, handleStageFailure, getTaskWorkflow, populateTaskRolesFromAgents } from '@/lib/workflow-engine';
 import { runPostStatusChangeSideEffects } from '@/lib/services/task-status';
-import { hasStageEvidence, checkStageEvidence, canUseBoardOverride, auditBoardOverride, taskCanBeDone, recordLearnerOnTransition, isTerminalStatus } from '@/lib/task-governance';
+import { hasStageEvidence, checkStageEvidence, canUseBoardOverride, auditBoardOverride, whyCannotBeDone, recordLearnerOnTransition, isTerminalStatus } from '@/lib/task-governance';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
 import { UpdateTaskSchema } from '@/lib/validation';
@@ -255,24 +255,33 @@ export async function PATCH(
         return NextResponse.json({ error: 'status_reason is required when failing a stage' }, { status: 400 });
       }
 
-      // Self-clear stale "Failed: …" reasons on successful recovery (mirror
-      // of the same check in services/task-status.ts:transitionTaskStatus).
-      // Without this, a task that was bounced by a prior reviewer and has
-      // since been re-tested + re-reviewed successfully still has the old
-      // failure text on the row, and taskCanBeDone's substring-includes-fail
-      // check rejects the final transition.
-      const existingReason = (existing as { status_reason?: string }).status_reason ?? '';
+      // Forward (non-failing) transitions clear the structured `is_failed`
+      // flag set by handleStageFailure on the prior loop, plus any stale
+      // "Failed: …" status_reason kept around for human readability. The
+      // flag is the source of truth read by taskCanBeDone — keeping it in
+      // sync replaces the substring check we used to do here.
+      const existingRow = existing as { status_reason?: string; is_failed?: number };
+      const existingReason = existingRow.status_reason ?? '';
+      const wasMarkedFailed = Number(existingRow.is_failed ?? 0) === 1;
       const shouldClearStaleFailure =
         !failingBackwards &&
         validatedData.status_reason === undefined &&
         /^failed:/i.test(existingReason.trim());
 
-      if (nextStatus === 'done' && !boardOverrideAllowed && !taskCanBeDone(id, { ignoreStaleFailureReason: shouldClearStaleFailure })) {
-        return NextResponse.json({ error: 'Cannot mark done: validation/evidence requirements not met' }, { status: 400 });
+      if (nextStatus === 'done' && !boardOverrideAllowed) {
+        const reason = whyCannotBeDone(id, {
+          ignoreFailureFlag: !failingBackwards && wasMarkedFailed,
+        });
+        if (reason) {
+          return NextResponse.json({ error: `Cannot mark done: ${reason}` }, { status: 400 });
+        }
       }
 
       if (shouldClearStaleFailure) {
         updates.push('status_reason = NULL');
+      }
+      if (!failingBackwards && wasMarkedFailed) {
+        updates.push('is_failed = 0');
       }
 
       updates.push('status = ?');

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3508,6 +3508,33 @@ const migrations: Migration[] = [
       console.log('[Migration 058] task_evidence created.');
     },
   },
+  {
+    id: '059',
+    name: 'tasks_is_failed_flag',
+    up: (db) => {
+      // Replace the brittle `status_reason.toLowerCase().includes('fail')`
+      // gate in `taskCanBeDone` with a structured boolean. PR #112 narrowly
+      // forgave the canonical "Failed:" prefix on recovery, but free-text
+      // status_reason values that legitimately contain "fail" (e.g. "all
+      // failure paths covered") still false-positive. With this flag,
+      // status_reason becomes purely descriptive — handleStageFailure sets
+      // is_failed=1, and successful forward transitions clear it.
+      const cols = db.prepare(`PRAGMA table_info(tasks)`).all() as Array<{ name: string }>;
+      if (!cols.some(c => c.name === 'is_failed')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN is_failed INTEGER NOT NULL DEFAULT 0`);
+      }
+      // Backfill: tasks currently carrying the canonical "Failed:" reason
+      // are the same set the substring check was rejecting. Marking them
+      // is_failed=1 preserves the prior block-on-done behavior; the next
+      // forward transition will clear both fields.
+      db.exec(
+        `UPDATE tasks SET is_failed = 1 WHERE is_failed = 0
+           AND status_reason IS NOT NULL
+           AND status_reason LIKE 'Failed:%'`,
+      );
+      console.log('[Migration 059] tasks.is_failed added + backfilled.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -74,6 +74,11 @@ CREATE TABLE IF NOT EXISTS tasks (
   planning_agents TEXT,
   planning_dispatch_error TEXT,
   status_reason TEXT,
+  -- Set to 1 by handleStageFailure when a task is bounced back from a
+  -- quality stage. Cleared by transitionTaskStatus on the next successful
+  -- forward transition. Read by taskCanBeDone — replaces the legacy
+  -- substring check on status_reason that false-positived on free text.
+  is_failed INTEGER NOT NULL DEFAULT 0,
   images TEXT,
   convoy_id TEXT,
   is_subtask INTEGER DEFAULT 0,

--- a/src/lib/services/task-status.ts
+++ b/src/lib/services/task-status.ts
@@ -29,7 +29,7 @@
 import { queryOne, run } from '@/lib/db';
 import {
   checkStageEvidence,
-  taskCanBeDone,
+  whyCannotBeDone,
   isTerminalStatus,
   auditBoardOverride,
 } from '@/lib/task-governance';
@@ -136,28 +136,32 @@ export function transitionTaskStatus(
     };
   }
 
-  // Self-clear stale failure reasons on successful recovery. handleStageFailure
-  // writes status_reason = "Failed: <text>" when bouncing a task back. If the
-  // work is later re-tested + re-reviewed and progresses forward again, that
-  // old reason is still on the row — and `taskCanBeDone` blocks the final
-  // transition to `done` because its substring check sees "fail". Clear the
-  // stale reason whenever the caller didn't explicitly set one AND we're
-  // moving forward (not failing-backwards), and only when the existing reason
-  // matches the canonical "Failed:" prefix produced by handleStageFailure —
-  // operator-set or other-source reasons (e.g. legacy "Validation failed:")
-  // are left alone.
+  // Forward (non-failing) transitions clear the structured `is_failed` flag
+  // and any stale "Failed:" status_reason from a prior loop. The flag is
+  // the single source of truth read by `taskCanBeDone` — keeping it in sync
+  // with the actual stage progression replaces the brittle substring check
+  // we used to do on status_reason.
+  const isExistingRow = existing as Task & { is_failed?: number; status_reason?: string };
+  const wasMarkedFailed = Number(isExistingRow.is_failed ?? 0) === 1;
   const shouldClearStaleFailure =
     !failingBackwards &&
     statusReason === undefined &&
-    typeof existing.status_reason === 'string' &&
-    /^failed:/i.test(existing.status_reason.trim());
+    typeof isExistingRow.status_reason === 'string' &&
+    /^failed:/i.test(isExistingRow.status_reason.trim());
 
-  if (newStatus === 'done' && !boardOverride && !taskCanBeDone(taskId, { ignoreStaleFailureReason: shouldClearStaleFailure })) {
-    return {
-      ok: false,
-      code: 'cannot_mark_done',
-      error: 'Cannot mark done: validation/evidence requirements not met',
-    };
+  if (newStatus === 'done' && !boardOverride) {
+    const reason = whyCannotBeDone(taskId, {
+      // The same UPDATE that performs this transition will clear is_failed,
+      // so don't block on it here.
+      ignoreFailureFlag: !failingBackwards && wasMarkedFailed,
+    });
+    if (reason) {
+      return {
+        ok: false,
+        code: 'cannot_mark_done',
+        error: `Cannot mark done: ${reason}`,
+      };
+    }
   }
 
   const now = new Date().toISOString();
@@ -168,6 +172,9 @@ export function transitionTaskStatus(
     values.push(statusReason);
   } else if (shouldClearStaleFailure) {
     updates.push('status_reason = NULL');
+  }
+  if (!failingBackwards && wasMarkedFailed) {
+    updates.push('is_failed = 0');
   }
   values.push(taskId);
   run(`UPDATE tasks SET ${updates.join(', ')} WHERE id = ?`, values);

--- a/src/lib/task-governance.test.ts
+++ b/src/lib/task-governance.test.ts
@@ -4,6 +4,7 @@ import { run, queryOne } from './db';
 import {
   hasStageEvidence,
   taskCanBeDone,
+  whyCannotBeDone,
   ensureFixerExists,
   getFailureCountInStage,
 } from './task-governance';
@@ -38,14 +39,17 @@ test('evidence gate requires deliverable + activity', () => {
   assert.equal(hasStageEvidence(taskId), true);
 });
 
-test('task cannot be done when status_reason indicates failure', () => {
+test('task cannot be done when is_failed flag is set', () => {
   const taskId = crypto.randomUUID();
   seedTask(taskId);
 
-  run(`UPDATE tasks SET status_reason = 'Validation failed: CSS broken' WHERE id = ?`, [taskId]);
+  // Free-text status_reason that legitimately contains "fail" no longer
+  // blocks — the structured flag is the source of truth. Set both to make
+  // the intent explicit.
+  run(`UPDATE tasks SET is_failed = 1, status_reason = 'Validation failed: CSS broken' WHERE id = ?`, [taskId]);
   run(
-    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, created_at)
-     VALUES (lower(hex(randomblob(16))), ?, 'file', 'index.html', datetime('now'))`,
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, role, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'file', 'index.html', 'output', datetime('now'))`,
     [taskId]
   );
   run(
@@ -54,12 +58,17 @@ test('task cannot be done when status_reason indicates failure', () => {
     [taskId]
   );
 
-  assert.equal(taskCanBeDone(taskId), false);
+  assert.equal(taskCanBeDone(taskId), false, 'is_failed=1 blocks');
 });
 
-test('ignoreStaleFailureReason forgives canonical "Failed:" prefix only', () => {
+test('descriptive status_reason containing "fail" no longer blocks (post is_failed flag)', () => {
   const taskId = crypto.randomUUID();
   seedTask(taskId);
+  // Common false-positive: descriptive text that mentions failure handling
+  // without actually being a failure — e.g. a successful task summarising
+  // its coverage. Pre-flag this would be rejected; now it's allowed because
+  // is_failed = 0.
+  run(`UPDATE tasks SET status_reason = 'all failure paths covered, fail-loud on missing config' WHERE id = ?`, [taskId]);
   run(
     `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, role, created_at)
      VALUES (lower(hex(randomblob(16))), ?, 'file', 'x.ts', 'output', datetime('now'))`,
@@ -71,14 +80,66 @@ test('ignoreStaleFailureReason forgives canonical "Failed:" prefix only', () => 
     [taskId]
   );
 
-  // Canonical handleStageFailure prefix — recovery path should forgive it.
-  run(`UPDATE tasks SET status_reason = 'Failed: CRITICAL — old reviewer finding' WHERE id = ?`, [taskId]);
-  assert.equal(taskCanBeDone(taskId), false, 'still blocks without the option');
-  assert.equal(taskCanBeDone(taskId, { ignoreStaleFailureReason: true }), true, 'option forgives canonical prefix');
+  assert.equal(taskCanBeDone(taskId), true);
+});
 
-  // Non-canonical "fail" reason — option must NOT forgive (still blocks).
-  run(`UPDATE tasks SET status_reason = 'Validation failed: CSS broken' WHERE id = ?`, [taskId]);
-  assert.equal(taskCanBeDone(taskId, { ignoreStaleFailureReason: true }), false, 'option still rejects non-canonical failures');
+test('ignoreFailureFlag bypasses is_failed for the same-UPDATE recovery path', () => {
+  const taskId = crypto.randomUUID();
+  seedTask(taskId);
+  run(`UPDATE tasks SET is_failed = 1 WHERE id = ?`, [taskId]);
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, role, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'file', 'x.ts', 'output', datetime('now'))`,
+    [taskId]
+  );
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'completed', 'did thing', datetime('now'))`,
+    [taskId]
+  );
+
+  assert.equal(taskCanBeDone(taskId), false, 'flag still blocks by default');
+  assert.equal(taskCanBeDone(taskId, { ignoreFailureFlag: true }), true, 'option lets the same-UPDATE recovery proceed');
+});
+
+test('whyCannotBeDone returns specific code-prefixed reasons', () => {
+  // Missing evidence path
+  const noEvidenceId = crypto.randomUUID();
+  seedTask(noEvidenceId);
+  const noEvidence = whyCannotBeDone(noEvidenceId);
+  assert.ok(noEvidence?.startsWith('code:evidence_gate'), `expected code:evidence_gate, got: ${noEvidence}`);
+
+  // is_failed flag path
+  const failedId = crypto.randomUUID();
+  seedTask(failedId);
+  run(`UPDATE tasks SET is_failed = 1 WHERE id = ?`, [failedId]);
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, role, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'file', 'x.ts', 'output', datetime('now'))`,
+    [failedId]
+  );
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'completed', 'did thing', datetime('now'))`,
+    [failedId]
+  );
+  const flagged = whyCannotBeDone(failedId);
+  assert.ok(flagged?.startsWith('code:task_marked_failed'), `expected code:task_marked_failed, got: ${flagged}`);
+
+  // Happy path returns null
+  const okId = crypto.randomUUID();
+  seedTask(okId);
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, role, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'file', 'x.ts', 'output', datetime('now'))`,
+    [okId]
+  );
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'completed', 'did thing', datetime('now'))`,
+    [okId]
+  );
+  assert.equal(whyCannotBeDone(okId), null);
 });
 
 test('ensureFixerExists creates fixer when missing', () => {

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -233,21 +233,48 @@ export async function recordLearnerOnTransition(taskId: string, previousStatus: 
   await notifyLearner(taskId, { previousStatus, newStatus, passed, failReason });
 }
 
+/**
+ * Return the specific reason a task cannot be marked done, or null if it
+ * can. Centralises the four distinct rejection paths so callers
+ * (transitionTaskStatus, the API PATCH route, MCP `update_task_status`)
+ * can surface the precise cause to the agent rather than the legacy
+ * generic "validation/evidence requirements not met". Each reason starts
+ * with a stable `code: …` prefix so smart callers can branch without
+ * parsing prose.
+ *
+ * The `ignoreFailureFlag` option is for transition paths that are about
+ * to clear `is_failed` in the same UPDATE — they shouldn't be blocked by
+ * the very flag they're erasing.
+ */
+export function whyCannotBeDone(
+  taskId: string,
+  opts: { ignoreFailureFlag?: boolean } = {},
+): string | null {
+  const task = queryOne<{ status: string; is_failed?: number }>(
+    'SELECT status, is_failed FROM tasks WHERE id = ?',
+    [taskId],
+  );
+  if (!task) return 'code:not_found — task does not exist';
+
+  const isFailed = !opts.ignoreFailureFlag && Number(task.is_failed ?? 0) === 1;
+  if (isFailed) {
+    return 'code:task_marked_failed — a prior stage flagged this task as failed; address the cause and clear the flag (a successful forward transition does so automatically)';
+  }
+
+  const evidence = checkStageEvidence(taskId);
+  if (!evidence.ok) {
+    // checkStageEvidence already produces a precise reason — surface it.
+    return `code:evidence_gate — ${evidence.reason || 'evidence requirements not met'}`;
+  }
+
+  return null;
+}
+
 export function taskCanBeDone(
   taskId: string,
-  opts: { ignoreStaleFailureReason?: boolean } = {},
+  opts: { ignoreFailureFlag?: boolean } = {},
 ): boolean {
-  const task = queryOne<{ status: string; status_reason?: string }>('SELECT status, status_reason FROM tasks WHERE id = ?', [taskId]);
-  if (!task) return false;
-  const reason = (task.status_reason || '').trim();
-  // The caller (transitionTaskStatus) detected a stale "Failed: …" reason
-  // that is about to be cleared by the same UPDATE — don't block the
-  // transition on the very reason we're erasing in the next statement.
-  // Only the canonical handleStageFailure prefix is forgiven; other
-  // failure-shaped reasons still block.
-  const isStaleAutoFailure = opts.ignoreStaleFailureReason && /^failed:/i.test(reason);
-  const hasValidationFailure = !isStaleAutoFailure && reason.toLowerCase().includes('fail');
-  return !hasValidationFailure && hasStageEvidence(taskId);
+  return whyCannotBeDone(taskId, opts) === null;
 }
 
 export function isActiveStatus(status: string): boolean {

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -333,9 +333,12 @@ export async function handleStageFailure(
     console.warn('[Workflow] composePriorStageReport failed:', err);
   }
 
-  // Update task status to the fail target
+  // Update task status to the fail target. Set the structured failure
+  // flag — this is the canonical source of truth read by taskCanBeDone.
+  // The "Failed: " prefix on status_reason is kept for human readability
+  // and audit timeline rendering, but the gate no longer parses it.
   run(
-    'UPDATE tasks SET status = ?, status_reason = ?, updated_at = ? WHERE id = ?',
+    'UPDATE tasks SET status = ?, status_reason = ?, is_failed = 1, updated_at = ? WHERE id = ?',
     [targetStatus, `Failed: ${failReason}`, now, taskId]
   );
 


### PR DESCRIPTION
## Summary

Replace the brittle \`status_reason.toLowerCase().includes('fail')\` gate in \`taskCanBeDone\` with a structured boolean column. [PR #112](https://github.com/smb209/mission-control/pull/112) narrowly forgave the canonical \`Failed:\` prefix on recovery, but free-text status_reason values that legitimately contain \"fail\" (e.g. \"all failure paths covered\") still false-positive. With this flag, status_reason becomes purely descriptive — \`handleStageFailure\` sets \`is_failed=1\`, and successful forward transitions clear it.

Also introduces \`whyCannotBeDone(taskId)\` so callers surface the precise rejection cause (\`code:task_marked_failed\`, \`code:evidence_gate\`, ...) instead of the legacy generic \"validation/evidence requirements not met\".

Stacked on [#114](https://github.com/smb209/mission-control/pull/114) (\`feat/evidence-gate\`) since both modify \`task-governance.ts\`. Migration renumbered to **059** since **058** is now \`task_evidence\`.

This satisfies **FM5** from [the autonomous-flow tightening spec](specs/autonomous-flow-tightening-spec.md) — better than the spec's proposal (broaden the regex), since it makes the failure state structured.

## Changes

- Migration 059 adds \`tasks.is_failed\` (default 0) + backfills from canonical \`Failed:\` reasons
- \`handleStageFailure\` sets \`is_failed=1\` alongside \`status_reason\`
- \`transitionTaskStatus\` clears \`is_failed=0\` on forward transitions
- New \`whyCannotBeDone(taskId)\` returns a coded rejection reason; \`taskCanBeDone\` is now a thin wrapper

## Test plan

- [x] \`yarn tsc --noEmit\` (pre-existing pm-decompose errors, unrelated)
- [x] 50/50 affected tests pass (task-governance + services + evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)