### PR TITLE
fix(shell): workspace switcher preserves current page

### DIFF
--- a/src/components/shell/AppNav.tsx
+++ b/src/components/shell/AppNav.tsx
@@ -270,6 +270,7 @@ function WorkspaceSwitcher({
   onWorkspaceCreated: () => void;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
   const currentWorkspaceId = useCurrentWorkspaceId();
   const setCurrentWorkspaceId = useSetCurrentWorkspaceId();
   const [open, setOpen] = useState(false);
@@ -294,9 +295,18 @@ function WorkspaceSwitcher({
     (w: WorkspaceLite) => {
       setCurrentWorkspaceId(w.id);
       setOpen(false);
-      router.push(`/workspace/${w.slug}`);
+      // Slug-scoped routes (/workspace/[slug]/*) need the slug segment
+      // rewritten so the page refetches against the new workspace.
+      // Context-scoped routes (/initiatives, /roadmap, /pm, etc.) read
+      // workspace from the localStorage-backed context and refetch via
+      // the useCurrentWorkspaceId hook — no navigation needed.
+      const m = pathname?.match(/^\/workspace\/[^/]+(\/.*)?$/);
+      if (m) {
+        const tail = m[1] ?? '';
+        router.push(`/workspace/${w.slug}${tail}`);
+      }
     },
-    [router, setCurrentWorkspaceId],
+    [router, setCurrentWorkspaceId, pathname],
   );
 
   const handleCreated = useCallback(


### PR DESCRIPTION
## Summary
Switching workspaces from the top-left picker always routed to \`/workspace/[slug]\` (Task Board), discarding whatever page the operator was on. Now the switcher preserves the current view.

## Behavior
| Where you are | Switch workspace → land on |
|---|---|
| \`/workspace/foia\` | \`/workspace/default\` (slug rewritten, tail preserved) |
| \`/workspace/foia/activity\` | \`/workspace/default/activity\` |
| \`/workspace/foia/settings\` | \`/workspace/default/settings\` |
| \`/initiatives\`, \`/roadmap\`, \`/pm\`, \`/pm/activity\`, \`/deliverables\`, \`/agents\`, \`/products\` | stay on the same path; page refetches via \`useCurrentWorkspaceId\` |

## Changes
- [AppNav.tsx](src/components/shell/AppNav.tsx) \`handlePick\`: only navigate when on a \`/workspace/[slug]/...\` route, and rewrite only the slug segment.

## Test plan
- [x] Verified in preview: from \`/roadmap\` switching FOIA→Default stays on \`/roadmap\` and flips initiative count from 0 → 81.
- [x] From \`/workspace/foia\` switching to Default lands on \`/workspace/default\` (same Task Board panel).
- [x] \`yarn tsc --noEmit\` clean for touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)