### PR TITLE
feat(pm): is_pm flag + operator-promotable PM identity (migration 061)

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -68,6 +68,7 @@ interface AgentLite {
   id: string;
   name: string;
   role: string;
+  is_pm?: number;
   workspace_id: string;
 }
 
@@ -151,11 +152,16 @@ function PmChatPageInner() {
     fetch(`/api/agents?workspace_id=${encodeURIComponent(workspaceId)}`)
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
       .then((agents: AgentLite[]) => {
-        const pm = agents.find(a => a.role === 'pm');
+        // Prefer the explicit is_pm flag (post-migration 061); fall
+        // back to the case-insensitive role match for legacy rows /
+        // the placeholder seeded by ensurePmAgent.
+        const pm =
+          agents.find(a => a.is_pm) ??
+          agents.find(a => a.role?.toLowerCase() === 'pm');
         setPmAgent(pm ?? null);
         if (!pm) {
           setError(
-            'No PM agent for this workspace. Migration 045 should have seeded one — try restarting the dev server, or create the workspace anew.',
+            'No PM agent for this workspace. Promote any agent via the AgentModal "PM for this workspace" checkbox on /agents.',
           );
         } else {
           setError(null);

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -46,8 +46,12 @@ export async function PATCH(
       values.push(body.name);
     }
     if (body.role !== undefined) {
+      // Normalize 'PM' / 'Pm' / 'pm' to lowercase 'pm' so the resolver's
+      // legacy fallback (LOWER(role)='pm') and direct equality both
+      // match. Other roles pass through unchanged — tightening to a
+      // whitelist would break operator-defined roles like "QA Tester".
       updates.push('role = ?');
-      values.push(body.role);
+      values.push(body.role.toLowerCase() === 'pm' ? 'pm' : body.role);
     }
     if (body.description !== undefined) {
       updates.push('description = ?');
@@ -72,6 +76,25 @@ export async function PATCH(
     if (body.is_master !== undefined) {
       updates.push('is_master = ?');
       values.push(body.is_master ? 1 : 0);
+    }
+    if (body.is_pm !== undefined) {
+      updates.push('is_pm = ?');
+      values.push(body.is_pm ? 1 : 0);
+      if (body.is_pm) {
+        // Promotion: this row is becoming the workspace's PM. Force
+        // role='pm' (so the legacy resolver fallback agrees with the
+        // flag) and clear is_pm on every sibling — one-PM-per-workspace
+        // invariant. We don't downgrade the sibling's role string;
+        // operators can rename a former PM via the modal if they want.
+        if (!updates.includes('role = ?')) {
+          updates.push('role = ?');
+          values.push('pm');
+        }
+        run(
+          `UPDATE agents SET is_pm = 0 WHERE workspace_id = ? AND id != ?`,
+          [existing.workspace_id, id],
+        );
+      }
     }
     if (body.soul_md !== undefined) {
       updates.push('soul_md = ?');

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -57,18 +57,24 @@ export async function POST(request: NextRequest) {
 
     const id = uuidv4();
     const now = new Date().toISOString();
+    const workspaceId = (body as { workspace_id?: string }).workspace_id || 'default';
+    // Match the PATCH normalization: 'PM'/'Pm' → 'pm' so the resolver's
+    // legacy fallback agrees with the is_pm flag.
+    const role = body.role.toLowerCase() === 'pm' ? 'pm' : body.role;
+    const isPm = body.is_pm ? 1 : 0;
 
     run(
-      `INSERT INTO agents (id, name, role, description, avatar_emoji, is_master, workspace_id, soul_md, user_md, agents_md, model, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO agents (id, name, role, description, avatar_emoji, is_master, is_pm, workspace_id, soul_md, user_md, agents_md, model, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         id,
         body.name,
-        body.role,
+        role,
         body.description || null,
         body.avatar_emoji || '🤖',
         body.is_master ? 1 : 0,
-        (body as { workspace_id?: string }).workspace_id || 'default',
+        isPm,
+        workspaceId,
         body.soul_md || null,
         body.user_md || null,
         body.agents_md || null,
@@ -77,6 +83,15 @@ export async function POST(request: NextRequest) {
         now,
       ]
     );
+
+    // One-PM-per-workspace invariant: if this new agent is being
+    // created as the PM, demote any prior PM in the same workspace.
+    if (isPm) {
+      run(
+        `UPDATE agents SET is_pm = 0 WHERE workspace_id = ? AND id != ?`,
+        [workspaceId, id],
+      );
+    }
 
     // Log event
     run(

--- a/src/components/AgentModal.tsx
+++ b/src/components/AgentModal.tsx
@@ -37,6 +37,7 @@ export function AgentModal({ agent, onClose, workspaceId, onAgentCreated }: Agen
     avatar_emoji: agent?.avatar_emoji || '🤖',
     status: agent?.status || 'standby' as AgentStatus,
     is_master: agent?.is_master || false,
+    is_pm: !!agent?.is_pm,
     soul_md: agent?.soul_md || '',
     user_md: agent?.user_md || '',
     agents_md: agent?.agents_md || '',
@@ -366,6 +367,23 @@ export function AgentModal({ agent, onClose, workspaceId, onAgentCreated }: Agen
                 />
                 <label htmlFor="is_master" className="text-sm">
                   Master Orchestrator (can coordinate other agents)
+                </label>
+              </div>
+
+              {/* PM Toggle — one PM per workspace; the API enforces the
+                  invariant (clears is_pm on every other agent in this
+                  workspace) and forces role='pm' so the resolver's
+                  legacy fallback agrees. */}
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="is_pm"
+                  checked={form.is_pm}
+                  onChange={(e) => setForm({ ...form, is_pm: e.target.checked })}
+                  className="w-4 h-4"
+                />
+                <label htmlFor="is_pm" className="text-sm">
+                  PM for this workspace (drives /pm chat + proposals)
                 </label>
               </div>
 

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -32,7 +32,7 @@
 
 import { getRoadmapSnapshot, type RoadmapSnapshot } from '@/lib/db/roadmap';
 import { previewDerivation } from '@/lib/roadmap/apply-derivation';
-import { queryAll, queryOne, run } from '@/lib/db';
+import { queryAll, run } from '@/lib/db';
 import { v4 as uuidv4 } from 'uuid';
 import {
   createProposal,
@@ -51,6 +51,7 @@ import {
   type SendChatClient,
 } from '@/lib/openclaw/send-chat';
 import { buildNotesIntakeMessage } from './pm-prompts/notes-intake';
+import { getPmAgent } from './pm-resolver';
 import type { Agent } from '@/lib/types';
 
 // ─── Public API ─────────────────────────────────────────────────────
@@ -377,11 +378,7 @@ function buildSnapshotSummary(snapshot: RoadmapSnapshot): string {
 // ─── Helpers ────────────────────────────────────────────────────────
 
 function lookupPmAgent(workspaceId: string): Agent | null {
-  const row = queryOne<Agent>(
-    `SELECT * FROM agents WHERE workspace_id = ? AND role = 'pm' LIMIT 1`,
-    [workspaceId],
-  );
-  return row ?? null;
+  return getPmAgent(workspaceId);
 }
 
 /**
@@ -978,10 +975,7 @@ interface PostPmChatMessage {
  * doesn't exist (caller is responsible for ensuring the migration ran).
  */
 export function postPmChatMessage(input: PostPmChatMessage): void {
-  const pm = queryOne<{ id: string }>(
-    `SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm' LIMIT 1`,
-    [input.workspace_id],
-  );
+  const pm = getPmAgent(input.workspace_id);
   if (!pm) {
     throw new Error(
       `No PM agent for workspace ${input.workspace_id} — migration 045 should have seeded one`,

--- a/src/lib/agents/pm-resolver.ts
+++ b/src/lib/agents/pm-resolver.ts
@@ -1,0 +1,36 @@
+/**
+ * Single seam for "which agent is the PM for this workspace?".
+ *
+ * Pre-061 every call site grew its own `WHERE workspace_id = ? AND
+ * role = 'pm'` query. That broke twice:
+ *   - the role match was case-sensitive, so a row persisted with
+ *     'PM' (which the API used to allow before normalization) was
+ *     invisible to the resolver, and
+ *   - prod→dev DB clones kept the prod gateway link on the PM row,
+ *     so dispatch chat was silently routed to the prod gateway.
+ *
+ * The new contract: the operator promotes any agent via the
+ * AgentModal "PM for this workspace" checkbox (which sets is_pm=1
+ * and clears it on every other agent in the workspace). This
+ * resolver prefers is_pm=1 and falls back to LOWER(role)='pm' for
+ * rows that pre-date migration 061.
+ */
+
+import { queryOne } from '@/lib/db';
+import type { Agent } from '@/lib/types';
+
+export function getPmAgent(workspaceId: string): Agent | null {
+  const flagged = queryOne<Agent>(
+    `SELECT * FROM agents
+       WHERE workspace_id = ? AND is_pm = 1
+       LIMIT 1`,
+    [workspaceId],
+  );
+  if (flagged) return flagged;
+  return queryOne<Agent>(
+    `SELECT * FROM agents
+       WHERE workspace_id = ? AND LOWER(role) = 'pm'
+       LIMIT 1`,
+    [workspaceId],
+  ) ?? null;
+}

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -91,13 +91,26 @@ function makeFakeClient(opts: {
   };
   return { client, seenSends };
 }
-import {
-  ensurePmAgent,
-  PM_GATEWAY_AGENT_ID,
-  PM_SESSION_KEY_PREFIX,
-  PM_NAMED_AGENT_NAME,
-  PM_NAMED_AGENT_AVATAR,
-} from '@/lib/bootstrap-agents';
+import { ensurePmAgent } from '@/lib/bootstrap-agents';
+
+// Concrete gateway link the dispatch tests promote the seeded PM with.
+// Pre-migration-061 these were exported from bootstrap-agents as
+// hardcoded constants, which baked the prod gateway id into seeded
+// workspaces. The new flow lets the operator promote any agent via
+// the AgentModal PM checkbox; tests simulate that promotion below.
+const TEST_PM_GATEWAY_AGENT_ID = 'mc-project-manager';
+const TEST_PM_SESSION_KEY_PREFIX = `agent:${TEST_PM_GATEWAY_AGENT_ID}:main`;
+
+function promotePmToGateway(workspaceId: string): void {
+  run(
+    `UPDATE agents
+        SET gateway_agent_id = ?,
+            session_key_prefix = ?,
+            source = 'gateway'
+      WHERE workspace_id = ? AND is_pm = 1`,
+    [TEST_PM_GATEWAY_AGENT_ID, TEST_PM_SESSION_KEY_PREFIX, workspaceId],
+  );
+}
 
 function freshWorkspace(): string {
   const id = `ws-${uuidv4().slice(0, 8)}`;
@@ -265,7 +278,7 @@ test('dispatchPm: returns a usable proposal even when nothing is parsed', async 
 
 // ─── Bootstrap: PM is now a named gateway agent ────────────────────
 
-test('ensurePmAgent: seeds the PM as a named gateway agent', () => {
+test('ensurePmAgent: seeds a generic local PM placeholder with is_pm=1', () => {
   const ws = freshWorkspace();
   const r = ensurePmAgent(ws);
   assert.equal(r.created, true);
@@ -274,20 +287,24 @@ test('ensurePmAgent: seeds the PM as a named gateway agent', () => {
     avatar_emoji: string;
     role: string;
     source: string;
-    gateway_agent_id: string;
-    session_key_prefix: string;
+    is_pm: number;
+    gateway_agent_id: string | null;
+    session_key_prefix: string | null;
   }>(
-    `SELECT name, avatar_emoji, role, source, gateway_agent_id, session_key_prefix
+    `SELECT name, avatar_emoji, role, source, is_pm, gateway_agent_id, session_key_prefix
        FROM agents WHERE id = ?`,
     [r.id],
   );
   assert.ok(row);
   assert.equal(row!.role, 'pm');
-  assert.equal(row!.gateway_agent_id, PM_GATEWAY_AGENT_ID);
-  assert.equal(row!.session_key_prefix, PM_SESSION_KEY_PREFIX);
-  assert.equal(row!.source, 'gateway');
-  assert.equal(row!.name, PM_NAMED_AGENT_NAME);
-  assert.equal(row!.avatar_emoji, PM_NAMED_AGENT_AVATAR);
+  assert.equal(row!.is_pm, 1);
+  assert.equal(row!.source, 'local');
+  // Pre-061 the seed baked the prod gateway link in here; post-061 the
+  // operator promotes a real gateway agent via the AgentModal checkbox.
+  assert.equal(row!.gateway_agent_id, null);
+  assert.equal(row!.session_key_prefix, null);
+  assert.equal(row!.name, 'PM');
+  assert.equal(row!.avatar_emoji, '📋');
 });
 
 // ─── Named-agent dispatch routing ──────────────────────────────────
@@ -295,6 +312,7 @@ test('ensurePmAgent: seeds the PM as a named gateway agent', () => {
 test('dispatchPm: routes through named agent when openclaw is connected; mock creates proposal via propose_changes simulation', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
 
   // The named agent would call propose_changes via MCP. Our mock client
   // simulates that side effect: when chat.send is invoked, it inserts a
@@ -332,7 +350,7 @@ test('dispatchPm: routes through named agent when openclaw is connected; mock cr
     const send = seenSends.find(s => s.method === 'chat.send');
     assert.ok(send);
     const sk = (send!.params as { sessionKey?: string }).sessionKey;
-    assert.equal(sk, `agent:${PM_GATEWAY_AGENT_ID}:main:dispatch-main`);
+    assert.equal(sk, `agent:${TEST_PM_GATEWAY_AGENT_ID}:main:dispatch-main`);
   } finally {
     __setOpenClawClientForTests(null);
     __setNamedAgentTimeoutForTests(null);
@@ -342,6 +360,7 @@ test('dispatchPm: routes through named agent when openclaw is connected; mock cr
 test('dispatchPm: falls back to synth when openclaw client is offline', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
   seedNamedAgent(ws, 'Sarah');
 
   const { client } = makeFakeClient({ isConnected: false });
@@ -369,6 +388,7 @@ test('dispatchPm: falls back to synth when openclaw client is offline', async ()
 test('dispatchPm: falls back to synth when named-agent send throws', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
   seedNamedAgent(ws, 'Sarah');
 
   const { client } = makeFakeClient({
@@ -397,6 +417,7 @@ test('dispatchPm: falls back to synth when named-agent send throws', async () =>
 test('dispatchPm: falls back to synth when named agent times out without writing', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
 
   // emitFinal: false → no chat_event arrives, await primitive will time out.
   const { client } = makeFakeClient({ emitFinal: false });
@@ -423,6 +444,7 @@ test('dispatchPm: falls back to synth when named agent times out without writing
 test('dispatchPm: notes_intake uses a fresh per-correlation session and the notes prompt', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
 
   const { client, seenSends } = makeFakeClient({
     onChatSend: () => {
@@ -463,6 +485,7 @@ test('dispatchPm: notes_intake uses a fresh per-correlation session and the note
 test('dispatchPm: allowFallback=false propagates gateway error instead of synth-falling-back', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
 
   // Gateway is down — synth path should be skipped.
   const { client } = makeFakeClient({ isConnected: false });
@@ -489,6 +512,7 @@ test('dispatchPm: allowFallback=false propagates gateway error instead of synth-
 test('dispatchPm: allowFallback=false + gateway-up but agent silent → completion.used_named_agent === false', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
 
   // Gateway up, but the agent emits final without writing a propose_changes
   // row. The reconciler tail expires; completion settles synth_only.
@@ -521,6 +545,7 @@ test('dispatchPm: allowFallback=false + gateway-up but agent silent → completi
 test('drainPendingNotes: skips when gateway is down', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
   const { enqueuePendingNote } = await import('@/lib/db/pm-pending-notes');
   enqueuePendingNote({ workspace_id: ws, agent_id: 'a', notes_text: 'x' });
 
@@ -541,6 +566,7 @@ test('drainPendingNotes: skips when gateway is down', async () => {
 test('drainPendingNotes: dispatches each pending row and marks dispatched', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
   // Earlier tests in the file may leave pending rows whose workspace
   // PMs aren't wired up to this fake client. Skip them so the drain
   // loop processes our row only.
@@ -593,6 +619,7 @@ const baseSynth = {
 test('dispatchPmSynthesized: returns synth placeholder synchronously when gateway is up', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
   const { client } = makeFakeClient({
     onChatSend: () => {
       // Simulate the agent landing a proposal via MCP propose_changes.
@@ -643,6 +670,7 @@ test('dispatchPmSynthesized: agent supersede re-echoes a chat message anchored t
   // disruption-path behavior in dispatchPm.
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
   const agentImpactMd = '### Agent reply\n- 8-story decomposition with deps';
   const { client } = makeFakeClient({
     onChatSend: () => {
@@ -705,6 +733,7 @@ test('dispatchPmSynthesized: agent supersede re-echoes a chat message anchored t
 test('dispatchPmSynthesized: timeoutMs is honored — bumping it lets a slow agent win', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
   // The fake client emits final 200ms after send; with a 50ms timeout the
   // primary wait fails, but the tail window catches it.
   const { client } = makeFakeClient({
@@ -742,6 +771,7 @@ test('dispatchPmSynthesized: timeoutMs is honored — bumping it lets a slow age
 test('dispatchPmSynthesized: synth_only when no agent reply ever arrives', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
   // No onChatSend → no agent row created. emitFinal default true so wait
   // returns sent:true but findProposal sees nothing.
   const { client } = makeFakeClient({});
@@ -771,6 +801,7 @@ test('dispatchPmSynthesized: synth_only when no agent reply ever arrives', async
 test('dispatchPmSynthesized: gateway down → synth-only placeholder, no background dispatch', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
   const { client } = makeFakeClient({ isConnected: false });
   __setOpenClawClientForTests(client);
   try {
@@ -794,6 +825,7 @@ test('dispatchPmSynthesized: gateway down → synth-only placeholder, no backgro
 test('dispatchPmSynthesized: target_initiative_id is stamped on the agent row during supersede', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
   const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Tier-2 target' });
   const { client } = makeFakeClient({
     onChatSend: () => {
@@ -832,6 +864,7 @@ test('dispatchPmSynthesized: target_initiative_id is stamped on the agent row du
 test('dispatchPmSynthesized: plan_initiative — agent omits target dates → reconciler backfills from synth', async () => {
   const ws = freshWorkspace();
   ensurePmAgent(ws);
+  promotePmToGateway(ws);
   // Build a synth that has populated dates (always true in production —
   // synthesizePlanInitiative inserts derived target_start / _end based on
   // complexity).

--- a/src/lib/bootstrap-agents.ts
+++ b/src/lib/bootstrap-agents.ts
@@ -52,34 +52,29 @@ export function bootstrapCoreAgentsRaw(
 }
 
 /**
- * Ensure the workspace has a PM (role='pm') agent. Idempotent. Reads the
- * soul_md from the .md file next to the pm-agent module so operators can
- * tweak the prompt without redeploying. Safe to call from API routes.
+ * Ensure the workspace has a PM agent. Idempotent.
  *
- * The PM is now seeded as a NAMED gateway agent (source='gateway') linked
- * to the openclaw workspace at `~/.openclaw/workspaces/mc-project-manager/`.
- * That workspace ships with full agent files (SOUL.md, IDENTITY.md, etc.)
- * — same pattern as mc-coordinator/mc-builder/etc. The `gateway_agent_id`
- * + `session_key_prefix` are what let `resolveAgentSessionKeyPrefix` route
- * real chat.send traffic to the gateway-hosted PM session.
+ * Pre-061 this seeded a hardcoded `mc-project-manager` gateway link with
+ * a default name ("Margaret 'Maps' Hamilton"). That bound the PM identity
+ * to a specific gateway agent, which broke when a dev DB cloned from
+ * prod via `db:import-from-prod --agent-suffix=-dev` ended up routing
+ * chat to the still-prod gateway session. The fix is to let operators
+ * promote ANY existing agent via the AgentModal "PM for this workspace"
+ * checkbox — `getPmAgent` resolves the chosen one.
  *
- * Migration 045 originally seeded PMs as ephemeral source='local' rows
- * with no gateway link; migration 049 backfills those rows so they pick
- * up the new routing.
- *
- * If a PM row already exists for the workspace this function does NOT
- * mutate it — operators may have customised it, and migration 049 owns
- * the backfill for older rows.
+ * What this function still does on a fresh workspace: insert a generic
+ * placeholder PM (local source, no gateway link, name "PM") so the /pm
+ * UI has something to render before the operator promotes a real agent.
+ * If a PM already exists (via is_pm=1 OR LOWER(role)='pm'), it's left
+ * untouched — operators may have customized it, and migration 061
+ * backfilled is_pm for legacy rows.
  */
-export const PM_GATEWAY_AGENT_ID = 'mc-project-manager';
-export const PM_SESSION_KEY_PREFIX = `agent:${PM_GATEWAY_AGENT_ID}:main`;
-export const PM_NAMED_AGENT_NAME = 'Margaret "Maps" Hamilton';
-export const PM_NAMED_AGENT_AVATAR = '🗺️';
-
 export function ensurePmAgent(workspaceId: string): { id: string; created: boolean } {
   const db = getDb();
   const existing = db.prepare(
-    `SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm' LIMIT 1`,
+    `SELECT id FROM agents
+       WHERE workspace_id = ? AND (is_pm = 1 OR LOWER(role) = 'pm')
+       LIMIT 1`,
   ).get(workspaceId) as { id: string } | undefined;
   if (existing) return { id: existing.id, created: false };
 
@@ -90,23 +85,21 @@ export function ensurePmAgent(workspaceId: string): { id: string; created: boole
 
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
-  // source='gateway' matches the convention used by agent-catalog-sync
-  // for every gateway-hosted named agent (mc-coordinator, mc-builder, …).
+  // source='local', no gateway link — a placeholder. The operator
+  // either edits this row to point at a gateway PM, or (more likely)
+  // promotes a different existing gateway agent via the AgentModal
+  // checkbox, which clears is_pm here and sets it on the new target.
   db.prepare(`
     INSERT INTO agents (
-      id, name, role, description, avatar_emoji, status, is_master,
-      workspace_id, soul_md, source, gateway_agent_id, session_key_prefix,
+      id, name, role, description, avatar_emoji, status, is_master, is_pm,
+      workspace_id, soul_md, source,
       is_active, created_at, updated_at
-    ) VALUES (?, ?, 'pm', ?, ?, 'standby', 0, ?, ?, 'gateway', ?, ?, 1, ?, ?)
+    ) VALUES (?, 'PM', 'pm', ?, '📋', 'standby', 0, 1, ?, ?, 'local', 1, ?, ?)
   `).run(
     id,
-    PM_NAMED_AGENT_NAME,
     PM_AGENT_DESCRIPTION,
-    PM_NAMED_AGENT_AVATAR,
     workspaceId,
     getPmSoulMd(),
-    PM_GATEWAY_AGENT_ID,
-    PM_SESSION_KEY_PREFIX,
     now,
     now,
   );

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3558,6 +3558,31 @@ const migrations: Migration[] = [
       console.log('[Migration 060] agents.runtime_kind added.');
     },
   },
+  {
+    id: '061',
+    name: 'agents_is_pm',
+    up: (db) => {
+      // Decouple PM identity from a hardcoded gateway agent id. Pre-061
+      // the PM was discovered via `WHERE role = 'pm'`, which (a) is
+      // case-sensitive (rows persisted as 'PM' silently disappeared from
+      // the resolver) and (b) baked the prod gateway link into seeded
+      // workspaces, so a dev DB cloned from prod kept routing PM chat
+      // to the prod gateway session. With is_pm the operator promotes
+      // any agent (including a `*-dev` clone) from the AgentModal
+      // checkbox; the resolver prefers is_pm=1 and falls back to
+      // LOWER(role)='pm' for legacy rows.
+      const cols = db.prepare(`PRAGMA table_info(agents)`).all() as Array<{ name: string }>;
+      if (!cols.some(c => c.name === 'is_pm')) {
+        db.exec(`ALTER TABLE agents ADD COLUMN is_pm INTEGER DEFAULT 0`);
+      }
+      // Backfill: any row whose role *parses* as PM (case-insensitive)
+      // becomes the PM. Also normalize the persisted role string so
+      // future reads don't depend on the resolver's compat fallback.
+      db.exec(`UPDATE agents SET is_pm = 1 WHERE LOWER(role) = 'pm'`);
+      db.exec(`UPDATE agents SET role = 'pm' WHERE LOWER(role) = 'pm' AND role != 'pm'`);
+      console.log('[Migration 061] agents.is_pm added + backfilled from role.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -43,6 +43,12 @@ CREATE TABLE IF NOT EXISTS agents (
   avatar_emoji TEXT DEFAULT '🤖',
   status TEXT DEFAULT 'standby' CHECK (status IN ('standby', 'working', 'offline')),
   is_master INTEGER DEFAULT 0,
+  -- One agent per workspace may carry is_pm=1. The PM resolver
+  -- (getPmAgent) prefers is_pm=1 and falls back to LOWER(role)='pm'
+  -- for compat with rows that pre-date migration 061. Operators flip
+  -- this from the AgentModal "PM for this workspace" checkbox; the
+  -- API enforces the single-PM invariant.
+  is_pm INTEGER DEFAULT 0,
   workspace_id TEXT DEFAULT 'default' REFERENCES workspaces(id) ON DELETE CASCADE,
   soul_md TEXT,
   user_md TEXT,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,10 @@ export interface Agent {
   avatar_emoji: string;
   status: AgentStatus;
   is_master: boolean;
+  /** Migration 061: workspace-scoped PM flag. The PM resolver prefers
+   *  this flag over the legacy `role='pm'` match. SQLite hydrates as
+   *  number (0|1); the modal coerces to boolean for the checkbox. */
+  is_pm?: number;
   workspace_id: string;
   soul_md?: string;
   user_md?: string;
@@ -421,6 +425,7 @@ export interface CreateAgentRequest {
   description?: string;
   avatar_emoji?: string;
   is_master?: boolean;
+  is_pm?: boolean;
   soul_md?: string;
   user_md?: string;
   agents_md?: string;


### PR DESCRIPTION
## Summary

- Adds `agents.is_pm` (migration 061) so the PM identity is no longer baked into a hardcoded gateway agent id. Backfills from `LOWER(role)='pm'` and normalizes the persisted role string.
- New `getPmAgent(workspaceId)` resolver — prefers `is_pm=1`, falls back to `LOWER(role)='pm'` for legacy rows. Replaces every ad-hoc `WHERE role = 'pm'` query in pm-dispatch.
- Drops `PM_GATEWAY_AGENT_ID` / `PM_SESSION_KEY_PREFIX` / `PM_NAMED_AGENT_NAME` / `PM_NAMED_AGENT_AVATAR` from `bootstrap-agents.ts`. `ensurePmAgent` now seeds a generic local placeholder; operators promote any agent (including `*-dev` clones) via the new AgentModal "PM for this workspace" checkbox without DB edits.
- Server-side: PATCH/POST `/api/agents` lowercase-normalize `role` (`'PM'` → `'pm'`) and enforce one-PM-per-workspace by clearing `is_pm` on siblings when promoting.

## Why

`db:import-from-prod --agent-suffix=-dev` cloned the prod PM row but the bootstrap-baked `mc-project-manager` gateway link kept routing dev PM chat to the prod gateway session. Symptom: `/pm` showed "No PM agent for this workspace" because (a) the role was persisted as `'PM'` (case mismatch with `WHERE role = 'pm'`) and (b) `session_key_prefix` was stale.

## Migration

- `061_agents_is_pm` — `ALTER TABLE agents ADD COLUMN is_pm INTEGER DEFAULT 0`, then `UPDATE agents SET is_pm = 1 WHERE LOWER(role) = 'pm'` and `UPDATE agents SET role = 'pm' WHERE LOWER(role) = 'pm' AND role != 'pm'`. Idempotent (PRAGMA-guarded).

## Test plan

- [x] `npx tsc --noEmit` — only pre-existing failures in `src/lib/agents/pm-decompose.test.ts` (lines 169, 173 — unrelated to this change). No new errors introduced.
- [x] `yarn test` — **all 467 tests pass** (suite of 11 files, 181s).
- [x] Preview verify on `mission-control-preview` (port 4011, fresh DB):
  - Migration 061 logged on boot.
  - `POST /api/agents` (Coordinator-Dev, `role: coordinator`) → `PATCH { is_pm: true }` → row has `is_pm=1, role='pm'`; prior PM (Margaret) had `is_pm` cleared.
  - `PATCH { role: 'PM' }` returned `role: 'pm'` (lowercase normalization confirmed).
  - `/api/agents` filtered for `is_pm` returned the promoted Coordinator-Dev (resolver picks correctly even with two `role='pm'` rows in the workspace).
  - Only error in preview logs was the expected gateway-token mismatch (no real openclaw in preview env); no errors from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)