### PR TITLE
fix(workflows): scope templates to the workspace (no default-union)

### DIFF
--- a/src/app/api/workspaces/[id]/workflows/route.ts
+++ b/src/app/api/workspaces/[id]/workflows/route.ts
@@ -19,8 +19,14 @@ export async function GET(
       stages: string; fail_targets: string; is_default: number;
       created_at: string; updated_at: string;
     }>(
+      // Workspace-scoped only. Every workspace gets its own copies of the
+      // canonical templates via cloneWorkflowTemplates at creation, so a
+      // union with `default` would surface duplicates (one row from the
+      // workspace's clone + one from default) on any non-default
+      // workspace. The `default` workspace gets its own 3 rows naturally
+      // because it owns them.
       `SELECT * FROM workflow_templates
-       WHERE workspace_id = ? OR workspace_id = 'default'
+       WHERE workspace_id = ?
        ORDER BY is_default DESC, name ASC`,
       [workspaceId]
     );


### PR DESCRIPTION
## Summary
The Team-tab workflow dropdown rendered each canonical template twice for any non-default workspace ("Simple", "Simple", "Standard", "Standard", ...). Root cause:

\`\`\`sql
SELECT * FROM workflow_templates
WHERE workspace_id = ? OR workspace_id = 'default'
\`\`\`

The OR-union was historically a fallback for workspaces without templates, but \`cloneWorkflowTemplates\` already copies all three into every new workspace at creation time. The union now surfaces 6 rows: 3 from the workspace's own clone + 3 from default.

## Fix
Drop the OR. Workspace-scoped query only. The \`default\` workspace still gets its 3 rows because it owns them.

## Test plan
- [x] \`GET /api/workspaces/<foia>/workflows\` returned 3 templates (\`Simple\`, \`Standard\`, \`Strict\`); was 6 pre-fix.
- [x] \`GET /api/workspaces/default/workflows\` still returns 3.
- [x] \`yarn tsc --noEmit\` clean for touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)