### PR TITLE
fix(pm-dispatch): embed agent UUID + gateway id in dispatch briefing

### DIFF
--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -137,6 +137,21 @@ function namedAgentTimeoutMs(): number {
 }
 
 /**
+ * Identity preamble prepended to every PM dispatch message. Required because
+ * `gateway_agent_id` is org-wide (PR #133): a single gateway id like
+ * `mc-project-manager` legitimately maps to N rows after workspace cloning,
+ * so `whoami({ agent_id: gateway_agent_id })` returns `ambiguous_gateway_id`.
+ * Embedding the workspace-scoped UUID up front lets the agent skip whoami
+ * entirely and call `propose_changes` immediately.
+ */
+function buildIdentityPreamble(pm: Agent): string {
+  return (
+    `Your agent_id is: ${pm.id}\n` +
+    `Your gateway_agent_id is: ${pm.gateway_agent_id ?? '(unset)'}\n\n`
+  );
+}
+
+/**
  * Top-level disruption dispatch. Returns the synth placeholder row
  * synchronously so the API can respond fast; the named-agent dispatch
  * runs in the background and either supersedes the placeholder via SSE
@@ -255,10 +270,12 @@ async function runDisruptionDispatchInBackground(
   const correlationId = uuidv4();
   const sinceIso = new Date().toISOString();
   const summary = buildSnapshotSummary(snapshot);
+  const preamble = buildIdentityPreamble(pm);
   const message =
     input.trigger_kind === 'notes_intake'
-      ? buildNotesIntakeMessage({ correlationId, notes: input.trigger_text, summary })
-      : `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
+      ? preamble + buildNotesIntakeMessage({ correlationId, notes: input.trigger_text, summary })
+      : preamble +
+        `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
         `Operator-reported event:\n> ${input.trigger_text}\n\n` +
         `Workspace snapshot summary (call \`get_roadmap_snapshot\` via MCP for full detail):\n\n` +
         `${summary}\n\n` +
@@ -527,6 +544,7 @@ async function runNamedAgentDispatchInBackground(
     result = await sendChatAndAwaitReply({
       agent: pm,
       message:
+        buildIdentityPreamble(pm) +
         `**PM ${input.trigger_kind} (correlation_id: ${correlationId})**\n\n` +
         input.agent_prompt,
       idempotencyKey: `pm-${input.trigger_kind}-${correlationId}`,

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -351,6 +351,17 @@ test('dispatchPm: routes through named agent when openclaw is connected; mock cr
     assert.ok(send);
     const sk = (send!.params as { sessionKey?: string }).sessionKey;
     assert.equal(sk, `agent:${TEST_PM_GATEWAY_AGENT_ID}:main:dispatch-main`);
+    // Identity preamble must embed the PM's MC agent_id (UUID) so the agent
+    // can call propose_changes without round-tripping whoami — required since
+    // PR #133 made gateway_agent_id ambiguous across cloned workspaces.
+    const pm = queryOne<{ id: string }>(
+      `SELECT id FROM agents WHERE workspace_id = ? AND is_pm = 1`,
+      [ws],
+    );
+    assert.ok(pm);
+    const msg = (send!.params as { message?: string }).message ?? '';
+    assert.match(msg, new RegExp(`Your agent_id is: ${pm!.id}`));
+    assert.match(msg, new RegExp(`Your gateway_agent_id is: ${TEST_PM_GATEWAY_AGENT_ID}`));
   } finally {
     __setOpenClawClientForTests(null);
     __setNamedAgentTimeoutForTests(null);


### PR DESCRIPTION
## Summary
- Every PM Chat reply was falling back to the synth-only placeholder ("No structured changes inferred — disruption acknowledged") because the dispatched PM agent couldn't resolve its own `agent_id`. After PR #133 made `gateway_agent_id` org-wide, `whoami({ agent_id: gateway_id })` returns `ambiguous_gateway_id` for any cloned workspace — and the dispatch briefing wasn't embedding the UUID despite the whoami error promising "the dispatch briefing embeds it as `Your agent_id is: …`".
- Adds `buildIdentityPreamble(pm)` and prepends it to all three dispatch message builders (disruption, notes-intake, synthesized for plan/decompose).
- Regression test in `pm.test.ts` asserts the briefing contains the UUID and gateway id; full 25/25 suite passes.

## Test plan
- [x] `pm.test.ts` — 25/25 pass, including the new regression assertions.
- [ ] Live PM Chat dispatch on FOIA workspace — send a real disruption, confirm the dev log shows `[pm-dispatch] disruption reconciler matched agent row` instead of `… timed out for placeholder … marking synth_only`, and the proposal lands with real diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)