### PR TITLE
fix(drawer): portal to document.body so the panel can't be trapped offscreen

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 
 /**
@@ -27,6 +28,11 @@ export default function Drawer({
 }) {
   const panelRef = useRef<HTMLDivElement | null>(null);
   const previouslyFocused = useRef<HTMLElement | null>(null);
+  // Render via portal so the fixed-positioned panel can't get trapped by
+  // an ancestor that creates a containing block (e.g. a parent flex column,
+  // CSS containment, or future transform). Mount-gated to keep SSR happy.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
 
   // Esc to close + focus trap + restore focus on close.
   useEffect(() => {
@@ -81,9 +87,9 @@ export default function Drawer({
     };
   }, [open, onClose]);
 
-  if (!open) return null;
+  if (!open || !mounted) return null;
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-50">
       {/* Backdrop */}
       <div
@@ -120,6 +126,7 @@ export default function Drawer({
           </footer>
         )}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Summary
The create-workspace drawer (and any other Drawer caller rendered nested in the left nav) was opening with the panel mostly offscreen — backdrop measured 239px wide instead of the viewport's 1206px, panel left=−281, right=239.

\`position:fixed\` should anchor to the viewport, but something in the ancestor chain was containing it. No \`transform\` / \`filter\` / \`contain\` / \`container-type\` showed up in the walk, so rather than continue chasing it, the fix is the standard pattern: render the drawer through \`React.createPortal\` into \`document.body\`. \`position:fixed\` inside \`<body>\` is guaranteed viewport-relative.

## Changes
- [Drawer.tsx](src/components/Drawer.tsx): wrap the returned tree in \`createPortal(..., document.body)\`, mount-gated so SSR returns null.

## Verification (preview)
After fix, with the create-workspace drawer open on a 1206px viewport:
- backdrop: \`{ left: 0, right: 1206, width: 1206 }\`
- panel: \`{ left: 686, right: 1206, width: 520 }\`
- parentTag: \`BODY\`

Before, panel was \`{ left: -281, right: 239, width: 520 }\` with parentTag \`NAV\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)