### PR TITLE
fix(agent-sync): update every row sharing a gateway_agent_id

### DIFF
--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -152,10 +152,19 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
     // mirroring disjoint subsets of agents).
     const { included, excludedGatewayIds } = selectGatewayAgents(gatewayAgents);
 
+    // Track *whether* a gateway_id has any existing rows (to choose
+     // INSERT vs UPDATE). Multiple rows per gateway_id are legal — the
+     // clone-agents-on-create feature copies an agent into a new
+     // workspace while preserving gateway_agent_id, since gateway agents
+     // are an org-wide identity. Both rows must receive sync updates,
+     // so the UPDATEs below match by gateway_agent_id rather than id.
     const existing = queryAll<{ id: string; gateway_agent_id: string | null }>(
       `SELECT id, gateway_agent_id FROM agents WHERE gateway_agent_id IS NOT NULL`
     );
-    const existingByGatewayId = new Map(existing.map((a) => [a.gateway_agent_id, a.id]));
+    const existingGatewayIds = new Set<string>();
+    for (const a of existing) {
+      if (a.gateway_agent_id) existingGatewayIds.add(a.gateway_agent_id);
+    }
 
     let changed = 0;
     let markedOffline = 0;
@@ -168,22 +177,22 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
 
         const name = ga.name || ga.label || gatewayId;
         const role = normalizeRole(name);
-        const existingId = existingByGatewayId.get(gatewayId) || null;
 
-        if (existingId) {
-          // Update existing row. Flip status off 'offline' if a previous
-          // sync had marked it filtered-out and the operator has now
-          // included it again (env var change → restart).
+        if (existingGatewayIds.has(gatewayId)) {
+          // Update every existing row for this gateway_agent_id (one per
+          // workspace that has an agent linked to it). Flip status off
+          // 'offline' if a previous sync had marked it filtered-out and
+          // the operator has now included it again.
           run(
             `UPDATE agents
                 SET name = ?,
                     role = CASE WHEN role IS NULL OR role = 'builder' THEN ? ELSE role END,
                     model = COALESCE(?, model),
                     source = 'gateway',
-                    status = CASE WHEN status = 'offline' THEN 'idle' ELSE status END,
+                    status = CASE WHEN status = 'offline' THEN 'standby' ELSE status END,
                     updated_at = ?
-              WHERE id = ?`,
-            [name, role, normaliseModel(ga.model), ts, existingId]
+              WHERE gateway_agent_id = ?`,
+            [name, role, normaliseModel(ga.model), ts, gatewayId]
           );
         } else {
           run(
@@ -202,13 +211,12 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
       // tasks / mailbox stay valid, and a future env-var relaxation
       // will flip status back to 'idle' automatically (above).
       for (const gatewayId of excludedGatewayIds) {
-        const existingId = existingByGatewayId.get(gatewayId);
-        if (!existingId) continue;
+        if (!existingGatewayIds.has(gatewayId)) continue;
         const result = run(
-          `UPDATE agents SET status = 'offline', updated_at = ? WHERE id = ? AND status != 'offline'`,
-          [ts, existingId]
+          `UPDATE agents SET status = 'offline', updated_at = ? WHERE gateway_agent_id = ? AND status != 'offline'`,
+          [ts, gatewayId]
         );
-        if (result.changes > 0) markedOffline += 1;
+        if (result.changes > 0) markedOffline += result.changes;
       }
 
       run(


### PR DESCRIPTION
## Summary
Two related bugs in [agent-catalog-sync.ts](src/lib/agent-catalog-sync.ts) surfaced after the clone-agents-on-create feature ([#133](https://github.com/smb209/mission-control/pull/133)):

### 1. Sync only updated one row per \`gateway_agent_id\`
The existing-rows lookup built a \`Map<gateway_agent_id, agent_id>\`, which silently collapsed duplicates. After clone-agents-on-create, two workspaces could legitimately share \`gateway_agent_id='mc-project-manager-dev'\` — gateway agents are an org-wide identity — but only one row received the UPDATE on each sync. The other stayed stale, so the operator saw the wrong model in the roster even after a manual force-sync.

**Fix:** Track existence with \`Set<gateway_agent_id>\`, key the UPDATEs by \`WHERE gateway_agent_id = ?\` so every clone gets the gateway-truth values in one statement.

### 2. \`status = 'idle'\` violates the schema's CHECK constraint
The "flip status off offline" CASE wrote \`status = 'idle'\`, but \`agents.status\` only allows \`('standby', 'working', 'offline')\`. Was masked by bug #1 — the collapsed Map almost never pointed at an offline row. With the fan-out fix, an offline clone row would flip the constraint on every sync and abort the transaction.

**Fix:** Write \`'standby'\` (the schema default) instead of \`'idle'\`.

## Test plan
- [x] Two rows sharing \`gateway_agent_id='mc-project-manager-dev'\` (one in \`default\`, one in a cloned workspace), both manually set to a stale \`spark-lb/agent\`, then \`syncGatewayAgentsToCatalog({ force: true })\` runs. Result: \`synced: 17\`, both rows updated to \`spark-lb/heavy\` with matching fresh timestamps. Pre-fix, only one row updated.
- [x] \`yarn tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)