### PR TITLE
feat(workspaces): clone agents from another workspace on create

### DIFF
--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
-import { bootstrapCoreAgents, cloneWorkflowTemplates, ensurePmAgent } from '@/lib/bootstrap-agents';
+import { bootstrapCoreAgents, cloneAgentsFromWorkspace, cloneWorkflowTemplates, ensurePmAgent } from '@/lib/bootstrap-agents';
 import type { Workspace, WorkspaceStats, TaskStatus } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -85,7 +85,12 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { name, description, icon } = body;
+    const { name, description, icon, clone_agents_from } = body as {
+      name?: string;
+      description?: string;
+      icon?: string;
+      clone_agents_from?: string;
+    };
 
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
       return NextResponse.json({ error: 'Name is required' }, { status: 400 });
@@ -109,7 +114,26 @@ export async function POST(request: NextRequest) {
     // Clone workflow templates and bootstrap core agents for the new workspace
     cloneWorkflowTemplates(db, id);
     bootstrapCoreAgents(id);
-    // Seed the workspace's PM agent (planning layer, role='pm'). Idempotent.
+
+    // Optional: copy the agent roster from another workspace. Useful when
+    // gateway sync only keys to one workspace and a fresh row would
+    // otherwise start empty. ensurePmAgent below is a no-op if any
+    // cloned agent already has is_pm=1.
+    if (clone_agents_from && typeof clone_agents_from === 'string') {
+      const source = db.prepare(
+        'SELECT id FROM workspaces WHERE id = ?',
+      ).get(clone_agents_from);
+      if (!source) {
+        return NextResponse.json(
+          { error: `Source workspace not found: ${clone_agents_from}` },
+          { status: 400 },
+        );
+      }
+      cloneAgentsFromWorkspace(clone_agents_from, id);
+    }
+
+    // Seed the workspace's PM agent (planning layer, role='pm'). Idempotent
+    // — bails out if cloneAgentsFromWorkspace already brought a PM across.
     ensurePmAgent(id);
 
     const workspace = db.prepare('SELECT * FROM workspaces WHERE id = ?').get(id);

--- a/src/components/shell/CreateWorkspaceDrawer.tsx
+++ b/src/components/shell/CreateWorkspaceDrawer.tsx
@@ -43,6 +43,8 @@ export function CreateWorkspaceDrawer({ open, onClose, onCreated }: CreateWorksp
   const [slugDirty, setSlugDirty] = useState(false);
   const [icon, setIcon] = useState('📁');
   const [description, setDescription] = useState('');
+  const [cloneAgentsFrom, setCloneAgentsFrom] = useState<string>('');
+  const [workspaces, setWorkspaces] = useState<Array<{ id: string; name: string; icon?: string | null }>>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -54,8 +56,23 @@ export function CreateWorkspaceDrawer({ open, onClose, onCreated }: CreateWorksp
     setSlugDirty(false);
     setIcon('📁');
     setDescription('');
+    setCloneAgentsFrom('');
     setSubmitting(false);
     setError(null);
+  }, [open]);
+
+  // Pre-load workspace list for the "copy agents from" dropdown when the
+  // drawer opens. Cheap (one /api/workspaces call) and avoids a flicker.
+  useEffect(() => {
+    if (!open) return;
+    (async () => {
+      try {
+        const res = await fetch('/api/workspaces');
+        if (!res.ok) return;
+        const list = await res.json();
+        setWorkspaces(Array.isArray(list) ? list : []);
+      } catch { /* non-fatal */ }
+    })();
   }, [open]);
 
   // Keep slug in sync with name unless the operator has explicitly edited it.
@@ -83,6 +100,7 @@ export function CreateWorkspaceDrawer({ open, onClose, onCreated }: CreateWorksp
           slug: slug.trim() || undefined,
           icon,
           description: description.trim() || undefined,
+          clone_agents_from: cloneAgentsFrom || undefined,
         }),
       });
 
@@ -211,6 +229,31 @@ export function CreateWorkspaceDrawer({ open, onClose, onCreated }: CreateWorksp
             placeholder="What lives in this workspace?"
             className="w-full px-3 py-2 bg-mc-bg border border-mc-border rounded-sm text-sm text-mc-text focus:border-mc-accent focus:outline-hidden resize-none"
           />
+        </div>
+
+        {/* Agents */}
+        <div>
+          <label htmlFor="ws-clone-agents" className="block text-xs uppercase tracking-wider text-mc-text-secondary mb-1">
+            Agents
+          </label>
+          <select
+            id="ws-clone-agents"
+            value={cloneAgentsFrom}
+            onChange={e => setCloneAgentsFrom(e.target.value)}
+            className="w-full px-3 py-2 bg-mc-bg border border-mc-border rounded-sm text-sm text-mc-text focus:border-mc-accent focus:outline-hidden"
+          >
+            <option value="">Default (placeholder PM only)</option>
+            {workspaces.map(w => (
+              <option key={w.id} value={w.id}>
+                Copy from: {w.icon ? `${w.icon} ` : ''}{w.name}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-mc-text-secondary mt-1">
+            Copies every active agent from the chosen workspace, preserving roles
+            and gateway links. Pick "Default" if you want this workspace to start
+            empty (just the PM placeholder).
+          </p>
         </div>
 
         {error && (

--- a/src/lib/bootstrap-agents.ts
+++ b/src/lib/bootstrap-agents.ts
@@ -107,6 +107,92 @@ export function ensurePmAgent(workspaceId: string): { id: string; created: boole
 }
 
 /**
+ * Copy every active agent from `sourceWorkspaceId` into `targetWorkspaceId`,
+ * preserving identity-shaped fields (name, role, description, avatar_emoji,
+ * soul/user/agents markdown, model, source, gateway_agent_id, runtime_kind,
+ * is_pm, is_master) but with fresh ids and reset runtime counters
+ * (status='standby', total_cost_usd=0, total_tokens_used=0, ephemeral=0).
+ *
+ * Use case: a new workspace inherits the operator's existing roster
+ * instead of starting empty (gateway sync only populates the workspace
+ * the operator's openclaw runner is keyed to, leaving fresh workspaces
+ * agentless until the operator manually adds rows).
+ *
+ * Returns the number of agents inserted.
+ */
+export function cloneAgentsFromWorkspace(
+  sourceWorkspaceId: string,
+  targetWorkspaceId: string,
+): number {
+  const db = getDb();
+  const sources = db.prepare(
+    `SELECT name, role, description, avatar_emoji, is_master, is_pm,
+            soul_md, user_md, agents_md, model, source, gateway_agent_id,
+            session_key_prefix, runtime_kind
+       FROM agents
+      WHERE workspace_id = ? AND is_active = 1`,
+  ).all(sourceWorkspaceId) as Array<{
+    name: string;
+    role: string;
+    description: string | null;
+    avatar_emoji: string | null;
+    is_master: number;
+    is_pm: number;
+    soul_md: string | null;
+    user_md: string | null;
+    agents_md: string | null;
+    model: string | null;
+    source: string | null;
+    gateway_agent_id: string | null;
+    session_key_prefix: string | null;
+    runtime_kind: string;
+  }>;
+
+  if (sources.length === 0) return 0;
+
+  const now = new Date().toISOString();
+  const insert = db.prepare(`
+    INSERT INTO agents (
+      id, name, role, description, avatar_emoji, status, is_master, is_pm,
+      workspace_id, soul_md, user_md, agents_md, model, source,
+      gateway_agent_id, session_key_prefix, is_active, runtime_kind,
+      created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, 'standby', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+  `);
+
+  const inserted = db.transaction(() => {
+    let n = 0;
+    for (const src of sources) {
+      insert.run(
+        crypto.randomUUID(),
+        src.name,
+        src.role,
+        src.description,
+        src.avatar_emoji ?? '🤖',
+        src.is_master,
+        src.is_pm,
+        targetWorkspaceId,
+        src.soul_md,
+        src.user_md,
+        src.agents_md,
+        src.model,
+        src.source ?? 'local',
+        src.gateway_agent_id,
+        src.session_key_prefix,
+        src.runtime_kind ?? 'host',
+        now,
+        now,
+      );
+      n += 1;
+    }
+    return n;
+  })();
+
+  console.log(`[Bootstrap] Cloned ${inserted} agent(s) from ${sourceWorkspaceId} → ${targetWorkspaceId}`);
+  return inserted;
+}
+
+/**
  * Clone workflow templates from the default workspace into a new workspace.
  */
 export function cloneWorkflowTemplates(db: Database.Database, targetWorkspaceId: string): void {


### PR DESCRIPTION
## Summary
A new workspace started with no worker agents — gateway sync keys to a single workspace and \`bootstrapCoreAgents\` has been a no-op since the gateway-sync architecture landed. Operators had to manually re-add each agent. This PR adds a "copy roster from existing workspace" option to the create-workspace flow.

## Behavior
\`POST /api/workspaces\` accepts optional \`clone_agents_from: <workspaceId>\`. When set:

- Validates the source workspace exists.
- Copies every \`is_active=1\` agent into the new workspace, preserving identity-shaped fields (\`name\`, \`role\`, \`description\`, \`avatar_emoji\`, \`gateway_agent_id\`, \`session_key_prefix\`, \`soul_md\`, \`user_md\`, \`agents_md\`, \`model\`, \`source\`, \`runtime_kind\`, \`is_pm\`, \`is_master\`).
- Fresh \`id\`s; \`status='standby'\`; \`total_cost_usd\`/\`total_tokens_used\` reset to 0.
- \`ensurePmAgent\` is still called after the clone — idempotent, bails out if any cloned agent already has \`is_pm=1\` so we don't double-up.

UI: \`CreateWorkspaceDrawer\` adds an "Agents" select with options \`Default (placeholder PM only)\` and \`Copy from: <every existing workspace>\`.

## Changes
- [bootstrap-agents.ts](src/lib/bootstrap-agents.ts): new \`cloneAgentsFromWorkspace(sourceId, targetId): number\`.
- [api/workspaces/route.ts](src/app/api/workspaces/route.ts): \`POST\` accepts \`clone_agents_from\`.
- [CreateWorkspaceDrawer.tsx](src/components/shell/CreateWorkspaceDrawer.tsx): "Agents" dropdown.

## Test plan
- [x] API smoke: \`POST /api/workspaces\` with \`clone_agents_from: default\` produced a new workspace with 9/9 agents matching the default roster, statuses reset to \`standby\`, PM and Coordinator master flags preserved, gateway_agent_ids identical.
- [x] UI: dropdown shows "Default (placeholder PM only)" + "Copy from: 🏠 Default Workspace" + "Copy from: 📁 FOIA".
- [x] \`yarn tsc --noEmit\` clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)