### PR TITLE
fix(workspace): scope Initiatives, Roadmap, PM activity to selected workspace

### DIFF
--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -26,6 +26,7 @@ import ActionMenu, { ActionMenuItem } from '@/components/ActionMenu';
 import PlanWithPmPanel, { type PlanInitiativeSuggestions } from '@/components/PlanWithPmPanel';
 import DecomposeWithPmModal from '@/components/DecomposeWithPmModal';
 import { showAlertDialog } from '@/lib/show-alert';
+import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 
 // Local types (kept separate from src/lib/types.ts so Phase 1 doesn't touch
 // the central type module — Phase 2 can promote these once the broader API
@@ -90,8 +91,6 @@ const KIND_BADGE: Record<Kind, string> = {
   story: 'bg-emerald-500/20 text-emerald-300',
 };
 
-const WORKSPACE_ID = 'default';
-
 const SHOW_CANCELLED_LS_KEY = 'mc:initiatives:show_cancelled';
 
 // Toggle persisted across the URL (`?show_cancelled=1`) so links survive
@@ -138,6 +137,7 @@ function useShowCancelled(): [boolean, (next: boolean) => void] {
 }
 
 export default function InitiativesPage() {
+  const workspaceId = useCurrentWorkspaceId();
   const [flat, setFlat] = useState<Initiative[]>([]);
   const [taskCounts, setTaskCounts] = useState<Record<string, TaskCounts>>({});
   const [loading, setLoading] = useState(true);
@@ -156,8 +156,8 @@ export default function InitiativesPage() {
     setError(null);
     try {
       const [iRes, tRes] = await Promise.all([
-        fetch(`/api/initiatives?workspace_id=${WORKSPACE_ID}`),
-        fetch(`/api/tasks?workspace_id=${WORKSPACE_ID}`),
+        fetch(`/api/initiatives?workspace_id=${encodeURIComponent(workspaceId)}`),
+        fetch(`/api/tasks?workspace_id=${encodeURIComponent(workspaceId)}`),
       ]);
       if (!iRes.ok) throw new Error(`Failed to load (${iRes.status})`);
       const rows: Initiative[] = await iRes.json();
@@ -184,7 +184,7 @@ export default function InitiativesPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [workspaceId]);
 
   useEffect(() => {
     refresh();
@@ -309,6 +309,7 @@ export default function InitiativesPage() {
       {creating && (
         <CreateModal
           parentId={creating.parent_id}
+          workspaceId={workspaceId}
           allInitiatives={pickableInitiatives}
           onClose={() => setCreating(null)}
           onSaved={() => {
@@ -899,11 +900,13 @@ function ModalShell({
 
 export function CreateModal({
   parentId,
+  workspaceId,
   allInitiatives,
   onClose,
   onSaved,
 }: {
   parentId: string | null;
+  workspaceId: string;
   allInitiatives: Initiative[];
   onClose: () => void;
   onSaved: () => void;
@@ -922,7 +925,7 @@ export function CreateModal({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          workspace_id: WORKSPACE_ID,
+          workspace_id: workspaceId,
           title,
           kind,
           parent_initiative_id: chosenParent,

--- a/src/app/(app)/pm/activity/page.tsx
+++ b/src/app/(app)/pm/activity/page.tsx
@@ -7,8 +7,7 @@ import { ChevronDown, ChevronRight, RotateCcw, ExternalLink } from 'lucide-react
 import { ProposalDiffsList, summarizeDiff, type PmDiff } from '@/components/pm/ProposalDiffsList';
 import { triggerBadgeFor } from '@/components/pm/triggerBadge';
 import { showAlertDialog } from '@/lib/show-alert';
-
-const WORKSPACE_ID = 'default';
+import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 
 interface PmProposal {
   id: string;
@@ -44,6 +43,7 @@ const DATE_RANGE_OPTIONS: Array<{ key: string; label: string; hours: number | nu
 
 export default function PmActivityPage() {
   const router = useRouter();
+  const workspaceId = useCurrentWorkspaceId();
   const [proposals, setProposals] = useState<PmProposal[]>([]);
   const [agents, setAgents] = useState<Record<string, AgentLite>>({});
   const [initiatives, setInitiatives] = useState<Record<string, InitiativeLite>>({});
@@ -61,9 +61,9 @@ export default function PmActivityPage() {
     setError(null);
     try {
       const [pRes, aRes, iRes] = await Promise.all([
-        fetch(`/api/pm/proposals?workspace_id=${WORKSPACE_ID}&status=accepted&limit=200`),
-        fetch(`/api/agents?workspace_id=${WORKSPACE_ID}`),
-        fetch(`/api/initiatives?workspace_id=${WORKSPACE_ID}`),
+        fetch(`/api/pm/proposals?workspace_id=${encodeURIComponent(workspaceId)}&status=accepted&limit=200`),
+        fetch(`/api/agents?workspace_id=${encodeURIComponent(workspaceId)}`),
+        fetch(`/api/initiatives?workspace_id=${encodeURIComponent(workspaceId)}`),
       ]);
       if (!pRes.ok) throw new Error(`Failed to load proposals (${pRes.status})`);
       const ps: PmProposal[] = await pRes.json();
@@ -86,7 +86,7 @@ export default function PmActivityPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [workspaceId]);
 
   useEffect(() => {
     refresh();

--- a/src/components/roadmap/RoadmapTimeline.tsx
+++ b/src/components/roadmap/RoadmapTimeline.tsx
@@ -26,8 +26,8 @@ import {
   toIsoDay,
   type ZoomLevel,
 } from '@/lib/roadmap/date-math';
+import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 
-const WORKSPACE_ID = 'default';
 const ZOOM_KEY = 'roadmap.zoom';
 const RAIL_WIDTH = 300; // px
 const ROW_HEIGHT = 36;  // px — must match RoadmapRail row height
@@ -109,6 +109,7 @@ function writeZoom(z: ZoomLevel) {
 }
 
 export function RoadmapTimeline() {
+  const workspaceId = useCurrentWorkspaceId();
   const [snapshot, setSnapshot] = useState<RoadmapSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -137,7 +138,7 @@ export function RoadmapTimeline() {
     try {
       setError(null);
       const params = new URLSearchParams();
-      params.set('workspace_id', WORKSPACE_ID);
+      params.set('workspace_id', workspaceId);
       if (filters.product_id) params.set('product_id', filters.product_id);
       if (filters.owner_agent_id) params.set('owner_agent_id', filters.owner_agent_id);
       const r = await fetch(`/api/roadmap?${params.toString()}`);
@@ -149,7 +150,7 @@ export function RoadmapTimeline() {
     } finally {
       setLoading(false);
     }
-  }, [filters.product_id, filters.owner_agent_id]);
+  }, [workspaceId, filters.product_id, filters.owner_agent_id]);
 
   useEffect(() => {
     refresh();
@@ -162,7 +163,7 @@ export function RoadmapTimeline() {
       const r = await fetch('/api/roadmap/recompute', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ workspace_id: WORKSPACE_ID }),
+        body: JSON.stringify({ workspace_id: workspaceId }),
       });
       if (!r.ok) {
         const body = await r.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- Three top-level pages (Initiatives, Roadmap, PM activity) hardcoded `WORKSPACE_ID = 'default'` and ignored the workspace picker, breaking isolation.
- Switched all three to read `useCurrentWorkspaceId()` from the existing workspace context, threaded through to CreateModal on Initiatives so new initiatives land in the right workspace.

## Changes
- \`src/app/(app)/initiatives/page.tsx\`: hook + prop-drilling to CreateModal
- \`src/app/(app)/pm/activity/page.tsx\`: hook in fetch loop
- \`src/components/roadmap/RoadmapTimeline.tsx\`: hook in fetch + recompute body

## Test plan
- [x] Verified in preview: switched to a non-default workspace, Roadmap header now reads "10 initiatives" matching the imported FOIA subtree; network log shows \`/api/roadmap?workspace_id=<uuid>\` (not \`default\`).
- [x] \`yarn tsc --noEmit\` clean for the touched files (the two pre-existing failures in \`src/lib/agents/pm-decompose.test.ts\` are unrelated and were already failing on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)