### PR TITLE
feat(stories): decompose story → draft tasks via agent picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,20 @@ itself was fine. Real corruption is rare; auto-backups exist mainly to
 recover from operator mistakes (a bad migration, a wrong `db:reset`,
 etc.) rather than file-level loss.
 
+## UI Conventions
+
+**No native `window.confirm()` / `alert()` / `prompt()`.** Use the reusable
+dialogs in `src/components/`:
+
+- `ConfirmDialog` — destructive or yes/no confirmations (delete, reset,
+  irreversible actions). Pass `destructive` for red styling.
+- `AlertDialog` — single-button informational alerts (also wired to the
+  global `alert()` shim, so legacy `alert(...)` calls route through it).
+
+Native modals block the JS event loop and aren't drivable from
+preview/automation tooling, which surfaces as flaky verification runs.
+Always thread the dialog through component state instead.
+
 ## Verification (MCP Preview)
 
 After multi-file changes that touch UI or MCP tool surfaces, verify before opening a PR:

--- a/src/app/(app)/initiatives/[id]/page.tsx
+++ b/src/app/(app)/initiatives/[id]/page.tsx
@@ -19,6 +19,9 @@ import {
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import DecomposeWithPmModal from '@/components/DecomposeWithPmModal';
+import DecomposeStoryToTasksModal from '@/components/DecomposeStoryToTasksModal';
+import { DecomposerAgentPicker, type DecomposerOption } from '@/components/inline/DecomposerAgentPicker';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import PlanWithPmPanel, {
   type PlanInitiativeSuggestions,
 } from '@/components/PlanWithPmPanel';
@@ -111,6 +114,7 @@ interface AgentLite {
   role: string;
   avatar_emoji: string;
   workspace_id: string;
+  is_pm?: number | boolean | null;
 }
 
 type Complexity = 'S' | 'M' | 'L' | 'XL';
@@ -180,6 +184,19 @@ export default function InitiativeDetailPage({
   const [agents, setAgents] = useState<AgentLite[]>([]);
   const [showPromoteModal, setShowPromoteModal] = useState(false);
   const [showDecomposeModal, setShowDecomposeModal] = useState(false);
+  // Story → tasks decomposition (sibling of decompose for epics/milestones).
+  const [showDecomposeStoryModal, setShowDecomposeStoryModal] = useState(false);
+  const [decomposeStoryAgent, setDecomposeStoryAgent] = useState<{ id: string; label: string } | null>(null);
+  // Generic destructive-action confirm. One slot is enough — we only ever
+  // prompt for one action at a time. Replaces native window.confirm() so
+  // the modal renders in the same visual style as the rest of the app and
+  // is preview/automation-driveable.
+  const [pendingConfirm, setPendingConfirm] = useState<{
+    title: string;
+    body: React.ReactNode;
+    confirmLabel: string;
+    action: () => void;
+  } | null>(null);
   const [showMoveModal, setShowMoveModal] = useState(false);
   const [showConvertModal, setShowConvertModal] = useState(false);
   const [showAddDepModal, setShowAddDepModal] = useState(false);
@@ -297,6 +314,23 @@ export default function InitiativeDetailPage({
     window.setTimeout(() => setPlanPanelHighlight(false), 1800);
   }, []);
 
+  // Decomposer agent options for the story → tasks picker. Today only the
+  // workspace PM has a task-decomposition prompt; other agents will be
+  // added once Builder/Coordinator/custom prompts exist (the picker is
+  // already shaped for it).
+  const decomposerOptions: DecomposerOption[] = (() => {
+    const out: DecomposerOption[] = [];
+    const pm = agents.find(a => a.is_pm === 1 || a.is_pm === true || a.role === 'pm');
+    if (pm) {
+      out.push({
+        id: pm.id,
+        label: 'PM',
+        description: 'Workspace PM. Proposes a small set of draft tasks the operator can review before promoting to Inbox.',
+      });
+    }
+    return out;
+  })();
+
   const openDecompose = useCallback((hint?: string) => {
     setDecomposeHint(hint && hint.length > 0 ? hint : null);
     setShowDecomposeModal(true);
@@ -372,35 +406,47 @@ export default function InitiativeDetailPage({
 
   // Delete with confirm. On success, route back to the list — the detail
   // page no longer has a row to render.
-  const deleteInitiative = useCallback(async () => {
+  const deleteInitiative = useCallback(() => {
     if (!initiative) return;
-    if (!confirm(`Delete "${initiative.title}"? This cannot be undone.`)) return;
-    setActionError(null);
-    try {
-      const res = await fetch(`/api/initiatives/${initiative.id}`, { method: 'DELETE' });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || `Delete failed (${res.status})`);
-      }
-      router.push('/initiatives');
-    } catch (e) {
-      setActionError(e instanceof Error ? e.message : 'Delete failed');
-    }
+    setPendingConfirm({
+      title: `Delete "${initiative.title}"?`,
+      body: 'This cannot be undone.',
+      confirmLabel: 'Delete',
+      action: async () => {
+        setActionError(null);
+        try {
+          const res = await fetch(`/api/initiatives/${initiative.id}`, { method: 'DELETE' });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({}));
+            throw new Error(body.error || `Delete failed (${res.status})`);
+          }
+          router.push('/initiatives');
+        } catch (e) {
+          setActionError(e instanceof Error ? e.message : 'Delete failed');
+        }
+      },
+    });
   }, [initiative, router]);
 
-  const deleteDraft = async (taskId: string) => {
-    setActionError(null);
-    if (!window.confirm('Delete this draft task? This cannot be undone.')) return;
-    try {
-      const res = await fetch(`/api/tasks/${taskId}`, { method: 'DELETE' });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || `Delete failed (${res.status})`);
-      }
-      refresh();
-    } catch (e) {
-      setActionError(e instanceof Error ? e.message : 'Delete failed');
-    }
+  const deleteDraft = (taskId: string) => {
+    setPendingConfirm({
+      title: 'Delete this draft task?',
+      body: 'This cannot be undone.',
+      confirmLabel: 'Delete',
+      action: async () => {
+        setActionError(null);
+        try {
+          const res = await fetch(`/api/tasks/${taskId}`, { method: 'DELETE' });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({}));
+            throw new Error(body.error || `Delete failed (${res.status})`);
+          }
+          refresh();
+        } catch (e) {
+          setActionError(e instanceof Error ? e.message : 'Delete failed');
+        }
+      },
+    });
   };
 
   const promoteDraft = async (taskId: string) => {
@@ -560,6 +606,19 @@ or "carve out the onboarding flow as its own story first"`}
               >
                 Decompose with PM
               </SplitToolbarButton>
+            )}
+            {initiative.kind === 'story' && (
+              <DecomposerAgentPicker
+                icon={<Sparkles className="w-3.5 h-3.5" />}
+                agents={decomposerOptions}
+                onPick={(id, label) => {
+                  setDecomposeStoryAgent({ id, label });
+                  setShowDecomposeStoryModal(true);
+                }}
+                title="Break this story into draft tasks"
+              >
+                Decompose to tasks
+              </DecomposerAgentPicker>
             )}
             <span className="w-px h-5 bg-mc-border/60 mx-1" aria-hidden />
             <ToolbarButton icon={<MoveRight className="w-3.5 h-3.5" />} onClick={() => setShowMoveModal(true)}>
@@ -927,6 +986,23 @@ or "carve out the onboarding flow as its own story first"`}
           }}
         />
       )}
+      {showDecomposeStoryModal && initiative.kind === 'story' && (
+        <DecomposeStoryToTasksModal
+          initiative={{
+            id: initiative.id,
+            title: initiative.title,
+            kind: initiative.kind,
+            workspace_id: initiative.workspace_id,
+          }}
+          agentId={decomposeStoryAgent?.id ?? null}
+          agentLabel={decomposeStoryAgent?.label}
+          onClose={() => setShowDecomposeStoryModal(false)}
+          onAccepted={() => {
+            setShowDecomposeStoryModal(false);
+            refresh();
+          }}
+        />
+      )}
       {showMoveModal && (
         <MoveModal
           initiative={initiative as ListInitiative}
@@ -966,6 +1042,19 @@ or "carve out the onboarding flow as its own story first"`}
           onClose={() => setShowHistoryDrawer(false)}
         />
       )}
+      <ConfirmDialog
+        open={pendingConfirm !== null}
+        title={pendingConfirm?.title ?? ''}
+        body={pendingConfirm?.body ?? null}
+        confirmLabel={pendingConfirm?.confirmLabel ?? 'Confirm'}
+        destructive
+        onConfirm={() => {
+          const c = pendingConfirm;
+          setPendingConfirm(null);
+          c?.action();
+        }}
+        onCancel={() => setPendingConfirm(null)}
+      />
     </div>
   );
 }

--- a/src/app/api/pm/decompose-story/route.ts
+++ b/src/app/api/pm/decompose-story/route.ts
@@ -1,0 +1,199 @@
+/**
+ * POST /api/pm/decompose-story
+ *
+ * Story → tasks decomposition. Sibling of /api/pm/decompose-initiative
+ * but for story-kind initiatives: each proposed child is a draft task
+ * (one `create_task_under_initiative` diff) attached to the story via
+ * task.initiative_id.
+ *
+ * Body:
+ *   { initiative_id, hint?, agent_id? }
+ *
+ * `agent_id` is reserved for the multi-agent picker. Today only the
+ * workspace PM is supported; passing any other id returns 400.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getInitiative } from '@/lib/db/initiatives';
+import { synthesizeStoryToTasks } from '@/lib/agents/pm-agent';
+import { PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { postPmChatMessage, dispatchPmSynthesized } from '@/lib/agents/pm-dispatch';
+import { getPmAgent } from '@/lib/agents/pm-resolver';
+import { queryOne } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  initiative_id: z.string().min(1),
+  hint: z.string().max(2000).optional(),
+  agent_id: z.string().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Body required' }, { status: 400 });
+  }
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const parent = getInitiative(parsed.data.initiative_id);
+    if (!parent) {
+      return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
+    }
+    if (parent.kind !== 'story') {
+      return NextResponse.json(
+        {
+          error: `Decompose-to-tasks only supported for story-kind initiatives (got "${parent.kind}"). Convert the initiative to a story first.`,
+        },
+        { status: 400 },
+      );
+    }
+
+    // Agent picker scaffolding. Today the only valid decomposer is the
+    // workspace PM; the picker accepts only that id (or omits it).
+    const pm = getPmAgent(parent.workspace_id);
+    if (parsed.data.agent_id && pm && parsed.data.agent_id !== pm.id) {
+      return NextResponse.json(
+        { error: 'Only the workspace PM can decompose stories into tasks (for now).' },
+        { status: 400 },
+      );
+    }
+
+    const synth = synthesizeStoryToTasks(parent, parsed.data.hint);
+
+    const triggerText = JSON.stringify({
+      mode: 'decompose_story',
+      initiative_id: parent.id,
+      parent_title: parent.title,
+      hint: parsed.data.hint ?? null,
+    });
+
+    // Dedup recent identical drafts (StrictMode + rapid re-opens).
+    const recent = queryOne<{ id: string; impact_md: string; proposed_changes: string }>(
+      `SELECT id, impact_md, proposed_changes FROM pm_proposals
+       WHERE workspace_id = ?
+         AND trigger_kind = 'decompose_story'
+         AND trigger_text = ?
+         AND status = 'draft'
+         AND created_at >= datetime('now', '-2 seconds')
+       ORDER BY created_at DESC LIMIT 1`,
+      [parent.workspace_id, triggerText],
+    );
+    if (recent) {
+      return NextResponse.json(
+        {
+          proposal: {
+            ...recent,
+            proposed_changes: JSON.parse(recent.proposed_changes),
+          },
+          deduped: true,
+        },
+        { status: 201 },
+      );
+    }
+
+    const dispatch = dispatchPmSynthesized({
+      workspace_id: parent.workspace_id,
+      trigger_text: triggerText,
+      trigger_kind: 'decompose_story',
+      target_initiative_id: parent.id,
+      timeoutMs: 120_000,
+      synth: { impact_md: synth.impact_md, changes: synth.changes },
+      agent_prompt:
+        `Decompose story ${parent.id} ("${parent.title}") into a small set of ` +
+        `draft TASKS (not initiatives) that an implementer can pick up directly.` +
+        (parsed.data.hint ? ` Operator hint: ${parsed.data.hint}.` : '') +
+        ` Call \`propose_changes\` with trigger_kind='decompose_story' and one ` +
+        `\`create_task_under_initiative\` diff per task, all targeting initiative_id='${parent.id}'. ` +
+        `Each task should be focused enough to land in a single PR. ` +
+        `Output discipline: tool call FIRST, then a single-line \`Proposal {id}.\` reply — ` +
+        `no freeform summary (the operator UI discards it).`,
+    });
+    const proposal = dispatch.proposal;
+
+    try {
+      postPmChatMessage({
+        workspace_id: parent.workspace_id,
+        role: 'user',
+        content:
+          `Decompose story to tasks: "${parent.title}"` +
+          (parsed.data.hint ? ` (hint: ${parsed.data.hint})` : ''),
+      });
+      postPmChatMessage({
+        workspace_id: parent.workspace_id,
+        role: 'assistant',
+        content: proposal.impact_md,
+        proposal_id: proposal.id,
+      });
+    } catch (err) {
+      console.warn('[pm-decompose-story] chat insert failed:', (err as Error).message);
+    }
+
+    return NextResponse.json({ proposal }, { status: 201 });
+  } catch (err) {
+    if (err instanceof PmProposalValidationError) {
+      return NextResponse.json({ error: err.message, hints: err.hints }, { status: 400 });
+    }
+    const msg = err instanceof Error ? err.message : 'Failed to decompose story';
+    console.error('Failed to decompose story:', err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+/**
+ * GET /api/pm/decompose-story?workspace_id=…&initiative_id=…
+ *
+ * Resume-lookup. Returns the latest draft decompose_story proposal for
+ * the given story so the modal re-opens the same draft instead of
+ * dispatching a fresh one every open.
+ */
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const workspaceId = url.searchParams.get('workspace_id');
+  const initiativeId = url.searchParams.get('initiative_id');
+  if (!workspaceId || !initiativeId) {
+    return NextResponse.json(
+      { error: 'workspace_id and initiative_id required' },
+      { status: 400 },
+    );
+  }
+
+  const row = queryOne<{
+    id: string;
+    workspace_id: string;
+    trigger_text: string;
+    trigger_kind: string;
+    impact_md: string;
+    proposed_changes: string;
+    status: string;
+    dispatch_state: string | null;
+  }>(
+    `SELECT id, workspace_id, trigger_text, trigger_kind, impact_md, proposed_changes, status, dispatch_state
+     FROM pm_proposals
+     WHERE workspace_id = ?
+       AND trigger_kind = 'decompose_story'
+       AND status = 'draft'
+       AND json_extract(trigger_text, '$.initiative_id') = ?
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [workspaceId, initiativeId],
+  );
+
+  if (!row) {
+    return NextResponse.json({ proposal: null });
+  }
+
+  return NextResponse.json({
+    proposal: { ...row, proposed_changes: JSON.parse(row.proposed_changes) },
+  });
+}

--- a/src/components/DecomposeStoryToTasksModal.tsx
+++ b/src/components/DecomposeStoryToTasksModal.tsx
@@ -1,0 +1,465 @@
+'use client';
+
+/**
+ * Decompose-story-to-tasks modal.
+ *
+ * Sibling of DecomposeWithPmModal. The operator picks a story; the
+ * selected agent (today only PM) proposes a small set of draft tasks.
+ * On accept, each task is created via the existing
+ * `create_task_under_initiative` diff path — landing in status='draft'
+ * linked to the story via task.initiative_id.
+ *
+ * Reuses the proposal lifecycle endpoints already in place:
+ *   - POST /api/pm/decompose-story          (or GET to resume a draft)
+ *   - PUT  /api/pm/proposals/[id]/diffs     (persist operator edits)
+ *   - POST /api/pm/proposals/[id]/refine    (regen with extra constraint)
+ *   - POST /api/pm/proposals/[id]/accept    (apply transactionally)
+ */
+
+import { useState, useEffect } from 'react';
+import { Sparkles, Send, RefreshCw, Plus, Trash2, ArrowUp, ArrowDown, X } from 'lucide-react';
+
+interface InitiativeLite {
+  id: string;
+  title: string;
+  kind: string;
+  workspace_id: string;
+}
+
+interface TaskDiff {
+  kind: 'create_task_under_initiative';
+  initiative_id: string;
+  title: string;
+  description?: string | null;
+  priority?: 'low' | 'normal' | 'high';
+  assigned_agent_id?: string | null;
+  status_check_md?: string | null;
+}
+
+interface ProposalRow {
+  id: string;
+  trigger_text: string;
+  trigger_kind: string;
+  impact_md: string;
+  proposed_changes: TaskDiff[];
+  status: string;
+  dispatch_state?: 'pending_agent' | 'agent_complete' | 'synth_only' | null;
+}
+
+export default function DecomposeStoryToTasksModal({
+  initiative,
+  agentId,
+  agentLabel,
+  initialHint,
+  onClose,
+  onAccepted,
+}: {
+  initiative: InitiativeLite;
+  /** Selected decomposer agent id from the picker. Reserved for the
+   *  multi-agent future; the route enforces PM-only today. */
+  agentId?: string | null;
+  /** Display label for the picked agent ("PM"), shown in the header so
+   *  the operator can confirm which agent ran. */
+  agentLabel?: string;
+  initialHint?: string | null;
+  onClose: () => void;
+  onAccepted: () => void;
+}) {
+  const [proposalId, setProposalId] = useState<string | null>(null);
+  const [impactMd, setImpactMd] = useState<string>('');
+  const [tasks, setTasks] = useState<TaskDiff[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [refining, setRefining] = useState(false);
+  const [refineText, setRefineText] = useState('');
+  const [accepting, setAccepting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [dispatchState, setDispatchState] = useState<'pending_agent' | 'agent_complete' | 'synth_only' | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setErr(null);
+      try {
+        const resumeRes = await fetch(
+          `/api/pm/decompose-story?workspace_id=${encodeURIComponent(initiative.workspace_id)}&initiative_id=${encodeURIComponent(initiative.id)}`,
+        );
+        if (resumeRes.ok) {
+          const resumeBody = await resumeRes.json() as { proposal?: ProposalRow | null };
+          if (resumeBody?.proposal) {
+            if (cancelled) return;
+            setProposalId(resumeBody.proposal.id);
+            setImpactMd(resumeBody.proposal.impact_md);
+            setTasks(resumeBody.proposal.proposed_changes);
+            setDispatchState(resumeBody.proposal.dispatch_state ?? null);
+            return;
+          }
+        }
+        const res = await fetch('/api/pm/decompose-story', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            initiative_id: initiative.id,
+            ...(initialHint ? { hint: initialHint } : {}),
+            ...(agentId ? { agent_id: agentId } : {}),
+          }),
+        });
+        const body = await res.json();
+        if (!res.ok) throw new Error((body as { error?: string }).error || `Decompose failed (${res.status})`);
+        if (cancelled) return;
+        const proposal = body.proposal as ProposalRow;
+        setProposalId(proposal.id);
+        setImpactMd(proposal.impact_md);
+        setTasks(proposal.proposed_changes);
+        setDispatchState(proposal.dispatch_state ?? null);
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : 'Decompose failed');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [initiative.id, initiative.workspace_id, initialHint, agentId]);
+
+  // SSE: when the named-agent reply lands, swap the synth placeholder for
+  // the agent's row. Mirrors DecomposeWithPmModal.
+  useEffect(() => {
+    if (!proposalId) return;
+    if (dispatchState !== 'pending_agent') return;
+    const es = new EventSource('/api/events/stream');
+    let cancelled = false;
+    const refetch = async () => {
+      try {
+        const url = `/api/pm/decompose-story?workspace_id=${encodeURIComponent(initiative.workspace_id)}&initiative_id=${encodeURIComponent(initiative.id)}`;
+        const res = await fetch(url);
+        if (!res.ok) return;
+        const body = await res.json() as { proposal?: ProposalRow | null };
+        if (cancelled || !body?.proposal) return;
+        setProposalId(body.proposal.id);
+        setImpactMd(body.proposal.impact_md);
+        setTasks(body.proposal.proposed_changes);
+        setDispatchState(body.proposal.dispatch_state ?? null);
+      } catch {
+        // best-effort
+      }
+    };
+    es.onmessage = (ev) => {
+      if (cancelled) return;
+      let parsed: { type?: string; payload?: Record<string, unknown> } | null = null;
+      try { parsed = JSON.parse(ev.data); } catch { return; }
+      if (!parsed || !parsed.type) return;
+      if (parsed.type === 'pm_proposal_replaced') {
+        const oldId = parsed.payload?.old_id as string | undefined;
+        if (oldId === proposalId) void refetch();
+      } else if (parsed.type === 'pm_proposal_dispatch_state_changed') {
+        const id = parsed.payload?.proposal_id as string | undefined;
+        const next = parsed.payload?.dispatch_state as 'pending_agent' | 'agent_complete' | 'synth_only' | undefined;
+        if (id === proposalId && next) setDispatchState(next);
+      }
+    };
+    return () => {
+      cancelled = true;
+      es.close();
+    };
+  }, [proposalId, dispatchState, initiative.id, initiative.workspace_id]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const refine = async () => {
+    if (!proposalId || !refineText.trim()) return;
+    setRefining(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/pm/proposals/${proposalId}/refine`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ additional_constraint: refineText.trim() }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || `Refine failed (${res.status})`);
+      const proposal = body.proposal as ProposalRow;
+      setProposalId(proposal.id);
+      setImpactMd(proposal.impact_md);
+      setTasks(proposal.proposed_changes);
+      setRefineText('');
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Refine failed');
+    } finally {
+      setRefining(false);
+    }
+  };
+
+  const accept = async () => {
+    if (!proposalId) return;
+    if (tasks.length === 0) {
+      setErr('Add at least one task or close the modal.');
+      return;
+    }
+    setAccepting(true);
+    setErr(null);
+    try {
+      const persist = await fetch(`/api/pm/proposals/${proposalId}/diffs`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ proposed_changes: tasks }),
+      });
+      if (!persist.ok) {
+        const body = await persist.json().catch(() => ({}));
+        throw new Error(body.error || `Could not persist edits (${persist.status})`);
+      }
+      const res = await fetch(`/api/pm/proposals/${proposalId}/accept`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || `Accept failed (${res.status})`);
+      onAccepted();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Accept failed');
+    } finally {
+      setAccepting(false);
+    }
+  };
+
+  const move = (i: number, dir: -1 | 1) => {
+    const j = i + dir;
+    if (j < 0 || j >= tasks.length) return;
+    const next = [...tasks];
+    [next[i], next[j]] = [next[j], next[i]];
+    setTasks(next);
+  };
+
+  const updateTask = (i: number, patch: Partial<TaskDiff>) => {
+    setTasks(prev => prev.map((c, idx) => (idx === i ? { ...c, ...patch } : c)));
+  };
+
+  const removeTask = (i: number) => {
+    setTasks(prev => prev.filter((_, idx) => idx !== i));
+  };
+
+  const addTask = () => {
+    setTasks(prev => [
+      ...prev,
+      {
+        kind: 'create_task_under_initiative',
+        initiative_id: initiative.id,
+        title: 'New task',
+        description: null,
+        priority: 'normal',
+      },
+    ]);
+  };
+
+  const displayMd = impactMd.replace(/<!--pm-plan-suggestions[\s\S]*?-->/g, '').trim();
+  const headerLabel = agentLabel ? `Decompose with ${agentLabel}` : 'Decompose to tasks';
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Decompose story into tasks"
+    >
+      <div
+        className="bg-mc-bg-secondary border border-mc-border rounded-lg w-full max-w-5xl h-[88vh] flex flex-col text-mc-text"
+        onClick={e => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between px-5 py-3 border-b border-mc-border">
+          <div className="flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-mc-accent" />
+            <h2 className="text-lg font-semibold">{headerLabel}: &ldquo;{initiative.title}&rdquo;</h2>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            title="Close (Esc)"
+            className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </header>
+
+        <div className="flex-1 min-h-0 flex flex-col px-5 py-4 gap-4">
+          {err && (
+            <div className="p-3 rounded bg-red-500/10 border border-red-500/30 text-red-300 text-sm">
+              {err}
+            </div>
+          )}
+
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-mc-text-secondary">
+              <RefreshCw className="w-4 h-4 animate-spin" /> Asking {agentLabel ?? 'PM'} to decompose…
+            </div>
+          ) : (
+            <>
+              {dispatchState === 'pending_agent' && (
+                <div
+                  className="flex items-start gap-2 rounded border border-mc-accent/30 bg-mc-accent/5 px-3 py-2 text-[11px] text-mc-text-secondary"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <RefreshCw className="w-3.5 h-3.5 mt-[1px] animate-spin text-mc-accent" />
+                  <div>
+                    {agentLabel ?? 'PM'} agent is still composing — these are draft tasks from the deterministic synth.
+                    The agent&apos;s final breakdown will replace this list automatically when it lands.
+                  </div>
+                </div>
+              )}
+
+              {displayMd && (
+                <div className="shrink-0 max-h-32 overflow-y-auto text-xs text-mc-text-secondary whitespace-pre-wrap rounded border border-mc-border bg-mc-bg p-3">
+                  {displayMd}
+                </div>
+              )}
+
+              <div className="flex-1 min-h-0 flex flex-col">
+                <div className="shrink-0 flex items-center gap-2 mb-2">
+                  <h3 className="text-sm font-medium text-mc-text">
+                    Proposed tasks ({tasks.length})
+                  </h3>
+                  <button
+                    onClick={addTask}
+                    className="ml-auto inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-mc-border text-mc-text-secondary hover:text-mc-text hover:border-mc-accent/40"
+                  >
+                    <Plus className="w-3 h-3" /> Add task
+                  </button>
+                </div>
+
+                {tasks.length === 0 ? (
+                  <p className="text-sm text-mc-text-secondary">No tasks proposed. Add one manually above or refine below.</p>
+                ) : (
+                  <ul className="flex-1 min-h-0 overflow-y-auto space-y-2 pr-1">
+                    {tasks.map((c, i) => (
+                      <li
+                        key={i}
+                        className="rounded border border-mc-border bg-mc-bg p-3 space-y-2"
+                      >
+                        <div className="flex items-center gap-2">
+                          <div className="flex flex-col gap-1">
+                            <button
+                              onClick={() => move(i, -1)}
+                              disabled={i === 0}
+                              aria-label="Move up"
+                              className="p-1 rounded hover:bg-mc-bg-secondary text-mc-text-secondary disabled:opacity-30"
+                            >
+                              <ArrowUp className="w-3 h-3" />
+                            </button>
+                            <button
+                              onClick={() => move(i, 1)}
+                              disabled={i === tasks.length - 1}
+                              aria-label="Move down"
+                              className="p-1 rounded hover:bg-mc-bg-secondary text-mc-text-secondary disabled:opacity-30"
+                            >
+                              <ArrowDown className="w-3 h-3" />
+                            </button>
+                          </div>
+                          <input
+                            type="text"
+                            value={c.title}
+                            onChange={e => updateTask(i, { title: e.target.value })}
+                            className="flex-1 px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border text-sm"
+                            aria-label={`Title for task ${i + 1}`}
+                          />
+                          <select
+                            value={c.priority ?? 'normal'}
+                            onChange={e => updateTask(i, { priority: e.target.value as 'low' | 'normal' | 'high' })}
+                            className="px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border text-xs"
+                            aria-label="Priority"
+                          >
+                            <option value="low">low</option>
+                            <option value="normal">normal</option>
+                            <option value="high">high</option>
+                          </select>
+                          <button
+                            onClick={() => removeTask(i)}
+                            aria-label={`Remove task ${i + 1}`}
+                            className="p-1 rounded hover:bg-red-500/20 text-mc-text-secondary hover:text-red-400"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        </div>
+                        <textarea
+                          value={c.description ?? ''}
+                          onChange={e => updateTask(i, { description: e.target.value })}
+                          placeholder="Description (optional)"
+                          className="w-full px-2 py-1.5 rounded bg-mc-bg-secondary border border-mc-border text-xs min-h-[80px] resize-y leading-relaxed"
+                          aria-label={`Description for task ${i + 1}`}
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div className="shrink-0 space-y-2">
+                <label className="block">
+                  <span className="text-xs text-mc-text-secondary">
+                    Refine (e.g., &ldquo;merge the test step into implementation&rdquo;, &ldquo;add a docs task&rdquo;)
+                  </span>
+                  <div className="mt-1 flex items-center gap-2">
+                    <input
+                      type="text"
+                      value={refineText}
+                      onChange={e => setRefineText(e.target.value)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault();
+                          refine();
+                        }
+                      }}
+                      className="flex-1 px-2 py-1.5 rounded bg-mc-bg border border-mc-border text-xs"
+                      placeholder="What should change?"
+                      disabled={refining}
+                    />
+                    <button
+                      onClick={refine}
+                      disabled={refining || !refineText.trim()}
+                      className="inline-flex items-center gap-1 px-2 py-1.5 rounded bg-mc-bg border border-mc-border text-xs text-mc-text disabled:opacity-50"
+                    >
+                      <Send className="w-3 h-3" />
+                      {refining ? 'Refining…' : 'Send'}
+                    </button>
+                  </div>
+                </label>
+              </div>
+            </>
+          )}
+        </div>
+
+        <footer className="border-t border-mc-border px-5 py-3 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={accept}
+            disabled={accepting || loading || tasks.length === 0 || !proposalId || dispatchState === 'pending_agent'}
+            title={
+              dispatchState === 'pending_agent'
+                ? `${agentLabel ?? 'PM'} agent is still composing — wait for the breakdown or click Cancel.`
+                : undefined
+            }
+            className="px-3 py-2 rounded bg-mc-accent text-white text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {accepting ? 'Creating…' : `Accept (${tasks.length} draft task${tasks.length === 1 ? '' : 's'})`}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/inline/DecomposerAgentPicker.tsx
+++ b/src/components/inline/DecomposerAgentPicker.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+/**
+ * Inline picker for "which agent should decompose this story into tasks?".
+ *
+ * Today the workspace PM is the only agent with a task-decomposition
+ * prompt, so the picker shows it as the sole option. The shape is
+ * forward-compatible: when other agents (Builder / Coordinator / custom)
+ * grow `can_decompose_tasks` prompts, they get added to `agents` and the
+ * picker grows automatically.
+ *
+ * Behavior:
+ *   - Default click on the main face: invokes onPick with the first
+ *     (and today only) agent — keeps the button feeling like a single
+ *     action when there's nothing to choose.
+ *   - Chevron click: opens a popover listing all decomposers with their
+ *     description; selecting one fires onPick(id, label).
+ */
+export interface DecomposerOption {
+  id: string;
+  label: string;
+  description: string;
+  disabled?: boolean;
+  disabledReason?: string;
+}
+
+export function DecomposerAgentPicker({
+  icon,
+  agents,
+  onPick,
+  children,
+  title,
+  disabled,
+}: {
+  icon: ReactNode;
+  agents: DecomposerOption[];
+  onPick: (agentId: string, agentLabel: string) => void;
+  children: ReactNode;
+  title?: string;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDoc);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const firstEnabled = agents.find(a => !a.disabled);
+  const noneAvailable = !firstEnabled;
+
+  return (
+    <div ref={wrapRef} className="relative inline-flex">
+      <button
+        type="button"
+        onClick={() => {
+          if (firstEnabled) onPick(firstEnabled.id, firstEnabled.label);
+        }}
+        disabled={disabled || noneAvailable}
+        title={noneAvailable ? 'No decomposer agents available in this workspace' : title}
+        className="inline-flex items-center gap-1.5 text-xs px-2 py-1.5 rounded-l border border-mc-border border-r-0 text-mc-accent hover:bg-mc-accent/10 hover:border-mc-accent/40 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {icon}
+        <span>{children}</span>
+      </button>
+      <button
+        type="button"
+        aria-label="Choose decomposer agent"
+        onClick={() => setOpen(o => !o)}
+        disabled={disabled || noneAvailable}
+        className="inline-flex items-center px-1.5 py-1.5 rounded-r border border-mc-border text-mc-accent hover:bg-mc-accent/10 hover:border-mc-accent/40 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <ChevronDown className="w-3.5 h-3.5" />
+      </button>
+      {open && (
+        <div
+          className="absolute top-full left-0 mt-1 z-30 w-72 rounded border border-mc-border bg-mc-bg-secondary shadow-lg p-1"
+          role="menu"
+        >
+          <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-mc-text-secondary/70">
+            Decompose with…
+          </div>
+          {agents.length === 0 ? (
+            <div className="px-2 py-2 text-xs text-mc-text-secondary">
+              No decomposer agents in this workspace.
+            </div>
+          ) : (
+            agents.map(a => (
+              <button
+                key={a.id}
+                type="button"
+                disabled={a.disabled}
+                title={a.disabled ? a.disabledReason : undefined}
+                onClick={() => {
+                  setOpen(false);
+                  onPick(a.id, a.label);
+                }}
+                className="w-full text-left px-2 py-2 rounded hover:bg-mc-bg disabled:opacity-50 disabled:cursor-not-allowed"
+                role="menuitem"
+              >
+                <div className="text-sm text-mc-text">{a.label}</div>
+                <div className="text-[11px] text-mc-text-secondary mt-0.5 leading-snug">
+                  {a.description}
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/pm/triggerBadge.ts
+++ b/src/components/pm/triggerBadge.ts
@@ -41,6 +41,10 @@ export const TRIGGER_BADGE: Record<string, TriggerBadge> = {
     label: 'decompose',
     cls: 'bg-pink-500/15 text-pink-300 border-pink-500/30',
   },
+  decompose_story: {
+    label: 'story → tasks',
+    cls: 'bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-500/30',
+  },
   notes_intake: {
     label: 'notes',
     cls: 'bg-yellow-500/15 text-yellow-300 border-yellow-500/30',

--- a/src/lib/agents/pm-agent.ts
+++ b/src/lib/agents/pm-agent.ts
@@ -383,6 +383,96 @@ export function synthesizeDecompose(
   return { impact_md: lines.join('\n'), changes };
 }
 
+// ─── Story → tasks decomposition ─────────────────────────────────────
+//
+// Sibling of `synthesizeDecompose`, but the parent is a story-kind
+// initiative and the children are draft tasks (not initiatives). One
+// `create_task_under_initiative` diff per task, all targeting the
+// story's id directly — no placeholders since the story already exists.
+//
+// LLM swap-in seam: the named PM agent can replace this with a richer
+// implementation-level breakdown via `propose_changes` with
+// trigger_kind='decompose_story'. The synth keeps working as the
+// offline floor and the deterministic placeholder.
+
+export interface SynthesizeStoryTasksResult {
+  impact_md: string;
+  changes: PmDiff[];
+}
+
+export function synthesizeStoryToTasks(
+  parent: Initiative,
+  hint?: string,
+): SynthesizeStoryTasksResult {
+  const x = parent.title;
+  const lowerTitle = parent.title.toLowerCase();
+  const isBuild = /^(build|feature|implement|create|add|wire)\b/i.test(parent.title);
+  const isFix = /^(fix|repair|debug)\b/i.test(parent.title);
+  const isRefactor = /^(refactor|rewrite|migrate|clean\s*up)\b/i.test(lowerTitle);
+
+  let titles: string[];
+  if (isFix) {
+    titles = [
+      `Reproduce: ${x}`,
+      `Patch: ${x}`,
+      `Regression test for ${x}`,
+    ];
+  } else if (isRefactor) {
+    titles = [
+      `Inventory current behavior for ${x}`,
+      `Land the refactor for ${x}`,
+      `Verify no behavior change in ${x}`,
+    ];
+  } else if (isBuild) {
+    titles = [
+      `Scaffold the data + types for ${x}`,
+      `Implement the core logic for ${x}`,
+      `Wire ${x} into the UI`,
+      `Add tests for ${x}`,
+    ];
+  } else {
+    titles = [
+      `Plan ${x}`,
+      `Implement ${x}`,
+      `Verify ${x}`,
+    ];
+  }
+
+  const baseDesc = parent.description?.trim() ?? '';
+  const hintBlock = hint ? `\n\n_Operator hint: ${hint.trim()}_` : '';
+
+  const changes: PmDiff[] = titles.map(t => ({
+    kind: 'create_task_under_initiative',
+    initiative_id: parent.id,
+    title: t,
+    description:
+      `${t}\n\nFor story "${x}".` +
+      (baseDesc ? `\n\nStory context:\n${baseDesc}` : '') +
+      hintBlock,
+    priority: 'normal' as const,
+  }));
+
+  const lines: string[] = [
+    `### Task breakdown for "${x}"`,
+    ``,
+    `Proposed ${changes.length} draft task${changes.length === 1 ? '' : 's'}` +
+      ` (${isFix ? 'fix template' : isRefactor ? 'refactor template' : isBuild ? 'build template' : 'generic template'}):`,
+    ``,
+    ...changes.map(c =>
+      c.kind === 'create_task_under_initiative' ? `- ${c.title}` : '',
+    ),
+  ];
+  if (hint) {
+    lines.push(``, `_Operator hint applied: "${hint.trim()}"._`);
+  }
+  lines.push(
+    ``,
+    `Apply to insert these as draft tasks under this story. Drafts land in the Draft column on the task board — promote to Inbox when ready.`,
+  );
+
+  return { impact_md: lines.join('\n'), changes };
+}
+
 // ─── Helpers ────────────────────────────────────────────────────────
 
 function capitalizeFirst(s: string): string {

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3652,6 +3652,71 @@ const migrations: Migration[] = [
       console.log('[Migration 062] pm_proposals.reverts_proposal_id + revert trigger_kind ready.');
     },
   },
+  {
+    id: '063',
+    name: 'pm_proposals_decompose_story_trigger_kind',
+    up: (db) => {
+      // Story → tasks decomposition lands as a PM proposal with a new
+      // trigger_kind so the timeline + badges can render it distinctly
+      // from `decompose_initiative` (which is parent → child initiatives).
+      // Same table-rebuild pattern as 062 since SQLite can't ALTER a CHECK.
+      const tableSql = (db.prepare(
+        `SELECT sql FROM sqlite_master WHERE type='table' AND name='pm_proposals'`,
+      ).get() as { sql: string } | undefined)?.sql ?? '';
+      if (tableSql.includes("'decompose_story'")) {
+        console.log('[Migration 063] Already applied; skipping.');
+        return;
+      }
+
+      const cols = db.prepare(`PRAGMA table_info(pm_proposals)`).all() as Array<{ name: string }>;
+      const fkList = db.prepare(`PRAGMA foreign_key_list(pm_proposals)`).all() as Array<{ from: string; on_delete: string }>;
+      const targetFk = fkList.find(fk => fk.from === 'target_initiative_id');
+      const targetCascade = targetFk?.on_delete === 'CASCADE' ? 'CASCADE' : 'SET NULL';
+      const dispatchStateExists = cols.some(c => c.name === 'dispatch_state');
+      const revertsExists = cols.some(c => c.name === 'reverts_proposal_id');
+
+      const carryCols = [
+        'id', 'workspace_id', 'trigger_text', 'trigger_kind', 'impact_md',
+        'proposed_changes', 'status', 'applied_at', 'applied_by_agent_id',
+        'parent_proposal_id', 'created_at', 'target_initiative_id',
+        'plan_suggestions',
+        ...(dispatchStateExists ? ['dispatch_state'] : []),
+        ...(revertsExists ? ['reverts_proposal_id'] : []),
+      ].filter(c => cols.some(x => x.name === c));
+      const carryList = carryCols.join(', ');
+
+      db.exec(`
+        CREATE TABLE pm_proposals_new (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          trigger_text TEXT NOT NULL,
+          trigger_kind TEXT NOT NULL DEFAULT 'manual'
+            CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation','plan_initiative','decompose_initiative','decompose_story','notes_intake','revert')),
+          impact_md TEXT NOT NULL,
+          proposed_changes TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'draft'
+            CHECK (status IN ('draft','accepted','rejected','superseded')),
+          applied_at TEXT,
+          applied_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+          parent_proposal_id TEXT REFERENCES pm_proposals(id) ON DELETE SET NULL,
+          created_at TEXT DEFAULT (datetime('now')),
+          target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE ${targetCascade},
+          plan_suggestions TEXT,
+          ${dispatchStateExists ? 'dispatch_state TEXT,' : ''}
+          ${revertsExists ? 'reverts_proposal_id TEXT REFERENCES pm_proposals(id) ON DELETE SET NULL' : ''}
+        )
+      `);
+      db.exec(`INSERT INTO pm_proposals_new (${carryList}) SELECT ${carryList} FROM pm_proposals`);
+      db.exec(`DROP TABLE pm_proposals`);
+      db.exec(`ALTER TABLE pm_proposals_new RENAME TO pm_proposals`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_status ON pm_proposals(status, created_at DESC)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_target_init ON pm_proposals(target_initiative_id, status, created_at DESC)`);
+      if (revertsExists) {
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_pm_proposals_reverts ON pm_proposals(reverts_proposal_id) WHERE reverts_proposal_id IS NOT NULL`);
+      }
+      console.log('[Migration 063] pm_proposals.trigger_kind extended with decompose_story.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -39,6 +39,7 @@ export type PmProposalTriggerKind =
   | 'status_check_investigation'
   | 'plan_initiative'
   | 'decompose_initiative'
+  | 'decompose_story'
   | 'notes_intake'
   | 'revert';
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -974,7 +974,7 @@ CREATE TABLE IF NOT EXISTS pm_proposals (
   workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   trigger_text TEXT NOT NULL,
   trigger_kind TEXT NOT NULL DEFAULT 'manual'
-    CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation','plan_initiative','decompose_initiative','notes_intake')),
+    CHECK (trigger_kind IN ('manual','scheduled_drift_scan','disruption_event','status_check_investigation','plan_initiative','decompose_initiative','decompose_story','notes_intake','revert')),
   impact_md TEXT NOT NULL,
   proposed_changes TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'draft'

--- a/src/lib/mcp/roadmap-tools.ts
+++ b/src/lib/mcp/roadmap-tools.ts
@@ -607,6 +607,7 @@ export function registerRoadmapTools(server: McpServer): void {
             'status_check_investigation',
             'plan_initiative',
             'decompose_initiative',
+            'decompose_story',
             'notes_intake',
           ])
           .optional(),


### PR DESCRIPTION
## Summary

Adds a "Decompose to tasks" affordance on story-kind initiatives — sibling of the existing "Decompose with PM" flow on epics/milestones, but produces draft tasks under the story instead of child initiatives. The picker UI is shaped for multiple decomposer agents; today PM is the only one wired.

- Migration 063 extends `pm_proposals.trigger_kind` with `decompose_story`.
- New `synthesizeStoryToTasks` (build/fix/refactor/generic templates) emits `create_task_under_initiative` diffs targeting the story id.
- New `POST /api/pm/decompose-story` (+ GET resume) mirrors `decompose-initiative` with kind=story validation and a PM-only `agent_id` check.
- New `DecomposeStoryToTasksModal` + `DecomposerAgentPicker` components.
- Drive-by: replaces the two `window.confirm()` call sites on the initiative detail page with the reusable `ConfirmDialog`. Added a "UI Conventions" section to `CLAUDE.md` codifying that.

## Out of scope (follow-ups noted in original brief)

- Multi-agent expert→PM pipeline.
- Builder/Coordinator/custom decomp prompts (picker shows them empty until those land).

## Test plan

- [x] `npx tsc --noEmit` clean (pre-existing `pm-decompose.test.ts:169-173` errors unrelated).
- [x] `pm-proposals`, `pm-decompose`, `promotion`, `decompose-initiative/route` test suites green.
- [x] Preview smoke: POST creates a `decompose_story` proposal with 3 task diffs; accept inserts them as `status='draft'` tasks linked to the story; epic-kind initiative rejected with 400.
- [x] Preview UI: picker dropdown opens, shows PM with description, no console errors.
- [x] Preview UI: clicking Delete renders the reusable ConfirmDialog (not native confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)