### PR TITLE
feat(agents): "Sync from Gateway" button to force-resync the catalog

### DIFF
--- a/src/app/(app)/agents/page.tsx
+++ b/src/app/(app)/agents/page.tsx
@@ -30,6 +30,7 @@ import {
   ChevronUp,
   ChevronDown,
   ChevronsUpDown,
+  RefreshCw,
 } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
@@ -89,6 +90,7 @@ export default function AgentsPage() {
   const [rollCallBusy, setRollCallBusy] = useState(false);
   const [rollCallResult, setRollCallResult] = useState<RollCallResultView | null>(null);
   const [resetSessionsBusy, setResetSessionsBusy] = useState(false);
+  const [syncBusy, setSyncBusy] = useState(false);
   // Replaces native window.confirm() — see §1.7 finding in PREVIEW_TEST_FINDINGS.
   // The native dialog blocks automation tooling and breaks the test-flow walk.
   const [pendingConfirm, setPendingConfirm] = useState<null | {
@@ -255,6 +257,28 @@ export default function AgentsPage() {
       });
     } finally {
       setRollCallBusy(false);
+    }
+  };
+
+  const syncFromGateway = async () => {
+    setSyncBusy(true);
+    try {
+      const res = await fetch('/api/agents/sync', { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        showAlertDialog('Sync failed', data.error || `Sync failed (${res.status})`);
+        return;
+      }
+      // Refetch the roster so the page reflects whatever the gateway just
+      // wrote (model changes, new agents, status flips).
+      const refresh = await fetch(`/api/agents?workspace_id=${encodeURIComponent(workspaceId)}`);
+      if (refresh.ok) {
+        setAgents((await refresh.json()) as Agent[]);
+      }
+    } catch (e) {
+      showAlertDialog('Sync failed', e instanceof Error ? e.message : 'Sync failed');
+    } finally {
+      setSyncBusy(false);
     }
   };
 
@@ -471,6 +495,14 @@ export default function AgentsPage() {
           </div>
 
           <div className="ml-auto flex flex-wrap items-center gap-2">
+            <HeaderButton
+              icon={syncBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
+              onClick={syncFromGateway}
+              disabled={syncBusy}
+              tone="purple"
+            >
+              {syncBusy ? 'Syncing…' : 'Sync from Gateway'}
+            </HeaderButton>
             <HeaderButton
               icon={rollCallBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Megaphone className="w-4 h-4" />}
               onClick={runRollCall}

--- a/src/app/api/agents/sync/route.ts
+++ b/src/app/api/agents/sync/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Force-sync the local agent catalog from the OpenClaw gateway. The
+ * background sync runs every 60s and on dispatch/PATCH; this endpoint
+ * lets the operator trigger one immediately when they've edited an
+ * agent in OpenClaw and want the change (model, name, etc.) to
+ * propagate without waiting for the timer.
+ */
+export async function POST(): Promise<NextResponse> {
+  try {
+    const synced = await syncGatewayAgentsToCatalog({
+      force: true,
+      reason: 'manual',
+    });
+    return NextResponse.json({ synced });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Sync failed';
+    console.error('[POST /api/agents/sync] failed:', error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
The agent catalog syncs from OpenClaw on a 60s timer and on dispatch / PATCH. When an operator edits an agent in OpenClaw (most commonly swapping the model), they had no way to pull that change into MC without waiting for the timer or triggering a task. This adds a manual force-sync button on the agents page.

## Changes
- New \`POST /api/agents/sync\` — calls \`syncGatewayAgentsToCatalog({ force: true, reason: 'manual' })\` (bypasses the 60s debounce) and returns \`{ synced }\`.
- "Sync from Gateway" header button on \`/agents\` that hits the endpoint, then refetches \`/api/agents\` to update the table.

## Note
Doesn't address the underlying "model field doesn't always sync" report — that's a separate sync-logic question (likely something about how OpenClaw exposes the model in \`models.list\` vs \`config.get\`, or how \`normaliseModel\` flattens the \`{primary, fallbacks}\` shape). This just removes the wait-for-the-timer friction so the operator can verify whether their gateway edit landed.

## Test plan
- [x] Verified in preview: clicking "Sync from Gateway" issues \`POST /api/agents/sync → 200\` immediately followed by \`GET /api/agents?workspace_id=default → 200\` (the refetch).
- [x] \`yarn tsc --noEmit\` clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)