### PR TITLE
feat(tasks): collapse Inbox+Assigned into Queued + Start work / Promote-and-start

### DIFF
--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -17,17 +17,24 @@ interface MissionQueueProps {
   isPortrait?: boolean;
 }
 
-const COLUMNS: { id: TaskStatus; label: string; color: string }[] = [
-  { id: 'draft', label: '✎ Draft', color: 'border-t-slate-500' },
-  { id: 'planning', label: '📋 Planning', color: 'border-t-mc-accent-purple' },
-  { id: 'inbox', label: 'Inbox', color: 'border-t-mc-accent-pink' },
-  { id: 'assigned', label: 'Assigned', color: 'border-t-mc-accent-yellow' },
-  { id: 'in_progress', label: 'In Progress', color: 'border-t-mc-accent' },
-  { id: 'convoy_active', label: '🚚 Convoy', color: 'border-t-cyan-400' },
-  { id: 'testing', label: 'Testing', color: 'border-t-mc-accent-cyan' },
-  { id: 'review', label: 'Review', color: 'border-t-mc-accent-purple' },
-  { id: 'verification', label: 'Verification', color: 'border-t-orange-500' },
-  { id: 'done', label: 'Done', color: 'border-t-mc-accent-green' },
+// `id` is the drop-target status — dragging into this column sets task.status
+// to this value. `matches` is the set of statuses rendered in the column.
+// Most columns are 1:1; the "Queued" column collapses inbox+assigned because
+// they're functionally indistinguishable idle states (both mean "committed
+// work, not running yet"). Operators saw three pre-execution columns of
+// nothing-happening and got understandably confused about why their assigned
+// task wasn't being worked on.
+interface Column { id: TaskStatus; label: string; color: string; matches: TaskStatus[] }
+const COLUMNS: Column[] = [
+  { id: 'draft', label: '✎ Draft', color: 'border-t-slate-500', matches: ['draft'] },
+  { id: 'planning', label: '📋 Planning', color: 'border-t-mc-accent-purple', matches: ['planning'] },
+  { id: 'inbox', label: '⏳ Queued', color: 'border-t-mc-accent-pink', matches: ['inbox', 'assigned'] },
+  { id: 'in_progress', label: 'In Progress', color: 'border-t-mc-accent', matches: ['in_progress'] },
+  { id: 'convoy_active', label: '🚚 Convoy', color: 'border-t-cyan-400', matches: ['convoy_active'] },
+  { id: 'testing', label: 'Testing', color: 'border-t-mc-accent-cyan', matches: ['testing'] },
+  { id: 'review', label: 'Review', color: 'border-t-mc-accent-purple', matches: ['review'] },
+  { id: 'verification', label: 'Verification', color: 'border-t-orange-500', matches: ['verification'] },
+  { id: 'done', label: 'Done', color: 'border-t-mc-accent-green', matches: ['done'] },
 ];
 
 interface InitiativeMini {
@@ -106,6 +113,13 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
     tasks.filter(
       (task) =>
         task.status === status &&
+        (showArchived || !task.is_archived),
+    );
+
+  const getTasksForColumn = (column: Column) =>
+    tasks.filter(
+      (task) =>
+        column.matches.includes(task.status) &&
         (showArchived || !task.is_archived),
     );
 
@@ -212,7 +226,10 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
     setDraggedTask(null);
   };
 
-  const mobileTasks = getTasksByStatus(mobileStatus);
+  // Mobile view shows the column whose `id` matches the selected mobileStatus.
+  // For the Queued column this means inbox+assigned tasks both appear.
+  const mobileColumn = COLUMNS.find(c => c.id === mobileStatus) ?? COLUMNS[0];
+  const mobileTasks = getTasksForColumn(mobileColumn);
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
@@ -248,7 +265,7 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
       {!mobileMode ? (
         <div className="mission-queue-scroll-x flex-1 flex gap-3 p-3 overflow-x-auto">
           {COLUMNS.map((column) => {
-            const columnTasks = getTasksByStatus(column.id);
+            const columnTasks = getTasksForColumn(column);
             const hasTasks = columnTasks.length > 0;
             const collapsed = isColumnCollapsed(column.id, columnTasks.length);
 
@@ -326,7 +343,7 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
         <div className={`flex-1 overflow-y-auto ${isPortrait ? 'p-3 pb-[calc(1rem+env(safe-area-inset-bottom))]' : 'p-2.5 pb-[calc(0.75rem+env(safe-area-inset-bottom))]'}`}>
           <div className={`flex gap-2 overflow-x-auto ${isPortrait ? 'pb-3' : 'pb-2'}`}>
             {COLUMNS.map((column) => {
-              const count = getTasksByStatus(column.id).length;
+              const count = getTasksForColumn(column).length;
               const selected = mobileStatus === column.id;
               return (
                 <button

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -56,12 +56,90 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
         id: task.id + '-promote-' + Date.now(),
         type: 'task_status_changed',
         task_id: task.id,
-        message: `Promoted draft to inbox: ${task.title}`,
+        message: `Promoted draft to queue: ${task.title}`,
         created_at: new Date().toISOString(),
       });
       onClose();
     } catch (e) {
       setPromoteError(e instanceof Error ? e.message : 'Promote failed');
+    } finally {
+      setIsPromoting(false);
+    }
+  };
+
+  // Set status='in_progress' (which the existing auto-dispatch path detects)
+  // and trigger the gateway dispatch. Used both by "Start work" on a queued
+  // task and by "Promote and start" on a draft (after promotion).
+  const startWork = async (
+    targetTask: Task,
+    options: { agentId?: string | null; agentName?: string } = {},
+  ): Promise<void> => {
+    const agentId = options.agentId ?? targetTask.assigned_agent_id ?? null;
+    const agentName =
+      options.agentName ?? agents.find(a => a.id === agentId)?.name ?? 'Unknown Agent';
+    const patchRes = await fetch(`/api/tasks/${targetTask.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'in_progress' }),
+    });
+    if (!patchRes.ok) {
+      const body = await patchRes.json().catch(() => ({}));
+      throw new Error(body.error || `Status update failed (${patchRes.status})`);
+    }
+    updateTaskStatus(targetTask.id, 'in_progress');
+    if (agentId) {
+      const result = await triggerAutoDispatch({
+        taskId: targetTask.id,
+        taskTitle: targetTask.title,
+        agentId,
+        agentName,
+        workspaceId: targetTask.workspace_id,
+      });
+      if (!result.success) {
+        throw new Error(result.error || 'Dispatch failed');
+      }
+    }
+    addEvent({
+      id: targetTask.id + '-start-' + Date.now(),
+      type: 'task_status_changed',
+      task_id: targetTask.id,
+      message: `Started: ${targetTask.title}`,
+      created_at: new Date().toISOString(),
+    });
+  };
+
+  const handleStartWork = async () => {
+    if (!task) return;
+    setIsPromoting(true);
+    setPromoteError(null);
+    try {
+      await startWork(task);
+      onClose();
+    } catch (e) {
+      setPromoteError(e instanceof Error ? e.message : 'Start failed');
+    } finally {
+      setIsPromoting(false);
+    }
+  };
+
+  const handlePromoteAndStart = async () => {
+    if (!task) return;
+    setIsPromoting(true);
+    setPromoteError(null);
+    try {
+      const promoteRes = await fetch(`/api/tasks/${task.id}/promote`, { method: 'POST' });
+      if (!promoteRes.ok) {
+        const body = await promoteRes.json().catch(() => ({}));
+        throw new Error(body.error || `Promote failed (${promoteRes.status})`);
+      }
+      updateTaskStatus(task.id, 'inbox');
+      // The promote endpoint doesn't change assigned_agent_id, so we can use
+      // the task's existing assignment (set when the workflow template
+      // auto-assigned at draft-creation time) to drive the dispatch.
+      await startWork({ ...task, status: 'inbox' });
+      onClose();
+    } catch (e) {
+      setPromoteError(e instanceof Error ? e.message : 'Promote-and-start failed');
     } finally {
       setIsPromoting(false);
     }
@@ -822,23 +900,49 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
               )}
             </div>
             <div className="flex items-center gap-2">
-              {task?.status === 'draft' && (
+              {(task?.status === 'draft' || task?.status === 'inbox' || task?.status === 'assigned') && (
                 <>
                   {promoteError && (
                     <span className="text-xs text-red-400 max-w-48 truncate" title={promoteError}>
                       {promoteError}
                     </span>
                   )}
-                  <button
-                    type="button"
-                    onClick={handlePromote}
-                    disabled={isPromoting}
-                    title="Promote draft to execution queue (status → inbox)"
-                    className="min-h-11 flex items-center gap-2 px-3 py-2 rounded-sm text-sm border border-amber-500/40 text-amber-300 hover:bg-amber-500/10 disabled:opacity-50"
-                  >
-                    <Send className="w-4 h-4" />
-                    {isPromoting ? 'Promoting…' : 'Promote to inbox'}
-                  </button>
+                  {task.status === 'draft' && (
+                    <button
+                      type="button"
+                      onClick={handlePromote}
+                      disabled={isPromoting}
+                      title="Promote draft to the queue (status → inbox); doesn't start work"
+                      className="min-h-11 flex items-center gap-2 px-3 py-2 rounded-sm text-sm border border-amber-500/40 text-amber-300 hover:bg-amber-500/10 disabled:opacity-50"
+                    >
+                      <Send className="w-4 h-4" />
+                      {isPromoting ? 'Working…' : 'Promote to queue'}
+                    </button>
+                  )}
+                  {task.status === 'draft' && task.assigned_agent_id && (
+                    <button
+                      type="button"
+                      onClick={handlePromoteAndStart}
+                      disabled={isPromoting}
+                      title="Promote draft and immediately dispatch to the assigned agent"
+                      className="min-h-11 flex items-center gap-2 px-3 py-2 rounded-sm text-sm bg-mc-accent text-mc-bg hover:bg-mc-accent/90 disabled:opacity-50"
+                    >
+                      <Send className="w-4 h-4" />
+                      {isPromoting ? 'Working…' : 'Promote and start'}
+                    </button>
+                  )}
+                  {(task.status === 'inbox' || task.status === 'assigned') && task.assigned_agent_id && (
+                    <button
+                      type="button"
+                      onClick={handleStartWork}
+                      disabled={isPromoting}
+                      title="Dispatch to the assigned agent and move to In Progress"
+                      className="min-h-11 flex items-center gap-2 px-3 py-2 rounded-sm text-sm bg-mc-accent text-mc-bg hover:bg-mc-accent/90 disabled:opacity-50"
+                    >
+                      <Send className="w-4 h-4" />
+                      {isPromoting ? 'Starting…' : 'Start work'}
+                    </button>
+                  )}
                 </>
               )}
               <button


### PR DESCRIPTION
## Summary
The kanban had three pre-execution columns (Draft, Inbox, Assigned), all variants of "no agent is currently running this." Inbox/Assigned in particular were operator ceremony — workflow templates auto-assign at promote time, so Inbox almost never persisted. Operators reasonably asked: why are there three idle columns before work actually starts, and why isn't my "assigned" task being worked on? Auto-dispatch only fired on the \`in_progress\` transition, leaving the operator on the hook to make a "go now" gesture that wasn't surfaced anywhere.

## Changes
- **Kanban:** Collapse \`inbox\` + \`assigned\` into a single **⏳ Queued** column. Both statuses match the column; drop-in defaults to \`inbox\`. \`COLUMNS\` now carries a \`matches: TaskStatus[]\` field — most columns are 1:1, Queued is the only multi-status one. The underlying \`TaskStatus\` enum is unchanged, so workflow-template stages, API filters, and existing PATCH transitions all keep working.
- **TaskModal "Start work":** When \`status ∈ {inbox, assigned}\` and an agent is assigned, the footer shows a primary "Start work" button. Calls \`PATCH /tasks/:id { status: 'in_progress' }\` then \`triggerAutoDispatch\` — same path the kanban drag-handler uses, just discoverable from the modal.
- **TaskModal "Promote and start":** When a draft has an assigned agent, a primary "Promote and start" button sits alongside "Promote to queue". Promotes then starts work in one gesture.
- Renamed "Promote to inbox" → "Promote to queue" to match the new column name.

## Out of scope
- Auto-dispatching on \`inbox\` automatically (without explicit gesture). Considered, ruled out — too wide-reaching, anything landing in Inbox with an agent would immediately fire.
- Changing post-execution columns (In Progress / Convoy / Testing / Review / Verification) — those track real pipeline location.

## Test plan
- [x] Kanban renders 9 columns now (was 10): Draft / Planning / **Queued** / In Progress / Convoy / Testing / Review / Verification / Done.
- [x] Inbox task with no agent shows: \`inbox\` badge, no Start work button (correctly gated on \`assigned_agent_id\`).
- [x] Draft task with agent shows: \`draft\` badge, "Promote to queue" + "Promote and start" buttons.
- [x] \`yarn tsc --noEmit\` clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)