### PR TITLE
feat(pm): invertDiff helper + /api/pm/proposals/[id]/revert endpoint

### DIFF
--- a/src/app/api/pm/proposals/[id]/revert/route.ts
+++ b/src/app/api/pm/proposals/[id]/revert/route.ts
@@ -1,0 +1,95 @@
+/**
+ * POST /api/pm/proposals/[id]/revert
+ *
+ * Synthesize the inverse of an accepted proposal and persist it as a
+ * NEW draft proposal — the operator must accept it through the normal
+ * review/accept flow before any state is mutated.
+ *
+ * Body:
+ *   - { } (no fields required today)
+ *
+ * Response:
+ *   - 201 with the new draft proposal + per-diff `notes` (one entry
+ *     per source diff, including any 'limited' explanations the UI can
+ *     surface as warning chips).
+ *   - 404 when the source proposal isn't found.
+ *   - 409 when the source isn't in status='accepted'.
+ *   - 422 when every source diff was 'limited' (nothing to revert).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  createProposal,
+  getProposal,
+  PmProposalValidationError,
+} from '@/lib/db/pm-proposals';
+import { invertProposalDiffs } from '@/lib/pm/invertDiff';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(_request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  const source = getProposal(id);
+  if (!source) {
+    return NextResponse.json({ error: 'Proposal not found' }, { status: 404 });
+  }
+  if (source.status !== 'accepted') {
+    return NextResponse.json(
+      {
+        error: `Only accepted proposals can be reverted (this one is '${source.status}')`,
+      },
+      { status: 409 },
+    );
+  }
+
+  const { diffs, notes } = invertProposalDiffs(source.proposed_changes);
+
+  if (diffs.length === 0) {
+    return NextResponse.json(
+      {
+        error:
+          'Nothing to revert — every diff in this proposal pre-dates the capture pattern or has no defined inverse.',
+        notes,
+      },
+      { status: 422 },
+    );
+  }
+
+  const limitedCount = notes.filter(n => n.status === 'limited').length;
+  const summary = limitedCount > 0
+    ? `### Revert proposal\n\nInverts proposal \`${source.id}\` (${notes.length} forward diff${notes.length === 1 ? '' : 's'}, ${limitedCount} unrevertable — see per-diff notes).`
+    : `### Revert proposal\n\nInverts proposal \`${source.id}\` (${notes.length} forward diff${notes.length === 1 ? '' : 's'}).`;
+
+  // The trigger_text envelope mirrors the shape used elsewhere in
+  // pm-dispatch (JSON with a `mode` discriminator) so future filters
+  // and the resume/lookup endpoints can introspect cleanly.
+  const triggerText = JSON.stringify({
+    mode: 'revert',
+    source_proposal_id: source.id,
+  });
+
+  try {
+    const draft = createProposal({
+      workspace_id: source.workspace_id,
+      trigger_text: triggerText,
+      trigger_kind: 'revert',
+      impact_md: summary,
+      proposed_changes: diffs,
+      reverts_proposal_id: source.id,
+      target_initiative_id: source.target_initiative_id,
+    });
+    return NextResponse.json({ proposal: draft, notes }, { status: 201 });
+  } catch (e) {
+    if (e instanceof PmProposalValidationError) {
+      return NextResponse.json(
+        { error: e.message, hints: e.hints, notes },
+        { status: 400 },
+      );
+    }
+    throw e;
+  }
+}

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -79,6 +79,8 @@ export interface PmDiffCapture {
   created_task_id?: string;
   /** Set by `applyDiff` for `add_availability` — id of the inserted row. */
   created_availability_id?: string;
+  /** Set by `applyDiff` for `set_task_status`. */
+  prev_task_status?: string;
 }
 
 export type PmDiff =
@@ -99,7 +101,11 @@ export type PmDiff =
   | ({
       kind: 'set_initiative_status';
       initiative_id: string;
-      status: 'planned' | 'in_progress' | 'at_risk' | 'blocked';
+      // Forward proposals are PM-restricted to planned|in_progress|at_risk|blocked
+      // (validated when trigger_kind != 'revert'). Revert proposals may
+      // restore done/cancelled if that was the captured prev_status, so
+      // the diff shape covers all six values.
+      status: 'planned' | 'in_progress' | 'at_risk' | 'blocked' | 'done' | 'cancelled';
     } & PmDiffCapture)
   | ({
       kind: 'add_dependency';
@@ -149,6 +155,16 @@ export type PmDiff =
       status_check_md?: string | null;
       assigned_agent_id?: string | null;
       priority?: 'low' | 'normal' | 'high';
+    } & PmDiffCapture)
+  | ({
+      // Slice 2 of revertable PM proposals. Used as the inverse of
+      // `create_task_under_initiative` — the "tombstone" pattern: PM
+      // never hard-deletes, it cancels. Narrowly scoped to status='cancelled'
+      // for now since that's the only revert use case; if a broader
+      // task-status kind is needed in the future, generalize there.
+      kind: 'set_task_status';
+      task_id: string;
+      status: 'cancelled';
     } & PmDiffCapture);
 
 export interface PmProposal {
@@ -241,6 +257,7 @@ function assertInitiativeInWorkspace(
 export function validateProposedChanges(
   workspaceId: string,
   changes: PmDiff[],
+  options: { trigger_kind?: PmProposalTriggerKind } = {},
 ): string[] {
   const errors: string[] = [];
   const initiativeCache = new Map<string, boolean>();
@@ -306,9 +323,19 @@ export function validateProposedChanges(
           break;
         }
         assertInitiativeInWorkspace(workspaceId, c.initiative_id, errors, initiativeCache);
-        if (!STATUS_ALLOWED_FROM_PM.has(c.status)) {
+        // Forward proposals are PM-restricted to the four working statuses.
+        // Revert proposals legitimately need to restore done/cancelled when
+        // the captured prev_status was one of those — keep the diff shape
+        // honest here and trust the operator's accept review.
+        const isRevert = options.trigger_kind === 'revert';
+        const allowed = isRevert
+          ? new Set(['planned', 'in_progress', 'at_risk', 'blocked', 'done', 'cancelled'])
+          : STATUS_ALLOWED_FROM_PM;
+        if (!allowed.has(c.status)) {
           errors.push(
-            `changes[${i}]: status "${c.status}" not allowed from PM (planned/in_progress/at_risk/blocked only)`,
+            isRevert
+              ? `changes[${i}]: status "${c.status}" is not a valid initiative status`
+              : `changes[${i}]: status "${c.status}" not allowed from PM (planned/in_progress/at_risk/blocked only)`,
           );
         }
         break;
@@ -431,6 +458,25 @@ export function validateProposedChanges(
         }
         break;
       }
+      case 'set_task_status': {
+        if (!c.task_id) {
+          errors.push(`changes[${i}]: task_id required`);
+          break;
+        }
+        if (c.status !== 'cancelled') {
+          errors.push(
+            `changes[${i}]: set_task_status only supports status='cancelled' (revert use only)`,
+          );
+        }
+        const t = queryOne<{ id: string }>(
+          'SELECT id FROM tasks WHERE id = ? AND workspace_id = ?',
+          [c.task_id, workspaceId],
+        );
+        if (!t) {
+          errors.push(`changes[${i}]: task ${c.task_id} not found in workspace ${workspaceId}`);
+        }
+        break;
+      }
       default: {
         const exhaustive: never = c;
         errors.push(`changes[${i}]: unknown kind "${(exhaustive as { kind?: string }).kind ?? '?'}"`);
@@ -501,7 +547,11 @@ export function createProposal(input: CreateProposalInput): PmProposal {
     throw new PmProposalValidationError('impact_md required');
   }
 
-  const errors = validateProposedChanges(input.workspace_id, input.proposed_changes ?? []);
+  const errors = validateProposedChanges(
+    input.workspace_id,
+    input.proposed_changes ?? [],
+    { trigger_kind: input.trigger_kind ?? 'manual' },
+  );
   if (errors.length > 0) {
     throw new PmProposalValidationError(
       `Invalid proposed_changes: ${errors.length} error(s)`,
@@ -662,7 +712,11 @@ export function acceptProposal(
 
   // Re-validate against current DB state — initiatives could've been
   // deleted between draft and accept.
-  const errors = validateProposedChanges(existing.workspace_id, existing.proposed_changes);
+  const errors = validateProposedChanges(
+    existing.workspace_id,
+    existing.proposed_changes,
+    { trigger_kind: existing.trigger_kind },
+  );
   if (errors.length > 0) {
     throw new PmProposalValidationError(
       `Cannot apply proposal ${id}: ${errors.length} validation error(s)`,
@@ -963,6 +1017,18 @@ function applyDiff(diff: PmDiff, now: string): void {
       // Same out-of-band pattern: handled in acceptProposal so
       // initiative_id placeholders can resolve from the same proposal.
       throw new Error('create_task_under_initiative must be applied via acceptProposal pass-2');
+    }
+    case 'set_task_status': {
+      const prev = queryOne<{ status: string }>(
+        `SELECT status FROM tasks WHERE id = ?`,
+        [diff.task_id],
+      );
+      if (prev) diff.prev_task_status = prev.status;
+      run(
+        `UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?`,
+        [diff.status, now, diff.task_id],
+      );
+      return;
     }
     default: {
       const exhaustive: never = diff;

--- a/src/lib/pm/invertDiff.test.ts
+++ b/src/lib/pm/invertDiff.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Round-trip tests for invertDiff.
+ *
+ * For each diff kind: apply forward → invert → apply inverse, then
+ * assert the DB is back to its initial state. This is the load-bearing
+ * guarantee of the revert feature: the inverse must be a pure function
+ * of the captured diff, executable without any extra "modified since"
+ * accommodation.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, queryAll, run } from '@/lib/db';
+import {
+  createProposal,
+  getProposal,
+  acceptProposal,
+} from '@/lib/db/pm-proposals';
+import {
+  createInitiative,
+  addInitiativeDependency,
+  type Initiative,
+} from '@/lib/db/initiatives';
+import { invertProposalDiffs } from './invertDiff';
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at)
+     VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+/**
+ * Helper: accept the forward proposal, then synthesize + accept its
+ * inverse via createProposal+acceptProposal (the same flow the real
+ * endpoint uses minus the HTTP shell).
+ */
+function applyAndRevert(workspaceId: string, forwardProposalId: string): void {
+  acceptProposal(forwardProposalId);
+  const accepted = getProposal(forwardProposalId)!;
+  const { diffs } = invertProposalDiffs(accepted.proposed_changes);
+  if (diffs.length === 0) throw new Error('No invertible diffs');
+  const revert = createProposal({
+    workspace_id: workspaceId,
+    trigger_text: 'revert-test',
+    trigger_kind: 'revert',
+    impact_md: 'revert',
+    proposed_changes: diffs,
+    reverts_proposal_id: forwardProposalId,
+  });
+  acceptProposal(revert.id);
+}
+
+// ─── Per-kind round-trip ────────────────────────────────────────────
+
+test('round-trip: set_initiative_status restores prior status', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'X' });
+  const before = init.status;
+
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      { kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' },
+    ],
+  });
+  applyAndRevert(ws, p.id);
+
+  const after = queryOne<{ status: string }>(
+    'SELECT status FROM initiatives WHERE id = ?',
+    [init.id],
+  );
+  assert.equal(after?.status, before);
+});
+
+test('round-trip: shift_initiative_target restores prior targets', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({
+    workspace_id: ws,
+    kind: 'milestone',
+    title: 'Launch',
+    target_start: '2026-04-01',
+    target_end: '2026-05-01',
+  });
+
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      {
+        kind: 'shift_initiative_target',
+        initiative_id: init.id,
+        target_start: '2026-06-01',
+        target_end: '2026-07-01',
+      },
+    ],
+  });
+  applyAndRevert(ws, p.id);
+
+  const after = queryOne<{ target_start: string | null; target_end: string | null }>(
+    'SELECT target_start, target_end FROM initiatives WHERE id = ?',
+    [init.id],
+  );
+  assert.equal(after?.target_start?.slice(0, 10), '2026-04-01');
+  assert.equal(after?.target_end?.slice(0, 10), '2026-05-01');
+});
+
+test('round-trip: update_status_check restores prior markdown', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'X' });
+  run(`UPDATE initiatives SET status_check_md = ? WHERE id = ?`, ['original', init.id]);
+
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      { kind: 'update_status_check', initiative_id: init.id, status_check_md: 'updated' },
+    ],
+  });
+  applyAndRevert(ws, p.id);
+
+  const after = queryOne<{ status_check_md: string | null }>(
+    'SELECT status_check_md FROM initiatives WHERE id = ?',
+    [init.id],
+  );
+  assert.equal(after?.status_check_md, 'original');
+});
+
+test('round-trip: add_dependency removes the created edge', () => {
+  const ws = freshWorkspace();
+  const a = createInitiative({ workspace_id: ws, kind: 'epic', title: 'A' });
+  const b = createInitiative({ workspace_id: ws, kind: 'epic', title: 'B' });
+
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      { kind: 'add_dependency', initiative_id: a.id, depends_on_initiative_id: b.id },
+    ],
+  });
+  applyAndRevert(ws, p.id);
+
+  const rows = queryAll(
+    `SELECT id FROM initiative_dependencies WHERE initiative_id = ? AND depends_on_initiative_id = ?`,
+    [a.id, b.id],
+  );
+  assert.equal(rows.length, 0);
+});
+
+test('round-trip: remove_dependency restores the deleted edge', () => {
+  const ws = freshWorkspace();
+  const a = createInitiative({ workspace_id: ws, kind: 'epic', title: 'A' });
+  const b = createInitiative({ workspace_id: ws, kind: 'epic', title: 'B' });
+  const dep = addInitiativeDependency({
+    initiative_id: a.id,
+    depends_on_initiative_id: b.id,
+  });
+
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [{ kind: 'remove_dependency', dependency_id: dep.id }],
+  });
+  applyAndRevert(ws, p.id);
+
+  const rows = queryAll<{ id: string }>(
+    `SELECT id FROM initiative_dependencies
+      WHERE initiative_id = ? AND depends_on_initiative_id = ?`,
+    [a.id, b.id],
+  );
+  // The revert re-inserts an edge with the same (init, depends_on) pair.
+  // The actual id may be new (we don't reuse the original id today —
+  // applyDiff(add_dependency) generates a fresh uuid). The semantic
+  // restore is what matters.
+  assert.equal(rows.length, 1);
+});
+
+test('round-trip: reorder_initiatives restores prior order', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({ workspace_id: ws, kind: 'milestone', title: 'P' });
+  const c1 = createInitiative({ workspace_id: ws, kind: 'epic', title: 'C1', parent_initiative_id: parent.id, sort_order: 0 });
+  const c2 = createInitiative({ workspace_id: ws, kind: 'epic', title: 'C2', parent_initiative_id: parent.id, sort_order: 1 });
+  const c3 = createInitiative({ workspace_id: ws, kind: 'epic', title: 'C3', parent_initiative_id: parent.id, sort_order: 2 });
+
+  const reversed = [c3.id, c2.id, c1.id];
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      { kind: 'reorder_initiatives', parent_id: parent.id, child_ids_in_order: reversed },
+    ],
+  });
+  applyAndRevert(ws, p.id);
+
+  const after = queryAll<{ id: string; sort_order: number }>(
+    `SELECT id, sort_order FROM initiatives WHERE parent_initiative_id = ? ORDER BY sort_order ASC`,
+    [parent.id],
+  );
+  assert.deepEqual(
+    after.map(r => r.id),
+    [c1.id, c2.id, c3.id],
+  );
+});
+
+test('round-trip: create_child_initiative tombstones the created row as cancelled', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({ workspace_id: ws, kind: 'milestone', title: 'P' });
+
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      {
+        kind: 'create_child_initiative',
+        parent_initiative_id: parent.id,
+        title: 'New child',
+        child_kind: 'epic',
+      },
+    ],
+  });
+  applyAndRevert(ws, p.id);
+
+  // The row still exists but is now cancelled (PM never hard-deletes).
+  const accepted = getProposal(p.id)!;
+  const createdId = (
+    accepted.proposed_changes[0] as { created_initiative_id?: string }
+  ).created_initiative_id;
+  assert.ok(createdId);
+  const row = queryOne<{ status: string }>(
+    'SELECT status FROM initiatives WHERE id = ?',
+    [createdId],
+  );
+  assert.equal(row?.status, 'cancelled');
+});
+
+test('round-trip: create_task_under_initiative cancels the created task', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'I' });
+
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      {
+        kind: 'create_task_under_initiative',
+        initiative_id: init.id,
+        title: 'A task',
+      },
+    ],
+  });
+  applyAndRevert(ws, p.id);
+
+  const accepted = getProposal(p.id)!;
+  const taskId = (accepted.proposed_changes[0] as { created_task_id?: string }).created_task_id;
+  assert.ok(taskId);
+  const row = queryOne<{ status: string }>(
+    'SELECT status FROM tasks WHERE id = ?',
+    [taskId],
+  );
+  assert.equal(row?.status, 'cancelled');
+});
+
+// ─── Limited / edge cases ───────────────────────────────────────────
+
+test('invertProposalDiffs marks pre-capture diffs as limited', () => {
+  // Synthesize a forward diff WITHOUT capture fields — simulates a
+  // proposal accepted before Slice 1's capture pattern landed.
+  const result = invertProposalDiffs([
+    {
+      kind: 'set_initiative_status',
+      initiative_id: 'fake-id',
+      status: 'at_risk',
+    },
+  ]);
+  assert.equal(result.diffs.length, 0);
+  assert.equal(result.notes.length, 1);
+  assert.equal(result.notes[0].status, 'limited');
+});
+
+test('invertProposalDiffs reverses order so dependent diffs flip correctly', () => {
+  // create_child + create_task_under_initiative referencing the child
+  // by placeholder. The inverse should cancel the TASK first, then the
+  // CHILD INITIATIVE — otherwise cancelling the parent first would
+  // orphan the task in the inversed apply pass.
+  const captured: Parameters<typeof invertProposalDiffs>[0] = [
+    {
+      kind: 'create_child_initiative',
+      parent_initiative_id: 'p',
+      title: 'child',
+      child_kind: 'epic',
+      created_initiative_id: 'child-real-id',
+    },
+    {
+      kind: 'create_task_under_initiative',
+      initiative_id: 'child-real-id',
+      title: 'task',
+      created_task_id: 'task-real-id',
+    },
+  ];
+  const { diffs } = invertProposalDiffs(captured);
+  assert.equal(diffs.length, 2);
+  assert.equal(diffs[0].kind, 'set_task_status');
+  assert.equal(diffs[1].kind, 'set_initiative_status');
+});
+
+test('round-trip-of-revert: accepting a revert of a revert is supported', () => {
+  // Spec: "If the proposal being reverted is itself a revert, that's
+  // fine — it just produces another inverse." We exercise the full chain
+  // for a kind whose revert is itself fully invertible.
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'X' });
+
+  // Forward.
+  const fwd = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      { kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' },
+    ],
+  });
+  acceptProposal(fwd.id);
+  // Status now at_risk.
+
+  // First revert (back to planned).
+  const acceptedFwd = getProposal(fwd.id)!;
+  const inv1 = invertProposalDiffs(acceptedFwd.proposed_changes).diffs;
+  const rev1 = createProposal({
+    workspace_id: ws,
+    trigger_text: 'rev',
+    trigger_kind: 'revert',
+    impact_md: 'rev',
+    proposed_changes: inv1,
+    reverts_proposal_id: fwd.id,
+  });
+  acceptProposal(rev1.id);
+
+  const r1State = queryOne<{ status: string }>(
+    'SELECT status FROM initiatives WHERE id = ?',
+    [init.id],
+  );
+  assert.equal(r1State?.status, 'planned');
+
+  // Revert the revert (should land us back at at_risk).
+  const acceptedRev1 = getProposal(rev1.id)!;
+  const inv2 = invertProposalDiffs(acceptedRev1.proposed_changes).diffs;
+  const rev2 = createProposal({
+    workspace_id: ws,
+    trigger_text: 'rev2',
+    trigger_kind: 'revert',
+    impact_md: 'rev2',
+    proposed_changes: inv2,
+    reverts_proposal_id: rev1.id,
+  });
+  acceptProposal(rev2.id);
+
+  const r2State = queryOne<{ status: string }>(
+    'SELECT status FROM initiatives WHERE id = ?',
+    [init.id],
+  );
+  assert.equal(r2State?.status, 'at_risk');
+});
+
+// ─── Endpoint smoke (createProposal + invert path matches the route) ──
+
+test('createProposal+revert flow is what the endpoint does', () => {
+  // We exercise the same code path as the route handler (without HTTP)
+  // to lock in the contract: source must be accepted, response carries
+  // the new draft + notes.
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'X' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 't',
+    impact_md: 'm',
+    proposed_changes: [
+      { kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' },
+    ],
+  });
+  acceptProposal(p.id);
+
+  const accepted = getProposal(p.id)!;
+  const { diffs, notes } = invertProposalDiffs(accepted.proposed_changes);
+  assert.equal(diffs.length, 1);
+  assert.equal(notes[0].status, 'inverted');
+
+  const revert = createProposal({
+    workspace_id: ws,
+    trigger_text: JSON.stringify({ mode: 'revert', source_proposal_id: p.id }),
+    trigger_kind: 'revert',
+    impact_md: 'r',
+    proposed_changes: diffs,
+    reverts_proposal_id: p.id,
+  });
+  assert.equal(revert.status, 'draft');
+  assert.equal(revert.trigger_kind, 'revert');
+  assert.equal(revert.reverts_proposal_id, p.id);
+});
+
+// ─── Type assertion to silence unused import warning if Initiative
+// isn't referenced directly above. ──────────────────────────────────
+const _initType: Initiative | null = null;
+void _initType;

--- a/src/lib/pm/invertDiff.ts
+++ b/src/lib/pm/invertDiff.ts
@@ -1,0 +1,251 @@
+/**
+ * Synthesize the inverse of an accepted PM proposal's diff list.
+ *
+ * Slice 2 of specs/pm-revertable-proposals.md. Read in tandem with the
+ * `applyDiff` capture pattern in `src/lib/db/pm-proposals.ts` — every
+ * forward apply records enough prior state onto the diff that the inverse
+ * is computable as a pure function of the diff row alone, without
+ * recomputing from drifted DB state.
+ *
+ * Diffs are inverted in REVERSE order. Within a single proposal, later
+ * diffs may depend on entities created by earlier diffs (e.g. a
+ * `create_task_under_initiative` referencing a `create_child_initiative`
+ * via `$N` placeholder). Reverting in reverse keeps those dependencies
+ * intact: the task is cancelled before the initiative it lived under is.
+ */
+
+import type { PmDiff } from '@/lib/db/pm-proposals';
+
+export type InvertibilityStatus =
+  | 'inverted'
+  /** Diff was missing capture state needed to compute its inverse — most
+   *  often a pre-Slice-1 row, or a forward apply path that didn't write
+   *  back. UI surfaces a "Revert (limited)" tooltip per affected diff. */
+  | 'limited';
+
+export interface InvertedDiff {
+  /** The forward diff's index in the original `proposed_changes` array.
+   *  Useful for the UI's per-diff warning chip. */
+  original_index: number;
+  /** The synthesized inverse, or null when capture was missing. */
+  inverse: PmDiff | null;
+  status: InvertibilityStatus;
+  /** Human-readable explanation for the UI tooltip when status='limited'. */
+  reason?: string;
+}
+
+export interface InvertProposalResult {
+  /** Inverted diffs in REVERSE forward order, ready to seed into a new
+   *  draft proposal. Limited diffs are omitted; the per-diff notes cover
+   *  what was skipped. */
+  diffs: PmDiff[];
+  /** One entry per forward diff in original order so the UI can render
+   *  a 1:1 chip strip. */
+  notes: InvertedDiff[];
+}
+
+/**
+ * Compute inverses for an accepted proposal's diff list.
+ *
+ * `forward` is the proposal's `proposed_changes` array post-apply (i.e.
+ * with capture fields populated by Slice 1's apply path).
+ */
+export function invertProposalDiffs(forward: PmDiff[]): InvertProposalResult {
+  const notes: InvertedDiff[] = [];
+
+  for (let i = 0; i < forward.length; i++) {
+    notes.push(invertOne(forward[i], i));
+  }
+
+  // Reverse so dependent inverses run first (e.g. cancel a task before
+  // cancelling the initiative it was created under).
+  const diffs = notes
+    .slice()
+    .reverse()
+    .filter(n => n.inverse !== null)
+    .map(n => n.inverse as PmDiff);
+
+  return { diffs, notes };
+}
+
+function invertOne(diff: PmDiff, index: number): InvertedDiff {
+  switch (diff.kind) {
+    case 'shift_initiative_target': {
+      // prev_target_start/end are populated by Slice 1's apply path.
+      // Restore both targets even if only one moved forward — the
+      // capture is symmetric and an UPDATE setting both is idempotent.
+      if (diff.prev_target_start === undefined && diff.prev_target_end === undefined) {
+        return limited(index, 'pre-capture proposal: target state was not recorded');
+      }
+      return {
+        original_index: index,
+        status: 'inverted',
+        inverse: {
+          kind: 'shift_initiative_target',
+          initiative_id: diff.initiative_id,
+          target_start: diff.prev_target_start ?? null,
+          target_end: diff.prev_target_end ?? null,
+          reason: 'revert',
+        },
+      };
+    }
+
+    case 'set_initiative_status': {
+      if (!diff.prev_status) {
+        return limited(index, 'pre-capture proposal: prior status was not recorded');
+      }
+      return {
+        original_index: index,
+        status: 'inverted',
+        inverse: {
+          kind: 'set_initiative_status',
+          initiative_id: diff.initiative_id,
+          status: diff.prev_status,
+        },
+      };
+    }
+
+    case 'update_status_check': {
+      if (diff.prev_status_check_md === undefined) {
+        return limited(index, 'pre-capture proposal: prior status_check_md was not recorded');
+      }
+      return {
+        original_index: index,
+        status: 'inverted',
+        inverse: {
+          kind: 'update_status_check',
+          initiative_id: diff.initiative_id,
+          // Empty-string back-fill: applyDiff treats null and '' the
+          // same shape (UPDATE … SET status_check_md = ?). The forward
+          // diff's `status_check_md` is required-string, so we coerce.
+          status_check_md: diff.prev_status_check_md ?? '',
+        },
+      };
+    }
+
+    case 'add_dependency': {
+      if (!diff.created_dependency_id) {
+        return limited(index, 'pre-capture proposal: created edge id was not recorded');
+      }
+      return {
+        original_index: index,
+        status: 'inverted',
+        inverse: {
+          kind: 'remove_dependency',
+          dependency_id: diff.created_dependency_id,
+        },
+      };
+    }
+
+    case 'remove_dependency': {
+      const row = diff.removed_dependency_row;
+      if (!row) {
+        return limited(index, 'pre-capture proposal: removed edge snapshot was not recorded');
+      }
+      return {
+        original_index: index,
+        status: 'inverted',
+        inverse: {
+          kind: 'add_dependency',
+          initiative_id: row.initiative_id,
+          depends_on_initiative_id: row.depends_on_initiative_id,
+          note: row.note ?? undefined,
+        },
+      };
+    }
+
+    case 'reorder_initiatives': {
+      if (!diff.prev_child_ids_in_order) {
+        return limited(index, 'pre-capture proposal: prior order was not recorded');
+      }
+      return {
+        original_index: index,
+        status: 'inverted',
+        inverse: {
+          kind: 'reorder_initiatives',
+          parent_id: diff.parent_id,
+          child_ids_in_order: diff.prev_child_ids_in_order,
+        },
+      };
+    }
+
+    case 'create_child_initiative': {
+      if (!diff.created_initiative_id) {
+        return limited(index, 'pre-capture proposal: new initiative id was not recorded');
+      }
+      // PM never hard-deletes — tombstone via status=cancelled. The
+      // operator sees the row in /initiatives if they toggle "Show
+      // cancelled" on, and Slice 4's filter hides it by default.
+      return {
+        original_index: index,
+        status: 'inverted',
+        inverse: {
+          kind: 'set_initiative_status',
+          initiative_id: diff.created_initiative_id,
+          status: 'cancelled',
+        },
+      };
+    }
+
+    case 'create_task_under_initiative': {
+      if (!diff.created_task_id) {
+        return limited(index, 'pre-capture proposal: new task id was not recorded');
+      }
+      return {
+        original_index: index,
+        status: 'inverted',
+        inverse: {
+          kind: 'set_task_status',
+          task_id: diff.created_task_id,
+          status: 'cancelled',
+        },
+      };
+    }
+
+    case 'add_availability': {
+      // No forward `remove_availability` diff kind exists today (the PM
+      // never proposes a removal), so we surface this as 'limited'.
+      // owner_availability is a pure annotation row with no downstream
+      // references; the operator can delete the row directly via the
+      // DB or via a future `remove_availability` diff kind if needed.
+      return limited(
+        index,
+        'add_availability: revert is not modeled as a diff yet — delete the owner_availability row manually if needed',
+      );
+    }
+
+    case 'set_task_status': {
+      // Already-revert-shaped diff. Inverting a set_task_status('cancelled')
+      // means restoring the captured prev_task_status. The PM never
+      // forwards this kind, so the only way to hit this branch is when
+      // someone reverts a previous revert — which the spec explicitly
+      // says should "just produce another inverse" without special-casing.
+      if (!diff.prev_task_status) {
+        return limited(index, 'pre-capture proposal: prior task status was not recorded');
+      }
+      // We can't emit a generic forward `set_task_status` since the type
+      // narrowly only allows status='cancelled'. Mark limited; future
+      // generalization (slice 3 polish) can widen the type.
+      return {
+        original_index: index,
+        status: 'limited',
+        inverse: null,
+        reason: `set_task_status revert needs a wider task-status diff kind (prev was '${diff.prev_task_status}')`,
+      };
+    }
+
+    default: {
+      const exhaustive: never = diff;
+      return {
+        original_index: index,
+        inverse: null,
+        status: 'limited',
+        reason: `unknown diff kind ${(exhaustive as { kind?: string }).kind ?? '?'}`,
+      };
+    }
+  }
+}
+
+function limited(index: number, reason: string): InvertedDiff {
+  return { original_index: index, inverse: null, status: 'limited', reason };
+}


### PR DESCRIPTION
Builds on the foundation that landed in #125. Synthesizes the inverse of an accepted proposal and exposes it via a new endpoint as a draft revert proposal — the operator must accept it through the normal review/accept flow before any state mutates. Slice 3 will surface this in the UI.

## Summary

- New pure helper [`src/lib/pm/invertDiff.ts`](src/lib/pm/invertDiff.ts) takes the captured forward diff list and returns inverse diffs + per-original-diff notes (`'inverted'` | `'limited'` with a reason).
- New endpoint `POST /api/pm/proposals/[id]/revert` creates the draft.
- Diffs are inverted in **reverse order** so dependents run first (cancel a child task before cancelling the initiative it lived under).

## Inverse mappings

| Forward kind | Inverse |
|---|---|
| `set_initiative_status` | restore `prev_status` |
| `shift_initiative_target` | swap before/after targets |
| `update_status_check` | restore `prev_status_check_md` |
| `add_dependency` | `remove_dependency` of captured `created_dependency_id` |
| `remove_dependency` | re-insert from the captured row snapshot |
| `reorder_initiatives` | restore `prev_child_ids_in_order` |
| `create_child_initiative` | `set_initiative_status('cancelled')` on the captured id (PM never hard-deletes) |
| `create_task_under_initiative` | new `set_task_status('cancelled')` diff kind |
| `add_availability` | surfaced as `'limited'` (no forward `remove_availability` kind exists today) |

## Diff vocabulary additions

- **`set_task_status`** — narrowly scoped to `status='cancelled'`, used as the inverse of `create_task_under_initiative`. Captures `prev_task_status` for revert-of-revert chains.
- **`set_initiative_status`** type widens to all 6 statuses. Validation still enforces the PM-only subset (`planned/in_progress/at_risk/blocked`) for non-revert proposals; revert proposals can restore `done`/`cancelled` if that was the captured `prev_status`.

## Endpoint contract

- `404` when source proposal absent
- `409` when source isn't `status='accepted'`
- `422` when every source diff is `'limited'` (nothing to revert)
- `201` with `{ proposal, notes }` otherwise

## Test plan

- [x] 12 new tests in [`src/lib/pm/invertDiff.test.ts`](src/lib/pm/invertDiff.test.ts):
  - Round-trip per kind: apply forward → invert → accept-invert leaves DB at initial state
  - Pre-capture proposals (no Slice-1 capture state) correctly mark every diff as `'limited'`
  - Reverse-order ordering verified for `create_child` + `create_task` pairs
  - Revert-of-revert chain verified end-to-end
  - Endpoint contract smoke (createProposal + invert path matches the route)
- [x] Full suite: **487 passing, 0 failing** (`yarn test`)
- [x] Endpoint smoked against running preview: `POST /api/pm/proposals/<bad-id>/revert` → `404` with the expected error shape
- [x] Typecheck clean for touched files