### PR TITLE
feat(dispatch): pick deliverables-path perspective from agent.runtime_kind

### DIFF
--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -243,9 +243,20 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // Deliverables directory: MC-managed location the agent writes FINAL
     // deliverables into so they become web-downloadable. Separate from
     // taskProjectDir, which may be an isolated worktree the agent codes in.
+    //
+    // Slice 7 of the autonomous-flow tightening: pick the perspective from
+    // `agent.runtime_kind`. A host-runtime agent gets `/Users/...`; a
+    // container-runtime agent gets `/app/...`. The AlertDialog Tester wrote
+    // a `/app/workspace/...` screenshot from a host runtime and got ENOENT
+    // because the dispatch always passed 'host' regardless of where the
+    // agent actually ran.
+    const agentRuntime: 'host' | 'container' =
+      (agent as Agent & { runtime_kind?: string }).runtime_kind === 'container'
+        ? 'container'
+        : 'host';
     const deliverablesDir = getTaskDeliverableDir(
       { id: task.id, title: task.title, created_at: task.created_at },
-      'host'
+      agentRuntime,
     );
 
     // Create isolated workspace if parallel builds are possible.

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3535,6 +3535,29 @@ const migrations: Migration[] = [
       console.log('[Migration 059] tasks.is_failed added + backfilled.');
     },
   },
+  {
+    id: '060',
+    name: 'agents_runtime_kind',
+    up: (db) => {
+      // Disambiguate the path scheme MC uses when computing the
+      // deliverables-root surfaced in dispatch. Slice 7 of the
+      // autonomous-flow tightening: the AlertDialog Tester wrote
+      // screenshots to `/app/workspace/...` (container path) on a host
+      // runtime, getting ENOENT, because the dispatch doesn't differentiate
+      // host vs container. With this column the dispatch picks the right
+      // perspective per agent — and the role souls can call out the
+      // container/host distinction unambiguously.
+      const cols = db.prepare(`PRAGMA table_info(agents)`).all() as Array<{ name: string }>;
+      if (!cols.some(c => c.name === 'runtime_kind')) {
+        db.exec(
+          `ALTER TABLE agents ADD COLUMN runtime_kind TEXT
+             NOT NULL DEFAULT 'host'
+             CHECK (runtime_kind IN ('host', 'container'))`,
+        );
+      }
+      console.log('[Migration 060] agents.runtime_kind added.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -31,6 +31,10 @@ CREATE TABLE IF NOT EXISTS workspaces (
 );
 
 -- Agents table
+-- Note: agents.runtime_kind ("host" or "container") disambiguates the path
+-- perspective the agent sees. MC uses it to pick host- vs container-rooted
+-- deliverables paths at dispatch time so an agent running in a Docker
+-- container gets a /app/... path and a host agent gets a /Users/... path.
 CREATE TABLE IF NOT EXISTS agents (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
@@ -50,6 +54,7 @@ CREATE TABLE IF NOT EXISTS agents (
   is_active INTEGER DEFAULT 1,
   total_cost_usd REAL DEFAULT 0,
   total_tokens_used INTEGER DEFAULT 0,
+  runtime_kind TEXT NOT NULL DEFAULT 'host' CHECK (runtime_kind IN ('host', 'container')),
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );

--- a/src/lib/deliverables/storage.test.ts
+++ b/src/lib/deliverables/storage.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Smoke tests for getTaskDeliverableDir's perspective handling.
+ *
+ * Slice 7 of the autonomous-flow tightening. The AlertDialog Tester
+ * wrote a screenshot to `/app/workspace/...` (container path) on a host
+ * runtime and got ENOENT because the dispatch always passed 'host'.
+ * Now `agent.runtime_kind` picks the perspective at dispatch time. This
+ * test pins the underlying resolver behavior so future refactors can't
+ * silently regress.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getTaskDeliverableDir } from './storage';
+
+test('getTaskDeliverableDir(host) and (container) diverge when env paths differ', () => {
+  const prevHost = process.env.MC_DELIVERABLES_HOST_PATH;
+  const prevContainer = process.env.MC_DELIVERABLES_CONTAINER_PATH;
+  process.env.MC_DELIVERABLES_HOST_PATH = '/Users/op/projects';
+  process.env.MC_DELIVERABLES_CONTAINER_PATH = '/app/workspace/projects';
+
+  const taskId = 'tid-7';
+  const hostPath = getTaskDeliverableDir(taskId, 'host');
+  const containerPath = getTaskDeliverableDir(taskId, 'container');
+
+  assert.match(hostPath, /^\/Users\/op\/projects/);
+  assert.match(containerPath, /^\/app\/workspace\/projects/);
+  assert.notEqual(hostPath, containerPath);
+
+  // Cleanup
+  if (prevHost === undefined) delete process.env.MC_DELIVERABLES_HOST_PATH;
+  else process.env.MC_DELIVERABLES_HOST_PATH = prevHost;
+  if (prevContainer === undefined) delete process.env.MC_DELIVERABLES_CONTAINER_PATH;
+  else process.env.MC_DELIVERABLES_CONTAINER_PATH = prevContainer;
+});
+
+test('getTaskDeliverableDir collapses when env paths coincide (local dev default)', () => {
+  const prevHost = process.env.MC_DELIVERABLES_HOST_PATH;
+  const prevContainer = process.env.MC_DELIVERABLES_CONTAINER_PATH;
+  delete process.env.MC_DELIVERABLES_HOST_PATH;
+  delete process.env.MC_DELIVERABLES_CONTAINER_PATH;
+
+  const taskId = 'tid-collapse';
+  const hostPath = getTaskDeliverableDir(taskId, 'host');
+  const containerPath = getTaskDeliverableDir(taskId, 'container');
+  assert.equal(hostPath, containerPath);
+
+  if (prevHost !== undefined) process.env.MC_DELIVERABLES_HOST_PATH = prevHost;
+  if (prevContainer !== undefined) process.env.MC_DELIVERABLES_CONTAINER_PATH = prevContainer;
+});


### PR DESCRIPTION
## Summary

Slice 7 (final functional slice) of the autonomous-flow tightening (stacked on [#119](https://github.com/smb209/mission-control/pull/119)). Closes **FM7** from the post-mortem: the AlertDialog Tester wrote screenshots to \`/app/workspace/...\` (container path) on a host runtime and got ENOENT because the dispatch always passed \`'host'\`.

## Changes

- **Migration 060** adds \`agents.runtime_kind\` (\`'host'\` or \`'container'\`, default \`'host'\`)
- Dispatch route reads \`agent.runtime_kind\` and picks the perspective when computing \`deliverablesDir\`
- 2 new resolver tests pinning the host/container divergence

## Operator note

Containerized agents need \`runtime_kind='container'\` on their agent row. Default \`'host'\` preserves current behavior for all existing agents — this is purely additive.

## Test plan

- [x] \`yarn tsc --noEmit\` (pre-existing pm-decompose errors unrelated)
- [x] 75/75 affected tests pass
- [ ] Smoke: flip a Docker-runtime agent to \`runtime_kind='container'\`, dispatch, confirm the \`DELIVERABLES DIR\` line in their message matches the \`/app/...\` mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)