### PR TITLE
feat(dispatch): enforce workspace isolation for repo-backed tasks

### DIFF
--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -15,7 +15,7 @@ import { clearStallFlag } from '@/lib/stall-detection';
 import { logDebugEvent } from '@/lib/debug-log';
 import { formatMailForDispatch } from '@/lib/mailbox';
 import { getPendingNotesForDispatch } from '@/lib/task-notes';
-import { createTaskWorkspace, determineIsolationStrategy } from '@/lib/workspace-isolation';
+import { createTaskWorkspace, resolveDispatchWorkspace } from '@/lib/workspace-isolation';
 import { parsePlanningSpec } from '@/lib/planning-spec';
 import {
   getPrescribedCommandsForRole,
@@ -24,6 +24,7 @@ import {
 } from '@/lib/gates/config';
 import { formatRoleSoulSection } from '@/lib/agents/role-souls';
 import { execSync } from 'child_process';
+import { existsSync } from 'fs';
 import type { Task, Agent, Product, OpenClawSession, WorkflowStage, TaskImage } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -246,24 +247,54 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       'host'
     );
 
-    // Create isolated workspace if parallel builds are possible
-    // Only for builder dispatches (assigned/in_progress), not tester/reviewer
+    // Create isolated workspace if parallel builds are possible.
+    //
+    // Slice 3 of the autonomous-flow tightening tightens this:
+    //   1. Builder: hard-fail dispatch when the product is repo-backed
+    //      (`determineIsolationStrategy` returned a strategy) but workspace
+    //      creation throws. The previous behavior — warn-and-continue with
+    //      the shared `${projectsPath}/${slug}` directory — is what put the
+    //      AlertDialog Builder on `main` (see PR #117 spec post-mortem).
+    //   2. Tester / Reviewer: read back the workspace the Builder created
+    //      (persisted on `task.workspace_path` by createTaskWorkspace) so
+    //      downstream stages exercise the SAME tree the build happened in,
+    //      rather than the shared default path.
+    //   3. Non-repo-backed products (no isolation strategy) keep the shared
+    //      dir — the strict mode only triggers when isolation was supposed
+    //      to be available.
     let workspaceIsolated = false;
     let workspaceBranchName: string | undefined;
     let workspacePort: number | undefined;
-    const isolationStrategy = determineIsolationStrategy(task as Task);
     const isBuilderDispatch = task.status === 'assigned' || task.status === 'in_progress' || task.status === 'inbox';
-    if (isolationStrategy && isBuilderDispatch) {
-      try {
-        const workspace = await createTaskWorkspace(task as Task);
-        taskProjectDir = workspace.path;
-        workspaceIsolated = true;
-        workspaceBranchName = workspace.branch;
-        workspacePort = workspace.port;
-        console.log(`[Dispatch] Created ${workspace.strategy} workspace for task ${task.id}: ${workspace.path}`);
-      } catch (err) {
-        console.warn(`[Dispatch] Workspace isolation failed, using default path:`, (err as Error).message);
-      }
+    const isTesterOrReviewerDispatch = task.status === 'testing' || task.status === 'review' || task.status === 'verification';
+    const dispatchRole = isBuilderDispatch
+      ? 'builder'
+      : isTesterOrReviewerDispatch
+        ? 'tester_or_reviewer'
+        : 'other';
+
+    const wsResolution = await resolveDispatchWorkspace(
+      task as Task & { workspace_path?: string | null; workspace_port?: number | null },
+      dispatchRole,
+      { existsSync, createTaskWorkspace },
+    );
+    if (!wsResolution.ok) {
+      console.error(
+        `[Dispatch] ${wsResolution.code} for task ${task.id}: ${wsResolution.detail}`,
+      );
+      return NextResponse.json(
+        { error: wsResolution.code, detail: wsResolution.detail },
+        { status: wsResolution.http_status },
+      );
+    }
+    taskProjectDir = wsResolution.path;
+    workspaceIsolated = wsResolution.isolated;
+    workspaceBranchName = wsResolution.branch;
+    workspacePort = wsResolution.port;
+    if (workspaceIsolated) {
+      console.log(
+        `[Dispatch] ${dispatchRole} ${wsResolution.reused ? 'reusing' : 'created'} workspace for ${task.id}: ${taskProjectDir}`,
+      );
     }
 
     // Parse planning_spec and planning_agents if present (stored as JSON text on the task row)
@@ -825,10 +856,11 @@ ${task.description ? `**Description:** ${task.description}\n` : ''}
 ${task.due_date ? `**Due:** ${task.due_date}\n` : ''}
 **Task ID:** ${task.id}
 ${callHomeSection}${delegationContractSection}${roleSoulSection}${deliverablesLead}${criteriaLead}${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}${delegationRosterSection}${prescribedCommandsSection}
-${isBuilder ? (workspaceIsolated
-  ? `**\u{1F512} ISOLATED WORKSPACE:** ${taskProjectDir}\n- **Port:** ${workspacePort || 'default'} (use this for dev server, NOT the default)\n${workspaceBranchName ? `- **Branch:** ${workspaceBranchName}\n` : ''}- **IMPORTANT:** Do NOT modify files outside this workspace directory. Other agents may be working on the same project in parallel. All your work must stay within: ${taskProjectDir}\n**DELIVERABLES DIR (separate):** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`
-  : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n**DELIVERABLES DIR:** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`)
-: isCoordinator ? `**DELIVERABLES DIR:** ${deliverablesDir}\nAggregated deliverables registered via the deliverables endpoint should be written to this directory so they become web-downloadable.\n` : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n**DELIVERABLES DIR:** ${deliverablesDir}\nFinal deliverables should be saved to ${deliverablesDir} so they become web-downloadable.\n`}
+${isCoordinator
+  ? `**DELIVERABLES DIR:** ${deliverablesDir}\nAggregated deliverables registered via the deliverables endpoint should be written to this directory so they become web-downloadable.\n`
+  : workspaceIsolated
+    ? `**\u{1F512} ISOLATED WORKSPACE:** ${taskProjectDir}\n- **Port:** ${workspacePort || 'default'} (use this for dev server, NOT the default)\n${workspaceBranchName ? `- **Branch:** ${workspaceBranchName}\n` : ''}- **IMPORTANT:** Do NOT modify files outside this workspace directory. ${isBuilder ? 'Other agents may be working on the same project in parallel.' : 'This is the same tree the Builder produced — exercise the change here, do NOT cd into the shared project root.'} All your work must stay within: ${taskProjectDir}\n**DELIVERABLES DIR (separate):** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`
+    : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n**DELIVERABLES DIR:** ${deliverablesDir}\n${isBuilder ? 'Create' : 'Final deliverables should be saved to'} ${deliverablesDir}${isBuilder ? ' and save final deliverables there so they become web-downloadable from Mission Control.' : ' so they become web-downloadable.'}\n`}
 ${completionInstructions}
 
 If you need help or clarification, ask the orchestrator.`;

--- a/src/lib/workspace-isolation.test.ts
+++ b/src/lib/workspace-isolation.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for `resolveDispatchWorkspace` — the strict workspace resolver
+ * introduced in slice 3 of the autonomous-flow tightening.
+ *
+ * These cover the failure-mode matrix from the post-mortem:
+ *   - Builder hits unisolated path → must hard-fail (was warn-and-continue)
+ *   - Tester/reviewer with no Builder workspace → 409
+ *   - Re-dispatch reuses the existing workspace path
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { run } from '@/lib/db';
+import {
+  resolveDispatchWorkspace,
+  type DispatchRole,
+} from './workspace-isolation';
+import type { Task } from './types';
+
+function seedTask(
+  opts: {
+    repoUrl?: string;
+    workspacePath?: string;
+    workspacePort?: number;
+    status?: string;
+  } = {},
+): Task & { workspace_path?: string; workspace_port?: number } {
+  const id = crypto.randomUUID();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id,
+       repo_url, workspace_path, workspace_port, created_at, updated_at)
+     VALUES (?, 't', ?, 'normal', 'default', 'default', ?, ?, ?, datetime('now'), datetime('now'))`,
+    [
+      id,
+      opts.status ?? 'assigned',
+      opts.repoUrl ?? null,
+      opts.workspacePath ?? null,
+      opts.workspacePort ?? null,
+    ],
+  );
+  return {
+    id,
+    title: 't',
+    status: (opts.status ?? 'assigned') as Task['status'],
+    priority: 'normal',
+    workspace_id: 'default',
+    business_id: 'default',
+    repo_url: opts.repoUrl,
+    workspace_path: opts.workspacePath,
+    workspace_port: opts.workspacePort,
+    created_at: '',
+    updated_at: '',
+  } as Task & { workspace_path?: string; workspace_port?: number };
+}
+
+const okIO = {
+  existsSync: () => true,
+  createTaskWorkspace: async () => ({
+    path: '/tmp/created-ws',
+    strategy: 'worktree' as const,
+    branch: 'task/abc',
+    baseBranch: 'main',
+    port: 4011,
+  }),
+};
+
+test('non-repo product: returns shared dir, not isolated', async () => {
+  const task = seedTask(); // no repo_url → no isolation strategy
+  const result = await resolveDispatchWorkspace(task, 'builder', okIO);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.isolated, false);
+});
+
+test('repo-backed builder dispatch: creates fresh workspace when none recorded', async () => {
+
+  const task = seedTask({ repoUrl: 'https://github.com/x/y.git' });
+  const result = await resolveDispatchWorkspace(task, 'builder', okIO);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.isolated, true);
+  assert.equal(result.reused, false);
+  assert.equal(result.path, '/tmp/created-ws');
+  assert.equal(result.branch, 'task/abc');
+});
+
+test('repo-backed builder re-dispatch: reuses existing on-disk workspace', async () => {
+
+  const task = seedTask({ repoUrl: 'https://github.com/x/y.git',
+    workspacePath: '/already/exists',
+    workspacePort: 4019,
+  });
+  let createCalls = 0;
+  const io = {
+    existsSync: (p: string) => p === '/already/exists',
+    createTaskWorkspace: async () => {
+      createCalls++;
+      return okIO.createTaskWorkspace();
+    },
+  };
+  const result = await resolveDispatchWorkspace(task, 'builder', io);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.reused, true);
+  assert.equal(result.path, '/already/exists');
+  assert.equal(result.port, 4019);
+  assert.equal(createCalls, 0);
+});
+
+test('repo-backed builder: createTaskWorkspace failure returns 503 (not warn-and-continue)', async () => {
+
+  const task = seedTask({ repoUrl: 'https://github.com/x/y.git' });
+  const io = {
+    existsSync: () => false,
+    createTaskWorkspace: async () => {
+      throw new Error('rsync target missing');
+    },
+  };
+  const result = await resolveDispatchWorkspace(task, 'builder', io);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.code, 'workspace_isolation_failed');
+  assert.equal(result.http_status, 503);
+  assert.match(result.detail, /rsync target missing/);
+});
+
+test('repo-backed tester/reviewer: reuses Builder workspace when present', async () => {
+
+  const task = seedTask({ repoUrl: 'https://github.com/x/y.git',
+    workspacePath: '/wt/task-x',
+    workspacePort: 4023,
+    status: 'testing',
+  });
+  let createCalls = 0;
+  const io = {
+    existsSync: () => true,
+    createTaskWorkspace: async () => {
+      createCalls++;
+      return okIO.createTaskWorkspace();
+    },
+  };
+  const result = await resolveDispatchWorkspace(task, 'tester_or_reviewer' as DispatchRole, io);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.path, '/wt/task-x');
+  assert.equal(result.reused, true);
+  assert.equal(createCalls, 0); // never call create on tester/reviewer
+});
+
+test('repo-backed tester: missing workspace_path returns 409', async () => {
+
+  const task = seedTask({ repoUrl: 'https://github.com/x/y.git', status: 'testing' }); // no workspace_path
+  const result = await resolveDispatchWorkspace(task, 'tester_or_reviewer', okIO);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.code, 'no_workspace_for_quality_stage');
+  assert.equal(result.http_status, 409);
+});
+
+test('non-repo tester: returns shared dir without 409 (no strategy → not enforced)', async () => {
+  const task = seedTask({ status: 'testing' });
+  const result = await resolveDispatchWorkspace(task, 'tester_or_reviewer', okIO);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.isolated, false);
+});

--- a/src/lib/workspace-isolation.ts
+++ b/src/lib/workspace-isolation.ts
@@ -123,6 +123,138 @@ export function determineIsolationStrategy(task: Task): IsolationStrategy | null
   return null;
 }
 
+// ─── Strict resolution for dispatch ──────────────────────────────────
+
+export type DispatchRole = 'builder' | 'tester_or_reviewer' | 'other';
+
+export interface ResolvedWorkspace {
+  ok: true;
+  path: string;
+  isolated: boolean;
+  port?: number;
+  branch?: string;
+  /** True when path was reused; false when freshly created. */
+  reused: boolean;
+}
+
+export interface WorkspaceResolutionError {
+  ok: false;
+  code: 'workspace_isolation_failed' | 'no_workspace_for_quality_stage';
+  detail: string;
+  http_status: 503 | 409;
+}
+
+/**
+ * Resolve the project directory a dispatch should land in. Slice 3 of
+ * the autonomous-flow tightening: when a product is repo-backed
+ * (`determineIsolationStrategy` returns a strategy), failure is fatal
+ * rather than silently falling back to the shared working tree. That
+ * fallback is what put the AlertDialog Builder on `main` in the
+ * post-mortem run.
+ *
+ * Behavior matrix (`strategy` from `determineIsolationStrategy`):
+ *
+ *   strategy   role           workspace_path  → result
+ *   ────────── ────────────── ─────────────── ──────────────────────────
+ *   null       any            *               not isolated, shared dir
+ *   set        builder        existing on FS  reuse (no recreate)
+ *   set        builder        unset/missing   create fresh; throws → 503
+ *   set        tester/reviewer set            reuse Builder's workspace
+ *   set        tester/reviewer unset          409: builder skipped iso
+ *   set        other          *               not isolated, shared dir
+ *
+ * Pure-ish — takes injectable IO so tests can drive without a real
+ * worktree. Production callers pass `existsSync` and
+ * `createTaskWorkspace`.
+ */
+export async function resolveDispatchWorkspace(
+  task: Task & {
+    workspace_path?: string | null;
+    workspace_port?: number | null;
+  },
+  role: DispatchRole,
+  io: {
+    existsSync: (p: string) => boolean;
+    createTaskWorkspace: (t: Task) => Promise<WorkspaceInfo>;
+  },
+): Promise<ResolvedWorkspace | WorkspaceResolutionError> {
+  const strategy = determineIsolationStrategy(task);
+  if (!strategy) {
+    // Non-repo-backed product: existing fallback path is fine.
+    return {
+      ok: true,
+      path: getProductProjectDir(task),
+      isolated: false,
+      reused: false,
+    };
+  }
+
+  if (role === 'builder') {
+    if (task.workspace_path && io.existsSync(task.workspace_path)) {
+      return {
+        ok: true,
+        path: task.workspace_path,
+        isolated: true,
+        port: task.workspace_port ?? undefined,
+        reused: true,
+      };
+    }
+    try {
+      const ws = await io.createTaskWorkspace(task);
+      return {
+        ok: true,
+        path: ws.path,
+        isolated: true,
+        branch: ws.branch,
+        port: ws.port,
+        reused: false,
+      };
+    } catch (err) {
+      const message = (err as Error).message || 'unknown error';
+      return {
+        ok: false,
+        code: 'workspace_isolation_failed',
+        http_status: 503,
+        detail:
+          `Could not create an isolated workspace for this task: ${message}. ` +
+          `The product is repo-backed (strategy=${strategy}); dispatching to ` +
+          `the shared working tree could let the Builder commit on main. ` +
+          `Resolve the underlying cause and retry.`,
+      };
+    }
+  }
+
+  if (role === 'tester_or_reviewer') {
+    if (task.workspace_path) {
+      return {
+        ok: true,
+        path: task.workspace_path,
+        isolated: true,
+        port: task.workspace_port ?? undefined,
+        reused: true,
+      };
+    }
+    return {
+      ok: false,
+      code: 'no_workspace_for_quality_stage',
+      http_status: 409,
+      detail:
+        `Task is in a quality stage but has no recorded workspace_path. ` +
+        `The Builder dispatched without workspace isolation, which means ` +
+        `downstream stages would exercise the shared working tree. ` +
+        `Re-dispatch the build stage or set workspace_path manually.`,
+    };
+  }
+
+  // Coordinator or other role: shared dir is fine.
+  return {
+    ok: true,
+    path: getProductProjectDir(task),
+    isolated: false,
+    reused: false,
+  };
+}
+
 // ─── Project Path Resolution ─────────────────────────────────────────
 
 function getProductProjectDir(task: Task): string {


### PR DESCRIPTION
## Summary

Slice 3 of the autonomous-flow tightening (stacked on [#117](https://github.com/smb209/mission-control/pull/117)). Closes **FM2** from the post-mortem: the AlertDialog Builder ran on \`main\` because workspace isolation failed silently and dispatch fell back to the shared working tree.

Three behavioral changes, all gated on \`determineIsolationStrategy\` returning a strategy (i.e. a repo-backed product):

1. **Builder + isolation failure → 503**, structured error. No more warn-and-continue.
2. **Builder re-dispatch reuses the existing on-disk workspace** rather than trying to recreate the worktree branch (which would fail).
3. **Tester / Reviewer dispatch reads back \`task.workspace_path\`** and dispatches into THAT tree. Missing workspace_path on a repo-backed quality stage returns 409 — operator must re-dispatch the build stage rather than silently exercise main.

The dispatch message's \"ISOLATED WORKSPACE\" callout now fires for any isolated dispatch, not just builder. Path-prefix discipline is surfaced in the role souls from [#117](https://github.com/smb209/mission-control/pull/117).

## Changes

- \`src/lib/workspace-isolation.ts\` — new \`resolveDispatchWorkspace(task, role, io)\` pure resolver (testable)
- \`src/lib/workspace-isolation.test.ts\` — 7 tests covering the failure-mode matrix
- \`src/app/api/tasks/[id]/dispatch/route.ts\` — collapses the inline 60-line workspace block to a single resolver call; uniform ISOLATED WORKSPACE callout

## Test plan

- [x] \`yarn tsc --noEmit\` (pre-existing pm-decompose errors unrelated)
- [x] 66/66 affected tests pass (workspace-isolation, services, task-evidence, gates, role-souls)
- [ ] Smoke: dispatch a builder task on a repo-backed product and confirm the worktree is created OR a 503 is returned (no shared-dir fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)