### PR TITLE
feat(ui): PM activity master-detail, task modal focus mode, deliverables grid

### DIFF
--- a/src/app/(app)/deliverables/page.tsx
+++ b/src/app/(app)/deliverables/page.tsx
@@ -16,9 +16,6 @@ import Link from 'next/link';
 import {
   Archive,
   ArchiveRestore,
-  ChevronDown,
-  ChevronUp,
-  ChevronsUpDown,
   Download,
   ExternalLink,
   Package,
@@ -120,12 +117,23 @@ export default function DeliverablesPage() {
   const totalFiles = visible.reduce((acc, r) => acc + r.file_count, 0);
   const totalDownloadable = visible.reduce((acc, r) => acc + r.mc_count, 0);
 
-  const toggleSort = (key: SortKey) => {
-    setSort(prev =>
-      prev.key === key
-        ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
-        : { key, dir: key === 'updated' ? 'desc' : 'asc' },
-    );
+  // Sort dropdown — combined key+direction so the operator picks one
+  // option ("Newest first") rather than juggling a key dropdown plus a
+  // direction toggle. Replaces the per-column header sort buttons that
+  // came with the old table layout.
+  const SORT_OPTIONS: Array<{ value: string; key: SortKey; dir: SortDir; label: string }> = [
+    { value: 'updated:desc', key: 'updated', dir: 'desc', label: 'Newest first' },
+    { value: 'updated:asc', key: 'updated', dir: 'asc', label: 'Oldest first' },
+    { value: 'title:asc', key: 'title', dir: 'asc', label: 'Title A→Z' },
+    { value: 'title:desc', key: 'title', dir: 'desc', label: 'Title Z→A' },
+    { value: 'files:desc', key: 'files', dir: 'desc', label: 'Most files' },
+    { value: 'files:asc', key: 'files', dir: 'asc', label: 'Fewest files' },
+    { value: 'status:asc', key: 'status', dir: 'asc', label: 'Status A→Z' },
+  ];
+  const sortValue = `${sort.key}:${sort.dir}`;
+  const setSortFromValue = (v: string) => {
+    const opt = SORT_OPTIONS.find(o => o.value === v);
+    if (opt) setSort({ key: opt.key, dir: opt.dir });
   };
 
   return (
@@ -146,6 +154,18 @@ export default function DeliverablesPage() {
             </div>
           </div>
           <div className="flex items-center gap-2 shrink-0">
+            <select
+              value={sortValue}
+              onChange={e => setSortFromValue(e.target.value)}
+              className="text-xs px-2 py-1.5 rounded border border-mc-border bg-mc-bg text-mc-text hover:border-mc-accent/40 focus:outline-none focus:border-mc-accent/60"
+              title="Sort cards"
+            >
+              {SORT_OPTIONS.map(o => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
             <label className="flex items-center gap-2 text-xs text-mc-text-secondary cursor-pointer">
               <input
                 type="checkbox"
@@ -194,33 +214,10 @@ export default function DeliverablesPage() {
             .
           </div>
         ) : (
-          <div className="rounded-lg border border-mc-border bg-mc-bg-secondary overflow-hidden">
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead className="bg-mc-bg/50 border-b border-mc-border">
-                  <tr className="text-left text-xs uppercase tracking-wide text-mc-text-secondary">
-                    <Th onSort={() => toggleSort('title')} sortDir={sort.key === 'title' ? sort.dir : null}>
-                      Task
-                    </Th>
-                    <Th onSort={() => toggleSort('status')} sortDir={sort.key === 'status' ? sort.dir : null}>
-                      Status
-                    </Th>
-                    <Th onSort={() => toggleSort('files')} sortDir={sort.key === 'files' ? sort.dir : null}>
-                      Files
-                    </Th>
-                    <Th onSort={() => toggleSort('updated')} sortDir={sort.key === 'updated' ? sort.dir : null}>
-                      Updated
-                    </Th>
-                    <Th>Actions</Th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {visible.map(r => (
-                    <DeliverableRow key={r.task_id} row={r} />
-                  ))}
-                </tbody>
-              </table>
-            </div>
+          <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+            {visible.map(r => (
+              <DeliverableCard key={r.task_id} row={r} />
+            ))}
           </div>
         )}
       </main>
@@ -228,41 +225,7 @@ export default function DeliverablesPage() {
   );
 }
 
-function Th({
-  children,
-  onSort,
-  sortDir,
-  width,
-}: {
-  children?: React.ReactNode;
-  onSort?: () => void;
-  sortDir?: SortDir | null;
-  width?: string;
-}) {
-  return (
-    <th className={`px-3 py-2 ${width ?? ''}`}>
-      {onSort ? (
-        <button
-          onClick={onSort}
-          className="inline-flex items-center gap-1 hover:text-mc-text"
-        >
-          <span>{children}</span>
-          {sortDir === 'asc' ? (
-            <ChevronUp className="w-3 h-3" />
-          ) : sortDir === 'desc' ? (
-            <ChevronDown className="w-3 h-3" />
-          ) : (
-            <ChevronsUpDown className="w-3 h-3 opacity-40" />
-          )}
-        </button>
-      ) : (
-        <span>{children}</span>
-      )}
-    </th>
-  );
-}
-
-function DeliverableRow({ row }: { row: Row }) {
+function DeliverableCard({ row }: { row: Row }) {
   const statusCls = STATUS_PALETTE[row.status] ?? 'bg-mc-bg-tertiary text-mc-text-secondary border-mc-border';
   const ago = (() => {
     try {
@@ -272,47 +235,56 @@ function DeliverableRow({ row }: { row: Row }) {
     }
   })();
   return (
-    <tr
-      className={`border-t border-mc-border/60 hover:bg-mc-bg/40 ${
+    <article
+      className={`flex flex-col gap-3 p-4 rounded-lg border border-mc-border bg-mc-bg-secondary hover:border-mc-accent/40 ${
         row.is_archived ? 'opacity-60' : ''
       }`}
     >
-      <td className="px-3 py-2">
-        <Link
-          href={`/?task=${row.task_id}`}
-          className="font-medium text-mc-text hover:text-mc-accent inline-flex items-center gap-1"
-          title={row.task_title}
+      <header className="flex items-start gap-2 min-w-0">
+        <span
+          className={`inline-block px-1.5 py-0.5 rounded-sm text-[10px] capitalize border shrink-0 ${statusCls}`}
         >
-          <span className="truncate max-w-[420px]">{row.task_title}</span>
-          <ExternalLink className="w-3 h-3 opacity-60 shrink-0" />
-        </Link>
+          {row.status.replace(/_/g, ' ')}
+        </span>
         {row.is_archived === 1 && (
-          <span className="ml-2 inline-flex items-center gap-0.5 text-[10px] text-mc-text-secondary uppercase tracking-wide">
+          <span className="inline-flex items-center gap-0.5 text-[10px] text-mc-text-secondary uppercase tracking-wide shrink-0">
             <Archive className="w-3 h-3" /> archived
           </span>
         )}
-      </td>
-      <td className="px-3 py-2">
-        <span className={`inline-block px-1.5 py-0.5 rounded-sm text-[11px] capitalize border ${statusCls}`}>
-          {row.status.replace(/_/g, ' ')}
-        </span>
-      </td>
-      <td className="px-3 py-2 tabular-nums">
-        {row.file_count}
-        {row.mc_count < row.file_count && (
-          <span className="text-mc-text-secondary text-xs ml-1" title="Some files are host-only">
-            ({row.mc_count} web)
-          </span>
-        )}
-      </td>
-      <td className="px-3 py-2 text-mc-text-secondary text-xs whitespace-nowrap">
-        {ago}
-      </td>
-      <td className="px-3 py-2">
+      </header>
+
+      <Link
+        href={`/?task=${row.task_id}`}
+        className="font-medium text-sm text-mc-text hover:text-mc-accent inline-flex items-start gap-1 min-w-0"
+        title={row.task_title}
+      >
+        <span className="line-clamp-2 break-words">{row.task_title}</span>
+        <ExternalLink className="w-3 h-3 opacity-60 shrink-0 mt-1" />
+      </Link>
+
+      <dl className="flex items-center gap-4 text-xs text-mc-text-secondary mt-auto">
+        <div>
+          <dt className="text-[10px] uppercase tracking-wide text-mc-text-secondary/70">Files</dt>
+          <dd className="text-mc-text tabular-nums">
+            {row.file_count}
+            {row.mc_count < row.file_count && (
+              <span className="text-mc-text-secondary text-[11px] ml-1" title="Some files are host-only">
+                ({row.mc_count} web)
+              </span>
+            )}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-[10px] uppercase tracking-wide text-mc-text-secondary/70">Updated</dt>
+          <dd className="text-mc-text whitespace-nowrap">{ago}</dd>
+        </div>
+      </dl>
+
+      <footer className="flex items-center justify-end">
         {row.mc_count > 0 ? (
           <a
             href={`/api/tasks/${row.task_id}/deliverables/download`}
-            className="inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded border border-mc-accent/40 text-mc-accent hover:bg-mc-accent/10"
+            className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded border border-mc-accent/40 text-mc-accent hover:bg-mc-accent/10"
             title={`Download ${row.mc_count} file${row.mc_count === 1 ? '' : 's'}`}
           >
             <Download className="w-3.5 h-3.5" />
@@ -324,9 +296,9 @@ function DeliverableRow({ row }: { row: Row }) {
             Archived
           </span>
         ) : (
-          <span className="text-xs text-mc-text-secondary">—</span>
+          <span className="text-xs text-mc-text-secondary">No downloadable files</span>
         )}
-      </td>
-    </tr>
+      </footer>
+    </article>
   );
 }

--- a/src/app/(app)/pm/activity/page.tsx
+++ b/src/app/(app)/pm/activity/page.tsx
@@ -3,11 +3,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { ChevronDown, ChevronRight, RotateCcw, ExternalLink } from 'lucide-react';
+import { RotateCcw, ExternalLink } from 'lucide-react';
 import { ProposalDiffsList, summarizeDiff, type PmDiff } from '@/components/pm/ProposalDiffsList';
 import { triggerBadgeFor } from '@/components/pm/triggerBadge';
 import { showAlertDialog } from '@/lib/show-alert';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
+import { PageWithRails } from '@/components/shell/PageWithRails';
 
 interface PmProposal {
   id: string;
@@ -49,8 +50,22 @@ export default function PmActivityPage() {
   const [initiatives, setInitiatives] = useState<Record<string, InitiativeLite>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [reverting, setReverting] = useState<string | null>(null);
+
+  // Master-detail selection — URL-backed via `?selected=<proposal_id>` so
+  // deep links + back/forward work; local state is the source of truth so
+  // the right pane re-renders immediately on click.
+  const [selectedId, setSelectedId] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null;
+    return new URL(window.location.href).searchParams.get('selected');
+  });
+  const selectProposal = useCallback((id: string | null) => {
+    setSelectedId(id);
+    const url = new URL(window.location.href);
+    if (id) url.searchParams.set('selected', id);
+    else url.searchParams.delete('selected');
+    window.history.replaceState(window.history.state, '', url.toString());
+  }, []);
 
   // Filter state. trigger_kinds is a Set so each chip toggles independently.
   const [activeKinds, setActiveKinds] = useState<Set<string>>(new Set());
@@ -162,74 +177,230 @@ export default function PmActivityPage() {
     });
   };
 
-  return (
-    <div className="min-h-screen bg-mc-bg p-6">
-      <header className="max-w-5xl mx-auto mb-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-mc-text">PM activity</h1>
-            <p className="text-sm text-mc-text-secondary">
-              Accepted proposals, newest first. Click any row to inspect the diff list, or
-              use <strong>Revert</strong> to draft an inverse proposal for review.
-            </p>
-          </div>
-          <Link
-            href="/pm"
-            className="text-sm text-mc-text-secondary hover:text-mc-text inline-flex items-center gap-1"
-          >
-            <ExternalLink className="w-3.5 h-3.5" /> Open PM chat
-          </Link>
+  const selectedProposal = selectedId ? proposals.find(p => p.id === selectedId) ?? null : null;
+
+  const header = (
+    <div className="flex items-center justify-between gap-3">
+      <div>
+        <h1 className="text-base font-semibold text-mc-text">PM activity</h1>
+        <p className="text-[11px] text-mc-text-secondary">Accepted proposals — newest first</p>
+      </div>
+      <Link
+        href="/pm"
+        className="text-xs text-mc-text-secondary hover:text-mc-text inline-flex items-center gap-1"
+      >
+        <ExternalLink className="w-3.5 h-3.5" /> Open PM chat
+      </Link>
+    </div>
+  );
+
+  // Left rail = filters + scrollable proposal list (compact rows).
+  const leftRail = (
+    <div className="text-sm flex flex-col h-full space-y-2">
+      <FilterBar
+        availableKinds={availableKinds}
+        availableAgents={availableAgents}
+        agents={agents}
+        activeKinds={activeKinds}
+        activeAgent={activeAgent}
+        dateRange={dateRange}
+        onToggleKind={toggleKind}
+        onSetAgent={setActiveAgent}
+        onSetDateRange={setDateRange}
+        totalCount={proposals.length}
+        shownCount={visibleProposals.length}
+      />
+      {error && (
+        <div className="p-2 rounded bg-red-500/10 border border-red-500/30 text-red-300 text-xs">
+          {error}
         </div>
+      )}
+      {loading ? (
+        <p className="text-mc-text-secondary text-xs">Loading activity…</p>
+      ) : visibleProposals.length === 0 ? (
+        <p className="text-mc-text-secondary text-xs">
+          No accepted proposals match these filters.
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {visibleProposals.map(p => (
+            <ActivityListItem
+              key={p.id}
+              proposal={p}
+              agent={p.applied_by_agent_id ? agents[p.applied_by_agent_id] : undefined}
+              targetTitle={
+                p.target_initiative_id ? initiatives[p.target_initiative_id]?.title : undefined
+              }
+              selected={selectedId === p.id}
+              onSelect={() => selectProposal(p.id)}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+
+  return (
+    <PageWithRails
+      header={header}
+      leftRail={leftRail}
+      leftRailWidth="w-[24rem]"
+      mainMaxWidth=""
+      outerMaxWidth={null}
+      outerPaddingX="px-4"
+    >
+      {selectedProposal ? (
+        <ProposalDetailPane
+          proposal={selectedProposal}
+          agent={selectedProposal.applied_by_agent_id ? agents[selectedProposal.applied_by_agent_id] : undefined}
+          targetTitle={
+            selectedProposal.target_initiative_id
+              ? initiatives[selectedProposal.target_initiative_id]?.title
+              : undefined
+          }
+          onRevert={() => onRevert(selectedProposal)}
+          reverting={reverting === selectedProposal.id}
+        />
+      ) : (
+        <div className="rounded-lg border border-dashed border-mc-border bg-mc-bg-secondary/30 p-12 text-center text-sm text-mc-text-secondary">
+          Select an accepted proposal on the left to inspect its diffs and
+          revert if needed.
+        </div>
+      )}
+    </PageWithRails>
+  );
+}
+
+/** Compact list row used inside the left rail. */
+function ActivityListItem({
+  proposal,
+  agent,
+  targetTitle,
+  selected,
+  onSelect,
+}: {
+  proposal: PmProposal;
+  agent?: AgentLite;
+  targetTitle?: string;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const badge = triggerBadgeFor(proposal.trigger_kind);
+  const summary = proposal.proposed_changes.length > 0
+    ? proposal.proposed_changes.length === 1
+      ? summarizeDiff(proposal.proposed_changes[0])
+      : `${proposal.proposed_changes.length} changes`
+    : '(no diffs)';
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-current={selected ? 'true' : undefined}
+        aria-label={`Select proposal ${proposal.id}`}
+        className={`w-full text-left p-2 rounded-lg border transition-colors ${
+          selected
+            ? 'bg-mc-accent/10 border-mc-accent/60'
+            : 'bg-mc-bg-secondary border-mc-border hover:border-mc-accent/40'
+        }`}
+      >
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className={`text-[10px] px-1.5 py-0.5 rounded border ${badge.cls}`}>
+            {badge.label}
+          </span>
+          <span className="text-[10px] text-mc-text-secondary ml-auto shrink-0">
+            {proposal.applied_at && relativeTime(proposal.applied_at)}
+          </span>
+        </div>
+        <div className="text-xs text-mc-text truncate">
+          {targetTitle ?? <span className="text-mc-text-secondary italic">(no target)</span>}
+        </div>
+        <div className="text-[11px] text-mc-text-secondary truncate">{summary}</div>
+        {agent && (
+          <div className="text-[10px] text-mc-text-secondary/80 mt-0.5">
+            {agent.avatar_emoji ? `${agent.avatar_emoji} ` : ''}{agent.name}
+          </div>
+        )}
+      </button>
+    </li>
+  );
+}
+
+/** Right-pane detail view for the selected accepted proposal. */
+function ProposalDetailPane({
+  proposal,
+  agent,
+  targetTitle,
+  onRevert,
+  reverting,
+}: {
+  proposal: PmProposal;
+  agent?: AgentLite;
+  targetTitle?: string;
+  onRevert: () => void;
+  reverting: boolean;
+}) {
+  const badge = triggerBadgeFor(proposal.trigger_kind);
+  const isRevertItself = proposal.trigger_kind === 'revert';
+  return (
+    <div className="space-y-4">
+      <header className="rounded-lg bg-mc-bg-secondary border border-mc-border p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <span className={`text-xs px-2 py-0.5 rounded border ${badge.cls}`}>{badge.label}</span>
+          {agent && (
+            <span className="text-xs text-mc-text-secondary">
+              {agent.avatar_emoji ? `${agent.avatar_emoji} ` : ''}{agent.name}
+            </span>
+          )}
+          {proposal.applied_at && (
+            <span className="text-xs text-mc-text-secondary" title={proposal.applied_at}>
+              · applied {relativeTime(proposal.applied_at)}
+            </span>
+          )}
+          <div className="ml-auto flex items-center gap-2">
+            <Link
+              href={`/pm/proposals/${proposal.id}`}
+              title="Open the standalone proposal page"
+              className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-mc-border text-mc-text-secondary hover:text-mc-text hover:border-mc-accent/40"
+            >
+              <ExternalLink className="w-3 h-3" /> Full page
+            </Link>
+            <button
+              onClick={onRevert}
+              disabled={reverting}
+              title={
+                isRevertItself
+                  ? 'Revert this revert (synthesizes another inverse — produces the original forward state)'
+                  : 'Synthesize an inverse proposal in draft status. Nothing mutates until you accept the revert.'
+              }
+              className="text-xs px-2 py-1 rounded border border-mc-border text-mc-text-secondary hover:text-mc-text hover:border-mc-accent/40 inline-flex items-center gap-1 disabled:opacity-50"
+            >
+              <RotateCcw className="w-3 h-3" /> {reverting ? 'Reverting…' : 'Revert'}
+            </button>
+          </div>
+        </div>
+        <h2 className="text-lg font-semibold text-mc-text">
+          {targetTitle ?? <span className="text-mc-text-secondary italic">(no target initiative)</span>}
+        </h2>
+        {proposal.reverts_proposal_id && (
+          <div className="mt-2 text-xs text-mc-text-secondary">
+            Reverts proposal{' '}
+            <Link
+              href={`/pm/proposals/${proposal.reverts_proposal_id}`}
+              className="text-mc-accent hover:underline font-mono"
+            >
+              {proposal.reverts_proposal_id.slice(0, 8)}
+            </Link>
+          </div>
+        )}
       </header>
 
-      <main className="max-w-5xl mx-auto space-y-4">
-        <FilterBar
-          availableKinds={availableKinds}
-          availableAgents={availableAgents}
-          agents={agents}
-          activeKinds={activeKinds}
-          activeAgent={activeAgent}
-          dateRange={dateRange}
-          onToggleKind={toggleKind}
-          onSetAgent={setActiveAgent}
-          onSetDateRange={setDateRange}
-          totalCount={proposals.length}
-          shownCount={visibleProposals.length}
-        />
-
-        {error && (
-          <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300 text-sm">
-            {error}
-          </div>
-        )}
-
-        {loading ? (
-          <p className="text-mc-text-secondary">Loading activity…</p>
-        ) : visibleProposals.length === 0 ? (
-          <p className="text-mc-text-secondary">
-            No accepted proposals match these filters.
-          </p>
-        ) : (
-          <ul className="space-y-2">
-            {visibleProposals.map(p => (
-              <ActivityRow
-                key={p.id}
-                proposal={p}
-                agent={p.applied_by_agent_id ? agents[p.applied_by_agent_id] : undefined}
-                targetTitle={
-                  p.target_initiative_id ? initiatives[p.target_initiative_id]?.title : undefined
-                }
-                expanded={!!expanded[p.id]}
-                onToggle={() =>
-                  setExpanded(prev => ({ ...prev, [p.id]: !prev[p.id] }))
-                }
-                onRevert={() => onRevert(p)}
-                reverting={reverting === p.id}
-              />
-            ))}
-          </ul>
-        )}
-      </main>
+      <section className="rounded-lg bg-mc-bg-secondary border border-mc-border p-4">
+        <h3 className="text-xs uppercase tracking-wide text-mc-text-secondary/70 mb-3">
+          Diffs ({proposal.proposed_changes.length})
+        </h3>
+        <ProposalDiffsList diffs={proposal.proposed_changes} showAll />
+      </section>
     </div>
   );
 }
@@ -345,108 +516,6 @@ function FilterBar({
         </div>
       </div>
     </div>
-  );
-}
-
-function ActivityRow({
-  proposal,
-  agent,
-  targetTitle,
-  expanded,
-  onToggle,
-  onRevert,
-  reverting,
-}: {
-  proposal: PmProposal;
-  agent?: AgentLite;
-  targetTitle?: string;
-  expanded: boolean;
-  onToggle: () => void;
-  onRevert: () => void;
-  reverting: boolean;
-}) {
-  const badge = triggerBadgeFor(proposal.trigger_kind);
-  const appliedRaw = proposal.applied_at;
-  const applied = appliedRaw ? new Date(
-    /T.*Z$|[+-]\d{2}:?\d{2}$/.test(appliedRaw) ? appliedRaw : appliedRaw.replace(' ', 'T') + 'Z',
-  ) : null;
-  const summary = proposal.proposed_changes.length > 0
-    ? proposal.proposed_changes.length === 1
-      ? summarizeDiff(proposal.proposed_changes[0])
-      : `${proposal.proposed_changes.length} changes`
-    : '(no diffs)';
-  const isRevertItself = proposal.trigger_kind === 'revert';
-
-  return (
-    <li className="rounded-lg bg-mc-bg-secondary border border-mc-border hover:border-mc-accent/40">
-      <div className="flex items-center gap-2 p-3">
-        <button
-          onClick={onToggle}
-          aria-expanded={expanded}
-          aria-label={expanded ? 'Collapse diff list' : 'Expand diff list'}
-          className="p-1 rounded hover:bg-mc-bg text-mc-text-secondary"
-        >
-          {expanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-        </button>
-        <span className={`text-xs px-2 py-0.5 rounded border ${badge.cls}`}>
-          {badge.label}
-        </span>
-        <button onClick={onToggle} className="text-left flex-1 min-w-0 hover:text-mc-accent">
-          <div className="text-sm text-mc-text truncate">
-            {targetTitle ?? <span className="text-mc-text-secondary italic">(no target)</span>}
-          </div>
-          <div className="text-xs text-mc-text-secondary truncate">{summary}</div>
-        </button>
-        <div className="text-xs text-mc-text-secondary text-right shrink-0">
-          {applied && appliedRaw && (
-            <div title={applied.toISOString()}>
-              {relativeTime(appliedRaw)}
-            </div>
-          )}
-          {agent && (
-            <div className="text-[11px]">
-              {agent.avatar_emoji ? `${agent.avatar_emoji} ` : ''}
-              {agent.name}
-            </div>
-          )}
-        </div>
-        <Link
-          href={`/pm/proposals/${proposal.id}`}
-          title="Open proposal detail page"
-          className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text"
-        >
-          <ExternalLink className="w-3.5 h-3.5" />
-        </Link>
-        <button
-          onClick={onRevert}
-          disabled={reverting}
-          title={
-            isRevertItself
-              ? 'Revert this revert (synthesizes another inverse — produces the original forward state)'
-              : 'Synthesize an inverse proposal in draft status. Nothing mutates until you accept the revert.'
-          }
-          className="text-xs px-2 py-1 rounded border border-mc-border text-mc-text-secondary hover:text-mc-text hover:border-mc-accent/40 inline-flex items-center gap-1 disabled:opacity-50"
-        >
-          <RotateCcw className="w-3 h-3" /> {reverting ? 'Reverting…' : 'Revert'}
-        </button>
-      </div>
-      {expanded && (
-        <div className="border-t border-mc-border/60 px-3 py-2">
-          <ProposalDiffsList diffs={proposal.proposed_changes} showAll />
-          {proposal.reverts_proposal_id && (
-            <div className="mt-2 text-[11px] text-mc-text-secondary">
-              Reverts proposal{' '}
-              <Link
-                href={`/pm/proposals/${proposal.reverts_proposal_id}`}
-                className="text-mc-accent hover:underline font-mono"
-              >
-                {proposal.reverts_proposal_id.slice(0, 8)}
-              </Link>
-            </div>
-          )}
-        </div>
-      )}
-    </li>
   );
 }
 

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef, useState, useCallback } from 'react';
-import { X, Save, Trash2, Activity, Package, Bot, ClipboardList, Plus, Users, ImageIcon, Truck, Radio, MessageSquare, ExternalLink, HardDrive, Archive, ArchiveRestore, Paperclip, Upload, Link as LinkIcon, FileText, BookOpen, Send } from 'lucide-react';
+import { X, Save, Trash2, Activity, Package, Bot, ClipboardList, Plus, Users, ImageIcon, Truck, Radio, MessageSquare, ExternalLink, HardDrive, Archive, ArchiveRestore, Paperclip, Upload, Link as LinkIcon, FileText, BookOpen, Send, Maximize2, Minimize2 } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import { triggerAutoDispatch, shouldTriggerAutoDispatch } from '@/lib/auto-dispatch';
 import { ActivityLog } from './ActivityLog';
@@ -151,6 +151,27 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
   const [activeTab, setActiveTab] = useState<TabType>(
     task?.status === 'planning' ? 'planning' : task?.status === 'convoy_active' ? 'convoy' : 'overview'
   );
+  // "Focus" toggle — promotes the modal from the default ~1024px width
+  // to near-full viewport so long descriptions and tab content (planning
+  // diffs, deliverables, activity feed) get real horizontal room.
+  // Persisted in localStorage so once the operator opts into the wider
+  // layout it sticks across task opens.
+  const FOCUS_LS_KEY = 'mc:taskModal:focus';
+  const [focused, setFocused] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(FOCUS_LS_KEY) === '1';
+  });
+  const toggleFocus = () => {
+    setFocused(v => {
+      const next = !v;
+      try {
+        window.localStorage.setItem(FOCUS_LS_KEY, next ? '1' : '0');
+      } catch {
+        /* private mode — ignore */
+      }
+      return next;
+    });
+  };
 
   // Stable callback for when spec is locked - use window.location.reload() to refresh data
   const handleSpecLocked = useCallback(() => {
@@ -482,10 +503,16 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
   ];
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50 p-3 sm:p-4">
-      <div className="bg-mc-bg-secondary border border-mc-border rounded-t-xl sm:rounded-lg w-full max-w-5xl max-h-[92vh] sm:max-h-[92vh] h-[92vh] flex flex-col pb-[env(safe-area-inset-bottom)] sm:pb-0">
+    <div className={`fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50 ${
+      focused ? 'p-2' : 'p-3 sm:p-4'
+    }`}>
+      <div className={`bg-mc-bg-secondary border border-mc-border rounded-t-xl sm:rounded-lg w-full flex flex-col pb-[env(safe-area-inset-bottom)] sm:pb-0 ${
+        focused
+          ? 'max-w-[1700px] max-h-[96vh] h-[96vh]'
+          : 'max-w-5xl max-h-[92vh] sm:max-h-[92vh] h-[92vh]'
+      }`}>
         {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-mc-border shrink-0">
+        <div className="flex items-center justify-between p-4 border-b border-mc-border shrink-0 gap-2">
           <div className="flex items-center gap-3 min-w-0">
             {task && (
               <span
@@ -502,12 +529,22 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
               {task ? task.title : 'Create New Task'}
             </h2>
           </div>
-          <button
-            onClick={onClose}
-            className="p-1 hover:bg-mc-bg-tertiary rounded-sm shrink-0"
-          >
-            <X className="w-5 h-5" />
-          </button>
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              onClick={toggleFocus}
+              title={focused ? 'Exit focus mode (compact width)' : 'Enter focus mode (use full viewport width)'}
+              aria-label={focused ? 'Exit focus mode' : 'Enter focus mode'}
+              className="hidden sm:flex p-1.5 hover:bg-mc-bg-tertiary rounded-sm text-mc-text-secondary hover:text-mc-text"
+            >
+              {focused ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
+            </button>
+            <button
+              onClick={onClose}
+              className="p-1 hover:bg-mc-bg-tertiary rounded-sm"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
         </div>
 
         {/* Tabs - only show for existing tasks */}


### PR DESCRIPTION
## Summary

Round 3 in the layout-overhaul series ([#142](https://github.com/smb209/mission-control/pull/142), [#143](https://github.com/smb209/mission-control/pull/143)). Three orthogonal cosmetic-ish wins, kept together because they share no code paths but ship the same vibe — make wide-monitor operators feel like the UI knows about their viewport.

## Changes

### PM activity (`/pm/activity`) → master-detail
- Convert from a tall scrolling list with per-row inline-expand to a master-detail layout using `PageWithRails`.
- Filters + compact rows live in the left rail (`w-[24rem]`, flush left).
- Selecting a row renders the proposal's full diff list + metadata + Revert button in the main pane.
- URL-backed via `?selected=<proposal_id>` for bookmarks + back/forward; local state is the source of truth so the pane re-renders immediately on click.
- Empty state in the pane until a row is picked. Standalone \`/pm/proposals/[id]\` page is unchanged and reachable via a \"Full page\" button on the pane header.

### Task modal (\`TaskModal\`) → Focus toggle
- New Maximize/Minimize icon next to the X promotes the modal from \`max-w-5xl\` (~1024px) to \`max-w-[1700px]\` + \`h-[96vh]\`.
- Operators get real horizontal room for the Description textarea and tab content (planning diffs, deliverables, activity feed).
- Preference persisted to \`localStorage[\"mc:taskModal:focus\"]\` so it sticks across opens.

### Deliverables (\`/deliverables\`) → card grid
- Replace the table with a responsive 1 / 2 / 3 / 4-column card grid (sm/xl/2xl breakpoints).
- Each card: status pill + archived badge → task title (\`line-clamp-2\`) → file count + updated time → Download.
- Per-column sort buttons gone; a single \"Sort cards\" \`<select>\` in the page header offers Newest/Oldest/Title/Files/Status keyed off the existing sort state.

## Test plan

- [x] \`yarn tsc --noEmit\` — no new errors (the 2 in \`pm-decompose.test.ts\` are pre-existing on \`main\`).
- [x] \`/pm/activity\`: rail flush left at viewport x=256; clicking a row sets \`?selected=<id>\` and renders the pane.
- [x] TaskModal: Maximize2 click flips width 1024 → 1584px (1600px viewport), Minimize2 appears, value persisted in \`localStorage\`.
- [x] \`/deliverables\`: card grid renders, sort dropdown switches order.
- [ ] Operator sanity check: open a real task, toggle focus, edit a long description; reload — focus mode should still be on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)