### PR TITLE
feat(pm): foundation for revertable proposals — capture state on apply

### DIFF
--- a/specs/pm-revertable-proposals.md
+++ b/specs/pm-revertable-proposals.md
@@ -1,0 +1,116 @@
+# PM action audit log + revertable proposals
+
+## Why
+
+The PM agent mutates initiative/story state via accepted proposals. Today there is no end-user-visible audit timeline and no one-click revert. Product decision: the PM should never hard-delete — `set_initiative_status: 'cancelled'` is the strongest destructive action it can take — but cancelled rows currently still render inline in the tree. We need:
+
+1. Reversibility on every accepted proposal.
+2. A UI affordance that keeps cancelled tombstones from cluttering normal browsing.
+
+## Existing infrastructure (do NOT re-invent)
+
+- **`pm_proposals` table** — schema in [src/lib/db/migrations.ts](../src/lib/db/migrations.ts) around line 2468. Already persists each proposal with its full diff list, `applied_at`, `applied_by_agent_id`, `status` (`draft|accepted|rejected|superseded`). This **is** the audit log; we just don't surface it.
+- **`initiative_parent_history`** ([migrations.ts:2423](../src/lib/db/migrations.ts)) and **`task_initiative_history`** ([migrations.ts:2435](../src/lib/db/migrations.ts)) — parent/task move audit, already written by the proposal accept path.
+- **`rollback_history`** table (migration 026, [migrations.ts:1482](../src/lib/db/migrations.ts)) — currently scoped to product rollbacks. Do **not** repurpose; add a separate concept.
+- **Diff vocabulary** lives in [src/lib/db/pm-proposals.ts:46–105](../src/lib/db/pm-proposals.ts). Supported kinds:
+  - `shift_initiative_target`
+  - `set_initiative_status`
+  - `add_dependency`
+  - `remove_dependency`
+  - `reorder_initiatives`
+  - `update_status_check`
+  - `create_child_initiative`
+  - `create_task_under_initiative`
+  - `add_availability`
+
+  No delete kind exists, by design.
+- **`applyDiff` switch** at [pm-proposals.ts:752](../src/lib/db/pm-proposals.ts) — that's where each kind's forward apply lives, and where you'll discover the per-kind state needed to compute an inverse.
+- **PM page**: [src/app/(app)/pm/page.tsx](../src/app/(app)/pm/page.tsx).
+- **Proposal diffs UI**: [src/components/pm/ProposalDiffsList.tsx](../src/components/pm/ProposalDiffsList.tsx).
+- **Initiatives tree**: [src/app/(app)/initiatives/page.tsx](../src/app/(app)/initiatives/page.tsx).
+
+## Scope — three deliverables
+
+### 1. Hide cancelled initiatives by default with a filter toggle
+
+- In the initiatives tree (`/initiatives`) and any picker/select that lists initiatives (PM proposal target picker, dependency picker), filter out rows where `status='cancelled'` by default.
+- Add a "Show cancelled" toggle in the tree header. Persist preference in URL query param (`?show_cancelled=1`) so links are shareable; mirror to localStorage as a fallback default.
+- Cancelled rows, when shown, should render with reduced opacity + a "cancelled" pill so they're visually distinct.
+- Decide and document whether `done` deserves the same hidden-by-default treatment. **Recommendation:** leave `done` visible (it's positive completion signal); only hide `cancelled`. If you disagree after auditing, propose the alternative in the PR description.
+- Children of a cancelled parent should **not** be auto-hidden — only direct `status='cancelled'` rows. (User may want to see what was scoped under a cancelled epic.)
+- **Do not** touch the API filter — keep backend returning everything; this is purely a client-side filter so the audit/revert paths can still see cancelled rows.
+
+### 2. Revertable proposals
+
+Add a `revert_proposal` action: given an accepted proposal, synthesize the inverse diff list and create a **new draft proposal** with `trigger_kind='revert'` and a `reverts_proposal_id` foreign key column on `pm_proposals` (new migration).
+
+**Inverse mappings** — implement in a new helper, e.g. `src/lib/pm/invertDiff.ts`:
+
+| Forward kind | Inverse strategy |
+|---|---|
+| `set_initiative_status: { from: A, to: B }` | `set_initiative_status: { from: B, to: A }`. Forward apply must capture `from` if it doesn't already; check current schema. |
+| `shift_initiative_target` | Swap before/after dates (already symmetric). |
+| `update_status_check` | Restore previous markdown. Forward apply must persist the previous value into the diff record at apply time. |
+| `add_dependency` | `remove_dependency` (need the created dependency_id, captured at apply). |
+| `remove_dependency` | `add_dependency` (need the full dependency row snapshot, captured at apply). |
+| `reorder_initiatives` | Reorder back to the previous sort_order list. |
+| `create_child_initiative` | `set_initiative_status: 'cancelled'` on the created row (we don't delete). The created child's id must be captured back into the diff record at apply time so revert can target it. |
+| `create_task_under_initiative` | `set_task_status: 'cancelled'` (if that diff kind exists; if not, add it). Same id-capture pattern. |
+| `add_availability` | Mark the row inactive or mirror with a removal diff. Audit current `add_availability` apply path; choose the cleanest inverse. |
+
+**The "captured at apply time" pattern is critical:** each forward apply should persist enough state into the diff record (or a sibling table) that the inverse is a pure function of the diff row alone. Don't recompute from current DB state at revert time — it'll have drifted.
+
+**Review flow:**
+- Reverts produce a new proposal that goes through the normal review→accept flow. Do **not** auto-apply. The user must approve the revert just like any other proposal, so they can see and edit it first.
+- If the proposal being reverted is itself a revert, that's fine — it just produces another inverse. No special-casing.
+- If any state the original diff touched has been further modified since (e.g. someone manually changed status after the PM set it), surface that in the revert preview as a **warning chip per affected diff**. Do **not** block — let the user decide.
+
+### 3. PM activity timeline UI
+
+- New tab or section on `/pm` (or a new route `/pm/activity`) showing a chronological feed of accepted proposals: `trigger_kind`, target initiative title, summary of diffs, `applied_at`, `applied_by_agent_id`, and a "Revert" button per row.
+- Filter chips: `trigger_kind` (decompose, status, dependency, etc.), agent, date range.
+- Clicking a row expands the full diff list (reuse `ProposalDiffsList` in a read-only mode if reasonable).
+- "Revert" button calls the new revert endpoint and routes the user to the resulting draft proposal.
+
+## Non-goals
+
+- Hard delete of initiatives/stories. Stays disabled in the PM. Operator-only via existing `DELETE /api/initiatives/[id]`.
+- Reverting non-PM mutations (direct API edits, UI edits made outside the proposal flow). Only proposals get the revert button.
+- Auto-revert / scheduled revert / TTL on proposals. Manual only.
+
+## Migration & backfill
+
+- New migration: add `reverts_proposal_id` column on `pm_proposals` (nullable). Add `'revert'` to the `trigger_kind` enum (check current CHECK constraint in `migrations.ts`).
+- Add capture columns on the diff JSON shape — the diff is stored as JSON so this is a code-level change, not a schema one, but the TypeScript types in [pm-proposals.ts:46–105](../src/lib/db/pm-proposals.ts) need updating.
+- **Existing accepted proposals** predate the capture pattern — they'll show "Revert (limited)" with a tooltip explaining the inverse can't be computed for diffs that didn't capture before-state. Do not block; just disable the button per-diff with a hover explanation.
+
+## Tests
+
+- Unit tests for `invertDiff.ts` covering each kind round-trip: `apply(forward) → apply(invert(forward))` returns DB state to baseline. Use the in-memory test DB pattern already in [pm-proposals.test.ts](../src/lib/db/pm-proposals.test.ts).
+- Integration test: full proposal accept → revert → accept-revert flow, verify final state matches initial.
+- UI smoke: `/pm/activity` renders, revert button creates a draft, draft renders correctly in the proposal review UI.
+
+## Verification
+
+Use `preview_*` tools after implementation:
+
+1. Start dev server.
+2. Click through `/initiatives` — toggle works, cancelled hidden by default.
+3. Visit `/pm/activity` — timeline renders, revert creates a draft.
+4. Accept a revert proposal and confirm state restoration end-to-end.
+
+## Project conventions (from CLAUDE.md)
+
+- **Yarn**, not npm.
+- PRs target `smb209/mission-control` with `--repo smb209/mission-control --base main`.
+- Run the full test suite before declaring green; surface any pre-existing failures explicitly.
+- Spec-first for multi-layer changes — this doc fulfills that requirement; revise it as scope shifts during implementation.
+
+## Suggested PR breakdown
+
+1. **Foundation** — migration + diff capture columns + types. No UI.
+2. **Logic** — `invertDiff.ts` + revert endpoint + tests. No UI.
+3. **Timeline UI** — `/pm/activity` + revert button. UI on top of the working backend.
+4. **Cancelled-filter toggle** on `/initiatives`. Independent slice, can ship parallel to 1–3.
+
+Each as its own PR stacked on the previous. **Retarget child PR bases to `main` before merging the parent with `--delete-branch`** (per CLAUDE.md stacked-PR note) — otherwise GitHub auto-closes the children.

--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import Link from 'next/link';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import {
   Plus,
   ChevronRight,
@@ -91,8 +92,52 @@ const KIND_BADGE: Record<Kind, string> = {
 
 const WORKSPACE_ID = 'default';
 
+const SHOW_CANCELLED_LS_KEY = 'mc:initiatives:show_cancelled';
+
+// Toggle persisted across the URL (`?show_cancelled=1`) so links survive
+// reload + are shareable. localStorage is the fallback default when the
+// URL has no opinion. URL value, when present, wins over localStorage.
+function useShowCancelled(): [boolean, (next: boolean) => void] {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const urlValue = searchParams.get('show_cancelled');
+
+  const initial = (() => {
+    if (urlValue === '1') return true;
+    if (urlValue === '0') return false;
+    if (typeof window !== 'undefined') {
+      return window.localStorage.getItem(SHOW_CANCELLED_LS_KEY) === '1';
+    }
+    return false;
+  })();
+
+  const [value, setValue] = useState<boolean>(initial);
+
+  useEffect(() => {
+    if (urlValue === '1') setValue(true);
+    else if (urlValue === '0') setValue(false);
+  }, [urlValue]);
+
+  const update = useCallback(
+    (next: boolean) => {
+      setValue(next);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(SHOW_CANCELLED_LS_KEY, next ? '1' : '0');
+      }
+      const params = new URLSearchParams(searchParams.toString());
+      if (next) params.set('show_cancelled', '1');
+      else params.delete('show_cancelled');
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname);
+    },
+    [router, pathname, searchParams],
+  );
+
+  return [value, update];
+}
+
 export default function InitiativesPage() {
-  const [tree, setTree] = useState<TreeNode[]>([]);
   const [flat, setFlat] = useState<Initiative[]>([]);
   const [taskCounts, setTaskCounts] = useState<Record<string, TaskCounts>>({});
   const [loading, setLoading] = useState(true);
@@ -105,6 +150,7 @@ export default function InitiativesPage() {
   const [historyFor, setHistoryFor] = useState<Initiative | null>(null);
   const [addingDepFor, setAddingDepFor] = useState<Initiative | null>(null);
   const [decomposing, setDecomposing] = useState<Initiative | null>(null);
+  const [showCancelled, setShowCancelled] = useShowCancelled();
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -116,7 +162,6 @@ export default function InitiativesPage() {
       if (!iRes.ok) throw new Error(`Failed to load (${iRes.status})`);
       const rows: Initiative[] = await iRes.json();
       setFlat(rows);
-      setTree(buildTree(rows));
 
       // Count tasks per initiative_id, partitioned by status family.
       const counts: Record<string, TaskCounts> = {};
@@ -144,6 +189,20 @@ export default function InitiativesPage() {
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  // Tree + picker list derive from flat + the cancelled-filter toggle.
+  // Cancelled rows are spliced out and their non-cancelled children
+  // re-parent to the cancelled row's effective parent so the subtree
+  // doesn't get orphaned.
+  const tree = useMemo(() => buildTree(flat, !showCancelled), [flat, showCancelled]);
+  const pickableInitiatives = useMemo(
+    () => (showCancelled ? flat : flat.filter(i => i.status !== 'cancelled')),
+    [flat, showCancelled],
+  );
+  const cancelledCount = useMemo(
+    () => flat.filter(i => i.status === 'cancelled').length,
+    [flat],
+  );
 
   // Detach = move to no parent. Surfaced from the action menu when the
   // initiative currently has a parent.
@@ -178,6 +237,21 @@ export default function InitiativesPage() {
         <div className="flex items-center gap-2">
           {/* "Workspaces" button removed — global workspace switcher lives
               in the unified left nav now. */}
+          <label
+            className="inline-flex items-center gap-1.5 text-xs text-mc-text-secondary cursor-pointer select-none"
+            title="Toggle visibility of cancelled initiatives. Persisted in URL (?show_cancelled=1) and localStorage."
+          >
+            <input
+              type="checkbox"
+              className="accent-mc-accent"
+              checked={showCancelled}
+              onChange={e => setShowCancelled(e.target.checked)}
+            />
+            Show cancelled
+            {cancelledCount > 0 && (
+              <span className="text-[11px] text-mc-text-secondary/70">({cancelledCount})</span>
+            )}
+          </label>
           <button
             onClick={() => setCreating({ parent_id: null })}
             className="px-3 py-2 rounded-lg bg-mc-accent text-white hover:bg-mc-accent/90 text-sm flex items-center gap-2"
@@ -205,6 +279,7 @@ export default function InitiativesPage() {
                 node={node}
                 depth={0}
                 allInitiatives={flat}
+                pickableInitiatives={pickableInitiatives}
                 taskCounts={taskCounts}
                 onEdit={setEditing}
                 onAddChild={parent => setCreating({ parent_id: parent.id })}
@@ -234,7 +309,7 @@ export default function InitiativesPage() {
       {creating && (
         <CreateModal
           parentId={creating.parent_id}
-          allInitiatives={flat}
+          allInitiatives={pickableInitiatives}
           onClose={() => setCreating(null)}
           onSaved={() => {
             setCreating(null);
@@ -253,7 +328,7 @@ export default function InitiativesPage() {
       {moving && (
         <MoveModal
           initiative={moving}
-          allInitiatives={flat}
+          allInitiatives={pickableInitiatives}
           onClose={() => setMoving(null)}
           onSaved={() => {
             setMoving(null);
@@ -291,7 +366,7 @@ export default function InitiativesPage() {
       {addingDepFor && (
         <AddDependencyModal
           initiative={addingDepFor}
-          allInitiatives={flat}
+          allInitiatives={pickableInitiatives}
           onClose={() => setAddingDepFor(null)}
           onSaved={() => {
             setAddingDepFor(null);
@@ -313,10 +388,26 @@ export default function InitiativesPage() {
   );
 }
 
-function buildTree(rows: Initiative[]): TreeNode[] {
+function buildTree(rows: Initiative[], hideCancelled: boolean): TreeNode[] {
+  const byId = new Map(rows.map(r => [r.id, r] as const));
+  const isHidden = (r: Initiative | undefined) =>
+    !!r && hideCancelled && r.status === 'cancelled';
+
+  // If a parent is hidden (cancelled), walk up until we hit a visible
+  // ancestor — that's where the visible child should attach so the
+  // subtree doesn't render as orphaned root rows.
+  function effectiveParent(parentId: string | null): string | null {
+    if (parentId == null) return null;
+    const p = byId.get(parentId);
+    if (!p) return null;
+    if (isHidden(p)) return effectiveParent(p.parent_initiative_id);
+    return parentId;
+  }
+
+  const visible = rows.filter(r => !isHidden(r));
   const byParent = new Map<string | null, Initiative[]>();
-  for (const r of rows) {
-    const k = r.parent_initiative_id ?? null;
+  for (const r of visible) {
+    const k = effectiveParent(r.parent_initiative_id);
     const list = byParent.get(k) ?? [];
     list.push(r);
     byParent.set(k, list);
@@ -332,6 +423,7 @@ function InitiativeRow({
   node,
   depth,
   allInitiatives,
+  pickableInitiatives,
   taskCounts,
   onEdit,
   onAddChild,
@@ -347,6 +439,7 @@ function InitiativeRow({
   node: TreeNode;
   depth: number;
   allInitiatives: Initiative[];
+  pickableInitiatives: Initiative[];
   taskCounts: Record<string, TaskCounts>;
   onEdit: (init: Initiative) => void;
   onAddChild: (parent: Initiative) => void;
@@ -429,7 +522,9 @@ function InitiativeRow({
   return (
     <>
       <li
-        className="flex items-center gap-2 p-2 rounded-lg bg-mc-bg-secondary border border-mc-border hover:border-mc-accent/40"
+        className={`flex items-center gap-2 p-2 rounded-lg bg-mc-bg-secondary border border-mc-border hover:border-mc-accent/40 ${
+          node.status === 'cancelled' ? 'opacity-60' : ''
+        }`}
         style={{ marginLeft: depth * 24 }}
       >
         <button
@@ -467,7 +562,16 @@ function InitiativeRow({
         >
           <ExternalLink className="w-3.5 h-3.5" />
         </Link>
-        <span className="text-xs text-mc-text-secondary">{node.status}</span>
+        {node.status === 'cancelled' ? (
+          <span
+            className="text-[11px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-red-500/15 text-red-300 border border-red-500/30"
+            title="This initiative is cancelled"
+          >
+            cancelled
+          </span>
+        ) : (
+          <span className="text-xs text-mc-text-secondary">{node.status}</span>
+        )}
         {!childrenExpanded && directChildrenCount > 0 && (
           <span
             className="text-[11px] text-mc-text-secondary/80"
@@ -521,7 +625,11 @@ function InitiativeRow({
           className="rounded-lg bg-mc-bg border border-mc-border/60 px-3 py-2 -mt-1 text-sm"
           style={{ marginLeft: depth * 24 + 12 }}
         >
-          <DetailsPanel initiative={node} allInitiatives={allInitiatives} />
+          <DetailsPanel
+            initiative={node}
+            allInitiatives={allInitiatives}
+            pickableInitiatives={pickableInitiatives}
+          />
           <div className="mt-2 pt-2 border-t border-mc-border/60 flex justify-end">
             <Link
               href={`/initiatives/${node.id}`}
@@ -539,6 +647,7 @@ function InitiativeRow({
             node={c}
             depth={depth + 1}
             allInitiatives={allInitiatives}
+            pickableInitiatives={pickableInitiatives}
             taskCounts={taskCounts}
             onEdit={onEdit}
             onAddChild={onAddChild}
@@ -581,9 +690,11 @@ interface DepEdges {
 function DetailsPanel({
   initiative,
   allInitiatives,
+  pickableInitiatives,
 }: {
   initiative: Initiative;
   allInitiatives: Initiative[];
+  pickableInitiatives: Initiative[];
 }) {
   const [history, setHistory] = useState<HistoryRow[]>([]);
   const [deps, setDeps] = useState<DepEdges | null>(null);
@@ -691,7 +802,7 @@ function DetailsPanel({
               onChange={e => setChosenDep(e.target.value)}
             >
               <option value="">(choose initiative this depends on)</option>
-              {allInitiatives
+              {pickableInitiatives
                 .filter(i => i.id !== initiative.id)
                 .map(i => (
                   <option key={i.id} value={i.id}>

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -1201,8 +1201,11 @@ function ApplyPlanToInitiativeModal({
       try {
         const res = await fetch(`/api/initiatives?workspace_id=${encodeURIComponent(workspaceId)}`);
         if (!res.ok) throw new Error(`Failed to load initiatives (${res.status})`);
-        const list = (await res.json()) as InitiativeLite[];
+        const raw = (await res.json()) as InitiativeLite[];
         if (cancelled) return;
+        // Cancelled initiatives are tombstones; never preselect or offer
+        // them as a target for new PM suggestions.
+        const list = raw.filter(i => i.status !== 'cancelled');
         setInitiatives(list);
         // Preselect by case-insensitive title equality first, then by
         // longest substring overlap. If nothing matches, leave the

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3583,6 +3583,75 @@ const migrations: Migration[] = [
       console.log('[Migration 061] agents.is_pm added + backfilled from role.');
     },
   },
+  {
+    id: '062',
+    name: 'pm_proposals_revert_foundation',
+    up: (db) => {
+      // Slice 1 of revertable PM proposals (specs/pm-revertable-proposals.md):
+      //   1. Add `reverts_proposal_id` (nullable FK) so a revert proposal can
+      //      point back at the proposal it inverts.
+      //   2. Extend the trigger_kind CHECK to permit 'revert'.
+      //
+      // Mirrors the table-rebuild pattern from migration 054, since SQLite
+      // can't ALTER a CHECK in place. We also re-declare every column so the
+      // schema stays canonical after the rebuild.
+      const cols = db.prepare(`PRAGMA table_info(pm_proposals)`).all() as Array<{ name: string }>;
+      const tableSql = (db.prepare(
+        `SELECT sql FROM sqlite_master WHERE type='table' AND name='pm_proposals'`,
+      ).get() as { sql: string } | undefined)?.sql ?? '';
+
+      const hasRevertsCol = cols.some(c => c.name === 'reverts_proposal_id');
+      const checkHasRevert = tableSql.includes("'revert'");
+
+      if (hasRevertsCol && checkHasRevert) {
+        console.log('[Migration 062] Already applied; skipping.');
+        return;
+      }
+
+      const fkList = db.prepare(`PRAGMA foreign_key_list(pm_proposals)`).all() as Array<{ from: string; on_delete: string }>;
+      const targetFk = fkList.find(fk => fk.from === 'target_initiative_id');
+      const targetCascade = targetFk?.on_delete === 'CASCADE' ? 'CASCADE' : 'SET NULL';
+      const dispatchStateExists = cols.some(c => c.name === 'dispatch_state');
+
+      const carryCols = [
+        'id', 'workspace_id', 'trigger_text', 'trigger_kind', 'impact_md',
+        'proposed_changes', 'status', 'applied_at', 'applied_by_agent_id',
+        'parent_proposal_id', 'created_at', 'target_initiative_id',
+        'plan_suggestions',
+        ...(dispatchStateExists ? ['dispatch_state'] : []),
+      ].filter(c => cols.some(x => x.name === c));
+      const carryList = carryCols.join(', ');
+
+      db.exec(`
+        CREATE TABLE pm_proposals_new (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          trigger_text TEXT NOT NULL,
+          trigger_kind TEXT NOT NULL DEFAULT 'manual'
+            CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation','plan_initiative','decompose_initiative','notes_intake','revert')),
+          impact_md TEXT NOT NULL,
+          proposed_changes TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'draft'
+            CHECK (status IN ('draft','accepted','rejected','superseded')),
+          applied_at TEXT,
+          applied_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+          parent_proposal_id TEXT REFERENCES pm_proposals(id) ON DELETE SET NULL,
+          created_at TEXT DEFAULT (datetime('now')),
+          target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE ${targetCascade},
+          plan_suggestions TEXT,
+          ${dispatchStateExists ? 'dispatch_state TEXT,' : ''}
+          reverts_proposal_id TEXT REFERENCES pm_proposals(id) ON DELETE SET NULL
+        )
+      `);
+      db.exec(`INSERT INTO pm_proposals_new (${carryList}) SELECT ${carryList} FROM pm_proposals`);
+      db.exec(`DROP TABLE pm_proposals`);
+      db.exec(`ALTER TABLE pm_proposals_new RENAME TO pm_proposals`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_status ON pm_proposals(status, created_at DESC)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_target_init ON pm_proposals(target_initiative_id, status, created_at DESC)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_reverts ON pm_proposals(reverts_proposal_id) WHERE reverts_proposal_id IS NOT NULL`);
+      console.log('[Migration 062] pm_proposals.reverts_proposal_id + revert trigger_kind ready.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/pm-proposals.test.ts
+++ b/src/lib/db/pm-proposals.test.ts
@@ -567,3 +567,191 @@ test('acceptProposal emits a pm_proposal_accepted event row', () => {
   });
   assert.ok(latest, 'event metadata.proposal_id should match');
 });
+
+// ─── Slice 1: capture-at-apply pattern (revertable proposals) ───────
+
+test('apply captures prev_status on set_initiative_status', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Capture me' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      { kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' },
+    ],
+  });
+  acceptProposal(p.id);
+  const updated = getProposal(p.id)!;
+  const diff = updated.proposed_changes[0];
+  assert.equal(diff.kind, 'set_initiative_status');
+  // initial status defaults to 'planned' from createInitiative
+  assert.equal((diff as { prev_status?: string }).prev_status, 'planned');
+});
+
+test('apply captures prev_target_start/end on shift_initiative_target', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Shifty',
+    target_start: '2026-01-01',
+    target_end: '2026-02-01',
+  });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      {
+        kind: 'shift_initiative_target',
+        initiative_id: init.id,
+        target_start: '2026-03-01',
+        target_end: '2026-04-01',
+      },
+    ],
+  });
+  acceptProposal(p.id);
+  const diff = getProposal(p.id)!.proposed_changes[0] as {
+    prev_target_start?: string | null;
+    prev_target_end?: string | null;
+  };
+  assert.equal(diff.prev_target_start?.slice(0, 10), '2026-01-01');
+  assert.equal(diff.prev_target_end?.slice(0, 10), '2026-02-01');
+});
+
+test('apply captures created_dependency_id on add_dependency', () => {
+  const ws = freshWorkspace();
+  const a = createInitiative({ workspace_id: ws, kind: 'epic', title: 'A' });
+  const b = createInitiative({ workspace_id: ws, kind: 'epic', title: 'B' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      { kind: 'add_dependency', initiative_id: a.id, depends_on_initiative_id: b.id },
+    ],
+  });
+  acceptProposal(p.id);
+  const diff = getProposal(p.id)!.proposed_changes[0] as { created_dependency_id?: string };
+  assert.ok(diff.created_dependency_id, 'capture should record the new edge id');
+  const row = queryOne<{ id: string }>(
+    `SELECT id FROM initiative_dependencies WHERE id = ?`,
+    [diff.created_dependency_id],
+  );
+  assert.ok(row, 'captured id must reference a real edge');
+});
+
+test('apply captures removed_dependency_row on remove_dependency', () => {
+  const ws = freshWorkspace();
+  const a = createInitiative({ workspace_id: ws, kind: 'epic', title: 'A' });
+  const b = createInitiative({ workspace_id: ws, kind: 'epic', title: 'B' });
+  const dep = addInitiativeDependency({
+    initiative_id: a.id,
+    depends_on_initiative_id: b.id,
+  });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [{ kind: 'remove_dependency', dependency_id: dep.id }],
+  });
+  acceptProposal(p.id);
+  const diff = getProposal(p.id)!.proposed_changes[0] as {
+    removed_dependency_row?: { id: string; initiative_id: string; depends_on_initiative_id: string };
+  };
+  assert.ok(diff.removed_dependency_row);
+  assert.equal(diff.removed_dependency_row!.id, dep.id);
+  assert.equal(diff.removed_dependency_row!.initiative_id, a.id);
+  assert.equal(diff.removed_dependency_row!.depends_on_initiative_id, b.id);
+});
+
+test('apply captures prev_child_ids_in_order on reorder_initiatives', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({ workspace_id: ws, kind: 'milestone', title: 'P' });
+  const c1 = createInitiative({ workspace_id: ws, kind: 'epic', title: 'C1', parent_initiative_id: parent.id, sort_order: 0 });
+  const c2 = createInitiative({ workspace_id: ws, kind: 'epic', title: 'C2', parent_initiative_id: parent.id, sort_order: 1 });
+  const c3 = createInitiative({ workspace_id: ws, kind: 'epic', title: 'C3', parent_initiative_id: parent.id, sort_order: 2 });
+  const reversed = [c3.id, c2.id, c1.id];
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      { kind: 'reorder_initiatives', parent_id: parent.id, child_ids_in_order: reversed },
+    ],
+  });
+  acceptProposal(p.id);
+  const diff = getProposal(p.id)!.proposed_changes[0] as { prev_child_ids_in_order?: string[] };
+  // c1, c2, c3 were inserted in creation order, so the captured prior
+  // arrangement should match that ordering.
+  assert.deepEqual(diff.prev_child_ids_in_order, [c1.id, c2.id, c3.id]);
+});
+
+test('apply captures prev_status_check_md on update_status_check', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'I' });
+  // Seed an initial status_check_md so capture is non-null.
+  run(
+    `UPDATE initiatives SET status_check_md = ? WHERE id = ?`,
+    ['previous-md', init.id],
+  );
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      { kind: 'update_status_check', initiative_id: init.id, status_check_md: 'new-md' },
+    ],
+  });
+  acceptProposal(p.id);
+  const diff = getProposal(p.id)!.proposed_changes[0] as { prev_status_check_md?: string | null };
+  assert.equal(diff.prev_status_check_md, 'previous-md');
+});
+
+test('apply captures created_initiative_id on create_child_initiative', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({ workspace_id: ws, kind: 'milestone', title: 'P' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      {
+        kind: 'create_child_initiative',
+        parent_initiative_id: parent.id,
+        title: 'Child',
+        child_kind: 'epic',
+      },
+    ],
+  });
+  acceptProposal(p.id);
+  const diff = getProposal(p.id)!.proposed_changes[0] as { created_initiative_id?: string };
+  assert.ok(diff.created_initiative_id);
+  const row = queryOne<{ id: string }>(
+    `SELECT id FROM initiatives WHERE id = ?`,
+    [diff.created_initiative_id],
+  );
+  assert.ok(row);
+});
+
+test('createProposal accepts reverts_proposal_id and rowToProposal surfaces it', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'X' });
+  const original = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [{ kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' }],
+  });
+  const revert = createProposal({
+    workspace_id: ws,
+    trigger_text: 't-revert',
+    trigger_kind: 'revert',
+    impact_md: 'undo it',
+    proposed_changes: [],
+    reverts_proposal_id: original.id,
+  });
+  assert.equal(revert.reverts_proposal_id, original.id);
+  assert.equal(revert.trigger_kind, 'revert');
+});

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -39,46 +39,86 @@ export type PmProposalTriggerKind =
   | 'status_check_investigation'
   | 'plan_initiative'
   | 'decompose_initiative'
-  | 'notes_intake';
+  | 'notes_intake'
+  | 'revert';
+
+/**
+ * Capture state recorded at apply time onto each accepted diff (slice 1 of
+ * revertable PM proposals). The field is optional on the type because (a)
+ * draft proposals don't have it yet and (b) accepted proposals predating
+ * the capture pattern won't either — the revert UI surfaces a "limited"
+ * tooltip for those.
+ *
+ * Per-kind shapes are documented inline on each variant below.
+ */
+export interface PmDiffCapture {
+  /** Set by `applyDiff` for `set_initiative_status`. */
+  prev_status?: 'planned' | 'in_progress' | 'at_risk' | 'blocked' | 'done' | 'cancelled';
+  /** Set by `applyDiff` for `update_status_check`. */
+  prev_status_check_md?: string | null;
+  /** Set by `applyDiff` for `shift_initiative_target`. */
+  prev_target_start?: string | null;
+  /** Set by `applyDiff` for `shift_initiative_target`. */
+  prev_target_end?: string | null;
+  /** Set by `applyDiff` for `add_dependency` — id of the inserted edge. */
+  created_dependency_id?: string;
+  /** Set by `applyDiff` for `remove_dependency` — full row prior to delete. */
+  removed_dependency_row?: {
+    id: string;
+    initiative_id: string;
+    depends_on_initiative_id: string;
+    kind: string;
+    note: string | null;
+    created_at: string;
+  };
+  /** Set by `applyDiff` for `reorder_initiatives`. */
+  prev_child_ids_in_order?: string[];
+  /** Set by `applyCreateChildInitiative` — id of the inserted initiative. */
+  created_initiative_id?: string;
+  /** Set by the create_task_under_initiative apply pass — id of the new task. */
+  created_task_id?: string;
+  /** Set by `applyDiff` for `add_availability` — id of the inserted row. */
+  created_availability_id?: string;
+}
 
 export type PmDiff =
-  | {
+  | ({
       kind: 'shift_initiative_target';
       initiative_id: string;
       target_start?: string | null;
       target_end?: string | null;
       reason?: string;
-    }
-  | {
+    } & PmDiffCapture)
+  | ({
       kind: 'add_availability';
       agent_id: string;
       start: string;
       end: string;
       reason?: string;
-    }
-  | {
+    } & PmDiffCapture)
+  | ({
       kind: 'set_initiative_status';
       initiative_id: string;
       status: 'planned' | 'in_progress' | 'at_risk' | 'blocked';
-    }
-  | {
+    } & PmDiffCapture)
+  | ({
       kind: 'add_dependency';
       initiative_id: string;
       depends_on_initiative_id: string;
       note?: string;
-    }
-  | { kind: 'remove_dependency'; dependency_id: string }
-  | {
+    } & PmDiffCapture)
+  | ({ kind: 'remove_dependency'; dependency_id: string } & PmDiffCapture)
+  | ({
       kind: 'reorder_initiatives';
       parent_id: string | null;
       child_ids_in_order: string[];
-    }
-  | {
+    } & PmDiffCapture)
+  | ({
       kind: 'update_status_check';
       initiative_id: string;
       status_check_md: string;
-    }
-  | {
+    } & PmDiffCapture)
+  | ({
       // Polish B (decompose flow). On accept, the decompose handler inserts
       // one initiative row under `parent_initiative_id`. `depends_on_initiative_ids`
       // can carry placeholder ids (`$0`, `$1`, …) that point to other
@@ -96,8 +136,8 @@ export type PmDiff =
       depends_on_initiative_ids?: string[];
       /** Optional placeholder id for cross-sibling dep resolution. */
       placeholder_id?: string;
-    }
-  | {
+    } & PmDiffCapture)
+  | ({
       // Freeform-notes intake: create one draft task attached to an
       // initiative. `initiative_id` may be a placeholder ($N or a custom
       // `placeholder_id` from a same-proposal `create_child_initiative`)
@@ -109,7 +149,7 @@ export type PmDiff =
       status_check_md?: string | null;
       assigned_agent_id?: string | null;
       priority?: 'low' | 'normal' | 'high';
-    };
+    } & PmDiffCapture);
 
 export interface PmProposal {
   id: string;
@@ -130,6 +170,9 @@ export interface PmProposal {
    *  pm-dispatch-async spec). For pre-migration rows or non-dispatched
    *  proposals, defaults to 'agent_complete'. */
   dispatch_state: PmProposalDispatchState;
+  /** When this proposal was synthesized to undo another accepted proposal,
+   *  this points back at it. NULL for forward proposals. */
+  reverts_proposal_id: string | null;
   created_at: string;
 }
 
@@ -147,6 +190,7 @@ interface PmProposalRow {
   parent_proposal_id: string | null;
   target_initiative_id: string | null;
   dispatch_state: PmProposalDispatchState | null;
+  reverts_proposal_id: string | null;
   created_at: string;
 }
 
@@ -424,6 +468,7 @@ function rowToProposal(row: PmProposalRow): PmProposal {
     parent_proposal_id: row.parent_proposal_id,
     target_initiative_id: row.target_initiative_id ?? null,
     dispatch_state: (row.dispatch_state ?? 'agent_complete') as PmProposalDispatchState,
+    reverts_proposal_id: row.reverts_proposal_id ?? null,
     created_at: row.created_at,
   };
 }
@@ -443,6 +488,10 @@ export interface CreateProposalInput {
    *  when persisting a synth placeholder while the named-agent dispatch
    *  is still in flight (Tier 3 of pm-dispatch-async). */
   dispatch_state?: PmProposalDispatchState;
+  /** Slice 1 of revertable proposals: when this draft is the inverse of
+   *  another accepted proposal, point back at it so the timeline can
+   *  render a chain. Slice 2 wires the inverse synthesis. */
+  reverts_proposal_id?: string | null;
 }
 
 export function createProposal(input: CreateProposalInput): PmProposal {
@@ -465,8 +514,8 @@ export function createProposal(input: CreateProposalInput): PmProposal {
   run(
     `INSERT INTO pm_proposals (
        id, workspace_id, trigger_text, trigger_kind, impact_md,
-       proposed_changes, plan_suggestions, status, parent_proposal_id, target_initiative_id, dispatch_state, created_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?)`,
+       proposed_changes, plan_suggestions, status, parent_proposal_id, target_initiative_id, dispatch_state, reverts_proposal_id, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?, ?)`,
     [
       id,
       input.workspace_id,
@@ -478,6 +527,7 @@ export function createProposal(input: CreateProposalInput): PmProposal {
       input.parent_proposal_id ?? null,
       input.target_initiative_id ?? null,
       input.dispatch_state ?? 'agent_complete',
+      input.reverts_proposal_id ?? null,
       now,
     ],
   );
@@ -646,6 +696,9 @@ export function acceptProposal(
             applied_by_agent_id,
             id,
           );
+          // Capture the new initiative id back onto the diff so revert
+          // can target the right row without recomputing.
+          change.created_initiative_id = newId;
           // Two index forms accepted: explicit `placeholder_id` field or
           // ordinal `$N` based on diff position.
           placeholderMap.set(`$${idx}`, newId);
@@ -694,7 +747,7 @@ export function acceptProposal(
               `create_task_under_initiative: unresolved placeholder "${change.initiative_id}"`,
             );
           }
-          createTaskFromInitiative({
+          const created = createTaskFromInitiative({
             initiative_id: realInit,
             workspace_id: existing.workspace_id,
             title: change.title,
@@ -705,12 +758,26 @@ export function acceptProposal(
             created_by_agent_id: applied_by_agent_id,
             reason: `created via PM notes proposal #${id}`,
           });
+          // Capture the new task id so revert can cancel that exact row.
+          change.created_task_id = created.id;
           changesApplied++;
           continue;
         }
         applyDiff(change, now);
         changesApplied++;
       }
+    }
+
+    // Persist the augmented proposed_changes JSON. The apply path above
+    // mutated each diff in place to add capture state (prev_status,
+    // created_dependency_id, etc.) — write that back so Slice 2's
+    // invertDiff can synthesize a pure-function revert from the row alone.
+    // Skipped on the advisory path since no diffs ran.
+    if (!isAdvisory) {
+      run(
+        `UPDATE pm_proposals SET proposed_changes = ? WHERE id = ?`,
+        [JSON.stringify(existing.proposed_changes), id],
+      );
     }
 
     // Flip the proposal row.
@@ -751,6 +818,16 @@ export function acceptProposal(
 function applyDiff(diff: PmDiff, now: string): void {
   switch (diff.kind) {
     case 'shift_initiative_target': {
+      // Capture the previous targets BEFORE the UPDATE so revert can
+      // restore them without recomputing from drifted DB state.
+      const prev = queryOne<{ target_start: string | null; target_end: string | null }>(
+        `SELECT target_start, target_end FROM initiatives WHERE id = ?`,
+        [diff.initiative_id],
+      );
+      if (prev) {
+        diff.prev_target_start = prev.target_start ?? null;
+        diff.prev_target_end = prev.target_end ?? null;
+      }
       const sets: string[] = [];
       const params: unknown[] = [];
       if (diff.target_start !== undefined) {
@@ -768,14 +845,25 @@ function applyDiff(diff: PmDiff, now: string): void {
       return;
     }
     case 'add_availability': {
+      const newId = uuidv4();
       run(
         `INSERT INTO owner_availability (id, agent_id, unavailable_start, unavailable_end, reason, created_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
-        [uuidv4(), diff.agent_id, diff.start, diff.end, diff.reason ?? null, now],
+        [newId, diff.agent_id, diff.start, diff.end, diff.reason ?? null, now],
       );
+      diff.created_availability_id = newId;
       return;
     }
     case 'set_initiative_status': {
+      // Capture previous status so revert can restore it. PM-driven
+      // statuses are limited (planned|in_progress|at_risk|blocked) but
+      // an operator could have left the row in done/cancelled before the
+      // proposal lands — `prev_status` covers all six values.
+      const prev = queryOne<{ status: PmDiffCapture['prev_status'] }>(
+        `SELECT status FROM initiatives WHERE id = ?`,
+        [diff.initiative_id],
+      );
+      if (prev) diff.prev_status = prev.status;
       run(
         `UPDATE initiatives SET status = ?, updated_at = ? WHERE id = ?`,
         [diff.status, now, diff.initiative_id],
@@ -783,26 +871,64 @@ function applyDiff(diff: PmDiff, now: string): void {
       return;
     }
     case 'add_dependency': {
+      const newId = uuidv4();
       try {
         run(
           `INSERT INTO initiative_dependencies (id, initiative_id, depends_on_initiative_id, kind, note, created_at)
            VALUES (?, ?, ?, 'finish_to_start', ?, ?)`,
-          [uuidv4(), diff.initiative_id, diff.depends_on_initiative_id, diff.note ?? null, now],
+          [newId, diff.initiative_id, diff.depends_on_initiative_id, diff.note ?? null, now],
         );
+        diff.created_dependency_id = newId;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         // SQLite throws SQLITE_CONSTRAINT_UNIQUE on duplicate edges. Treat
-        // as idempotent — the desired state already exists.
-        if (/UNIQUE constraint failed/i.test(msg)) return;
+        // as idempotent — the desired state already exists. Resolve and
+        // capture the existing edge's id so revert still works.
+        if (/UNIQUE constraint failed/i.test(msg)) {
+          const existing = queryOne<{ id: string }>(
+            `SELECT id FROM initiative_dependencies
+              WHERE initiative_id = ? AND depends_on_initiative_id = ?`,
+            [diff.initiative_id, diff.depends_on_initiative_id],
+          );
+          if (existing) diff.created_dependency_id = existing.id;
+          return;
+        }
         throw err;
       }
       return;
     }
     case 'remove_dependency': {
+      // Snapshot the row BEFORE delete so revert can re-insert the
+      // identical edge. We capture the full row (including original id +
+      // created_at) — Slice 2's invertDiff will reuse the id when it
+      // re-inserts so any references stay valid.
+      const row = queryOne<{
+        id: string;
+        initiative_id: string;
+        depends_on_initiative_id: string;
+        kind: string;
+        note: string | null;
+        created_at: string;
+      }>(
+        `SELECT id, initiative_id, depends_on_initiative_id, kind, note, created_at
+           FROM initiative_dependencies WHERE id = ?`,
+        [diff.dependency_id],
+      );
+      if (row) diff.removed_dependency_row = row;
       run(`DELETE FROM initiative_dependencies WHERE id = ?`, [diff.dependency_id]);
       return;
     }
     case 'reorder_initiatives': {
+      // Snapshot the prior order of these siblings BEFORE the UPDATE so
+      // revert restores the exact previous arrangement. We only capture
+      // the ids the diff is touching — siblings outside that set keep
+      // their existing sort_order through both apply and revert.
+      const placeholders = diff.child_ids_in_order.map(() => '?').join(',');
+      const prevRows = queryAll<{ id: string; sort_order: number }>(
+        `SELECT id, sort_order FROM initiatives WHERE id IN (${placeholders}) ORDER BY sort_order ASC`,
+        diff.child_ids_in_order,
+      );
+      diff.prev_child_ids_in_order = prevRows.map(r => r.id);
       // Bulk update sort_order. Validation already confirmed every id
       // exists in this workspace.
       let order = 0;
@@ -816,6 +942,11 @@ function applyDiff(diff: PmDiff, now: string): void {
       return;
     }
     case 'update_status_check': {
+      const prev = queryOne<{ status_check_md: string | null }>(
+        `SELECT status_check_md FROM initiatives WHERE id = ?`,
+        [diff.initiative_id],
+      );
+      if (prev) diff.prev_status_check_md = prev.status_check_md ?? null;
       run(
         `UPDATE initiatives SET status_check_md = ?, updated_at = ? WHERE id = ?`,
         [diff.status_check_md, now, diff.initiative_id],


### PR DESCRIPTION
Stacked on #124. Second slice of [specs/pm-revertable-proposals.md](specs/pm-revertable-proposals.md). Pure backend foundation — no revert UI, no revert endpoint yet (those are slices 2 + 3).

## Summary

Lays the groundwork so slice 2's `invertDiff` can synthesize a pure-function inverse from a diff row alone, without recomputing from drifted DB state.

## Changes

**Migration 062** (table-rebuild pattern, mirrors 054):
- Adds `pm_proposals.reverts_proposal_id` (nullable FK → `pm_proposals`, `ON DELETE SET NULL`) so a revert proposal chains back to the proposal it inverts.
- Extends the `trigger_kind` CHECK to permit `'revert'`.
- Indexes `reverts_proposal_id` for the chain lookup.

**Types** (`src/lib/db/pm-proposals.ts`):
- Adds `'revert'` to `PmProposalTriggerKind`.
- Adds `reverts_proposal_id` to `PmProposal` and `CreateProposalInput`.
- Introduces `PmDiffCapture` intersected onto every `PmDiff` variant. All capture fields are optional — drafts and pre-migration accepted proposals don't have them, so the eventual revert UI surfaces those as ""limited"" per the spec.

**Apply path** (`acceptProposal`/`applyDiff`):
- Each forward apply records prior state onto the diff before mutating:
  - `set_initiative_status`: `prev_status`
  - `shift_initiative_target`: `prev_target_start`, `prev_target_end`
  - `update_status_check`: `prev_status_check_md`
  - `add_dependency`: `created_dependency_id`
  - `remove_dependency`: full `removed_dependency_row` snapshot
  - `reorder_initiatives`: `prev_child_ids_in_order`
  - `create_child_initiative`: `created_initiative_id`
  - `create_task_under_initiative`: `created_task_id`
  - `add_availability`: `created_availability_id`
- After both passes, the augmented `proposed_changes` JSON is written back inside the same transaction.

## Test plan

- [x] 8 new tests covering capture for each diff kind plus `reverts_proposal_id` round-trip
- [x] Full suite: 475 passing, 0 failing (`yarn test`)
- [x] Migration 062 verified against the live preview DB — `_migrations` records both 061 + 062, the new column is present, the CHECK constraint includes `'revert'`, and the existing 4 seeded initiatives survived the table rebuild
- [x] Typecheck clean for touched files (pre-existing failures in `pm-decompose.test.ts` are unrelated)

> Note: this PR's base is `feat/initiatives-hide-cancelled` (#124). When merging, retarget to `main` first per the stacked-merge rule in CLAUDE.md.