### PR TITLE
feat(initiatives): move subtree between workspaces

### DIFF
--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -20,6 +20,7 @@ import {
   FileText,
   CalendarRange,
   ExternalLink,
+  FolderInput,
 } from 'lucide-react';
 import Drawer from '@/components/Drawer';
 import ActionMenu, { ActionMenuItem } from '@/components/ActionMenu';
@@ -145,6 +146,7 @@ export default function InitiativesPage() {
   const [editing, setEditing] = useState<Initiative | null>(null);
   const [creating, setCreating] = useState<{ parent_id: string | null } | null>(null);
   const [moving, setMoving] = useState<Initiative | null>(null);
+  const [movingToWorkspace, setMovingToWorkspace] = useState<Initiative | null>(null);
   const [converting, setConverting] = useState<Initiative | null>(null);
   const [promoting, setPromoting] = useState<Initiative | null>(null);
   const [historyFor, setHistoryFor] = useState<Initiative | null>(null);
@@ -284,6 +286,7 @@ export default function InitiativesPage() {
                 onEdit={setEditing}
                 onAddChild={parent => setCreating({ parent_id: parent.id })}
                 onMove={setMoving}
+                onMoveToWorkspace={setMovingToWorkspace}
                 onConvert={setConverting}
                 onPromote={setPromoting}
                 onShowHistory={setHistoryFor}
@@ -333,6 +336,16 @@ export default function InitiativesPage() {
           onClose={() => setMoving(null)}
           onSaved={() => {
             setMoving(null);
+            refresh();
+          }}
+        />
+      )}
+      {movingToWorkspace && (
+        <MoveToWorkspaceModal
+          initiative={movingToWorkspace}
+          onClose={() => setMovingToWorkspace(null)}
+          onSaved={() => {
+            setMovingToWorkspace(null);
             refresh();
           }}
         />
@@ -429,6 +442,7 @@ function InitiativeRow({
   onEdit,
   onAddChild,
   onMove,
+  onMoveToWorkspace,
   onConvert,
   onPromote,
   onShowHistory,
@@ -445,6 +459,7 @@ function InitiativeRow({
   onEdit: (init: Initiative) => void;
   onAddChild: (parent: Initiative) => void;
   onMove: (init: Initiative) => void;
+  onMoveToWorkspace: (init: Initiative) => void;
   onConvert: (init: Initiative) => void;
   onPromote: (init: Initiative) => void;
   onShowHistory: (init: Initiative) => void;
@@ -500,6 +515,7 @@ function InitiativeRow({
         ]
       : []),
     { label: 'Move', icon: <MoveRight className="w-3.5 h-3.5" />, onClick: () => onMove(node) },
+    { label: 'Move to workspace…', icon: <FolderInput className="w-3.5 h-3.5" />, onClick: () => onMoveToWorkspace(node) },
     { label: 'Convert kind', icon: <Shuffle className="w-3.5 h-3.5" />, onClick: () => onConvert(node) },
     { label: 'Add dependency', icon: <Link2 className="w-3.5 h-3.5" />, onClick: () => onAddDependency(node) },
     { label: 'View history', icon: <History className="w-3.5 h-3.5" />, onClick: () => onShowHistory(node) },
@@ -653,6 +669,7 @@ function InitiativeRow({
             onEdit={onEdit}
             onAddChild={onAddChild}
             onMove={onMove}
+            onMoveToWorkspace={onMoveToWorkspace}
             onConvert={onConvert}
             onPromote={onPromote}
             onShowHistory={onShowHistory}
@@ -1759,5 +1776,112 @@ export function HistoryDrawer({
         </ul>
       )}
     </Drawer>
+  );
+}
+
+interface WorkspaceLite { id: string; slug: string; name: string; icon?: string | null }
+
+function MoveToWorkspaceModal({
+  initiative,
+  onClose,
+  onSaved,
+}: {
+  initiative: Initiative;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [workspaces, setWorkspaces] = useState<WorkspaceLite[]>([]);
+  const [target, setTarget] = useState<string>('');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/api/workspaces');
+        if (!res.ok) throw new Error(`Failed to load workspaces (${res.status})`);
+        const list: WorkspaceLite[] = await res.json();
+        const others = list.filter(w => w.id !== initiative.workspace_id);
+        setWorkspaces(others);
+        if (others.length > 0) setTarget(others[0].id);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : 'Failed to load workspaces');
+      }
+    })();
+  }, [initiative.workspace_id]);
+
+  const submit = async () => {
+    if (!target) return;
+    setSubmitting(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/initiatives/${initiative.id}/move-to-workspace`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to_workspace_id: target }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Move failed (${res.status})`);
+      }
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Move failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50" onClick={onClose}>
+      <div
+        className="bg-mc-bg-secondary border border-mc-border rounded-lg p-6 w-full max-w-lg text-mc-text"
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold mb-2">Move subtree to workspace</h2>
+        <p className="text-sm text-mc-text-secondary mb-4">
+          Moves <strong>{initiative.title}</strong> and every descendant initiative to the
+          chosen workspace. The root will land as a top-level node there. Tasks linked to
+          these initiatives stay in their original workspace — task↔initiative links may
+          now span workspaces.
+        </p>
+        {workspaces.length === 0 ? (
+          <p className="text-sm text-mc-text-secondary">
+            No other workspaces available.
+          </p>
+        ) : (
+          <label className="block">
+            <span className="text-sm text-mc-text-secondary">Target workspace</span>
+            <select
+              className="mt-1 w-full px-3 py-2 rounded bg-mc-bg border border-mc-border"
+              value={target}
+              onChange={e => setTarget(e.target.value)}
+            >
+              {workspaces.map(w => (
+                <option key={w.id} value={w.id}>
+                  {w.icon ? `${w.icon} ` : ''}{w.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        {err && <div className="text-red-400 text-sm mt-3">{err}</div>}
+        <div className="flex justify-end gap-2 pt-4">
+          <button
+            onClick={onClose}
+            className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={submitting || !target || workspaces.length === 0}
+            className="px-3 py-2 rounded bg-mc-accent text-white disabled:opacity-50 text-sm"
+          >
+            {submitting ? 'Moving…' : 'Move subtree'}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/app/api/initiatives/[id]/move-to-workspace/route.ts
+++ b/src/app/api/initiatives/[id]/move-to-workspace/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { moveInitiativeSubtreeToWorkspace } from '@/lib/db/initiatives';
+
+export const dynamic = 'force-dynamic';
+
+const Schema = z.object({
+  to_workspace_id: z.string().min(1),
+  moved_by_agent_id: z.string().nullish(),
+  reason: z.string().max(2000).nullish(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    const parsed = Schema.safeParse(body ?? {});
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const result = moveInitiativeSubtreeToWorkspace(
+      id,
+      parsed.data.to_workspace_id,
+      parsed.data.moved_by_agent_id ?? null,
+      parsed.data.reason ?? null,
+    );
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to move initiative subtree';
+    if (msg.startsWith('Initiative not found') || msg.startsWith('Target workspace not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    if (msg.startsWith('Initiative is already')) {
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    console.error('Failed to move initiative subtree:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/lib/db/initiatives.ts
+++ b/src/lib/db/initiatives.ts
@@ -337,6 +337,84 @@ export function moveInitiative(
 }
 
 /**
+ * Move an initiative subtree to a different workspace. The root + every
+ * descendant initiative gets its workspace_id rewritten; the root's
+ * parent_initiative_id is nulled so it lands as a top-level node in the
+ * destination. Tasks are intentionally left in their original workspace —
+ * task.workspace_id is independent of initiative.workspace_id, and the
+ * cross-workspace task→initiative_id link is acceptable.
+ *
+ * initiative_dependencies are not touched: they reference initiatives by
+ * id, so they follow the tree naturally as long as both endpoints move
+ * together (which they do, since dependencies inside the subtree stay
+ * intact, and dependencies that cross out of the subtree are left alone
+ * — they may now span workspaces, same shape as the task case).
+ */
+export function moveInitiativeSubtreeToWorkspace(
+  id: string,
+  to_workspace_id: string,
+  moved_by_agent_id?: string | null,
+  reason?: string | null,
+): { moved_count: number; root: Initiative } {
+  const root = queryOne<Initiative>('SELECT * FROM initiatives WHERE id = ?', [id]);
+  if (!root) throw new Error(`Initiative not found: ${id}`);
+
+  const targetWorkspace = queryOne<{ id: string }>(
+    'SELECT id FROM workspaces WHERE id = ?',
+    [to_workspace_id],
+  );
+  if (!targetWorkspace) throw new Error(`Target workspace not found: ${to_workspace_id}`);
+
+  if (root.workspace_id === to_workspace_id) {
+    throw new Error(`Initiative is already in workspace ${to_workspace_id}`);
+  }
+
+  // BFS the descendant set.
+  const descendantIds: string[] = [id];
+  const stack: string[] = [id];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    const children = queryAll<{ id: string }>(
+      'SELECT id FROM initiatives WHERE parent_initiative_id = ?',
+      [cur],
+    );
+    for (const c of children) {
+      descendantIds.push(c.id);
+      stack.push(c.id);
+    }
+  }
+
+  return transaction(() => {
+    const now = new Date().toISOString();
+    const placeholders = descendantIds.map(() => '?').join(',');
+    run(
+      `UPDATE initiatives SET workspace_id = ?, updated_at = ? WHERE id IN (${placeholders})`,
+      [to_workspace_id, now, ...descendantIds],
+    );
+    if (root.parent_initiative_id !== null) {
+      run(
+        'UPDATE initiatives SET parent_initiative_id = NULL, updated_at = ? WHERE id = ?',
+        [now, id],
+      );
+      run(
+        `INSERT INTO initiative_parent_history (id, initiative_id, from_parent_id, to_parent_id, moved_by_agent_id, reason, created_at)
+         VALUES (?, ?, ?, NULL, ?, ?, ?)`,
+        [
+          uuidv4(),
+          id,
+          root.parent_initiative_id,
+          moved_by_agent_id ?? null,
+          reason ?? `moved subtree to workspace ${to_workspace_id}`,
+          now,
+        ],
+      );
+    }
+    const updatedRoot = queryOne<Initiative>('SELECT * FROM initiatives WHERE id = ?', [id])!;
+    return { moved_count: descendantIds.length, root: updatedRoot };
+  });
+}
+
+/**
  * Returns true if `candidate` is a descendant of `ancestor` (or equal to it).
  * Walk down the tree from ancestor and look for candidate.
  */


### PR DESCRIPTION
## Summary
Lets the operator relocate an initiative + every descendant to a different workspace from the action menu on the initiatives tree.

## Behavior
- Root + descendants get \`workspace_id\` rewritten in a single transaction.
- Root's \`parent_initiative_id\` is nulled so it lands as a top-level node in the destination; a \`initiative_parent_history\` row records the detach if the root had a parent.
- **Tasks stay in their original workspace** by design — \`task.workspace_id\` is independent of \`initiative.workspace_id\`. Cross-workspace \`task → initiative_id\` links are acceptable; this keeps the move surface narrow (no workflow-template re-resolution, no agent reassignment).
- \`initiative_dependencies\` aren't touched; they reference initiatives by id and follow the tree naturally.

## Changes
- \`src/lib/db/initiatives.ts\`: new \`moveInitiativeSubtreeToWorkspace(id, to_workspace_id, ...)\`.
- \`src/app/api/initiatives/[id]/move-to-workspace/route.ts\`: \`POST\` handler with Zod-validated body.
- \`src/app/(app)/initiatives/page.tsx\`: "Move to workspace…" action menu item + \`MoveToWorkspaceModal\` component (workspace picker excluding the current workspace).

## Test plan
- [x] API smoke (\`POST /api/initiatives/<theme>/move-to-workspace\` to FOIA): \`moved_count: 30\`, default count 81→51, FOIA 0→30; rollback restored 81/0.
- [x] UI: action menu shows "Move to workspace…", modal opens, dropdown lists only other workspaces (FOIA when on default), submit POSTs and refreshes.
- [x] \`yarn tsc --noEmit\` clean for touched files (only pre-existing failures in \`pm-decompose.test.ts\` remain, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)