### PR TITLE
feat(rollcall): surface pending roll-calls on every dispatch

### DIFF
--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -14,6 +14,7 @@ import { buildCheckpointContext, saveCheckpoint, getLatestCheckpoint } from '@/l
 import { clearStallFlag } from '@/lib/stall-detection';
 import { logDebugEvent } from '@/lib/debug-log';
 import { formatMailForDispatch } from '@/lib/mailbox';
+import { formatPendingRollcallsForDispatch } from '@/lib/rollcall';
 import { getPendingNotesForDispatch } from '@/lib/task-notes';
 import { createTaskWorkspace, resolveDispatchWorkspace } from '@/lib/workspace-isolation';
 import { parsePlanningSpec } from '@/lib/planning-spec';
@@ -855,7 +856,7 @@ ${task.description ? `**Description:** ${task.description}\n` : ''}
 **Priority:** ${task.priority.toUpperCase()}
 ${task.due_date ? `**Due:** ${task.due_date}\n` : ''}
 **Task ID:** ${task.id}
-${callHomeSection}${delegationContractSection}${roleSoulSection}${deliverablesLead}${criteriaLead}${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}${delegationRosterSection}${prescribedCommandsSection}
+${callHomeSection}${delegationContractSection}${roleSoulSection}${deliverablesLead}${criteriaLead}${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${formatPendingRollcallsForDispatch(agent.id)}${repoSection}${delegationRosterSection}${prescribedCommandsSection}
 ${isCoordinator
   ? `**DELIVERABLES DIR:** ${deliverablesDir}\nAggregated deliverables registered via the deliverables endpoint should be written to this directory so they become web-downloadable.\n`
   : workspaceIsolated

--- a/src/lib/rollcall.test.ts
+++ b/src/lib/rollcall.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for `getPendingRollcallsForAgent` / `formatPendingRollcallsForDispatch` —
+ * slice 4 of the autonomous-flow tightening.
+ *
+ * Closes FM3 from the post-mortem: stage-isolated sessions never saw
+ * the rollcall mail (it had been delivered + cleaned up by the prior
+ * session), so all replies came back with `rollcall_matched: false`.
+ * This module reads from the durable `rollcall_entries` table so the
+ * dispatch path can surface unanswered rollcalls regardless of mail
+ * lifecycle.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { run } from '@/lib/db';
+import {
+  getPendingRollcallsForAgent,
+  formatPendingRollcallsForDispatch,
+} from './rollcall';
+
+function seedAgent(name: string): string {
+  const id = crypto.randomUUID();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, created_at, updated_at)
+     VALUES (?, ?, 'builder', 'default', 1, datetime('now'), datetime('now'))`,
+    [id, name],
+  );
+  return id;
+}
+
+interface SeedRollcallOpts {
+  initiator: string;
+  target: string;
+  expiresInSeconds?: number;
+  replied?: boolean;
+  deliveryStatus?: 'pending' | 'sent' | 'failed' | 'skipped';
+}
+
+function seedRollcall(opts: SeedRollcallOpts): string {
+  const rcId = crypto.randomUUID();
+  const expires = new Date(
+    Date.now() + (opts.expiresInSeconds ?? 30) * 1000,
+  ).toISOString();
+  run(
+    `INSERT INTO rollcall_sessions (id, workspace_id, initiator_agent_id, mode, timeout_seconds, created_at, expires_at)
+     VALUES (?, 'default', ?, 'direct', 30, datetime('now'), ?)`,
+    [rcId, opts.initiator, expires],
+  );
+  run(
+    `INSERT INTO rollcall_entries (id, rollcall_id, target_agent_id, delivery_status, replied_at, created_at)
+     VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+    [
+      crypto.randomUUID(),
+      rcId,
+      opts.target,
+      opts.deliveryStatus ?? 'sent',
+      opts.replied ? new Date().toISOString() : null,
+    ],
+  );
+  return rcId;
+}
+
+test('getPendingRollcallsForAgent returns active unreplied entries', () => {
+  const orchestrator = seedAgent('orch');
+  const target = seedAgent('builder-a');
+  const rcId = seedRollcall({ initiator: orchestrator, target });
+  const pending = getPendingRollcallsForAgent(target);
+  assert.equal(pending.length, 1);
+  assert.equal(pending[0]!.rollcall_id, rcId);
+  assert.equal(pending[0]!.initiator_agent_name, 'orch');
+});
+
+test('getPendingRollcallsForAgent skips replied entries', () => {
+  const orchestrator = seedAgent('orch');
+  const target = seedAgent('builder-b');
+  seedRollcall({ initiator: orchestrator, target, replied: true });
+  const pending = getPendingRollcallsForAgent(target);
+  assert.equal(pending.length, 0);
+});
+
+test('getPendingRollcallsForAgent skips expired sessions', () => {
+  const orchestrator = seedAgent('orch');
+  const target = seedAgent('builder-c');
+  // Expired 60s ago
+  seedRollcall({ initiator: orchestrator, target, expiresInSeconds: -60 });
+  const pending = getPendingRollcallsForAgent(target);
+  assert.equal(pending.length, 0);
+});
+
+test('getPendingRollcallsForAgent skips delivery failures', () => {
+  const orchestrator = seedAgent('orch');
+  const target = seedAgent('builder-d');
+  seedRollcall({ initiator: orchestrator, target, deliveryStatus: 'failed' });
+  const pending = getPendingRollcallsForAgent(target);
+  assert.equal(pending.length, 0);
+});
+
+test('formatPendingRollcallsForDispatch returns empty string when none pending', () => {
+  const target = seedAgent('builder-e');
+  assert.equal(formatPendingRollcallsForDispatch(target), '');
+});
+
+test('formatPendingRollcallsForDispatch surfaces the reply subject', () => {
+  const orchestrator = seedAgent('orch');
+  const target = seedAgent('builder-f');
+  const rcId = seedRollcall({ initiator: orchestrator, target });
+  const out = formatPendingRollcallsForDispatch(target);
+  assert.match(out, /PENDING ROLL-CALLS/);
+  assert.match(out, new RegExp(`roll_call_reply:${rcId}`));
+});
+
+// ─── Replay test from the AlertDialog post-mortem ─────────────────────
+
+test("replay: stage-isolated session would see the rollcall the parent received", () => {
+  // Original flow: orchestrator initiates a rollcall → mail delivered to
+  // session A; session A is reset for stage isolation (new openclaw_session_id);
+  // session B starts with no mail history. Pre-fix, session B wouldn't know
+  // about the rollcall and reply with `roll_call_reply:false`. Post-fix, it
+  // sees the entry directly because we read from rollcall_entries.
+  const orchestrator = seedAgent('orch');
+  const target = seedAgent('builder-replay');
+  const rcId = seedRollcall({ initiator: orchestrator, target });
+  // Simulate that the mail was already consumed by a prior session (we
+  // never insert it; the entry is what survives).
+  const dispatchSection = formatPendingRollcallsForDispatch(target);
+  assert.match(dispatchSection, new RegExp(rcId));
+});

--- a/src/lib/rollcall.ts
+++ b/src/lib/rollcall.ts
@@ -265,6 +265,72 @@ export function getRollCallStatus(rollcallId: string): {
 }
 
 /**
+ * Pending roll-call entries the agent must answer. Read directly from
+ * `rollcall_entries` (durable) rather than `agent_mailbox` (one-shot
+ * deliveries that get cleaned up by formatMailForDispatch). This is the
+ * fix for FM3 from the autonomous-flow tightening: a stage-isolated
+ * session that's freshly created has no mail history, but the rollcall
+ * entry for the agent persists and we can surface it on every dispatch.
+ *
+ * Returns rows for which:
+ *   - target_agent_id = agent
+ *   - replied_at IS NULL
+ *   - session is not expired (now < expires_at)
+ *   - delivery_status != 'failed' / 'skipped' (don't badger an agent
+ *     about a roll-call we never managed to deliver)
+ */
+export interface PendingRollcall {
+  rollcall_id: string;
+  initiator_agent_id: string;
+  initiator_agent_name: string | null;
+  expires_at: string;
+  created_at: string;
+}
+
+export function getPendingRollcallsForAgent(agentId: string): PendingRollcall[] {
+  return queryAll<PendingRollcall>(
+    `SELECT rs.id as rollcall_id,
+            rs.initiator_agent_id,
+            ia.name as initiator_agent_name,
+            rs.expires_at,
+            rs.created_at
+       FROM rollcall_entries re
+       JOIN rollcall_sessions rs ON rs.id = re.rollcall_id
+       LEFT JOIN agents ia ON ia.id = rs.initiator_agent_id
+      WHERE re.target_agent_id = ?
+        AND re.replied_at IS NULL
+        AND re.delivery_status IN ('pending', 'sent')
+        AND datetime(rs.expires_at) > datetime('now')
+      ORDER BY rs.created_at ASC`,
+    [agentId],
+  );
+}
+
+/**
+ * Render the pending roll-calls as a dispatch-ready section. Empty
+ * string when there are none.
+ */
+export function formatPendingRollcallsForDispatch(agentId: string): string {
+  const pending = getPendingRollcallsForAgent(agentId);
+  if (pending.length === 0) return '';
+  const lines: string[] = [];
+  lines.push('---');
+  lines.push('**📣 PENDING ROLL-CALLS — reply to each before doing other work:**');
+  lines.push('');
+  for (const rc of pending) {
+    const initiator = rc.initiator_agent_name || rc.initiator_agent_id;
+    lines.push(
+      `- From **${initiator}** (id \`${rc.rollcall_id}\`, expires ${rc.expires_at}). Reply with subject \`roll_call_reply:${rc.rollcall_id}\`.`,
+    );
+  }
+  lines.push('');
+  lines.push(
+    'Use `send_mail` with the exact subject above so the orchestrator records your reply. A short status sentence in the body is enough.',
+  );
+  return '\n' + lines.join('\n') + '\n';
+}
+
+/**
  * Try to record a mail message as the reply to an open roll-call entry.
  * Called from the mail POST handler when `subject` starts with
  * "roll_call_reply" or "roll_call:<id>" — matches by (rollcall_id,


### PR DESCRIPTION
## Summary

Slice 4 of the autonomous-flow tightening (stacked on [#118](https://github.com/smb209/mission-control/pull/118)). Closes **FM3** from the post-mortem: all three sessions in the AlertDialog run replied with \`rollcall_matched: false\` because the rollcall mail had been delivered to (and consumed by) the pre-stage-isolation gateway session.

Reads from \`rollcall_entries\` (durable) rather than \`agent_mailbox\` (one-shot). The dispatch path embeds a 📣 **PENDING ROLL-CALLS** section listing the agent's unanswered, non-expired rollcalls — including the \`roll_call_reply:<id>\` subject they must use.

## Changes

- \`src/lib/rollcall.ts\` — new \`getPendingRollcallsForAgent\` / \`formatPendingRollcallsForDispatch\`
- \`src/lib/rollcall.test.ts\` — 7 unit tests (active/replied/expired/failed + replay of the post-mortem)
- \`src/app/api/tasks/[id]/dispatch/route.ts\` — embeds \`formatPendingRollcallsForDispatch(agent.id)\` next to the existing mail formatter

## FM4 dropped

The spec called out **FM4** (ACL widening for \`get_task\`) but on investigation \`get_task\` doesn't call \`assertAgentCanActOnTask\` at all — any caller with a valid \`agent_id\` can read. The post-mortem \`agent_not_coordinator\` error was likely on \`spawn_subtask\` (genuinely coordinator-only). No change needed.

## Test plan

- [x] \`yarn tsc --noEmit\` (pre-existing pm-decompose errors unrelated)
- [x] 73/73 affected tests pass
- [ ] Smoke: initiate a roll-call, transition the target task across stages, confirm the agent sees the pending entry on every stage's dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)