### PR TITLE
fix(workspace): scope every agent lookup to the task's workspace

### DIFF
--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -284,6 +284,16 @@ export function ensureCatalogSyncScheduled(): void {
 }
 
 export function getAgentByPreferredRoles(taskId: string, preferredRoles: string[]): { id: string; name: string } | null {
+  // Workspace-scope the global-role fallback. Without this filter a
+  // multi-workspace gateway clone (#133) can be selected for a task in
+  // another workspace, which then trips authz:workspace_mismatch on
+  // every MCP call. The byTaskRole path is already implicitly scoped
+  // because task_roles rows are populated from workspace agents
+  // (populateTaskRolesFromAgents).
+  const taskWorkspace = queryOne<{ workspace_id: string | null }>(
+    'SELECT workspace_id FROM tasks WHERE id = ?',
+    [taskId],
+  )?.workspace_id ?? 'default';
   // Filter out operator-disabled agents (is_active=0). COALESCE(is_active, 1)
   // guards rows created before the column existed.
   for (const role of preferredRoles) {
@@ -302,8 +312,9 @@ export function getAgentByPreferredRoles(taskId: string, preferredRoles: string[
     const byGlobalRole = queryOne<{ id: string; name: string }>(
       `SELECT id, name FROM agents
        WHERE role = ? AND status != 'offline' AND COALESCE(is_active, 1) = 1
+         AND COALESCE(workspace_id, 'default') = ?
        ORDER BY updated_at DESC LIMIT 1`,
-      [role]
+      [role, taskWorkspace]
     );
     if (byGlobalRole) return byGlobalRole;
   }

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -135,18 +135,46 @@ export function registerAllTools(server: McpServer): void {
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
     trace('whoami', async ({ agent_id }) => {
-      const me = queryOne<{
+      // Multi-workspace gateway clones (#133) make `gateway_agent_id`
+      // ambiguous on its own. Try UUID first; on miss, only fall back to
+      // gateway_agent_id when it resolves to exactly one row. Otherwise
+      // return a structured error listing the candidate workspaces so
+      // the operator can re-dispatch with the correct UUID — silently
+      // returning the first match would mint the wrong workspace_id and
+      // break every subsequent MCP call with workspace_mismatch.
+      type AgentRow = {
         id: string;
         name: string;
         role: string;
         workspace_id: string;
         gateway_agent_id: string | null;
         is_active: number | null;
-      }>(
+      };
+      let me = queryOne<AgentRow>(
         `SELECT id, name, role, workspace_id, gateway_agent_id, is_active
-           FROM agents WHERE id = ? OR gateway_agent_id = ? LIMIT 1`,
-        [agent_id, agent_id],
+           FROM agents WHERE id = ? LIMIT 1`,
+        [agent_id],
       );
+      if (!me) {
+        const byGateway = queryAll<AgentRow>(
+          `SELECT id, name, role, workspace_id, gateway_agent_id, is_active
+             FROM agents WHERE gateway_agent_id = ?`,
+          [agent_id],
+        );
+        if (byGateway.length === 1) {
+          me = byGateway[0];
+        } else if (byGateway.length > 1) {
+          const candidates = byGateway.map((r) => ({ id: r.id, workspace_id: r.workspace_id, name: r.name }));
+          return {
+            isError: true,
+            content: [{
+              type: 'text',
+              text: `gateway_agent_id "${agent_id}" exists in ${byGateway.length} workspaces. Pass your MC agent_id (UUID) instead — the dispatch briefing embeds it as "Your agent_id is: …".`,
+            }],
+            structuredContent: { error: 'ambiguous_gateway_id', gateway_agent_id: agent_id, candidates },
+          };
+        }
+      }
       if (!me) {
         return {
           isError: true,
@@ -214,10 +242,35 @@ export function registerAllTools(server: McpServer): void {
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
     trace('get_workspace_context', async ({ agent_id }) => {
-      const me = queryOne<{ workspace_id: string }>(
-        `SELECT workspace_id FROM agents WHERE id = ? OR gateway_agent_id = ? LIMIT 1`,
-        [agent_id, agent_id],
+      // Same multi-workspace ambiguity guard as whoami — picking the
+      // first row by gateway_agent_id would surface the wrong
+      // workspace's context_md silently.
+      let me = queryOne<{ workspace_id: string }>(
+        `SELECT workspace_id FROM agents WHERE id = ? LIMIT 1`,
+        [agent_id],
       );
+      if (!me) {
+        const byGateway = queryAll<{ id: string; workspace_id: string; name: string }>(
+          `SELECT id, workspace_id, name FROM agents WHERE gateway_agent_id = ?`,
+          [agent_id],
+        );
+        if (byGateway.length === 1) {
+          me = { workspace_id: byGateway[0].workspace_id };
+        } else if (byGateway.length > 1) {
+          return {
+            isError: true,
+            content: [{
+              type: 'text',
+              text: `gateway_agent_id "${agent_id}" exists in ${byGateway.length} workspaces. Pass your MC agent_id (UUID) instead.`,
+            }],
+            structuredContent: {
+              error: 'ambiguous_gateway_id',
+              gateway_agent_id: agent_id,
+              candidates: byGateway,
+            },
+          };
+        }
+      }
       if (!me) {
         return {
           isError: true,
@@ -286,7 +339,34 @@ export function registerAllTools(server: McpServer): void {
       inputSchema: { agent_id: agentIdArg, task_id: taskIdArg },
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
-    trace('get_task', async ({ task_id }) => {
+    trace('get_task', async ({ agent_id, task_id }) => {
+      // Gate cross-workspace reads. Until this PR get_task accepted the
+      // bearer alone, so any agent could enumerate task UUIDs from
+      // other workspaces. We only enforce workspace match here (not the
+      // stricter on-task membership) so coordinators can still inspect
+      // peer subtasks they didn't directly assign — list_my_subtasks
+      // already proves they own the parent.
+      const callerWs = queryOne<{ workspace_id: string | null }>(
+        'SELECT workspace_id FROM agents WHERE id = ?',
+        [agent_id],
+      );
+      const taskWs = queryOne<{ workspace_id: string | null }>(
+        'SELECT workspace_id FROM tasks WHERE id = ?',
+        [task_id],
+      );
+      if (!callerWs) {
+        throw new AuthzError('agent_not_found', `agent not found: ${agent_id}`, { agentId: agent_id, taskId: task_id });
+      }
+      if (!taskWs) {
+        // Fall through — the existing 'task not found' branch below
+        // will return the structured not_found result.
+      } else if ((callerWs.workspace_id ?? 'default') !== (taskWs.workspace_id ?? 'default')) {
+        throw new AuthzError(
+          'workspace_mismatch',
+          `agent ${agent_id} cannot read task ${task_id} (different workspace)`,
+          { agentId: agent_id, taskId: task_id, action: 'read' },
+        );
+      }
       const task = queryOne<Record<string, unknown>>(
         `SELECT t.*,
            aa.name as assigned_agent_name,
@@ -1059,11 +1139,46 @@ export function registerAllTools(server: McpServer): void {
         };
       }
 
+      // Scope peer lookup to the parent task's workspace. Without this,
+      // the multi-workspace gateway clones from #133 mean we can grab
+      // any workspace's row for `peer_gateway_id` — the child task is
+      // created with parent.workspace_id but assigned_agent_id ends up
+      // pointing at the foreign-workspace clone, and every subsequent
+      // MCP call from the peer trips authz:workspace_mismatch.
+      const parentWs = queryOne<{ workspace_id: string | null }>(
+        'SELECT workspace_id FROM tasks WHERE id = ?',
+        [args.task_id],
+      )?.workspace_id ?? 'default';
       const peer = queryOne<{ id: string; name: string; role: string | null }>(
-        `SELECT id, name, role FROM agents WHERE gateway_agent_id = ? LIMIT 1`,
-        [args.peer_gateway_id],
+        `SELECT id, name, role FROM agents
+          WHERE gateway_agent_id = ?
+            AND COALESCE(workspace_id, 'default') = ?
+          LIMIT 1`,
+        [args.peer_gateway_id, parentWs],
       );
       if (!peer) {
+        // Distinguish "exists, wrong workspace" from "doesn't exist
+        // anywhere" so the coordinator gets an actionable error.
+        const elsewhere = queryAll<{ workspace_id: string | null }>(
+          `SELECT workspace_id FROM agents WHERE gateway_agent_id = ?`,
+          [args.peer_gateway_id],
+        );
+        if (elsewhere.length > 0) {
+          const otherWorkspaces = elsewhere.map((r) => r.workspace_id ?? 'default');
+          return {
+            isError: true,
+            content: [{
+              type: 'text',
+              text: `Peer "${args.peer_gateway_id}" exists but not in this task's workspace (${parentWs}). Found in: ${otherWorkspaces.join(', ')}. Call list_peers to see the in-workspace roster, or have the operator clone the agent into ${parentWs}.`,
+            }],
+            structuredContent: {
+              error: 'peer_not_in_workspace',
+              peer_gateway_id: args.peer_gateway_id,
+              task_workspace_id: parentWs,
+              found_in_workspaces: otherWorkspaces,
+            },
+          };
+        }
         return {
           isError: true,
           content: [{

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -282,11 +282,19 @@ export function isActiveStatus(status: string): boolean {
 }
 
 export function pickDynamicAgent(taskId: string, stageRole?: string | null): { id: string; name: string } | null {
-  const planningAgentsTask = queryOne<{ planning_agents?: string }>('SELECT planning_agents FROM tasks WHERE id = ?', [taskId]);
+  // Workspace-scope every lookup. Without this filter, a multi-workspace
+  // gateway_agent_id (clones produced by feat(workspaces)#133) lets the
+  // role/fallback queries silently route a task to a foreign-workspace
+  // agent, which then trips authz:workspace_mismatch on every MCP call.
+  const taskRow = queryOne<{ planning_agents?: string; workspace_id: string | null }>(
+    'SELECT planning_agents, workspace_id FROM tasks WHERE id = ?',
+    [taskId],
+  );
+  const workspaceId = taskRow?.workspace_id ?? 'default';
   const plannerCandidates: string[] = [];
-  if (planningAgentsTask?.planning_agents) {
+  if (taskRow?.planning_agents) {
     try {
-      const parsed = JSON.parse(planningAgentsTask.planning_agents) as Array<{ agent_id?: string; role?: string }>;
+      const parsed = JSON.parse(taskRow.planning_agents) as Array<{ agent_id?: string; role?: string }>;
       for (const a of parsed) {
         if (a.role && stageRole && a.role.toLowerCase().includes(stageRole.toLowerCase()) && a.agent_id) plannerCandidates.push(a.agent_id);
       }
@@ -298,11 +306,12 @@ export function pickDynamicAgent(taskId: string, stageRole?: string | null): { i
   // marked inactive agent is excluded from every routing decision.
   const checked = new Set<string>();
   for (const candidateId of plannerCandidates) {
-    const candidate = queryOne<{ id: string; name: string; is_master: number; status: string; is_active: number }>(
-      'SELECT id, name, is_master, status, is_active FROM agents WHERE id = ? LIMIT 1',
+    const candidate = queryOne<{ id: string; name: string; is_master: number; status: string; is_active: number; workspace_id: string | null }>(
+      'SELECT id, name, is_master, status, is_active, workspace_id FROM agents WHERE id = ? LIMIT 1',
       [candidateId]
     );
     if (!candidate || candidate.status === 'offline' || Number(candidate.is_active ?? 1) !== 1) continue;
+    if ((candidate.workspace_id ?? 'default') !== workspaceId) continue;
     checked.add(candidate.id);
     return { id: candidate.id, name: candidate.name };
   }
@@ -314,12 +323,13 @@ export function pickDynamicAgent(taskId: string, stageRole?: string | null): { i
     const byRole = queryOne<{ id: string; name: string }>(
       `SELECT id, name FROM agents
        WHERE role = ? AND status != 'offline' AND COALESCE(is_active, 1) = 1
+         AND COALESCE(workspace_id, 'default') = ?
        ORDER BY
          (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL) DESC,
          status = 'standby' DESC,
          updated_at DESC
        LIMIT 1`,
-      [stageRole]
+      [stageRole, workspaceId]
     );
     if (byRole) return byRole;
   }
@@ -327,11 +337,13 @@ export function pickDynamicAgent(taskId: string, stageRole?: string | null): { i
   const fallback = queryOne<{ id: string; name: string }>(
     `SELECT id, name FROM agents
      WHERE status != 'offline' AND COALESCE(is_active, 1) = 1
+       AND COALESCE(workspace_id, 'default') = ?
      ORDER BY
        (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL) DESC,
        is_master ASC,
        updated_at DESC
-     LIMIT 1`
+     LIMIT 1`,
+    [workspaceId]
   );
   if (fallback && !checked.has(fallback.id)) return fallback;
 


### PR DESCRIPTION
## Summary

After the multi-workspace clone work (#133, #136), several agent-lookup paths still matched by `gateway_agent_id` or by role **without filtering by `workspace_id`**. A task in workspace B could be assigned a clone that lives in workspace A; every subsequent MCP call from that agent then tripped `authz:workspace_mismatch` (root cause of the live MCP failure observed today on `register_deliverable`).

## Changes

- **`pickDynamicAgent`** ([task-governance.ts](src/lib/task-governance.ts)): scope `byRole`, fallback, and planner-candidate queries to the task's workspace.
- **`getAgentByPreferredRoles`** ([agent-catalog-sync.ts](src/lib/agent-catalog-sync.ts)): scope the `byGlobalRole` fallback to the task's workspace. (`byTaskRole` was already implicitly scoped.)
- **`spawn_subtask` peer lookup** ([mcp/tools.ts](src/lib/mcp/tools.ts)): scope by the parent task's workspace; surface a new `peer_not_in_workspace` error (with the workspaces the gateway clone *does* exist in) so coordinators get an actionable response instead of silently picking a foreign clone.
- **`whoami` / `get_workspace_context`** ([mcp/tools.ts](src/lib/mcp/tools.ts)): if `agent_id` matches multiple rows by `gateway_agent_id`, return a structured `ambiguous_gateway_id` error listing the candidate workspaces. UUID lookups are unaffected; the dispatch briefing already embeds the UUID, so well-behaved agents keep working.
- **`get_task`** ([mcp/tools.ts](src/lib/mcp/tools.ts)): add a workspace-match check (read-only, intentionally softer than `assertAgentCanActOnTask` so coordinators can still inspect peer subtasks they own via the parent convoy).

## Test plan

- [x] `yarn test` — full suite, 487/487 pass
- [x] Targeted re-run of `src/lib/mcp/**/*.test.ts`, `src/lib/authz/**/*.test.ts`, `task-governance.test.ts`, `agent-catalog-sync.test.ts` — all green
- [x] `yarn tsc --noEmit` — no new errors (pre-existing failure in `pm-decompose.test.ts` is unrelated)
- [ ] Manual MCP smoke: dispatch a task in a non-`default` workspace and confirm `register_deliverable` no longer 403s