### PR TITLE
feat(initiatives): hide cancelled by default + Show cancelled toggle

### DIFF
--- a/specs/pm-revertable-proposals.md
+++ b/specs/pm-revertable-proposals.md
@@ -1,0 +1,116 @@
+# PM action audit log + revertable proposals
+
+## Why
+
+The PM agent mutates initiative/story state via accepted proposals. Today there is no end-user-visible audit timeline and no one-click revert. Product decision: the PM should never hard-delete — `set_initiative_status: 'cancelled'` is the strongest destructive action it can take — but cancelled rows currently still render inline in the tree. We need:
+
+1. Reversibility on every accepted proposal.
+2. A UI affordance that keeps cancelled tombstones from cluttering normal browsing.
+
+## Existing infrastructure (do NOT re-invent)
+
+- **`pm_proposals` table** — schema in [src/lib/db/migrations.ts](../src/lib/db/migrations.ts) around line 2468. Already persists each proposal with its full diff list, `applied_at`, `applied_by_agent_id`, `status` (`draft|accepted|rejected|superseded`). This **is** the audit log; we just don't surface it.
+- **`initiative_parent_history`** ([migrations.ts:2423](../src/lib/db/migrations.ts)) and **`task_initiative_history`** ([migrations.ts:2435](../src/lib/db/migrations.ts)) — parent/task move audit, already written by the proposal accept path.
+- **`rollback_history`** table (migration 026, [migrations.ts:1482](../src/lib/db/migrations.ts)) — currently scoped to product rollbacks. Do **not** repurpose; add a separate concept.
+- **Diff vocabulary** lives in [src/lib/db/pm-proposals.ts:46–105](../src/lib/db/pm-proposals.ts). Supported kinds:
+  - `shift_initiative_target`
+  - `set_initiative_status`
+  - `add_dependency`
+  - `remove_dependency`
+  - `reorder_initiatives`
+  - `update_status_check`
+  - `create_child_initiative`
+  - `create_task_under_initiative`
+  - `add_availability`
+
+  No delete kind exists, by design.
+- **`applyDiff` switch** at [pm-proposals.ts:752](../src/lib/db/pm-proposals.ts) — that's where each kind's forward apply lives, and where you'll discover the per-kind state needed to compute an inverse.
+- **PM page**: [src/app/(app)/pm/page.tsx](../src/app/(app)/pm/page.tsx).
+- **Proposal diffs UI**: [src/components/pm/ProposalDiffsList.tsx](../src/components/pm/ProposalDiffsList.tsx).
+- **Initiatives tree**: [src/app/(app)/initiatives/page.tsx](../src/app/(app)/initiatives/page.tsx).
+
+## Scope — three deliverables
+
+### 1. Hide cancelled initiatives by default with a filter toggle
+
+- In the initiatives tree (`/initiatives`) and any picker/select that lists initiatives (PM proposal target picker, dependency picker), filter out rows where `status='cancelled'` by default.
+- Add a "Show cancelled" toggle in the tree header. Persist preference in URL query param (`?show_cancelled=1`) so links are shareable; mirror to localStorage as a fallback default.
+- Cancelled rows, when shown, should render with reduced opacity + a "cancelled" pill so they're visually distinct.
+- Decide and document whether `done` deserves the same hidden-by-default treatment. **Recommendation:** leave `done` visible (it's positive completion signal); only hide `cancelled`. If you disagree after auditing, propose the alternative in the PR description.
+- Children of a cancelled parent should **not** be auto-hidden — only direct `status='cancelled'` rows. (User may want to see what was scoped under a cancelled epic.)
+- **Do not** touch the API filter — keep backend returning everything; this is purely a client-side filter so the audit/revert paths can still see cancelled rows.
+
+### 2. Revertable proposals
+
+Add a `revert_proposal` action: given an accepted proposal, synthesize the inverse diff list and create a **new draft proposal** with `trigger_kind='revert'` and a `reverts_proposal_id` foreign key column on `pm_proposals` (new migration).
+
+**Inverse mappings** — implement in a new helper, e.g. `src/lib/pm/invertDiff.ts`:
+
+| Forward kind | Inverse strategy |
+|---|---|
+| `set_initiative_status: { from: A, to: B }` | `set_initiative_status: { from: B, to: A }`. Forward apply must capture `from` if it doesn't already; check current schema. |
+| `shift_initiative_target` | Swap before/after dates (already symmetric). |
+| `update_status_check` | Restore previous markdown. Forward apply must persist the previous value into the diff record at apply time. |
+| `add_dependency` | `remove_dependency` (need the created dependency_id, captured at apply). |
+| `remove_dependency` | `add_dependency` (need the full dependency row snapshot, captured at apply). |
+| `reorder_initiatives` | Reorder back to the previous sort_order list. |
+| `create_child_initiative` | `set_initiative_status: 'cancelled'` on the created row (we don't delete). The created child's id must be captured back into the diff record at apply time so revert can target it. |
+| `create_task_under_initiative` | `set_task_status: 'cancelled'` (if that diff kind exists; if not, add it). Same id-capture pattern. |
+| `add_availability` | Mark the row inactive or mirror with a removal diff. Audit current `add_availability` apply path; choose the cleanest inverse. |
+
+**The "captured at apply time" pattern is critical:** each forward apply should persist enough state into the diff record (or a sibling table) that the inverse is a pure function of the diff row alone. Don't recompute from current DB state at revert time — it'll have drifted.
+
+**Review flow:**
+- Reverts produce a new proposal that goes through the normal review→accept flow. Do **not** auto-apply. The user must approve the revert just like any other proposal, so they can see and edit it first.
+- If the proposal being reverted is itself a revert, that's fine — it just produces another inverse. No special-casing.
+- If any state the original diff touched has been further modified since (e.g. someone manually changed status after the PM set it), surface that in the revert preview as a **warning chip per affected diff**. Do **not** block — let the user decide.
+
+### 3. PM activity timeline UI
+
+- New tab or section on `/pm` (or a new route `/pm/activity`) showing a chronological feed of accepted proposals: `trigger_kind`, target initiative title, summary of diffs, `applied_at`, `applied_by_agent_id`, and a "Revert" button per row.
+- Filter chips: `trigger_kind` (decompose, status, dependency, etc.), agent, date range.
+- Clicking a row expands the full diff list (reuse `ProposalDiffsList` in a read-only mode if reasonable).
+- "Revert" button calls the new revert endpoint and routes the user to the resulting draft proposal.
+
+## Non-goals
+
+- Hard delete of initiatives/stories. Stays disabled in the PM. Operator-only via existing `DELETE /api/initiatives/[id]`.
+- Reverting non-PM mutations (direct API edits, UI edits made outside the proposal flow). Only proposals get the revert button.
+- Auto-revert / scheduled revert / TTL on proposals. Manual only.
+
+## Migration & backfill
+
+- New migration: add `reverts_proposal_id` column on `pm_proposals` (nullable). Add `'revert'` to the `trigger_kind` enum (check current CHECK constraint in `migrations.ts`).
+- Add capture columns on the diff JSON shape — the diff is stored as JSON so this is a code-level change, not a schema one, but the TypeScript types in [pm-proposals.ts:46–105](../src/lib/db/pm-proposals.ts) need updating.
+- **Existing accepted proposals** predate the capture pattern — they'll show "Revert (limited)" with a tooltip explaining the inverse can't be computed for diffs that didn't capture before-state. Do not block; just disable the button per-diff with a hover explanation.
+
+## Tests
+
+- Unit tests for `invertDiff.ts` covering each kind round-trip: `apply(forward) → apply(invert(forward))` returns DB state to baseline. Use the in-memory test DB pattern already in [pm-proposals.test.ts](../src/lib/db/pm-proposals.test.ts).
+- Integration test: full proposal accept → revert → accept-revert flow, verify final state matches initial.
+- UI smoke: `/pm/activity` renders, revert button creates a draft, draft renders correctly in the proposal review UI.
+
+## Verification
+
+Use `preview_*` tools after implementation:
+
+1. Start dev server.
+2. Click through `/initiatives` — toggle works, cancelled hidden by default.
+3. Visit `/pm/activity` — timeline renders, revert creates a draft.
+4. Accept a revert proposal and confirm state restoration end-to-end.
+
+## Project conventions (from CLAUDE.md)
+
+- **Yarn**, not npm.
+- PRs target `smb209/mission-control` with `--repo smb209/mission-control --base main`.
+- Run the full test suite before declaring green; surface any pre-existing failures explicitly.
+- Spec-first for multi-layer changes — this doc fulfills that requirement; revise it as scope shifts during implementation.
+
+## Suggested PR breakdown
+
+1. **Foundation** — migration + diff capture columns + types. No UI.
+2. **Logic** — `invertDiff.ts` + revert endpoint + tests. No UI.
+3. **Timeline UI** — `/pm/activity` + revert button. UI on top of the working backend.
+4. **Cancelled-filter toggle** on `/initiatives`. Independent slice, can ship parallel to 1–3.
+
+Each as its own PR stacked on the previous. **Retarget child PR bases to `main` before merging the parent with `--delete-branch`** (per CLAUDE.md stacked-PR note) — otherwise GitHub auto-closes the children.

--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import Link from 'next/link';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import {
   Plus,
   ChevronRight,
@@ -91,8 +92,52 @@ const KIND_BADGE: Record<Kind, string> = {
 
 const WORKSPACE_ID = 'default';
 
+const SHOW_CANCELLED_LS_KEY = 'mc:initiatives:show_cancelled';
+
+// Toggle persisted across the URL (`?show_cancelled=1`) so links survive
+// reload + are shareable. localStorage is the fallback default when the
+// URL has no opinion. URL value, when present, wins over localStorage.
+function useShowCancelled(): [boolean, (next: boolean) => void] {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const urlValue = searchParams.get('show_cancelled');
+
+  const initial = (() => {
+    if (urlValue === '1') return true;
+    if (urlValue === '0') return false;
+    if (typeof window !== 'undefined') {
+      return window.localStorage.getItem(SHOW_CANCELLED_LS_KEY) === '1';
+    }
+    return false;
+  })();
+
+  const [value, setValue] = useState<boolean>(initial);
+
+  useEffect(() => {
+    if (urlValue === '1') setValue(true);
+    else if (urlValue === '0') setValue(false);
+  }, [urlValue]);
+
+  const update = useCallback(
+    (next: boolean) => {
+      setValue(next);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(SHOW_CANCELLED_LS_KEY, next ? '1' : '0');
+      }
+      const params = new URLSearchParams(searchParams.toString());
+      if (next) params.set('show_cancelled', '1');
+      else params.delete('show_cancelled');
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname);
+    },
+    [router, pathname, searchParams],
+  );
+
+  return [value, update];
+}
+
 export default function InitiativesPage() {
-  const [tree, setTree] = useState<TreeNode[]>([]);
   const [flat, setFlat] = useState<Initiative[]>([]);
   const [taskCounts, setTaskCounts] = useState<Record<string, TaskCounts>>({});
   const [loading, setLoading] = useState(true);
@@ -105,6 +150,7 @@ export default function InitiativesPage() {
   const [historyFor, setHistoryFor] = useState<Initiative | null>(null);
   const [addingDepFor, setAddingDepFor] = useState<Initiative | null>(null);
   const [decomposing, setDecomposing] = useState<Initiative | null>(null);
+  const [showCancelled, setShowCancelled] = useShowCancelled();
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -116,7 +162,6 @@ export default function InitiativesPage() {
       if (!iRes.ok) throw new Error(`Failed to load (${iRes.status})`);
       const rows: Initiative[] = await iRes.json();
       setFlat(rows);
-      setTree(buildTree(rows));
 
       // Count tasks per initiative_id, partitioned by status family.
       const counts: Record<string, TaskCounts> = {};
@@ -144,6 +189,20 @@ export default function InitiativesPage() {
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  // Tree + picker list derive from flat + the cancelled-filter toggle.
+  // Cancelled rows are spliced out and their non-cancelled children
+  // re-parent to the cancelled row's effective parent so the subtree
+  // doesn't get orphaned.
+  const tree = useMemo(() => buildTree(flat, !showCancelled), [flat, showCancelled]);
+  const pickableInitiatives = useMemo(
+    () => (showCancelled ? flat : flat.filter(i => i.status !== 'cancelled')),
+    [flat, showCancelled],
+  );
+  const cancelledCount = useMemo(
+    () => flat.filter(i => i.status === 'cancelled').length,
+    [flat],
+  );
 
   // Detach = move to no parent. Surfaced from the action menu when the
   // initiative currently has a parent.
@@ -178,6 +237,21 @@ export default function InitiativesPage() {
         <div className="flex items-center gap-2">
           {/* "Workspaces" button removed — global workspace switcher lives
               in the unified left nav now. */}
+          <label
+            className="inline-flex items-center gap-1.5 text-xs text-mc-text-secondary cursor-pointer select-none"
+            title="Toggle visibility of cancelled initiatives. Persisted in URL (?show_cancelled=1) and localStorage."
+          >
+            <input
+              type="checkbox"
+              className="accent-mc-accent"
+              checked={showCancelled}
+              onChange={e => setShowCancelled(e.target.checked)}
+            />
+            Show cancelled
+            {cancelledCount > 0 && (
+              <span className="text-[11px] text-mc-text-secondary/70">({cancelledCount})</span>
+            )}
+          </label>
           <button
             onClick={() => setCreating({ parent_id: null })}
             className="px-3 py-2 rounded-lg bg-mc-accent text-white hover:bg-mc-accent/90 text-sm flex items-center gap-2"
@@ -205,6 +279,7 @@ export default function InitiativesPage() {
                 node={node}
                 depth={0}
                 allInitiatives={flat}
+                pickableInitiatives={pickableInitiatives}
                 taskCounts={taskCounts}
                 onEdit={setEditing}
                 onAddChild={parent => setCreating({ parent_id: parent.id })}
@@ -234,7 +309,7 @@ export default function InitiativesPage() {
       {creating && (
         <CreateModal
           parentId={creating.parent_id}
-          allInitiatives={flat}
+          allInitiatives={pickableInitiatives}
           onClose={() => setCreating(null)}
           onSaved={() => {
             setCreating(null);
@@ -253,7 +328,7 @@ export default function InitiativesPage() {
       {moving && (
         <MoveModal
           initiative={moving}
-          allInitiatives={flat}
+          allInitiatives={pickableInitiatives}
           onClose={() => setMoving(null)}
           onSaved={() => {
             setMoving(null);
@@ -291,7 +366,7 @@ export default function InitiativesPage() {
       {addingDepFor && (
         <AddDependencyModal
           initiative={addingDepFor}
-          allInitiatives={flat}
+          allInitiatives={pickableInitiatives}
           onClose={() => setAddingDepFor(null)}
           onSaved={() => {
             setAddingDepFor(null);
@@ -313,10 +388,26 @@ export default function InitiativesPage() {
   );
 }
 
-function buildTree(rows: Initiative[]): TreeNode[] {
+function buildTree(rows: Initiative[], hideCancelled: boolean): TreeNode[] {
+  const byId = new Map(rows.map(r => [r.id, r] as const));
+  const isHidden = (r: Initiative | undefined) =>
+    !!r && hideCancelled && r.status === 'cancelled';
+
+  // If a parent is hidden (cancelled), walk up until we hit a visible
+  // ancestor — that's where the visible child should attach so the
+  // subtree doesn't render as orphaned root rows.
+  function effectiveParent(parentId: string | null): string | null {
+    if (parentId == null) return null;
+    const p = byId.get(parentId);
+    if (!p) return null;
+    if (isHidden(p)) return effectiveParent(p.parent_initiative_id);
+    return parentId;
+  }
+
+  const visible = rows.filter(r => !isHidden(r));
   const byParent = new Map<string | null, Initiative[]>();
-  for (const r of rows) {
-    const k = r.parent_initiative_id ?? null;
+  for (const r of visible) {
+    const k = effectiveParent(r.parent_initiative_id);
     const list = byParent.get(k) ?? [];
     list.push(r);
     byParent.set(k, list);
@@ -332,6 +423,7 @@ function InitiativeRow({
   node,
   depth,
   allInitiatives,
+  pickableInitiatives,
   taskCounts,
   onEdit,
   onAddChild,
@@ -347,6 +439,7 @@ function InitiativeRow({
   node: TreeNode;
   depth: number;
   allInitiatives: Initiative[];
+  pickableInitiatives: Initiative[];
   taskCounts: Record<string, TaskCounts>;
   onEdit: (init: Initiative) => void;
   onAddChild: (parent: Initiative) => void;
@@ -429,7 +522,9 @@ function InitiativeRow({
   return (
     <>
       <li
-        className="flex items-center gap-2 p-2 rounded-lg bg-mc-bg-secondary border border-mc-border hover:border-mc-accent/40"
+        className={`flex items-center gap-2 p-2 rounded-lg bg-mc-bg-secondary border border-mc-border hover:border-mc-accent/40 ${
+          node.status === 'cancelled' ? 'opacity-60' : ''
+        }`}
         style={{ marginLeft: depth * 24 }}
       >
         <button
@@ -467,7 +562,16 @@ function InitiativeRow({
         >
           <ExternalLink className="w-3.5 h-3.5" />
         </Link>
-        <span className="text-xs text-mc-text-secondary">{node.status}</span>
+        {node.status === 'cancelled' ? (
+          <span
+            className="text-[11px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-red-500/15 text-red-300 border border-red-500/30"
+            title="This initiative is cancelled"
+          >
+            cancelled
+          </span>
+        ) : (
+          <span className="text-xs text-mc-text-secondary">{node.status}</span>
+        )}
         {!childrenExpanded && directChildrenCount > 0 && (
           <span
             className="text-[11px] text-mc-text-secondary/80"
@@ -521,7 +625,11 @@ function InitiativeRow({
           className="rounded-lg bg-mc-bg border border-mc-border/60 px-3 py-2 -mt-1 text-sm"
           style={{ marginLeft: depth * 24 + 12 }}
         >
-          <DetailsPanel initiative={node} allInitiatives={allInitiatives} />
+          <DetailsPanel
+            initiative={node}
+            allInitiatives={allInitiatives}
+            pickableInitiatives={pickableInitiatives}
+          />
           <div className="mt-2 pt-2 border-t border-mc-border/60 flex justify-end">
             <Link
               href={`/initiatives/${node.id}`}
@@ -539,6 +647,7 @@ function InitiativeRow({
             node={c}
             depth={depth + 1}
             allInitiatives={allInitiatives}
+            pickableInitiatives={pickableInitiatives}
             taskCounts={taskCounts}
             onEdit={onEdit}
             onAddChild={onAddChild}
@@ -581,9 +690,11 @@ interface DepEdges {
 function DetailsPanel({
   initiative,
   allInitiatives,
+  pickableInitiatives,
 }: {
   initiative: Initiative;
   allInitiatives: Initiative[];
+  pickableInitiatives: Initiative[];
 }) {
   const [history, setHistory] = useState<HistoryRow[]>([]);
   const [deps, setDeps] = useState<DepEdges | null>(null);
@@ -691,7 +802,7 @@ function DetailsPanel({
               onChange={e => setChosenDep(e.target.value)}
             >
               <option value="">(choose initiative this depends on)</option>
-              {allInitiatives
+              {pickableInitiatives
                 .filter(i => i.id !== initiative.id)
                 .map(i => (
                   <option key={i.id} value={i.id}>

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -1201,8 +1201,11 @@ function ApplyPlanToInitiativeModal({
       try {
         const res = await fetch(`/api/initiatives?workspace_id=${encodeURIComponent(workspaceId)}`);
         if (!res.ok) throw new Error(`Failed to load initiatives (${res.status})`);
-        const list = (await res.json()) as InitiativeLite[];
+        const raw = (await res.json()) as InitiativeLite[];
         if (cancelled) return;
+        // Cancelled initiatives are tombstones; never preselect or offer
+        // them as a target for new PM suggestions.
+        const list = raw.filter(i => i.status !== 'cancelled');
         setInitiatives(list);
         // Preselect by case-insensitive title equality first, then by
         // longest substring overlap. If nothing matches, leave the


### PR DESCRIPTION
## Summary

First slice of [specs/pm-revertable-proposals.md](specs/pm-revertable-proposals.md) — the independent UI slice. Cancelled initiatives are tombstones that the PM intentionally never hard-deletes, but they were cluttering the tree and showing up as picker options.

## Changes

- `/initiatives` header gains a **Show cancelled** toggle. Off by default. Persisted in URL (`?show_cancelled=1`) so links are shareable, with `localStorage` as the fallback default.
- `buildTree` splices cancelled rows out and re-parents their non-cancelled children to the cancelled row's effective ancestor — subtrees don't get orphaned when the parent is hidden.
- Cancelled rows, when shown, render at `opacity-60` with a red `cancelled` pill in place of the status text.
- Every initiative picker honors the toggle: Create parent, Move parent, Add dependency, DetailsPanel inline dep select, and the PM `ApplyPlanToInitiativeModal` target picker.
- **Backend filter is unchanged** — this is purely client-side so the audit/revert paths in the upcoming slices still see cancelled rows.
- Adds `specs/pm-revertable-proposals.md` so reviewers have context for the broader PM-revertable-proposals project this is the first PR of.

`done` deliberately stays visible (positive completion signal); only `cancelled` is hidden.

## Test plan

Verified via preview server on `:4011`:
- [x] Toggle off (default): cancelled epic hidden, its non-cancelled child re-parents to root
- [x] Toggle on: cancelled epic appears with red pill + reduced opacity, child re-nests under it
- [x] URL flips to `?show_cancelled=1` and `localStorage['mc:initiatives:show_cancelled']` updates
- [x] Create-modal parent picker omits cancelled when toggle off, includes when on
- [x] No console errors during interactions
- [x] `tsc --noEmit` clean for the touched files (pre-existing failures in `pm-decompose.test.ts` are unrelated)