### PR TITLE
feat(tasks): draft column + delete drafts + N-task promote warning

### DIFF
--- a/src/app/(app)/initiatives/[id]/page.tsx
+++ b/src/app/(app)/initiatives/[id]/page.tsx
@@ -388,6 +388,21 @@ export default function InitiativeDetailPage({
     }
   }, [initiative, router]);
 
+  const deleteDraft = async (taskId: string) => {
+    setActionError(null);
+    if (!window.confirm('Delete this draft task? This cannot be undone.')) return;
+    try {
+      const res = await fetch(`/api/tasks/${taskId}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Delete failed (${res.status})`);
+      }
+      refresh();
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : 'Delete failed');
+    }
+  };
+
   const promoteDraft = async (taskId: string) => {
     setActionError(null);
     try {
@@ -818,6 +833,7 @@ or "carve out the onboarding flow as its own story first"`}
                 label="Draft (planning)"
                 rows={drafts}
                 onPromote={promoteDraft}
+                onDelete={deleteDraft}
               />
               <TaskGroup label="Active" rows={active} />
               {other.length > 0 && <TaskGroup label="Other" rows={other} />}
@@ -885,6 +901,8 @@ or "carve out the onboarding flow as its own story first"`}
       {showPromoteModal && (
         <PromoteToTaskModal
           initiative={initiative}
+          existingDraftCount={drafts.length}
+          existingActiveCount={active.length}
           onClose={() => setShowPromoteModal(false)}
           onSaved={() => {
             setShowPromoteModal(false);
@@ -1045,10 +1063,12 @@ function TaskGroup({
   label,
   rows,
   onPromote,
+  onDelete,
 }: {
   label: string;
   rows: TaskRow[];
   onPromote?: (taskId: string) => void;
+  onDelete?: (taskId: string) => void;
 }) {
   if (rows.length === 0) return null;
   return (
@@ -1079,6 +1099,15 @@ function TaskGroup({
                 <Send className="w-3 h-3" /> Promote
               </button>
             )}
+            {onDelete && t.status === 'draft' && (
+              <button
+                onClick={() => onDelete(t.id)}
+                className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded text-mc-text-secondary border border-mc-border hover:text-red-300 hover:border-red-500/40"
+                title="Delete this draft"
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
+            )}
           </li>
         ))}
       </ul>
@@ -1088,10 +1117,14 @@ function TaskGroup({
 
 function PromoteToTaskModal({
   initiative,
+  existingDraftCount,
+  existingActiveCount,
   onClose,
   onSaved,
 }: {
   initiative: Initiative;
+  existingDraftCount: number;
+  existingActiveCount: number;
   onClose: () => void;
   onSaved: () => void;
 }) {
@@ -1133,9 +1166,24 @@ function PromoteToTaskModal({
         <h2 className="text-lg font-semibold mb-4">Promote story to task draft</h2>
         <p className="text-sm text-mc-text-secondary mb-4">
           Creates one task in <code>status=draft</code>, linked to this initiative.
-          The draft lives on the planning board until you explicitly promote it
-          to the execution queue.
+          The draft lives on the task board's Draft column until you explicitly
+          promote it to the execution queue.
         </p>
+        {existingDraftCount + existingActiveCount > 0 && (
+          <div className="mb-4 p-3 rounded bg-amber-500/10 border border-amber-500/30 text-amber-200 text-sm">
+            This story already has{' '}
+            <strong>
+              {existingDraftCount + existingActiveCount} non-done task
+              {existingDraftCount + existingActiveCount === 1 ? '' : 's'}
+            </strong>
+            {existingDraftCount > 0 && existingActiveCount > 0
+              ? ` (${existingDraftCount} draft, ${existingActiveCount} active)`
+              : existingDraftCount > 0
+                ? ` (draft${existingDraftCount === 1 ? '' : 's'})`
+                : ` (active)`}
+            . Promote anyway only if you genuinely need another parallel task.
+          </div>
+        )}
         <div className="space-y-3">
           <label className="block">
             <span className="text-sm text-mc-text-secondary">Task title</span>

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -34,6 +34,7 @@ export async function GET(request: NextRequest) {
         `).all(workspace.id) as { status: TaskStatus; count: number }[];
         
         const counts: WorkspaceStats['taskCounts'] = {
+          draft: 0,
           pending_dispatch: 0,
           planning: 0,
           inbox: 0,

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -18,6 +18,7 @@ interface MissionQueueProps {
 }
 
 const COLUMNS: { id: TaskStatus; label: string; color: string }[] = [
+  { id: 'draft', label: '✎ Draft', color: 'border-t-slate-500' },
   { id: 'planning', label: '📋 Planning', color: 'border-t-mc-accent-purple' },
   { id: 'inbox', label: 'Inbox', color: 'border-t-mc-accent-pink' },
   { id: 'assigned', label: 'Assigned', color: 'border-t-mc-accent-yellow' },
@@ -101,13 +102,10 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
   const [statusMoveTask, setStatusMoveTask] = useState<Task | null>(null);
   const [pendingMove, setPendingMove] = useState<{ task: Task; targetStatus: TaskStatus } | null>(null);
 
-  // Drafts (status='draft') belong to the planning board only — see spec
-  // §13.2 (Workflow Unification). They never appear in the execution queue.
   const getTasksByStatus = (status: TaskStatus) =>
     tasks.filter(
       (task) =>
         task.status === status &&
-        task.status !== ('draft' as TaskStatus) &&
         (showArchived || !task.is_archived),
     );
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@
 
 export type AgentStatus = 'standby' | 'working' | 'offline';
 
-export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'done' | 'cancelled' | 'needs_user_input';
+export type TaskStatus = 'draft' | 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'done' | 'cancelled' | 'needs_user_input';
 
 /**
  * Phase of the enhanced planning flow. Drives which prompt the backend sends
@@ -222,6 +222,7 @@ export interface WorkspaceStats {
   slug: string;
   icon: string;
   taskCounts: {
+    draft: number;
     pending_dispatch: number;
     planning: number;
     inbox: number;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -9,6 +9,7 @@ const agentId = z.string().regex(
 
 // Task status and priority enums from types
 const TaskStatus = z.enum([
+  'draft',
   'pending_dispatch',
   'planning',
   'inbox',


### PR DESCRIPTION
## Summary
Three related fixes around draft tasks (status='draft'). Promote-to-task creates drafts, but until now they had no home on the board and no way to delete from the UI.

## Changes
- **Draft column on the task board** — leading \`✎ Draft\` column in [MissionQueue.tsx](src/components/MissionQueue.tsx) so promoted-but-not-yet-promoted-again tasks are triagable from the same surface; removes the \`status !== 'draft'\` filter and the stale "planning board only" comment.
- **Delete drafts from the initiative page** — trash button next to Promote in the Drafts list ([initiatives/[id]/page.tsx](src/app/(app)/initiatives/[id]/page.tsx)), confirms then \`DELETE /api/tasks/:id\`.
- **Pre-promote warning** — \`PromoteToTaskModal\` now shows an amber banner when the story already has non-done tasks (e.g. "2 non-done tasks (1 draft, 1 active)"). Non-blocking — N tasks per story is allowed by design — but surfaces existing state so accidental double-promotes are obvious.

Type alignment: adds \`'draft'\` to \`TaskStatus\` (the type was missing it though the DB has stored it for a while), the Zod \`TaskStatus\` enum, and \`WorkspaceStats.taskCounts\`.

## Test plan
- [x] Verified in preview: Draft column renders with the existing draft task; ✎ label visible.
- [x] Trash button on initiative detail page; confirm dialog wired up.
- [x] Warning banner reads "2 non-done tasks (1 draft, 1 active)" when promoting a story with existing tasks.
- [x] \`yarn tsc --noEmit\` clean for touched files (only pre-existing failures in \`src/lib/agents/pm-decompose.test.ts\` remain, unrelated).

## Follow-up
Story → tasks decomposition via agent picker is queued as a separate task — see chip in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)