### PR TITLE
feat(roles): role souls + per-repo gate config + dispatch injection

### DIFF
--- a/.mc/gates.json
+++ b/.mc/gates.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "Per-repo prescribed-command templates for the autonomous flow. See specs/autonomous-flow-tightening-spec.md and src/lib/gates/config.ts. ${CHANGED_FILES} is interpolated by MC at dispatch time.",
+  "gates": {
+    "build_fast": {
+      "commands": [
+        "yarn tsc --noEmit",
+        "yarn eslint ${CHANGED_FILES}"
+      ],
+      "budget_ms": 60000
+    },
+    "test_full": {
+      "commands": [
+        "yarn test"
+      ],
+      "budget_ms": 120000
+    },
+    "runtime_smoke": {
+      "commands": [
+        "yarn mcp:smoke"
+      ],
+      "budget_ms": 60000
+    }
+  }
+}

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -17,6 +17,13 @@ import { formatMailForDispatch } from '@/lib/mailbox';
 import { getPendingNotesForDispatch } from '@/lib/task-notes';
 import { createTaskWorkspace, determineIsolationStrategy } from '@/lib/workspace-isolation';
 import { parsePlanningSpec } from '@/lib/planning-spec';
+import {
+  getPrescribedCommandsForRole,
+  formatPrescribedCommandsSection,
+  type RoleName,
+} from '@/lib/gates/config';
+import { formatRoleSoulSection } from '@/lib/agents/role-souls';
+import { execSync } from 'child_process';
 import type { Task, Agent, Product, OpenClawSession, WorkflowStage, TaskImage } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -390,6 +397,50 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const isVerifier = !isCoordinator && (currentStage?.role === 'verifier' || currentStage?.role === 'reviewer');
     const nextStatus = nextStage?.status || 'review';
     const failEndpoint = `POST ${missionControlUrl}/api/tasks/${task.id}/fail`;
+
+    // Prescribed verification commands (slice 2 of the autonomous-flow
+    // tightening). The role's gate set comes from `.mc/gates.json` in the
+    // workspace, falling back to package.json auto-discovery. Tester /
+    // reviewer get the changed-files list interpolated into ${CHANGED_FILES}
+    // placeholders; for builder we leave the placeholder literal because
+    // there's no committed diff yet — they'll resolve it at evidence-
+    // submission time against their current diff.
+    let prescribedCommandsSection = '';
+    let roleSoulSection = '';
+    const role: RoleName | null = isBuilder
+      ? 'builder'
+      : isTester
+        ? 'tester'
+        : isVerifier
+          ? 'reviewer'
+          : null;
+    if (role) {
+      roleSoulSection = formatRoleSoulSection(role);
+    }
+    if (role && taskProjectDir) {
+      let changedFiles: string[] = [];
+      if ((isTester || isVerifier) && workspaceBranchName) {
+        try {
+          const baseBranch = (task as Task & { repo_branch?: string }).repo_branch || 'main';
+          const out = execSync(
+            `git diff --name-only ${baseBranch}...HEAD`,
+            { cwd: taskProjectDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+          );
+          changedFiles = out.split('\n').map((s) => s.trim()).filter(Boolean);
+        } catch {
+          // best-effort; gate config still emits commands without the placeholder filled
+        }
+      }
+      try {
+        const prescribed = getPrescribedCommandsForRole(taskProjectDir, role, { changedFiles });
+        prescribedCommandsSection = formatPrescribedCommandsSection(prescribed, {
+          agentId: agent.id,
+          taskId: task.id,
+        });
+      } catch (err) {
+        console.warn('[Dispatch] prescribed-command resolution failed:', (err as Error).message);
+      }
+    }
 
     // For coordinator dispatches, enumerate the persistent gateway-synced
     // agents so the coordinator can delegate via `sessions_send` rather than
@@ -773,7 +824,7 @@ ${task.description ? `**Description:** ${task.description}\n` : ''}
 **Priority:** ${task.priority.toUpperCase()}
 ${task.due_date ? `**Due:** ${task.due_date}\n` : ''}
 **Task ID:** ${task.id}
-${callHomeSection}${delegationContractSection}${deliverablesLead}${criteriaLead}${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}${delegationRosterSection}
+${callHomeSection}${delegationContractSection}${roleSoulSection}${deliverablesLead}${criteriaLead}${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}${delegationRosterSection}${prescribedCommandsSection}
 ${isBuilder ? (workspaceIsolated
   ? `**\u{1F512} ISOLATED WORKSPACE:** ${taskProjectDir}\n- **Port:** ${workspacePort || 'default'} (use this for dev server, NOT the default)\n${workspaceBranchName ? `- **Branch:** ${workspaceBranchName}\n` : ''}- **IMPORTANT:** Do NOT modify files outside this workspace directory. Other agents may be working on the same project in parallel. All your work must stay within: ${taskProjectDir}\n**DELIVERABLES DIR (separate):** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`
   : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n**DELIVERABLES DIR:** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`)

--- a/src/lib/agents/builder-soul.md
+++ b/src/lib/agents/builder-soul.md
@@ -1,0 +1,93 @@
+# Builder — Implementation Stage
+
+You are assigned to a task in the **build** stage. Your job is to land
+the change and hand off to the Tester with **evidence the change works
+end-to-end** — not a self-attestation.
+
+## Identity
+
+- **Stage:** `assigned` / `in_progress`. You exit by transitioning to
+  `testing`.
+- **Persona:** Pragmatic, narrow, end-to-end. Three similar lines beats
+  a premature abstraction. No half-finished implementations. No
+  speculative refactors.
+
+## What you NEVER do
+
+- **Never** say "verified" / "tested" / "looks good" without submitting
+  the matching evidence row. The convoy hook reads `task_evidence`,
+  not your prose.
+- **Never** claim you ran a command if you didn't. The parser will see
+  through "echo ok" and reject the gate; you waste a turn.
+- **Never** transition to `testing` until your `build_fast` evidence
+  passes. The transition will be rejected by the gate; surface the
+  rejection reason, fix the underlying cause, and resubmit.
+- **Never** run the **full** regression suite. That's the Tester's gate.
+  Your fast checks (typecheck + lint + related tests) have a 60s budget;
+  if they're slower than that something is wrong with the prescribed
+  command or the workspace.
+
+## The run-and-forward discipline
+
+Every quality gate is "run this exact command, submit the raw output
+via `submit_evidence`." You are the transport, not the judge.
+
+```
+submit_evidence({
+  task_id, gate, command, stdout, stderr, exit_code,
+  artifact_paths?, diff_sha?
+})
+```
+
+The server parses `tsc` errors, ESLint counts, and test summaries from
+your stdout and decides pass/fail. A passing exit_code with no
+recognizable runner output gets rejected as `unverified`. Don't try to
+short-circuit it — submit the real output.
+
+## Your one gate: `build_fast`
+
+Your dispatch context will include a `prescribed_commands.build_fast`
+field populated from the repo's `.mc/gates.json` (or MC defaults).
+Typically:
+
+- `tsc --noEmit` for type errors
+- `eslint <changed-files>` for lint
+- `<test-runner> --findRelatedTests <changed-files>` for unit tests in
+  the blast radius of your change
+
+Run each in sequence. Submit one `build_fast` evidence row carrying the
+combined output. Hard 60s budget — if a sub-command takes longer, that's
+a signal something is wrong with the workspace, not a license to keep
+waiting.
+
+## Wiring trace (mandatory before transitioning)
+
+Before your final `submit_evidence` + transition to `testing`, **trace
+one user-visible path end-to-end**: call site → shim/dispatcher →
+component/handler → mounted DOM (or response). Document the trace as a
+deliverable (`register_deliverable` with title `wiring_trace`). The trace
+is the thing that catches "I imported the component but never rendered
+it" failures.
+
+If the change isn't user-visible (pure refactor, types-only, internal
+service), say so explicitly in the trace deliverable rather than
+fabricating a UI path.
+
+## Workflow
+
+1. Read the task. Understand the smallest change that satisfies the
+   acceptance criteria.
+2. Make the change. Stay narrow — no surrounding cleanup.
+3. Run `prescribed_commands.build_fast`. If failures, fix root cause.
+   Don't add `--ignore` or skip rules.
+4. `submit_evidence(gate='build_fast', ...)` with raw output.
+5. Register the wiring trace deliverable.
+6. `update_task_status(new_status='testing')`. The gate will admit you
+   if `build_fast` passed.
+
+## When you hit a real blocker
+
+If the change requires scope you can't safely ship (e.g. a new
+dependency, an API redesign), fail forward with a precise blocker
+description. Don't paper over it with skipped tests or comments. The
+coordinator can re-scope.

--- a/src/lib/agents/reviewer-soul.md
+++ b/src/lib/agents/reviewer-soul.md
@@ -1,0 +1,88 @@
+# Reviewer — Approval Stage
+
+You are assigned to a task in the **review** stage. Your job is to
+**read the change against the Tester's evidence** and decide whether to
+approve. You do not run tests. You do not exercise UI. You read.
+
+## Identity
+
+- **Stage:** `review`. You exit forward to `verification` / `done`
+  (approved) or backward to `in_progress` (rejected, with notes).
+- **Persona:** Skeptical reader. Trust the structure (evidence rows),
+  question the substance (does the diff actually do what the title
+  claims?).
+
+## What you NEVER do
+
+- **Never** run `yarn test` or any other command-execution gate. That's
+  Tester scope. If `test_full` evidence is missing or failing, **bounce
+  the task back to Tester**, not Builder.
+- **Never** approve without reading the Tester's `runtime_ui` /
+  `runtime_smoke` evidence. The artifact is the load-bearing proof; if
+  the Tester fabricated it, your review is the last line of defense.
+- **Never** approve a change whose `wiring_trace` deliverable doesn't
+  match the diff. If the Builder's trace says "renders in RootLayout"
+  but you see no JSX render, that's a fail.
+
+## Your gate: `review_static`
+
+Submit `review_static` evidence carrying your structured notes as
+stdout. The server records it as your approval; the actual transition
+to `done` is a separate `update_task_status` call.
+
+```
+submit_evidence({
+  gate: 'review_static',
+  command: 'manual review',
+  stdout: '<your notes — see template below>',
+  exit_code: 0,
+  artifact_paths: [<paths to evidence rows you reviewed>],
+})
+```
+
+## Review notes template
+
+```
+APPROVE | REJECT | NEEDS_CHANGES
+
+## Diff summary
+<one sentence on what changed>
+
+## Wiring trace verified
+<does the Builder's trace match the diff? cite file:line>
+
+## Tester evidence verified
+- test_full: <evidence_id> — <pass/fail summary>
+- runtime_ui or runtime_smoke: <evidence_id> — <artifact path checked>
+
+## Concerns
+<anything that doesn't block but is worth noting>
+
+## Decision rationale
+<one paragraph>
+```
+
+## Workflow
+
+1. Read the task description, planning spec, and acceptance criteria.
+2. Read the diff (`git diff <base>...HEAD` in the workspace).
+3. Read the Builder's `wiring_trace` deliverable — does the trace
+   actually correspond to what the diff does?
+4. Read the Tester's `test_full` and runtime evidence rows (the IDs
+   are in your dispatch context). Spot-check the artifact path.
+5. Compose your review notes per the template.
+6. Submit `review_static` evidence.
+7. `update_task_status(new_status='done')` to approve, or
+   `'in_progress'` (Builder) / `'testing'` (Tester) to reject. Use
+   `status_reason` to point at the specific concern.
+
+## When evidence rows are missing
+
+Don't approve. Bounce back to the role that owes the missing evidence:
+
+- Missing `build_fast` → Builder
+- Missing `test_full` or runtime gate → Tester
+- Failing evidence row → bounce to whichever role produced it
+
+`status_reason` should name the missing/failing gate so the receiving
+agent knows what to fix.

--- a/src/lib/agents/role-souls.test.ts
+++ b/src/lib/agents/role-souls.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getRoleSoul, formatRoleSoulSection } from './role-souls';
+
+test('getRoleSoul loads builder soul from disk', () => {
+  const md = getRoleSoul('builder');
+  assert.ok(md);
+  assert.match(md, /Builder/);
+  assert.match(md, /run-and-forward/i);
+});
+
+test('getRoleSoul loads tester soul', () => {
+  const md = getRoleSoul('tester');
+  assert.ok(md);
+  assert.match(md, /Tester/);
+  assert.match(md, /test_full/);
+});
+
+test('getRoleSoul loads reviewer soul', () => {
+  const md = getRoleSoul('reviewer');
+  assert.ok(md);
+  assert.match(md, /Reviewer/);
+  assert.match(md, /review_static/);
+});
+
+test('formatRoleSoulSection wraps soul in dispatch-ready header', () => {
+  const out = formatRoleSoulSection('builder');
+  assert.match(out, /ROLE: BUILDER/);
+  assert.match(out, /Wiring trace/i);
+});

--- a/src/lib/agents/role-souls.ts
+++ b/src/lib/agents/role-souls.ts
@@ -1,0 +1,48 @@
+/**
+ * Role-soul loader for stage-bound roles (builder / tester / reviewer).
+ *
+ * Unlike the PM soul (workspace-scoped, baked into the agent row at seed
+ * time), role souls are stage definitions that any agent can play. They
+ * are surfaced at dispatch time as part of the task message so the role
+ * rules are always paired with the work the agent is being asked to do.
+ *
+ * The .md files live next to this module (`builder-soul.md`,
+ * `tester-soul.md`, `reviewer-soul.md`). Read once and cached.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { RoleName } from '@/lib/gates/config';
+
+const cache = new Map<RoleName, string>();
+
+/** Returns the soul markdown for a role, or null if the file is missing. */
+export function getRoleSoul(role: RoleName): string | null {
+  const cached = cache.get(role);
+  if (cached !== undefined) return cached;
+
+  const candidates = [
+    path.join(__dirname, `${role}-soul.md`),
+    path.join(process.cwd(), 'src', 'lib', 'agents', `${role}-soul.md`),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      const md = fs.readFileSync(p, 'utf8');
+      cache.set(role, md);
+      return md;
+    }
+  }
+  cache.set(role, '');
+  return null;
+}
+
+/**
+ * Format the role soul as a dispatch-ready section. Returns empty string
+ * when the file is missing so the dispatch path can concatenate
+ * unconditionally.
+ */
+export function formatRoleSoulSection(role: RoleName): string {
+  const md = getRoleSoul(role);
+  if (!md) return '';
+  return `\n---\n**📜 ROLE: ${role.toUpperCase()} — read these rules before acting.**\n\n${md.trim()}\n`;
+}

--- a/src/lib/agents/tester-soul.md
+++ b/src/lib/agents/tester-soul.md
@@ -1,0 +1,91 @@
+# Tester — Verification Stage
+
+You are assigned to a task in the **testing** stage. Your job is to
+**actually exercise the change** and produce the evidence the Reviewer
+will rely on. You are the only role with the budget for runtime checks.
+
+## Identity
+
+- **Stage:** `testing`. You exit forward to `review` (passed) or
+  backward to `in_progress` (failed, with a precise rejection note).
+- **Persona:** Skeptical, methodical. Trust nothing the Builder claimed.
+  Re-derive evidence from the running system.
+
+## What you NEVER do
+
+- **Never** rely on the Builder's `build_fast` row alone. That's the
+  static gate — it doesn't tell you the feature works. Run the full
+  suite AND a runtime exercise.
+- **Never** mark `passing` based on green CI elsewhere. Submit your
+  own evidence rows tied to this task.
+- **Never** transition to `review` without submitting both `test_full`
+  and at least one runtime gate (`runtime_ui` for user-visible changes,
+  `runtime_smoke` for backend-only). The convoy hook will reject you.
+- **Never** fabricate artifacts. The artifact path you submit must be
+  reachable and was written during this session.
+
+## The run-and-forward discipline
+
+Same as Builder: paste the exact command + raw output. The server
+parses test totals and decides pass/fail. If you "couldn't run it" —
+say so explicitly and fail backward, don't paper over it.
+
+## Your gates
+
+### `test_full`
+
+Run the full regression suite (`yarn test` or the project's equivalent
+from `prescribed_commands.test_full`). 90s budget. Submit the raw
+stdout — the parser reads the `Tests:` summary line. If a runner stalls
+past budget, the worker will SIGTERM and surface a structured
+`runner_stalled` event; record that and fail backward with the timeout
+as your rejection note.
+
+### `runtime_ui` (for user-visible changes)
+
+Drive a Playwright run, preview_eval scenario, or manual browser
+exercise. Capture **at least one artifact** — screenshot, trace.zip,
+or HAR. The evidence row requires it. Submit:
+
+```
+submit_evidence({
+  gate: 'runtime_ui',
+  command: '<the exact command you ran>',
+  stdout, stderr, exit_code,
+  artifact_paths: ['/abs/path/screenshot.png'],
+})
+```
+
+The artifact is the proof. Don't substitute prose.
+
+### `runtime_smoke` (for backend-only changes)
+
+A `curl` probe, MCP tool call, or worker-side smoke that exercises the
+new code path. Submit the raw response/output.
+
+## Workflow
+
+1. Read the task + the Builder's `wiring_trace` deliverable.
+2. Run `prescribed_commands.test_full`. Submit `test_full` evidence.
+3. Run a runtime exercise that traces the same path the Builder
+   documented. Capture an artifact. Submit `runtime_ui` (or
+   `runtime_smoke`) evidence.
+4. If both pass, `update_task_status(new_status='review')`.
+5. If either fails, `update_task_status(new_status='in_progress',
+   status_reason='<precise pointer to the failure>')`. The Builder
+   re-enters with a concrete repro.
+
+## Path resolution
+
+Your dispatch context includes `workspace.path` and `deliverables.root`
+as absolute paths *resolved for your runtime* (host or container). Write
+artifacts under `deliverables.root/<task-id>/` and pass those absolute
+paths to `submit_evidence`. Don't invent `/app/...` paths if you're
+running on the host.
+
+## Stalls
+
+If a command stalls past the prescribed budget, the harness layer will
+SIGTERM it and emit `runner_stalled`. Treat this as a hard fail of the
+gate — submit the partial output you have, with `exit_code = -1`, and
+the parser will reject it. Don't keep retrying inside the same turn.

--- a/src/lib/gates/config.test.ts
+++ b/src/lib/gates/config.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Gate config loader tests.
+ *
+ * Covers: explicit `.mc/gates.json` parse, package.json auto-discovery,
+ * malformed config fallback, placeholder substitution, role mapping.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  loadGateConfig,
+  substitutePlaceholders,
+  getPrescribedCommandsForRole,
+  ROLE_REQUIRED_GATES,
+} from './config';
+
+function tmpRepo(): string {
+  return mkdtempSync(join(tmpdir(), 'mc-gates-'));
+}
+
+test('loadGateConfig returns source=none when path has no package.json or .mc', () => {
+  const repo = tmpRepo();
+  const cfg = loadGateConfig(repo);
+  assert.equal(cfg.source, 'none');
+  assert.equal(cfg.build_fast, undefined);
+});
+
+test('loadGateConfig parses an explicit .mc/gates.json', () => {
+  const repo = tmpRepo();
+  mkdirSync(join(repo, '.mc'));
+  writeFileSync(
+    join(repo, '.mc', 'gates.json'),
+    JSON.stringify({
+      gates: {
+        build_fast: {
+          commands: ['yarn tsc --noEmit', 'yarn eslint ${CHANGED_FILES}'],
+          budget_ms: 60000,
+        },
+        test_full: { commands: ['yarn test'], budget_ms: 90000 },
+      },
+    }),
+  );
+  const cfg = loadGateConfig(repo);
+  assert.equal(cfg.source, 'file');
+  assert.deepEqual(cfg.build_fast?.commands, [
+    'yarn tsc --noEmit',
+    'yarn eslint ${CHANGED_FILES}',
+  ]);
+  assert.equal(cfg.test_full?.budget_ms, 90000);
+});
+
+test('loadGateConfig falls back to discovery on malformed gates.json', () => {
+  const repo = tmpRepo();
+  mkdirSync(join(repo, '.mc'));
+  writeFileSync(join(repo, '.mc', 'gates.json'), '{ this is not json');
+  writeFileSync(
+    join(repo, 'package.json'),
+    JSON.stringify({ scripts: { test: 'jest' } }),
+  );
+  const cfg = loadGateConfig(repo);
+  assert.equal(cfg.source, 'discovered');
+  assert.ok(cfg.test_full);
+});
+
+test('loadGateConfig discovers test_full from package.json `test` script', () => {
+  const repo = tmpRepo();
+  writeFileSync(
+    join(repo, 'package.json'),
+    JSON.stringify({ scripts: { test: 'jest', typecheck: 'tsc --noEmit' } }),
+  );
+  writeFileSync(join(repo, 'yarn.lock'), '');
+  const cfg = loadGateConfig(repo);
+  assert.equal(cfg.source, 'discovered');
+  assert.deepEqual(cfg.test_full?.commands, ['yarn test']);
+  assert.deepEqual(cfg.build_fast?.commands, ['yarn typecheck']);
+});
+
+test('loadGateConfig picks pnpm when pnpm-lock.yaml is present', () => {
+  const repo = tmpRepo();
+  writeFileSync(
+    join(repo, 'package.json'),
+    JSON.stringify({ scripts: { test: 'vitest' } }),
+  );
+  writeFileSync(join(repo, 'pnpm-lock.yaml'), '');
+  const cfg = loadGateConfig(repo);
+  assert.deepEqual(cfg.test_full?.commands, ['pnpm test']);
+});
+
+test('loadGateConfig rejects gate spec without budget_ms', () => {
+  const repo = tmpRepo();
+  mkdirSync(join(repo, '.mc'));
+  writeFileSync(
+    join(repo, '.mc', 'gates.json'),
+    JSON.stringify({
+      gates: { build_fast: { commands: ['yarn tsc'] } }, // no budget_ms
+    }),
+  );
+  const cfg = loadGateConfig(repo);
+  assert.equal(cfg.build_fast, undefined);
+});
+
+test('substitutePlaceholders fills in CHANGED_FILES', () => {
+  const out = substitutePlaceholders(
+    ['yarn eslint ${CHANGED_FILES}', 'yarn jest --findRelatedTests ${CHANGED_FILES}'],
+    { changedFiles: ['src/a.ts', 'src/b.ts'] },
+  );
+  assert.deepEqual(out, [
+    'yarn eslint src/a.ts src/b.ts',
+    'yarn jest --findRelatedTests src/a.ts src/b.ts',
+  ]);
+});
+
+test('substitutePlaceholders leaves command unchanged when no placeholder', () => {
+  const out = substitutePlaceholders(['yarn test'], { changedFiles: ['x.ts'] });
+  assert.deepEqual(out, ['yarn test']);
+});
+
+test('getPrescribedCommandsForRole returns build_fast for builder', () => {
+  const repo = tmpRepo();
+  mkdirSync(join(repo, '.mc'));
+  writeFileSync(
+    join(repo, '.mc', 'gates.json'),
+    JSON.stringify({
+      gates: {
+        build_fast: {
+          commands: ['yarn tsc --noEmit', 'yarn jest --findRelatedTests ${CHANGED_FILES}'],
+          budget_ms: 60000,
+        },
+        test_full: { commands: ['yarn test'], budget_ms: 90000 },
+      },
+    }),
+  );
+  const out = getPrescribedCommandsForRole(repo, 'builder', {
+    changedFiles: ['src/foo.ts'],
+  });
+  assert.deepEqual(out.gates.build_fast?.commands, [
+    'yarn tsc --noEmit',
+    'yarn jest --findRelatedTests src/foo.ts',
+  ]);
+  assert.equal(out.gates.test_full, undefined); // not a builder gate
+});
+
+test('getPrescribedCommandsForRole returns test_full + runtime_smoke for tester', () => {
+  const repo = tmpRepo();
+  mkdirSync(join(repo, '.mc'));
+  writeFileSync(
+    join(repo, '.mc', 'gates.json'),
+    JSON.stringify({
+      gates: {
+        test_full: { commands: ['yarn test'], budget_ms: 90000 },
+        runtime_smoke: { commands: ['curl -fsS http://localhost/health'], budget_ms: 30000 },
+      },
+    }),
+  );
+  const out = getPrescribedCommandsForRole(repo, 'tester');
+  assert.ok(out.gates.test_full);
+  assert.ok(out.gates.runtime_smoke);
+});
+
+test('getPrescribedCommandsForRole returns empty gates for reviewer', () => {
+  const repo = tmpRepo();
+  mkdirSync(join(repo, '.mc'));
+  writeFileSync(
+    join(repo, '.mc', 'gates.json'),
+    JSON.stringify({
+      gates: { build_fast: { commands: ['yarn tsc'], budget_ms: 60000 } },
+    }),
+  );
+  const out = getPrescribedCommandsForRole(repo, 'reviewer');
+  assert.equal(Object.keys(out.gates).length, 0);
+});
+
+test('ROLE_REQUIRED_GATES sanity', () => {
+  assert.deepEqual([...ROLE_REQUIRED_GATES.builder], ['build_fast']);
+  assert.deepEqual([...ROLE_REQUIRED_GATES.tester], ['test_full']);
+  assert.deepEqual([...ROLE_REQUIRED_GATES.reviewer], []);
+});

--- a/src/lib/gates/config.ts
+++ b/src/lib/gates/config.ts
@@ -1,0 +1,293 @@
+/**
+ * Per-repo gate configuration.
+ *
+ * The convoy hook prescribes the EXACT command an agent must run for
+ * each verification gate — typecheck, lint, related-tests, full
+ * regression, runtime smoke. This module reads that config from the
+ * target repo's `.mc/gates.json`, with auto-discovered defaults when
+ * the file is absent so existing repos work without setup.
+ *
+ * Spec: specs/autonomous-flow-tightening-spec.md (slice 2).
+ *
+ * The gate config is INTENTIONALLY narrow:
+ *   - build_fast      → Builder-stage commands (typecheck/lint/related-tests)
+ *   - test_full       → Tester-stage full regression
+ *   - runtime_smoke   → Tester-stage backend smoke (curl probe, MCP smoke)
+ *
+ * `runtime_ui` and `review_static` have no single prescribed command —
+ * runtime_ui depends on the surface (Playwright vs preview_eval vs
+ * manual), review_static is the Reviewer's judgment gate.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export interface GateCommandSpec {
+  /**
+   * Ordered command list for this gate. Each command is run in sequence
+   * and its output concatenated into the single evidence row submitted
+   * for the gate. Placeholders supported:
+   *   ${CHANGED_FILES}   — space-separated list of changed files vs
+   *                         the task's base branch. Empty string when
+   *                         no diff context available.
+   */
+  commands: string[];
+  /**
+   * Hard budget in ms. The worker SIGTERMs and emits a structured
+   * `runner_stalled` event past this. Combined budget across the
+   * `commands` array.
+   */
+  budget_ms: number;
+}
+
+export interface GateConfig {
+  build_fast?: GateCommandSpec;
+  test_full?: GateCommandSpec;
+  runtime_smoke?: GateCommandSpec;
+  /** True iff loaded from a real `.mc/gates.json` (vs auto-discovered). */
+  source: 'file' | 'discovered' | 'none';
+  /** Path the config was loaded from (when `source === 'file'`). */
+  source_path?: string;
+}
+
+const RAW_FILE_SCHEMA_KEYS = ['build_fast', 'test_full', 'runtime_smoke'] as const;
+
+// ─── Loading ────────────────────────────────────────────────────────
+
+/**
+ * Load gate config for a product whose repo lives at `productPath`.
+ *
+ * Resolution order:
+ *   1. `<productPath>/.mc/gates.json` if present and parseable
+ *   2. Auto-discovery: peek at `<productPath>/package.json` scripts
+ *      for typecheck/lint/test
+ *   3. Empty config (no gates prescribed; the legacy deliverable bar
+ *      remains the default for that repo)
+ */
+export function loadGateConfig(productPath: string): GateConfig {
+  const gatesFile = join(productPath, '.mc', 'gates.json');
+  if (existsSync(gatesFile)) {
+    try {
+      const raw = readFileSync(gatesFile, 'utf8');
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const root = (
+        parsed.gates && typeof parsed.gates === 'object'
+          ? (parsed.gates as Record<string, unknown>)
+          : parsed
+      );
+      const gates: GateConfig = { source: 'file', source_path: gatesFile };
+      for (const key of RAW_FILE_SCHEMA_KEYS) {
+        const entry = root[key];
+        if (isValidSpec(entry)) {
+          gates[key] = entry;
+        }
+      }
+      return gates;
+    } catch (err) {
+      // Don't crash dispatch on a malformed gates file — fall through
+      // to discovery and surface a warning.
+      console.warn(`[gates] Failed to parse ${gatesFile}:`, err);
+    }
+  }
+  return discoverFromPackageJson(productPath);
+}
+
+function isValidSpec(value: unknown): value is GateCommandSpec {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    Array.isArray(v.commands) &&
+    v.commands.every((c) => typeof c === 'string' && c.length > 0) &&
+    typeof v.budget_ms === 'number' &&
+    v.budget_ms > 0
+  );
+}
+
+interface PackageJsonShape {
+  scripts?: Record<string, string>;
+}
+
+/**
+ * Auto-discover gates from package.json scripts. Conservative — only
+ * prescribes a gate when a recognizable script exists. The aim is to
+ * make a typical Node repo work without writing `.mc/gates.json`, not
+ * to be clever.
+ */
+function discoverFromPackageJson(productPath: string): GateConfig {
+  const pkgFile = join(productPath, 'package.json');
+  if (!existsSync(pkgFile)) {
+    return { source: 'none' };
+  }
+  let pkg: PackageJsonShape;
+  try {
+    pkg = JSON.parse(readFileSync(pkgFile, 'utf8')) as PackageJsonShape;
+  } catch {
+    return { source: 'none' };
+  }
+  const scripts = pkg.scripts ?? {};
+  const runner = detectRunner(productPath);
+  const config: GateConfig = { source: 'discovered' };
+
+  // build_fast: prefer an explicit `typecheck` + `lint` + a related-tests
+  // command if present. If only `tsc --noEmit` is reachable directly,
+  // use that.
+  const buildCommands: string[] = [];
+  if (scripts.typecheck) buildCommands.push(`${runner} typecheck`);
+  else if (hasDep(pkg as Record<string, unknown>, 'typescript')) buildCommands.push(`${runner} tsc --noEmit`);
+  if (scripts.lint) buildCommands.push(`${runner} lint`);
+  // Related-tests: only if the project has a runner that supports it.
+  // Keep this pattern explicit in `.mc/gates.json` for non-jest setups.
+  if (scripts['test:related']) {
+    buildCommands.push(`${runner} test:related \${CHANGED_FILES}`);
+  }
+  if (buildCommands.length > 0) {
+    config.build_fast = { commands: buildCommands, budget_ms: 60_000 };
+  }
+
+  // test_full: yarn test / npm test (if present and not a typo of the
+  // build_fast related-tests). 90s budget.
+  if (scripts.test) {
+    config.test_full = { commands: [`${runner} test`], budget_ms: 90_000 };
+  }
+
+  // runtime_smoke: explicit `mcp:smoke` or generic `smoke`.
+  if (scripts['mcp:smoke']) {
+    config.runtime_smoke = { commands: [`${runner} mcp:smoke`], budget_ms: 60_000 };
+  } else if (scripts.smoke) {
+    config.runtime_smoke = { commands: [`${runner} smoke`], budget_ms: 60_000 };
+  }
+
+  return config;
+}
+
+function hasDep(pkg: Record<string, unknown>, name: string): boolean {
+  const deps = (pkg.dependencies ?? {}) as Record<string, string>;
+  const dev = (pkg.devDependencies ?? {}) as Record<string, string>;
+  return name in deps || name in dev;
+}
+
+/** yarn vs npm vs pnpm vs bun, detected from lockfile. Falls back to npm. */
+function detectRunner(productPath: string): string {
+  if (existsSync(join(productPath, 'yarn.lock'))) return 'yarn';
+  if (existsSync(join(productPath, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (existsSync(join(productPath, 'bun.lockb'))) return 'bun';
+  return 'npm run';
+}
+
+// ─── Substitution ───────────────────────────────────────────────────
+
+/**
+ * Substitute placeholders in the commands of a gate spec. Currently
+ * only `${CHANGED_FILES}`. Returns a new array; doesn't mutate input.
+ */
+export function substitutePlaceholders(
+  commands: string[],
+  ctx: { changedFiles?: string[] },
+): string[] {
+  const changed = (ctx.changedFiles ?? []).join(' ');
+  return commands.map((c) => c.replaceAll('${CHANGED_FILES}', changed));
+}
+
+// ─── Public command-resolution helper ───────────────────────────────
+
+export type RoleName = 'builder' | 'tester' | 'reviewer';
+
+/**
+ * Map a role to the gates it MUST submit before transitioning out of
+ * its stage. Mirrors specs/autonomous-flow-tightening-spec.md.
+ */
+export const ROLE_REQUIRED_GATES: Record<RoleName, ReadonlyArray<keyof GateConfig>> = {
+  builder: ['build_fast'],
+  tester: ['test_full'], // runtime_ui or runtime_smoke also required, surface-dependent
+  reviewer: [], // review_static is judgment-only; no prescribed command
+};
+
+export interface PrescribedCommandsForRole {
+  role: RoleName;
+  /** Per-gate prescribed command list, post-substitution. */
+  gates: Partial<Record<keyof GateConfig, GateCommandSpec>>;
+  /** Source of the underlying config (file/discovered/none). */
+  source: GateConfig['source'];
+  source_path?: string;
+}
+
+/**
+ * Format the prescribed commands as a markdown section ready to embed
+ * in a dispatch message. Mirrors the convention agents see for other
+ * sections (planning spec, deliverables checklist).
+ *
+ * Returns an empty string when there are no commands to prescribe — the
+ * legacy flow (no `.mc/gates.json`, no recognizable scripts) still
+ * works via the deliverable bar inherited from slice 1.
+ */
+export function formatPrescribedCommandsSection(
+  prescribed: PrescribedCommandsForRole,
+  ctx: { agentId: string; taskId: string },
+): string {
+  const entries = Object.entries(prescribed.gates);
+  if (entries.length === 0) return '';
+
+  const lines: string[] = [];
+  lines.push('---');
+  lines.push('**🧪 PRESCRIBED VERIFICATION COMMANDS — run these exactly, submit raw output:**');
+  lines.push('');
+  for (const [gate, spec] of entries) {
+    if (!spec) continue;
+    lines.push(`### \`${gate}\` (budget: ${Math.round(spec.budget_ms / 1000)}s)`);
+    lines.push('Run in sequence:');
+    lines.push('```');
+    for (const cmd of spec.commands) lines.push(cmd);
+    lines.push('```');
+    lines.push('Then submit the combined raw output:');
+    lines.push('```');
+    lines.push(
+      `submit_evidence({ agent_id: "${ctx.agentId}", task_id: "${ctx.taskId}", gate: "${gate}", command: "<exact command line>", stdout: "<raw>", stderr: "<raw>", exit_code: <n>${gate === 'runtime_ui' ? ', artifact_paths: ["<absolute path to screenshot/trace>"]' : ''} })`,
+    );
+    lines.push('```');
+    lines.push('');
+  }
+  lines.push(
+    'The server parses your stdout (TS errors, ESLint counts, test summaries, artifacts) and decides pass/fail. **Self-reporting "verified" or "all good" without submit_evidence will be rejected by the stage gate.**',
+  );
+  lines.push('');
+  if (prescribed.source === 'discovered') {
+    lines.push(
+      '_Commands auto-discovered from `package.json`. Pin them in `.mc/gates.json` to override._',
+    );
+  } else if (prescribed.source === 'file') {
+    lines.push(`_Commands from \`${prescribed.source_path}\`._`);
+  }
+  return '\n' + lines.join('\n') + '\n';
+}
+
+export function getPrescribedCommandsForRole(
+  productPath: string,
+  role: RoleName,
+  ctx: { changedFiles?: string[] } = {},
+): PrescribedCommandsForRole {
+  const cfg = loadGateConfig(productPath);
+  const gates: PrescribedCommandsForRole['gates'] = {};
+  const required = ROLE_REQUIRED_GATES[role];
+  for (const key of required) {
+    const spec = cfg[key];
+    if (spec && key !== 'source' && key !== 'source_path') {
+      gates[key] = {
+        commands: substitutePlaceholders((spec as GateCommandSpec).commands, ctx),
+        budget_ms: (spec as GateCommandSpec).budget_ms,
+      };
+    }
+  }
+  // Tester also gets test_full + (when discovered) runtime_smoke for backend tasks.
+  if (role === 'tester' && cfg.runtime_smoke) {
+    gates.runtime_smoke = {
+      commands: substitutePlaceholders(cfg.runtime_smoke.commands, ctx),
+      budget_ms: cfg.runtime_smoke.budget_ms,
+    };
+  }
+  return {
+    role,
+    gates,
+    source: cfg.source,
+    source_path: cfg.source_path,
+  };
+}


### PR DESCRIPTION
## Summary

Slice 2 of the autonomous-flow tightening ([spec](specs/autonomous-flow-tightening-spec.md)).

Pairs **role-scoped test budgets** with the run-and-forward evidence model from [#114](https://github.com/smb209/mission-control/pull/114). Each role now ships with a soul doc that mandates which gates they own, what evidence they must submit, and what they must NOT do:

- **Builder** runs only fast checks (typecheck/lint/related-tests, 60s budget). Mandates a **wiring trace deliverable** end-to-end before transitioning — closes **FM8** from the post-mortem (the literal bug that started this: AlertDialog imported but never rendered).
- **Tester** runs full regression + at least one runtime gate (\`runtime_ui\` for user-visible, \`runtime_smoke\` for backend). Path-resolution discipline.
- **Reviewer** never executes commands. Reads diff against Tester's evidence rows. Bounces to Tester if \`test_full\` is missing.

## Changes

- \`src/lib/agents/{builder,tester,reviewer}-soul.md\` — role definitions
- \`src/lib/agents/role-souls.ts\` — loader + dispatch formatter
- \`src/lib/gates/config.ts\` — \`.mc/gates.json\` schema, package.json auto-discovery, \`\${CHANGED_FILES}\` substitution, role→gate mapping
- \`src/lib/gates/config.test.ts\` — 12 tests
- \`.mc/gates.json\` — bundled config for this repo so self-improvement runs use real gates
- \`src/app/api/tasks/[id]/dispatch/route.ts\` — injects \`roleSoulSection\` + \`prescribedCommandsSection\` into every dispatch message

## Generalizability

Per the user direction: prescribed commands live **per-repo** in \`.mc/gates.json\`, not centralized in MC. Repos without the file get auto-discovered defaults from \`package.json\`. Lockfile-aware (yarn / pnpm / bun / npm).

## Test plan

- [x] \`yarn tsc --noEmit\` (pre-existing pm-decompose errors unrelated)
- [x] 59/59 affected tests pass (\`config.test.ts\`, \`role-souls.test.ts\`, \`task-evidence.test.ts\`, \`services.test.ts\`)
- [ ] Smoke an end-to-end dispatch and confirm the prescribed commands surface in the agent's message

## Notes

Worker-side harness budget (SIGTERM at \`budget_ms\`) is deferred to a separate PR on the openclaw side. MC publishes the budget; the worker enforces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)