### PR TITLE
spec(scope-keyed-sessions): end-of-durable-worker-agents + validation pack

### DIFF
--- a/scripts/seed-foia-fixture.ts
+++ b/scripts/seed-foia-fixture.ts
@@ -1,0 +1,177 @@
+/**
+ * Seeds the canonical FOIA initiative tree fixture used by the
+ * scope-keyed-sessions validation pack. See
+ * `specs/scope-keyed-sessions-validation/01-pre-check-initialization.md` §6.
+ *
+ * Idempotent: re-running against an existing FOIA workspace updates titles
+ * but does not duplicate rows. Safe to run after `yarn db:reset`.
+ *
+ * Tree shape (mirrors the production fixture seen in dispatch traces):
+ *   FOIA Request Pipeline                    (milestone)
+ *   ├── Discovery for FOIA Request Pipeline  (epic)
+ *   │   ├── Agency Profile Schema & Data Model
+ *   │   ├── Governing Statute & Records Officer Lookup
+ *   │   ├── Intake Channel Detection (Email, Portal Form, Mail)
+ *   │   ├── Fee Policy & Statutory Response Deadline Extraction
+ *   │   ├── Profile Validation & Screenshot Evidence
+ *   │   ├── Cache Persistence & Query Layer
+ *   │   └── Verification for FOIA Request Pipeline
+ *   └── Implementation for FOIA Request Pipeline (story sibling)
+ *
+ * Output: prints workspace_id and a tree summary on stdout. Captures the
+ * initiative ids to stderr (one per line) for downstream test scripts.
+ */
+
+import { closeDb, getDb, queryAll, queryOne, run } from '../src/lib/db';
+import { createInitiative } from '../src/lib/db/initiatives';
+import { ensurePmAgent } from '../src/lib/bootstrap-agents';
+import { v4 as uuidv4 } from 'uuid';
+
+interface SeededInitiative {
+  id: string;
+  kind: 'milestone' | 'epic' | 'story';
+  title: string;
+  parent: string | null;
+}
+
+const STORIES_UNDER_DISCOVERY = [
+  'Agency Profile Schema & Data Model',
+  'Governing Statute & Records Officer Lookup',
+  'Intake Channel Detection (Email, Portal Form, Mail)',
+  'Fee Policy & Statutory Response Deadline Extraction',
+  'Profile Validation & Screenshot Evidence',
+  'Cache Persistence & Query Layer',
+  'Verification for FOIA Request Pipeline',
+];
+
+function ensureFoiaWorkspace(): string {
+  const existing = queryOne<{ id: string }>(
+    `SELECT id FROM workspaces WHERE slug = 'foia' LIMIT 1`,
+  );
+  if (existing) return existing.id;
+
+  const id = uuidv4();
+  run(
+    `INSERT INTO workspaces (id, name, slug, created_at)
+     VALUES (?, 'FOIA', 'foia', datetime('now'))`,
+    [id],
+  );
+  return id;
+}
+
+function findInitiativeByTitle(workspaceId: string, title: string): { id: string } | null {
+  return queryOne<{ id: string }>(
+    `SELECT id FROM initiatives WHERE workspace_id = ? AND title = ? LIMIT 1`,
+    [workspaceId, title],
+  ) ?? null;
+}
+
+function ensureInitiative(
+  workspaceId: string,
+  kind: 'milestone' | 'epic' | 'story',
+  title: string,
+  parentId: string | null,
+  extras: { description?: string; target_end?: string } = {},
+): string {
+  const existing = findInitiativeByTitle(workspaceId, title);
+  if (existing) return existing.id;
+  const created = createInitiative({
+    workspace_id: workspaceId,
+    kind,
+    title,
+    parent_initiative_id: parentId,
+    description: extras.description ?? null,
+    target_end: extras.target_end ?? null,
+  });
+  return created.id;
+}
+
+function plus90Days(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 90);
+  return d.toISOString().slice(0, 10);
+}
+
+function seedFoiaFixture(): void {
+  // Touch the DB once up-front so migrations run if this is a fresh DB.
+  getDb();
+
+  const workspaceId = ensureFoiaWorkspace();
+  ensurePmAgent(workspaceId);
+
+  const seeded: SeededInitiative[] = [];
+
+  const milestoneId = ensureInitiative(
+    workspaceId,
+    'milestone',
+    'FOIA Request Pipeline',
+    null,
+    {
+      description:
+        'End-to-end pipeline for filing, tracking, and reasoning over public-records requests. Reaches every US state + federal agencies.',
+      target_end: plus90Days(),
+    },
+  );
+  seeded.push({ id: milestoneId, kind: 'milestone', title: 'FOIA Request Pipeline', parent: null });
+
+  const discoveryId = ensureInitiative(
+    workspaceId,
+    'epic',
+    'Discovery for FOIA Request Pipeline',
+    milestoneId,
+    {
+      description:
+        'Pre-build research and schema discovery: agency profiles, statutes, intake channels, fees, validation.',
+    },
+  );
+  seeded.push({
+    id: discoveryId,
+    kind: 'epic',
+    title: 'Discovery for FOIA Request Pipeline',
+    parent: milestoneId,
+  });
+
+  for (const title of STORIES_UNDER_DISCOVERY) {
+    const id = ensureInitiative(workspaceId, 'story', title, discoveryId);
+    seeded.push({ id, kind: 'story', title, parent: discoveryId });
+  }
+
+  const implementationId = ensureInitiative(
+    workspaceId,
+    'story',
+    'Implementation for FOIA Request Pipeline',
+    milestoneId,
+    {
+      description:
+        'Build phase. Picks up after Discovery hands off agency cache + statute set + channel detector.',
+    },
+  );
+  seeded.push({
+    id: implementationId,
+    kind: 'story',
+    title: 'Implementation for FOIA Request Pipeline',
+    parent: milestoneId,
+  });
+
+  // Output summary to stdout (machine-parseable).
+  console.log(JSON.stringify({ workspace_id: workspaceId, initiatives: seeded }, null, 2));
+
+  // Pretty-print to stderr for human consumption.
+  process.stderr.write(`\nFOIA fixture ready in workspace ${workspaceId}\n\n`);
+  for (const init of seeded) {
+    const indent = init.kind === 'milestone' ? '' : init.kind === 'epic' ? '  ' : '    ';
+    process.stderr.write(`${indent}${init.kind.padEnd(9)} ${init.id}  ${init.title}\n`);
+  }
+
+  const counts = queryAll<{ kind: string; n: number }>(
+    `SELECT kind, COUNT(*) AS n FROM initiatives WHERE workspace_id = ? GROUP BY kind`,
+    [workspaceId],
+  );
+  process.stderr.write('\nCounts: ');
+  process.stderr.write(counts.map((c) => `${c.kind}=${c.n}`).join(', '));
+  process.stderr.write('\n');
+
+  closeDb();
+}
+
+seedFoiaFixture();

--- a/specs/scope-keyed-sessions-validation/00-baseline-observations.md
+++ b/specs/scope-keyed-sessions-validation/00-baseline-observations.md
@@ -1,0 +1,193 @@
+# Baseline Observations — Pre-Phase-A
+
+> **Purpose:** State of the dev environment as of the spec's authoring,
+> captured for diff against later milestone runs. Read-only snapshot —
+> no DB modifications, no destructive commands, no interruption to the
+> live dev session.
+
+> **Captured:** 2026-05-02 evening. Before any phase of
+> [`scope-keyed-sessions.md`](../scope-keyed-sessions.md) lands.
+
+---
+
+## 1. Live dev DB state
+
+### Workspaces
+| id | name | slug |
+|---|---|---|
+| `default` | Default Workspace | `default` |
+| `1286dad1-b106-4c2a-9603-20a88add16d0` | FOIA | `foia` |
+
+### Agent rows (the ambiguity surface)
+
+`mc-runner-dev` exists in the `default` workspace only. The user
+created it for this work. **Critical:** `mc-runner-dev` does NOT yet
+exist in any other workspace, which means the spec can land Phase F
+without having to clean up cloned-runner duplicates.
+
+The other gateway-synced agents (`mc-builder-dev`, `mc-coordinator-dev`,
+`mc-tester-dev`, `mc-reviewer-dev`, `mc-writer-dev`, `mc-researcher-dev`,
+`mc-learner-dev`, `mc-project-manager-dev`) exist as expected: one row
+per workspace per gateway agent. The `mc-project-manager-dev` row
+exists in **both** `default` and FOIA workspaces — this is the
+ambiguity that drove this morning's PM Chat bug.
+
+Counts:
+- `default` workspace: 18 agent rows (8 dev + 8 prod variants + `mc-runner-dev` + `main`).
+- `FOIA` workspace: 9 agent rows (8 dev variants + `main`).
+
+After Phase F the table should collapse to:
+- `mc-runner-dev` × 1 (default workspace)
+- `Project Manager` × 2 (one per workspace, `is_pm=1`, `gateway_agent_id=NULL`)
+
+That's it. Everything else gets nulled `gateway_agent_id` and the
+catalog sync stops re-creating them.
+
+### Initiatives
+
+| Workspace | Count |
+|---|---|
+| `default` | 71 |
+| `foia` | 11 |
+
+The FOIA tree (11 initiatives) matches the structure the seed fixture
+recreates in [`scripts/seed-foia-fixture.ts`](../../scripts/seed-foia-fixture.ts):
+1 milestone, 1 epic, 8 stories, 1 sibling story.
+
+### Migrations head
+
+Latest applied: `063_pm_proposals_decompose_story_trigger_kind`.
+
+Phase A lands migrations 064–068 (per spec Appendix B):
+- 064 agent-role-overrides
+- 065 agent-notes
+- 066 mc-sessions
+- 067 recurring-jobs
+- 068 coordinator-mode
+
+---
+
+## 2. MCP tool surface (current)
+
+Existing tools that survive the refactor unchanged:
+- `whoami`, `propose_changes`, `log_activity`, `register_deliverable`
+- `update_task_status`, `save_checkpoint`, `send_mail`, `fetch_mail`
+- `list_peers`, `get_task`, `propose_from_notes`, `refine_proposal`
+- `spawn_subtask`, `cancel_subtask`, `accept_subtask`, `reject_subtask`
+
+Tools added by Phase A:
+- `take_note`, `read_notes`, `mark_note_consumed`, `archive_note`
+
+No tools are deprecated by the spec. `spawn_subtask` survives but its
+target peers shift from durable gateway agents to scope-keyed sessions
+on `mc-runner-dev`.
+
+---
+
+## 3. Test suite state
+
+`yarn test` last reported green from this morning's `pm.test.ts` run
+(25/25 passing) after the identity-preamble fix landed. Pre-existing
+TypeScript errors in `pm-decompose.test.ts:169` and
+`pm-decompose.test.ts:173` are tracked, unrelated, and acceptable per
+CLAUDE.md.
+
+`yarn tsc --noEmit` total error count: **2** (the same two). The new
+`scripts/seed-foia-fixture.ts` typechecks clean.
+
+---
+
+## 4. Openclaw workspace inventory
+
+User-visible at `~/.openclaw/workspaces/`:
+- 18 directories total.
+- 8 role-specific workspace pairs (`mc-{role}` and `mc-{role}-dev`).
+- `mc-runner` and `mc-runner-dev` (created by user for this work).
+- Shared docs at workspace-root level: `MEMORY-ORG.md`,
+  `MESSAGING-PROTOCOL.md`, `SHARED-RULES.md` — symlinked into each
+  agent workspace.
+
+`mc-runner-dev/` currently contains a *verbatim copy* of
+`mc-project-manager-dev/`'s SOUL/AGENTS/IDENTITY (PM-flavored, "Margaret
+Hamilton"). This needs neutralization in Phase C — replaced with the
+generic host docs from `agent-templates/runner-host/`.
+
+`mc-runner-dev/MC-CONTEXT.json` reports `my_gateway_id: mc-project-manager`
+— a leftover from the copy. Should self-heal on the first dispatch
+under the new architecture (MC writes this file). Non-blocking.
+
+---
+
+## 5. The PM Chat bug (this morning's fix)
+
+Confirmed fixed by [`pm-dispatch.ts:140 buildIdentityPreamble`](../../src/lib/agents/pm-dispatch.ts:140).
+The dispatch now embeds:
+```
+Your agent_id is: <UUID>
+Your gateway_agent_id is: mc-project-manager-dev
+```
+
+The agent skips the `whoami` round-trip entirely. Test coverage in
+[`pm.test.ts:357`](../../src/lib/agents/pm.test.ts:357) asserts the
+preamble appears in every dispatch.
+
+This means the validation pack's regression scenario S10.1 should pass
+on the current commit. (It hasn't been executed yet — it'll run when
+Phase A lands and the full plan goes green for the first time.)
+
+---
+
+## 6. Risk inventory at start of build
+
+| Risk | Mitigation in spec | Phase landing |
+|---|---|---|
+| Dual writes during phase A→B transition (old + new dispatch paths) | Feature flag per phase | A onward |
+| Test workspace pollution from real-agent runs | Validation pack pre-check wipes DB | every milestone |
+| Notes table growth | 90d archival pass, indexed by recent-time | F follow-up |
+| Trajectory file growth (recurring jobs) | After 5 compactions, mint new attempt key | E |
+| Briefing length overflow | Hard cap, oldest-first truncation, p95 metric | B |
+| Notes spam | Rubric-scored against rate; tighten addendum | C |
+| Operator note-fatigue | importance levels, filter chips on `/feed` | D |
+| Real-agent flake | up to 3 retries, FLAKE marker, 90min wall-clock | every milestone |
+| Pre-existing pm-decompose typecheck errors | Excluded from gates | already noted in CLAUDE.md |
+
+---
+
+## 7. Open work hand-off
+
+**Tonight's deliverables (this commit):**
+- [x] [`specs/scope-keyed-sessions.md`](../scope-keyed-sessions.md) — full spec, 804 lines.
+- [x] [`specs/scope-keyed-sessions-validation/01-pre-check-initialization.md`](01-pre-check-initialization.md) — destructive runbook for fresh-state setup.
+- [x] [`specs/scope-keyed-sessions-validation/02-test-plan.md`](02-test-plan.md) — concrete dispatch scenarios per role.
+- [x] [`specs/scope-keyed-sessions-validation/03-validation-criteria.md`](03-validation-criteria.md) — pass/fail per scenario + global gates.
+- [x] [`scripts/seed-foia-fixture.ts`](../../scripts/seed-foia-fixture.ts) — idempotent FOIA tree fixture for tests.
+- [x] [`specs/scope-keyed-sessions-validation/00-baseline-observations.md`](00-baseline-observations.md) — this file.
+
+**For morning review:**
+1. Read the spec — push back on anything that's wrong; the design is
+   not yet locked in code.
+2. Read the validation pack — confirm the scenarios cover what you
+   actually need to feel confident shipping.
+3. Decide: green-light Phase A implementation, or iterate the spec
+   first.
+
+**What I did NOT do tonight:**
+- Did not run the destructive pre-check (would have wiped your live
+  PM Chat dev session).
+- Did not start Phase A implementation (waiting for green light).
+- Did not run the LLM-as-judge eval harness (doesn't exist yet — it's
+  built in Phase B).
+- Did not push or open a PR.
+
+**What I'm ready to do once green-lit:**
+- Spawn worktree subagents in parallel for Phase A's slices (migrations,
+  MCP tools family, agent-templates/ seed, briefing builder skeleton).
+- Run the pre-check + test plan + validation criteria after each slice.
+- Halt and surface any FAIL or unexpected behavior, per
+  [`03-validation-criteria.md`](03-validation-criteria.md) §halt-criteria.
+
+The validation pack is intentionally over-specified for Phase A
+(many scenarios will be N/A until later phases implement the
+underlying flow). Per spec §6.1, each phase activates more rows in the
+applicability matrix in [`03-validation-criteria.md`](03-validation-criteria.md);
+gate thresholds themselves don't change between phases.

--- a/specs/scope-keyed-sessions-validation/01-pre-check-initialization.md
+++ b/specs/scope-keyed-sessions-validation/01-pre-check-initialization.md
@@ -1,0 +1,322 @@
+# Pre-Check Initialization — Scope-Keyed Sessions
+
+> **Purpose:** Before running the test plan at any milestone, bring the
+> dev environment to a known-good baseline. This file is the runbook;
+> every step has a concrete command and an expected output. If any
+> check fails, **halt** and surface the failure in the observations
+> log — do not skip steps.
+
+> **Scope:** This is a **destructive** runbook (wipes the dev DB).
+> Never execute it while the operator is actively using the dev server
+> at `localhost:4010` or `192.168.50.95:4010`. Confirm the operator
+> has signed off before running.
+
+> **Companion files:** [`02-test-plan.md`](02-test-plan.md),
+> [`03-validation-criteria.md`](03-validation-criteria.md).
+
+---
+
+## 0. Prerequisites
+
+| Check | Command | Expected |
+|---|---|---|
+| Repo clean | `git status --porcelain` | empty |
+| On feature branch | `git rev-parse --abbrev-ref HEAD` | not `main` |
+| Spec exists | `test -f specs/scope-keyed-sessions.md && echo ok` | `ok` |
+| Dev server stopped | `lsof -ti :4010 \|\| echo none` | `none` (or kill it: `kill $(lsof -ti :4010)`) |
+| Openclaw gateway running | `lsof -ti :18789 \|\| echo none` | non-empty |
+| `spark-lb/agent` model reachable | `curl -sS http://localhost:18789/health \|\| true` | non-error |
+
+If any prerequisite fails, fix it before continuing. **Especially** the
+dev-server-stopped check — wiping the DB while Next.js holds a
+connection corrupts the WAL.
+
+---
+
+## 1. Wipe and reseed the dev DB
+
+```bash
+cd /Users/snappytwo/snappytwo-sandbox/mission-control
+
+# Drop the dev database. The /dev-sync skill is canonical for this:
+#   wipes mission-control.db, syncs agents from openclaw,
+#   imports prod data with mc-* → mc-*-dev remap.
+# We run a stricter version — no prod data import, just a clean slate.
+
+rm -f mission-control.db mission-control.db-shm mission-control.db-wal
+yarn db:seed
+```
+
+**Expected:**
+- `mission-control.db` recreated (size > 0).
+- All migrations run to head (count line in seed log: `[DB] Migration NNN completed` for each).
+- Default workspace exists, no other workspaces.
+
+**Validation:**
+```bash
+sqlite3 mission-control.db "SELECT count(*) FROM workspaces;"  # expect 1
+sqlite3 mission-control.db "SELECT count(*) FROM agents;"       # expect 0 or 1 (PM placeholder per workspace)
+sqlite3 mission-control.db "SELECT MAX(version) FROM migration_history;"  # expect latest applied
+```
+
+---
+
+## 2. Verify migrations include this spec's additions
+
+After Phase A, the schema must include:
+
+```bash
+sqlite3 mission-control.db ".schema agent_role_overrides" \
+  | grep -q "soul_md" && echo "agent_role_overrides ok" || echo "FAIL"
+
+sqlite3 mission-control.db ".schema agent_notes" \
+  | grep -q "run_group_id" && echo "agent_notes ok" || echo "FAIL"
+
+sqlite3 mission-control.db ".schema mc_sessions" \
+  | grep -q "scope_key" && echo "mc_sessions ok" || echo "FAIL"
+
+sqlite3 mission-control.db ".schema recurring_jobs" \
+  | grep -q "cadence_seconds" && echo "recurring_jobs ok" || echo "FAIL"
+```
+
+**Halt if any prints `FAIL`.** Pre-Phase-A baselines will fail this
+check as expected — record that as the baseline, don't treat it as a
+test failure.
+
+---
+
+## 3. Sync agents from openclaw
+
+```bash
+# Start the dev server (briefly, just to drive the sync).
+PORT=4010 yarn dev > /tmp/mc-dev.log 2>&1 &
+DEV_PID=$!
+
+# Wait for the gateway to connect.
+for i in {1..30}; do
+  curl -sS http://localhost:4010/api/agents 2>/dev/null \
+    | grep -q "mc-runner" && break
+  sleep 1
+done
+
+# Force a sync.
+curl -sS -X POST http://localhost:4010/api/agents/sync \
+  -H "Content-Type: application/json" -d '{}'
+```
+
+**Expected agents table after Phase F:**
+
+```
+sqlite3 -header mission-control.db \
+  "SELECT id, name, gateway_agent_id, source, is_pm
+     FROM agents
+    ORDER BY workspace_id, name;"
+```
+
+Should return only:
+
+| name | gateway_agent_id | source | is_pm |
+|---|---|---|---|
+| `mc-runner-dev` | `mc-runner-dev` | `gateway` | 0 |
+| `Project Manager` (per workspace) | NULL | `local` | 1 |
+
+**Pre-Phase-F baseline** will additionally show: `mc-builder-dev`,
+`mc-coordinator-dev`, `mc-tester-dev`, `mc-reviewer-dev`,
+`mc-writer-dev`, `mc-researcher-dev`, `mc-learner-dev`,
+`mc-project-manager-dev`. Record this as the baseline; do not treat
+as failure pre-migration.
+
+**Halt criterion:** if `mc-runner-dev` is NOT in the list at any phase,
+that's a real failure — the gateway-bound source agent is missing.
+
+---
+
+## 4. Confirm openclaw connection
+
+```bash
+# The /api/health/openclaw endpoint should report connected=true.
+curl -sS http://localhost:4010/api/health/openclaw | tee /tmp/openclaw-health.json
+```
+
+**Expected fields:**
+- `connected: true`
+- `gateway_url: "ws://127.0.0.1:18789"`
+- `agent_count: ≥1`
+
+If `connected: false`: check openclaw is running (`lsof -ti :18789`),
+restart if needed, retry the sync, halt if still failing.
+
+---
+
+## 5. Verify role templates load
+
+```bash
+ls agent-templates/                         # expect: _shared, builder, coordinator, learner, pm, researcher, reviewer, runner-host, tester, writer
+ls agent-templates/_shared/                 # expect: messaging-protocol.md, notetaker.md, shared-rules.md
+test -f agent-templates/builder/SOUL.md && echo "builder template ok"
+test -f agent-templates/runner-host/SOUL.md && echo "runner-host template ok"
+```
+
+**Pre-Phase-A baseline:** `agent-templates/` doesn't exist; record as
+baseline. Phase A creates the directory + seeds it.
+
+---
+
+## 6. Load the FOIA initiative tree
+
+The FOIA tree is the canonical fixture for dispatch tests. It exercises
+all scopes (initiatives, epics, stories, tasks) at meaningful depth.
+
+```bash
+# A new fixture script seeds the tree under a 'foia' workspace.
+yarn tsx scripts/seed-foia-fixture.ts
+```
+
+**The script must:**
+1. Create a workspace named `FOIA` with slug `foia`.
+2. Insert one milestone: "FOIA Request Pipeline" (target_end 90d out).
+3. Insert one epic: "Discovery for FOIA Request Pipeline" (parent: milestone).
+4. Insert seven stories under the epic, mirroring the production fixture seen in dispatch traces:
+   - "Agency Profile Schema & Data Model"
+   - "Governing Statute & Records Officer Lookup"
+   - "Intake Channel Detection (Email, Portal Form, Mail)"
+   - "Fee Policy & Statutory Response Deadline Extraction"
+   - "Profile Validation & Screenshot Evidence"
+   - "Cache Persistence & Query Layer"
+   - "Verification for FOIA Request Pipeline"
+5. Insert "Implementation for FOIA Request Pipeline" as a sibling story to the epic above.
+6. Print the workspace_id and tree summary on stdout.
+
+**Validation:**
+```bash
+WS_ID=$(sqlite3 mission-control.db "SELECT id FROM workspaces WHERE slug='foia';")
+echo "FOIA workspace_id: $WS_ID"
+sqlite3 mission-control.db \
+  "SELECT kind, status, title FROM initiatives WHERE workspace_id='$WS_ID' ORDER BY kind, title;"
+```
+
+Expect 1 milestone, 1–2 epics, ≥7 stories, all `status='planned'`.
+
+**Halt criterion:** if the script fails or the tree shape doesn't match,
+the rest of the test plan can't run — halt.
+
+---
+
+## 7. Confirm SSE channel up
+
+```bash
+# Open the SSE stream for the FOIA workspace and capture for 5 seconds.
+timeout 5 curl -sN \
+  -H "Accept: text/event-stream" \
+  "http://localhost:4010/api/sse?workspace_id=$WS_ID" \
+  > /tmp/sse-precheck.log || true
+
+grep -q "event: connected\|event: heartbeat" /tmp/sse-precheck.log \
+  && echo "SSE ok" || echo "FAIL"
+```
+
+**Halt criterion:** if SSE is dead, observability tests in
+[`02-test-plan.md`](02-test-plan.md) §4 can't run.
+
+---
+
+## 8. Confirm MCP tools enumerate
+
+```bash
+# The MCP server should list all tools, including the notes family
+# after Phase A.
+curl -sS http://localhost:4010/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MC_API_TOKEN" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | tee /tmp/mcp-tools.json | jq -r '.result.tools[].name' | sort > /tmp/mcp-tool-names.txt
+```
+
+**Expected (post Phase A):**
+- `whoami`, `propose_changes`, `log_activity`, `register_deliverable`, `update_task_status`, `save_checkpoint`, `send_mail`, `fetch_mail`, `list_peers`, `get_task` (existing).
+- `take_note`, `read_notes`, `mark_note_consumed`, `archive_note` (new in Phase A).
+- `propose_from_notes`, `refine_proposal`, `spawn_subtask`, `cancel_subtask`, `accept_subtask`, `reject_subtask` (existing).
+
+```bash
+diff <(cat /tmp/mcp-tool-names.txt) \
+     <(printf "accept_subtask\narchive_note\ncancel_subtask\nfetch_mail\nget_task\nlist_peers\nlog_activity\nmark_note_consumed\npropose_changes\npropose_from_notes\nread_notes\nrefine_proposal\nregister_deliverable\nreject_subtask\nsave_checkpoint\nsend_mail\nspawn_subtask\ntake_note\nupdate_task_status\nwhoami\n")
+```
+
+**Pre-Phase-A baseline:** the four notes tools are missing. Record as
+baseline.
+
+---
+
+## 9. Confirm baseline pages render
+
+UI smoke. Fast — used to catch broken builds before running real-agent
+dispatches that take minutes each.
+
+```bash
+# Each of these should return HTTP 200 in <2s.
+for path in / /pm /tasks /agents /feed /workspace/foia/initiatives; do
+  status=$(curl -sS -o /dev/null -w "%{http_code} %{time_total}\n" \
+    "http://localhost:4010$path")
+  echo "$path -> $status"
+done
+```
+
+`/feed` is new in Phase D; pre-Phase-D baseline returns 404, that's
+expected.
+
+---
+
+## 10. Snapshot baseline state
+
+Capture state for diff against post-test-plan state:
+
+```bash
+mkdir -p /tmp/mc-validation/baseline
+sqlite3 mission-control.db ".dump" > /tmp/mc-validation/baseline/db-dump.sql
+cp /tmp/mc-dev.log /tmp/mc-validation/baseline/dev.log
+ls -la /tmp/mc-validation/baseline/
+```
+
+This snapshot lets the test plan compare "what was inserted by the
+test" vs "what existed before".
+
+---
+
+## 11. Stop the dev server
+
+```bash
+kill $DEV_PID 2>/dev/null
+wait $DEV_PID 2>/dev/null || true
+```
+
+Pre-check complete. Proceed to [`02-test-plan.md`](02-test-plan.md).
+
+---
+
+## Pre-check Result Summary Template
+
+When running this checklist, append to `/tmp/mc-validation/precheck-result.md`:
+
+```markdown
+# Pre-Check Result — <date> <commit>
+
+| Step | Status | Notes |
+|---|---|---|
+| 0. Prerequisites | PASS / FAIL | … |
+| 1. Wipe and reseed | PASS / FAIL | <NNN migrations applied> |
+| 2. Spec migrations present | PASS / FAIL / N/A (pre-Phase-A) | … |
+| 3. Agent sync | PASS / FAIL | <list of synced agents> |
+| 4. Openclaw connection | PASS / FAIL | … |
+| 5. Role templates | PASS / FAIL / N/A (pre-Phase-A) | … |
+| 6. FOIA tree loaded | PASS / FAIL | <workspace_id, tree summary> |
+| 7. SSE channel | PASS / FAIL | … |
+| 8. MCP tools enumerate | PASS / FAIL | <list of present + missing> |
+| 9. Baseline pages | PASS / FAIL | … |
+| 10. Baseline snapshot | DONE | <paths> |
+| 11. Cleanup | DONE | … |
+
+**Overall:** READY FOR TEST PLAN / NEEDS REWORK / BLOCKED — <one-line reason>
+```
+
+If overall is `BLOCKED`, log the blocking issue and halt — do not run
+the test plan against a degraded baseline.

--- a/specs/scope-keyed-sessions-validation/02-test-plan.md
+++ b/specs/scope-keyed-sessions-validation/02-test-plan.md
@@ -1,0 +1,485 @@
+# Test Plan — Scope-Keyed Sessions
+
+> **Purpose:** Concrete dispatch scenarios that exercise every flow in
+> the architecture. Each scenario describes setup, action, observation,
+> and what to capture for the validation criteria.
+
+> **Pre-requisite:** [`01-pre-check-initialization.md`](01-pre-check-initialization.md)
+> completed with overall status `READY FOR TEST PLAN`.
+
+> **Companion:** [`03-validation-criteria.md`](03-validation-criteria.md)
+> for pass/fail thresholds.
+
+> **All real-agent dispatches use `spark-lb/agent` per
+> `~/.claude/projects/.../memory/project_openclaw_model.md` —
+> self-hosted, no budget cap, run as many rounds as needed.**
+
+> **Convention:** every scenario captures its raw transcript to
+> `/tmp/mc-validation/<phase>/<scenario_id>/` for forensic review.
+
+---
+
+## Scenario taxonomy
+
+Scenarios are grouped by the dispatch path they exercise:
+
+- **§1 Disruption** — operator drops a disruption into PM Chat.
+- **§2 Plan a draft initiative** — multi-turn refine loop.
+- **§3 Decompose** — initiative and story.
+- **§4 Notes intake** — operator pastes meeting notes.
+- **§5 Task dispatch** — builder/tester/reviewer cycle.
+- **§6 Recurring jobs** — researcher on a 2-day cadence (compressed).
+- **§7 Heartbeat coordinator** — opt-in observational check-ins.
+- **§8 Notes observability** — SSE → UI surfaces fire correctly.
+- **§9 Failure modes** — gateway down, ambiguous identity, briefing overflow.
+- **§10 Regression** — bugs we've already fixed must stay fixed.
+
+Each scenario runs in **~5 minutes max** real-agent time. Total wall
+clock for the full plan is ~90 minutes.
+
+---
+
+## §1 Disruption
+
+### S1.1 Owner-out disruption produces correct shift proposal
+
+**Setup:**
+- FOIA workspace from pre-check.
+- Seed a worker named "Sarah" as owner of "Agency Profile Schema & Data Model".
+  ```sql
+  INSERT INTO agents (id, name, role, workspace_id, is_active)
+  VALUES ('sarah-uuid', 'Sarah', 'worker', :foia_id, 1);
+  UPDATE initiatives SET owner_agent_id = 'sarah-uuid'
+  WHERE workspace_id = :foia_id
+    AND title = 'Agency Profile Schema & Data Model';
+  ```
+
+**Action:** POST a chat message to the FOIA PM Chat:
+> "Sarah is out 2026-05-20 to 2026-05-25"
+
+**Observe:**
+- Synth placeholder lands within 1 second (UI shows draft proposal).
+- Within 30s, the placeholder is *superseded* by the agent's structured proposal (SSE event `pm_proposal_replaced`).
+- The accepted proposal contains:
+  - 1 `add_availability` diff for Sarah, 2026-05-20 to 2026-05-25.
+  - At least 1 `set_initiative_status` or `shift_initiative_target` diff for the initiative she owns (if her absence overlaps with target window).
+  - `impact_md` references "Sarah" and the initiative title verbatim.
+
+**Capture:**
+- The placeholder row id and the agent row id.
+- Time to supersede.
+- Full impact_md.
+- Any notes the agent took during dispatch (`agent_notes` rows where `scope_key` matches the dispatch).
+
+### S1.2 Disruption with no actionable content
+
+**Action:** Send the literal string "Test" to PM Chat.
+
+**Observe:**
+- Synth placeholder ("No structured changes inferred") lands.
+- Agent supersedes with a proposal that has `changes: []` and `impact_md` describing why nothing was actionable.
+
+**Halt criterion:** if the agent stalls past 60s (the bug we just fixed), the regression returned. Hard fail.
+
+### S1.3 Refine a draft proposal
+
+**Action:**
+- After S1.1 lands, POST to `/api/pm/proposals/<id>/refine` with `additional_constraint: "Don't slip Discovery — defer Cache Persistence instead"`.
+
+**Observe:**
+- A new proposal row lands within 30s with `parent_proposal_id = <S1.1 id>`.
+- The refined `changes` reflect the constraint (Discovery's `target_end` unchanged; Cache Persistence shifted).
+- The session key for refine matches S1.1's session key (continuity).
+
+---
+
+## §2 Plan a draft initiative
+
+### S2.1 Plan a fresh initiative draft
+
+**Action:**
+- Create a draft initiative in the FOIA workspace with title "Public-records analytics dashboard" and minimal description.
+- POST `/api/pm/plan-initiative` with `initiative_id` and a one-line guidance ("Goal: weekly insights from incoming requests").
+
+**Observe:**
+- Within 60s a `pm_proposals` row with `trigger_kind='plan_initiative'` lands.
+- `plan_suggestions` field populated with all required keys: `refined_description`, `complexity` ∈ {S,M,L,XL}, `target_start`, `target_end`, `status_check_md`, `dependencies`.
+- `proposed_changes` is `[]` (advisory only).
+- `refined_description` is meaningfully different from input (length > 3x input).
+
+### S2.2 Refine the plan twice
+
+**Action:**
+- POST refine: `additional_constraint: "Make this M-sized, not L"`.
+- POST refine again: `additional_constraint: "Add a dependency on Implementation for FOIA Request Pipeline"`.
+
+**Observe:**
+- Each refine produces a new proposal with `parent_proposal_id` chain back to S2.1.
+- All three proposals share the same `planSessionKey` in dispatch (verify via `mc_sessions.scope_key`).
+- Refine 2's `dependencies` array includes the Implementation initiative id.
+- Each refine completes in <60s.
+
+**Capture:** the chain length and all three impact_md/plan_suggestions.
+
+---
+
+## §3 Decompose
+
+### S3.1 Decompose an epic into stories
+
+**Action:** POST `/api/pm/decompose-initiative` with the FOIA epic
+"Discovery for FOIA Request Pipeline" and guidance "We have 7 stories
+already; suggest if any are missing."
+
+**Observe:**
+- A `pm_proposals` row with `trigger_kind='decompose_initiative'` lands within 90s.
+- `proposed_changes` contains one or more `create_child_initiative` diffs OR an empty array if the agent finds the existing 7 stories complete (acceptable).
+- `impact_md` explains the agent's reasoning (covers what's missing or confirms completeness).
+
+### S3.2 Decompose a story into tasks
+
+**Action:** POST `/api/pm/decompose-story` with story "Agency Profile
+Schema & Data Model" and guidance "Need a backend slice and a UI slice".
+
+**Observe:**
+- A `pm_proposals` row with `trigger_kind='decompose_story'` lands.
+- `proposed_changes` contains ≥2 `create_task_under_initiative` diffs.
+- Tasks have non-trivial `description` fields (>50 chars each).
+
+---
+
+## §4 Notes intake
+
+### S4.1 Operator pastes meeting notes
+
+**Action:** Call MCP tool `propose_from_notes` directly with a 600-word
+meeting transcript covering FOIA work:
+
+> "Stand-up notes Monday: Sarah's done with the agency schema, ready
+> for review. Statute lookup is blocked on the lawyer review — Mike's
+> chasing it. Email intake detection: Jen prototyped via SpamAssassin
+> rules; works for ~80% of agencies. Cache persistence: Dan has a draft
+> design, will share Wednesday. Fee policy: nothing yet, low priority.
+> Verification harness: blocker — we need a test fixture set."
+
+**Observe:**
+- A `pm_proposals` row with `trigger_kind='notes_intake'` lands within 90s.
+- `proposed_changes` is heterogeneous: some `set_initiative_status` ('blocked' for statute lookup), maybe a `create_task_under_initiative` for the test fixture set.
+- `impact_md` summarizes what was extracted.
+
+### S4.2 Notes intake with gateway down
+
+**Setup:** Stop the openclaw gateway (`kill $(lsof -ti :18789)`).
+
+**Action:** Same as S4.1.
+
+**Observe:**
+- The MCP call returns an error (allowFallback=false → throws PmDispatchGatewayUnavailableError).
+- A `pm_pending_notes` row is enqueued (verify in DB).
+- Restart openclaw, wait 60s for the drain → the queued note dispatches and lands a proposal.
+
+**Halt criterion:** if the queued note doesn't drain within 90s of gateway restart.
+
+---
+
+## §5 Task dispatch (worker stages)
+
+### S5.1 Builder dispatch on a story task
+
+**Setup:**
+- Pick story "Cache Persistence & Query Layer".
+- Use `decompose_story` (S3.2) to seed it with one builder task.
+- Promote the task `draft → inbox → assigned` and assign to the synthetic builder.
+
+**Action:** POST `/api/tasks/<task_id>/dispatch`.
+
+**Observe:**
+- Within 90s, the task transitions through: `assigned → in_progress`.
+- Builder calls `take_note` ≥3 times during work (verify `agent_notes` rows tagged with the builder's scope_key).
+- Builder calls `register_deliverable` ≥1 time.
+- Builder calls `log_activity(activity_type='completed')` before transitioning.
+- Builder transitions to `review` (or `testing` if the workflow demands that).
+
+**Note quality:**
+- ≥1 `kind='discovery'` or `decision`.
+- ≥1 `kind='breadcrumb'` with `audience='next-stage'`.
+- All notes have non-empty `attached_files` when discussing code.
+
+### S5.2 Tester dispatch on the same task
+
+**Action:** Tester picks up the task post-builder (or operator dispatches manually).
+
+**Observe:**
+- Tester reads the builder's notes via `read_notes(task_id)` (verify in MCP call log).
+- Tester calls `mark_note_consumed` for each builder breadcrumb it processes.
+- Tester takes its own notes (≥2).
+- Tester transitions task to `review`.
+
+### S5.3 Reviewer dispatch and rejection
+
+**Action:** Reviewer picks up; we'll script a forced rejection scenario by injecting a known issue in the deliverable.
+
+**Observe:**
+- Reviewer calls `read_notes` first (audience='next-stage' OR 'reviewer').
+- Reviewer takes a `kind='blocker'` or `decision` note explaining the rejection.
+- Reviewer calls `fail_task` with a reason.
+- Task transitions back to `in_progress` for re-dispatch.
+
+### S5.4 Builder retry attempt 2 (Q3 A/B sample)
+
+**Action:** Re-dispatch the builder. Per `agent_role_overrides.attempt_strategy`:
+- If `fresh`: scope key segment increments to `:builder:2`, agent gets a fresh briefing including reviewer's notes.
+- If `reuse`: same `:builder:1` key, agent sees its own prior reasoning.
+
+**Observe:**
+- Verify `mc_sessions` row for the new attempt.
+- Verify the briefing includes reviewer's blocker note.
+- Verify the second attempt completes (transition to `review`).
+
+**Capture for Q3 decision:**
+- Time-to-deliverable per strategy.
+- Number of `take_note` calls per strategy.
+- Whether the second attempt repeats the prior approach (failed) or chose a different one.
+
+---
+
+## §6 Recurring jobs
+
+### S6.1 Create a recurring researcher job
+
+**Action:**
+- POST `/api/recurring-jobs` for a job:
+  - `role: 'researcher'`
+  - `name: "Watch DGX Spark forum for new posts"`
+  - `cadence_seconds: 60` (compressed for testing — production would be 172800)
+  - `briefing_template: "Check /tmp/synthetic-forum.txt for new lines since last run. Report any deltas via take_note(kind='observation', audience='pm', task_id=<linked>)."`
+  - `task_id: <linked task in FOIA workspace>`
+
+**Setup:**
+- Pre-create `/tmp/synthetic-forum.txt` with 5 lines.
+
+**Action timeline:**
+- T+0: trigger job manually (skip the cadence wait).
+- T+0+30s: append 2 new lines to the file.
+- T+0+60s: scheduler should fire the second run.
+
+**Observe:**
+- Run 1 produces ≥1 note describing the initial 5 lines.
+- Run 2 produces ≥1 note describing the 2 new lines.
+- Both runs share the same scope_key (since `attempt_strategy='reuse'`).
+- `recurring_jobs.run_count` is 2; `last_run_at` and `next_run_at` updated.
+
+**Halt criterion:** Run 2 not firing within 90s of cadence elapsing → scheduler is broken.
+
+### S6.2 Recurring job with no new data
+
+**Action:** After S6.1, trigger Run 3 without changing the file.
+
+**Observe:** Researcher takes a note `kind='observation', body='No new posts since last check'`. Don't penalize the silence.
+
+### S6.3 Recurring job failure escalation
+
+**Setup:** Make the briefing template invalid (e.g., reference a non-existent file).
+
+**Action:** Trigger 3 consecutive runs (force-trigger).
+
+**Observe:**
+- Each run fails (the agent reports it can't find the file via a note `kind='blocker'`).
+- After 3 consecutive failures, `recurring_jobs.status` flips to `paused`.
+- An `importance: 2` note auto-posts to PM Chat.
+
+---
+
+## §7 Heartbeat coordinator
+
+### S7.1 Enable heartbeat on a task and verify check-ins
+
+**Action:**
+- Set `tasks.coordinator_mode = 'heartbeat'` on the in-progress task from S5.1.
+- Set `coordinator_heartbeat_seconds = 60`.
+
+**Observe over 5 minutes:**
+- 4–5 coordinator dispatches fire (one every 60s).
+- Each dispatch produces ≥1 note. Most should be `kind='observation', body~"ok"` or similar.
+- If the underlying task hasn't moved in 2 cycles, coordinator takes a `kind='question', audience='pm'` or `importance:2` escalation note.
+
+### S7.2 Heartbeat auto-removal on task completion
+
+**Action:** Force the underlying task to `status='done'`.
+
+**Observe:**
+- The heartbeat `recurring_jobs` row flips to `status='done'` (or is deleted, depending on impl choice).
+- No further coordinator dispatches fire after the task completes.
+
+---
+
+## §8 Notes observability
+
+### S8.1 SSE → Task detail rail
+
+**Setup:** Open `/workspace/foia/tasks/<task_id>` in a headless browser (or use the API directly).
+
+**Action:** Trigger an agent dispatch that takes a note for that task.
+
+**Observe:**
+- Within 2 seconds of the `take_note` MCP call, the task detail page receives an SSE `agent_note_created` event with matching `task_id`.
+- The Notes Rail component shows the new note (verify via `preview_*` snapshot).
+
+### S8.2 SSE → Initiative rollup
+
+**Action:** Take a note on a task that's a child of an initiative. View `/workspace/foia/initiatives/<initiative_id>`.
+
+**Observe:**
+- The initiative panel shows the note in its rollup (filtered by `task_id IN getInitiativeTaskIds(initiative_id)`).
+
+### S8.3 SSE → Workspace feed
+
+**Action:** Open `/feed?workspace_id=<foia>` (or its real path post-Phase-D). Trigger 5 notes across different tasks.
+
+**Observe:**
+- All 5 notes appear in the feed.
+- Filter chips work (filter by `kind='blocker'` shows only blockers, etc.).
+
+### S8.4 SSE → PM Chat for importance=2
+
+**Action:** Have an agent take a note with `importance: 2`.
+
+**Observe:**
+- Within 2 seconds, the FOIA workspace's PM Chat shows an assistant-role message with the note's body and a "(from <role>)" attribution.
+
+### S8.5 Card badge updates
+
+**Action:** Open the task list view at `/tasks?workspace_id=<foia>`. Trigger 3 notes on one task.
+
+**Observe:**
+- That task's card badge updates from "0 notes" → "1 note" → "2" → "3" without a page refresh.
+- Timestamp updates to the most recent note's timestamp.
+
+---
+
+## §9 Failure modes
+
+### S9.1 Gateway down on dispatch
+
+**Setup:** `kill $(lsof -ti :18789)`.
+
+**Action:** Send a disruption to PM Chat.
+
+**Observe:**
+- Synth placeholder lands.
+- `dispatch_state='synth_only'` (no background reconciler runs).
+- Operator can still accept the synth proposal manually if they want.
+
+### S9.2 Gateway recovers during dispatch
+
+**Setup:** Start dispatch, then immediately kill the gateway, then restart it 10s later.
+
+**Observe:**
+- The reconciler re-attempts during the 60s tail window.
+- If the gateway came back fast enough, the agent's proposal still supersedes.
+- Otherwise: synth_only as in S9.1.
+
+### S9.3 Briefing overflow
+
+**Setup:** Force a task with 200+ notes.
+
+**Action:** Dispatch a builder for that task.
+
+**Observe:**
+- Briefing builder caps notes at 50, oldest-first truncation.
+- Total briefing < 12,000 chars.
+- The agent does NOT see the older notes (verify via tool call log: it reads only the truncated set).
+- Truncation is logged as a metric.
+
+### S9.4 Ambiguous gateway_agent_id (the bug we fixed)
+
+**Setup:**
+- Manually insert a second `agents` row with `gateway_agent_id='mc-runner-dev'` in a different workspace.
+
+**Action:** Trigger any dispatch.
+
+**Observe:**
+- The identity preamble in the briefing carries the correct workspace's UUID.
+- The agent does NOT call `whoami({ agent_id: 'mc-runner-dev' })` — it uses the UUID directly.
+- If the agent does call `whoami`, the response is `ambiguous_gateway_id` but the agent already has its UUID and proceeds anyway.
+
+**Cleanup:** delete the inserted row.
+
+---
+
+## §10 Regression tests
+
+### S10.1 The PM dispatch ambiguity bug stays fixed
+
+Verified by S9.4. Additionally:
+
+```bash
+# Inspect the dispatch session's first message — must include "Your agent_id is".
+sqlite3 mission-control.db \
+  "SELECT trigger_text FROM pm_proposals
+   WHERE workspace_id = '<foia>'
+   ORDER BY created_at DESC LIMIT 1;"
+```
+
+The dispatch message in openclaw's session log must contain the
+identity preamble lines.
+
+### S10.2 cloneAgentsFromWorkspace leaves no broken refs
+
+**Action:** Create a new workspace via POST `/api/workspaces` with `clone_agents_from = <foia_id>`.
+
+**Observe:**
+- New workspace has its own PM placeholder.
+- No worker rows are cloned (post-Phase-F: cloning is no-op for non-PM).
+- The new workspace can dispatch without the ambiguity error.
+
+### S10.3 Workspace switcher preserves current page (PR #131)
+
+**Action:** Navigate to `/workspace/foia/initiatives/<id>`. Switch workspace via the switcher to `default`.
+
+**Observe:** URL becomes `/workspace/default/initiatives` (preserving the page type). No 404.
+
+### S10.4 Drawer portals (PR #134)
+
+**Action:** Open a side drawer that has a sub-modal (e.g., Edit Initiative → Confirm).
+
+**Observe:** Inner modal is portalled to body, not trapped offscreen.
+
+### S10.5 PR #136 — agent-catalog-sync handles duplicates
+
+**Action:** Run `/api/agents/sync` while two `agents` rows share `gateway_agent_id`.
+
+**Observe:** Both rows get the gateway-truth values via `WHERE gateway_agent_id = ?` (not Map collapse). Verify via the `model` column on both rows.
+
+---
+
+## Run instructions
+
+A test plan executor must:
+
+1. Run pre-check ([`01-pre-check-initialization.md`](01-pre-check-initialization.md)).
+2. For each scenario in order:
+   a. Create `/tmp/mc-validation/<phase>/<scenario_id>/`.
+   b. Capture pre-action DB state to `pre.sql`.
+   c. Execute the action.
+   d. Wait for terminal state (or timeout per scenario).
+   e. Capture post-action DB state to `post.sql`, openclaw session trajectory to `trajectory.jsonl`, dev log slice to `dev.log`, MCP tool call log to `mcp.log`, SSE captures to `sse.log`.
+   f. Append result to `/tmp/mc-validation/<phase>/test-plan-result.md`:
+      ```markdown
+      ## <scenario_id>: <name>
+      Status: PASS / FAIL / FLAKE
+      Duration: <s>
+      Observations: <one-paragraph>
+      Failures: <bullet list, if any>
+      Capture path: /tmp/mc-validation/<phase>/<scenario_id>/
+      ```
+3. After all scenarios run, compute summary against
+   [`03-validation-criteria.md`](03-validation-criteria.md).
+4. Halt if total `FAIL` count > 0.
+
+**Real-agent runtime budget:** ≤ 90 minutes wall-clock for the full
+plan. If a scenario hangs past its cap (per scenario), kill it and mark
+`FLAKE` rather than waiting forever.
+
+**Dispatch via `spark-lb/agent`:** every real-agent dispatch in this
+plan uses the self-hosted load-balanced model. No external API calls.

--- a/specs/scope-keyed-sessions-validation/03-validation-criteria.md
+++ b/specs/scope-keyed-sessions-validation/03-validation-criteria.md
@@ -1,0 +1,422 @@
+# Validation Criteria — Scope-Keyed Sessions
+
+> **Purpose:** Pass/fail criteria for the dispatch scenarios in
+> [`02-test-plan.md`](02-test-plan.md). Per-scenario gates plus
+> global gates. A milestone passes only if ALL gates pass.
+
+> **Use:** after running the test plan, compute results against this
+> file. The output is a single READY-TO-MERGE / NOT-READY judgment.
+
+---
+
+## How to read this document
+
+Each scenario has a gates table. Gates are AND-ed within a scenario.
+Scenarios are AND-ed within the global gate set. **All must pass.**
+
+A scenario is allowed to be marked `N/A` only when:
+- The phase under test does not implement the scenario yet (e.g., S6
+  Recurring jobs is N/A pre-Phase-E).
+- The scenario depends on another that already FAILed (cascading skip).
+
+`FLAKE` (intermittent) scenarios must be re-run up to 3 times. If 2/3
+pass, mark `PASS`. If 0/3 or 1/3 pass, mark `FAIL`.
+
+---
+
+## §1 Disruption — gates
+
+### S1.1 Owner-out disruption
+
+| Gate | Threshold |
+|---|---|
+| G1.1.a Synth placeholder lands | within 2s of POST |
+| G1.1.b Agent supersedes | within 60s of synth |
+| G1.1.c `add_availability` diff present | exactly 1, agent_id matches Sarah, dates match input |
+| G1.1.d Initiative impact diff | ≥1 `set_initiative_status` or `shift_initiative_target` for Sarah's initiative |
+| G1.1.e impact_md mentions inputs | "Sarah" + initiative title both substring-present |
+| G1.1.f Briefing has identity preamble | regex `Your agent_id is: <UUID>` matches |
+| G1.1.g No `ambiguous_gateway_id` errors | grep dev.log: 0 occurrences |
+| G1.1.h Notes taken during dispatch | ≥1 `agent_notes` row with matching scope_key |
+
+### S1.2 Disruption with no actionable content
+
+| Gate | Threshold |
+|---|---|
+| G1.2.a Synth placeholder lands | within 2s |
+| G1.2.b Agent supersedes (or marks synth_only) | within 90s |
+| G1.2.c No timeout regression | dispatch did not stall past 60s + 60s tail |
+| G1.2.d Final state | dispatch_state ∈ {`agent_complete`, `synth_only`} — never `pending_agent` after timeout |
+
+### S1.3 Refine
+
+| Gate | Threshold |
+|---|---|
+| G1.3.a Refined proposal lands | within 60s |
+| G1.3.b parent_proposal_id matches S1.1 | exact match |
+| G1.3.c Constraint reflected | Discovery target_end unchanged AND a different initiative shifted |
+| G1.3.d Same scope_key | refined dispatch reuses S1.1's `mc_sessions.scope_key` (continuity) |
+
+---
+
+## §2 Plan a draft initiative — gates
+
+### S2.1 First plan
+
+| Gate | Threshold |
+|---|---|
+| G2.1.a Proposal lands | within 60s |
+| G2.1.b trigger_kind=`plan_initiative` | exact |
+| G2.1.c plan_suggestions complete | all required keys non-null where applicable |
+| G2.1.d complexity in {S,M,L,XL} | exact |
+| G2.1.e refined_description meaningfully expanded | length ≥ 3× input length |
+| G2.1.f proposed_changes empty | `[]` |
+
+### S2.2 Refine twice
+
+| Gate | Threshold |
+|---|---|
+| G2.2.a Each refine lands | within 60s each |
+| G2.2.b parent_proposal_id chain valid | walks back to S2.1 in ≤2 hops |
+| G2.2.c All three share planSessionKey | same `mc_sessions.scope_key` |
+| G2.2.d Refine 1 honors complexity constraint | result.complexity = 'M' |
+| G2.2.e Refine 2 honors dependency constraint | result.dependencies includes Implementation initiative id |
+
+---
+
+## §3 Decompose — gates
+
+### S3.1 Epic decomposition
+
+| Gate | Threshold |
+|---|---|
+| G3.1.a Proposal lands | within 90s |
+| G3.1.b trigger_kind=`decompose_initiative` | exact |
+| G3.1.c proposed_changes valid | each `create_child_initiative` has parent_initiative_id matching epic id; valid kind ∈ {epic,story} |
+| G3.1.d No hallucinated parent ids | every parent reference resolves in the snapshot |
+
+### S3.2 Story decomposition
+
+| Gate | Threshold |
+|---|---|
+| G3.2.a Proposal lands | within 90s |
+| G3.2.b trigger_kind=`decompose_story` | exact |
+| G3.2.c ≥2 task creates | proposed_changes contains ≥2 `create_task_under_initiative` |
+| G3.2.d Task descriptions non-trivial | each description ≥50 chars |
+
+---
+
+## §4 Notes intake — gates
+
+### S4.1 Online intake
+
+| Gate | Threshold |
+|---|---|
+| G4.1.a Proposal lands | within 90s |
+| G4.1.b trigger_kind=`notes_intake` | exact |
+| G4.1.c Heterogeneous changes | proposed_changes has ≥2 distinct `kind` values |
+| G4.1.d Mentions the blocker | impact_md mentions the test fixture blocker from notes |
+
+### S4.2 Offline intake (queue and drain)
+
+| Gate | Threshold |
+|---|---|
+| G4.2.a MCP returns gateway error | `PmDispatchGatewayUnavailableError` thrown |
+| G4.2.b Queue row inserted | `pm_pending_notes` count = 1 |
+| G4.2.c Drain after restart | within 90s of gateway restart, queue is empty |
+| G4.2.d Resulting proposal lands | within 90s of gateway restart |
+
+---
+
+## §5 Task dispatch — gates
+
+### S5.1 Builder dispatch
+
+| Gate | Threshold |
+|---|---|
+| G5.1.a Status transitions | assigned → in_progress → review (or testing per workflow) |
+| G5.1.b Notes count | ≥3 `agent_notes` rows tagged with builder's scope_key |
+| G5.1.c Note kind diversity | ≥1 `kind ∈ {discovery, decision}` AND ≥1 `kind=breadcrumb` |
+| G5.1.d audience='next-stage' present | ≥1 breadcrumb has `audience='next-stage'` |
+| G5.1.e Deliverables registered | ≥1 `task_deliverables` row |
+| G5.1.f activity_type='completed' before transition | log_activity row with that type precedes the status transition |
+| G5.1.g Briefing includes notetaker addendum | regex `obsessive notetaker` matches in dispatch message |
+| G5.1.h Identity preamble | regex `Your agent_id is:` matches |
+
+### S5.2 Tester dispatch
+
+| Gate | Threshold |
+|---|---|
+| G5.2.a Reads prior notes | ≥1 `read_notes` MCP call observed |
+| G5.2.b mark_note_consumed called | ≥1 such call (count must equal at least the breadcrumbs from S5.1) |
+| G5.2.c Tester takes own notes | ≥2 new `agent_notes` rows tagged with tester scope_key |
+| G5.2.d Status transitions to review | exact |
+
+### S5.3 Reviewer rejection
+
+| Gate | Threshold |
+|---|---|
+| G5.3.a Reviewer reads notes | ≥1 read_notes call |
+| G5.3.b Reviewer takes blocker note | ≥1 `kind=blocker` or `decision` note |
+| G5.3.c Status reverts to in_progress | exact |
+| G5.3.d Failure reason captured | non-empty status_reason |
+
+### S5.4 Builder retry (Q3 sample)
+
+| Gate | Threshold |
+|---|---|
+| G5.4.a New session per attempt_strategy | per `agent_role_overrides.attempt_strategy` |
+| G5.4.b Briefing includes reviewer's blocker | regex match in dispatch message |
+| G5.4.c Second attempt completes | reaches review status |
+| G5.4.d No infinite loop | total attempts ≤3 in this scenario |
+
+**Q3 metrics captured (not gates):** time-to-deliverable per strategy,
+note count per strategy, repeat-approach rate per strategy. These feed
+the spec's appendix decision; they are *informational*, not pass/fail.
+
+---
+
+## §6 Recurring jobs — gates
+
+### S6.1 Two compressed runs
+
+| Gate | Threshold |
+|---|---|
+| G6.1.a Run 1 fires | within 5s of trigger |
+| G6.1.b Run 1 produces note | ≥1 note tagged with run_group_id #1 |
+| G6.1.c Run 2 fires on cadence | within 90s of cadence_seconds elapsing |
+| G6.1.d Run 2 produces delta note | note body references "new" or numeric count > 0 |
+| G6.1.e Same scope_key (reuse) | both runs' notes share scope_key, distinct run_group_ids |
+| G6.1.f recurring_jobs.run_count = 2 | exact |
+
+### S6.2 No-op run
+
+| Gate | Threshold |
+|---|---|
+| G6.2.a Note still produced | ≥1 note `kind=observation`, body not empty |
+| G6.2.b No proposal forced | no `pm_proposals` row for this run |
+
+### S6.3 Failure escalation
+
+| Gate | Threshold |
+|---|---|
+| G6.3.a Each failure registers | `consecutive_failures` increments per run |
+| G6.3.b Pause after 3 | status flips to `paused` after exactly 3 consecutive failures |
+| G6.3.c PM Chat alert | one assistant-role message in PM chat with `importance: 2` |
+
+---
+
+## §7 Heartbeat coordinator — gates
+
+### S7.1 Active monitoring
+
+| Gate | Threshold |
+|---|---|
+| G7.1.a 4–5 dispatches in 5min | with cadence=60s |
+| G7.1.b Each produces ≥1 note | exact |
+| G7.1.c Stalled-task escalation fires | at least 1 `audience=pm` or `importance: 2` note when underlying task hasn't moved in 2 cycles |
+
+### S7.2 Auto-removal
+
+| Gate | Threshold |
+|---|---|
+| G7.2.a recurring_jobs row updated | status='done' (or row deleted) within 60s of underlying task completion |
+| G7.2.b No new dispatches post-completion | grep dev.log: 0 dispatches for the heartbeat scope_key after status='done' |
+
+---
+
+## §8 Notes observability — gates
+
+### S8.1 Task detail rail
+
+| Gate | Threshold |
+|---|---|
+| G8.1.a SSE event arrives | within 2s of `take_note` |
+| G8.1.b UI rail updates | preview_snapshot shows the new note |
+| G8.1.c Correct grouping | notes grouped by run_group_id |
+
+### S8.2 Initiative rollup
+
+| Gate | Threshold |
+|---|---|
+| G8.2.a Note appears on initiative | within 2s |
+| G8.2.b Cross-task aggregation works | notes from multiple child tasks appear |
+
+### S8.3 Workspace feed
+
+| Gate | Threshold |
+|---|---|
+| G8.3.a Feed page exists | HTTP 200 |
+| G8.3.b All 5 notes visible | exact |
+| G8.3.c Filter chips work | filter by kind shows correct subset |
+
+### S8.4 PM Chat for importance=2
+
+| Gate | Threshold |
+|---|---|
+| G8.4.a Auto-post fires | within 2s |
+| G8.4.b Attribution correct | message contains "(from <role>)" |
+| G8.4.c No duplicate post | exactly 1 post per importance=2 note |
+
+### S8.5 Card badges
+
+| Gate | Threshold |
+|---|---|
+| G8.5.a Live count update | badge increments without page refresh |
+| G8.5.b Timestamp updates | latest note's timestamp shown |
+
+---
+
+## §9 Failure modes — gates
+
+| Scenario | Gate | Threshold |
+|---|---|---|
+| S9.1 Gateway down | dispatch_state='synth_only' | exact, no exceptions thrown |
+| S9.2 Gateway recovers | reconciler tries during tail window | grep dev.log for tail-poll log lines |
+| S9.3 Briefing overflow | note count ≤ 50 | per dispatch briefing |
+| S9.3 Briefing overflow | total chars ≤ 12000 | per dispatch briefing |
+| S9.4 Ambiguity stays harmless | dispatch succeeds | terminal state agent_complete |
+| S9.4 Ambiguity stays harmless | no `whoami` call | grep mcp.log: 0 occurrences |
+
+---
+
+## §10 Regression — gates
+
+| Scenario | Gate | Threshold |
+|---|---|---|
+| S10.1 Identity preamble present | regex match | every dispatch message |
+| S10.2 Workspace clone | new workspace dispatches successfully | exact |
+| S10.3 Workspace switcher | URL preserves page type | exact |
+| S10.4 Drawer portal | nested modal not trapped | preview_snapshot |
+| S10.5 Catalog sync | both duplicate rows updated | row diff |
+
+---
+
+## Global gates (apply across all scenarios)
+
+These run after all per-scenario gates and apply to the run as a whole.
+
+| ID | Gate | Threshold |
+|---|---|---|
+| GG1 | No P0 dev log errors | grep `[error]` in /tmp/mc-validation/<phase>/dev.log: 0 occurrences |
+| GG2 | No `ambiguous_gateway_id` errors | grep: 0 occurrences |
+| GG3 | No unhandled exceptions | grep `unhandledRejection` or `Uncaught`: 0 occurrences |
+| GG4 | TypeScript clean | `yarn tsc --noEmit` exit 0 (excluding pre-existing pm-decompose.test.ts noise) |
+| GG5 | Test suite green | `yarn test` exit 0; new tests added per phase |
+| GG6 | MCP smoke green | `yarn mcp:smoke` exit 0 |
+| GG7 | DB row count sanity | total `pm_proposals` rows ≤ scenario count × 4; no runaway proposal generation |
+| GG8 | Briefing length p95 | ≤ 12,000 chars (sampled across all dispatches) |
+| GG9 | Notes count median | ≥3 per worker dispatch (warns if <2) |
+| GG10 | Notes count p95 | ≤30 per dispatch (warns if pathological spam) |
+| GG11 | LLM-as-judge note quality | mean rubric score ≥3.5 / 5 (per `specs/evals/scope-keyed-sessions/rubrics/note-quality.md`) |
+| GG12 | LLM-as-judge briefing fidelity | mean rubric score ≥3.5 / 5 |
+| GG13 | LLM-as-judge handoff cohesion | mean rubric score ≥3.5 / 5 |
+| GG14 | Wall-clock budget | full plan completes ≤90 minutes |
+| GG15 | No hung sessions | every dispatch reached terminal state (agent_complete or synth_only) |
+| GG16 | SSE rate sane | <100 events / second sustained (catches infinite-loop bugs) |
+| GG17 | spec.md unchanged | the spec doc was not modified during this run |
+
+---
+
+## Final scoring
+
+The run produces `/tmp/mc-validation/<phase>/SCORECARD.md`:
+
+```markdown
+# Validation Scorecard — <phase> — <commit>
+
+## Per-scenario
+| Scenario | Status | Notes |
+|---|---|---|
+| S1.1 | PASS / FAIL / N/A | … |
+| S1.2 | PASS / FAIL / N/A | … |
+| ... |
+| S10.5 | PASS / FAIL / N/A | … |
+
+## Global gates
+| ID | Status | Value |
+|---|---|---|
+| GG1 | PASS / FAIL | <count> |
+| ... |
+
+## Q3 informational metrics (not gates)
+| Strategy | Time-to-deliverable median | Notes per dispatch | Repeat-approach rate |
+|---|---|---|---|
+| fresh | … | … | … |
+| reuse | … | … | … |
+
+## Verdict
+READY-TO-MERGE / NOT-READY — <one-line reason>
+```
+
+The verdict is **READY-TO-MERGE** only if:
+- All in-scope scenarios pass.
+- All global gates pass.
+- N/A count ≤ expected for the phase under test.
+
+If verdict is `NOT-READY`, the failing rows + their capture paths are
+the morning review's hot list. Halt the autonomous build pipeline until
+the operator reviews.
+
+---
+
+## Phase applicability matrix
+
+Which scenarios apply at which phase. Use this to compute legitimate
+N/A markings.
+
+| Scenario | Phase A | Phase B | Phase C | Phase D | Phase E | Phase F |
+|---|---|---|---|---|---|---|
+| S1.* (disruption) | N/A | YES (via dispatchScope) | YES | YES | YES | YES |
+| S2.* (plan) | N/A | YES | YES | YES | YES | YES |
+| S3.* (decompose) | N/A | YES | YES | YES | YES | YES |
+| S4.* (notes intake) | N/A | YES | YES | YES | YES | YES |
+| S5.* (worker dispatch) | N/A | N/A | YES | YES | YES | YES |
+| S6.* (recurring) | N/A | N/A | N/A | N/A | YES | YES |
+| S7.* (heartbeat) | N/A | N/A | N/A | N/A | YES | YES |
+| S8.* (observability) | N/A | YES (basic SSE) | YES | YES (full UI) | YES | YES |
+| S9.* (failure modes) | N/A | YES (S9.1, S9.2, S9.4) | YES | YES | YES | YES |
+| S10.* (regressions) | YES | YES | YES | YES | YES | YES |
+
+Phase-specific additions:
+
+- **Phase A:** must add S0 schema verification (covered in pre-check §2).
+- **Phase F:** must add S10.6 — `gateway_agent_id` is NULL on all non-runner rows; `mc-runner-dev` is the sole gateway-bearing agent.
+
+---
+
+## Halt criteria for the autonomous build pipeline
+
+The pipeline halts and pages the operator if any of these fire:
+
+1. Any scenario in the phase's applicability matrix returns `FAIL`.
+2. Any global gate `GG1`–`GG6` fails (these are absolute floors).
+3. The wall-clock cap (90min) is exceeded by >25%.
+4. The same scenario flakes 3 times in a row.
+5. Disk usage in `/tmp/mc-validation/` exceeds 5GB (capture files
+   accumulating without bound).
+6. The dev server crashes mid-plan and doesn't auto-recover.
+7. A new `[error]` line in dev.log matches a known-critical pattern
+   (`SQLITE_CORRUPT`, `ECONNREFUSED .*:18789`, `unhandledRejection`).
+
+Each halt logs to `/tmp/mc-validation/<phase>/HALT-<timestamp>.md` with
+the trigger, captures, and last 200 lines of dev.log.
+
+---
+
+## What changes between phases
+
+The criteria document is intended to be stable across phases (so the
+spec doesn't drift mid-build). When a phase implements new
+functionality, it activates more rows in the applicability matrix —
+gate thresholds themselves don't change.
+
+Two exceptions where thresholds tighten as phases land:
+- **GG9 / GG10 (notes count):** Phase C lands the role-soul addendum;
+  warns shift to FAILs at Phase D when the notetaker behavior should be
+  fully wired.
+- **GG11 / GG12 / GG13 (LLM-as-judge scores):** Phase B+ runs the
+  harness; threshold ≥3.5 from Phase B; tightens to ≥4.0 at Phase F.
+
+These tightening thresholds are tracked in this file's appendix when
+the phase lands; mid-run threshold drift is forbidden.

--- a/specs/scope-keyed-sessions.md
+++ b/specs/scope-keyed-sessions.md
@@ -1,0 +1,804 @@
+# Scope-Keyed Sessions — End of Durable Worker Agents
+
+## Why
+
+Today MC has long-lived gateway-synced agents per role per workspace
+(`mc-builder-dev`, `mc-tester-dev`, `mc-coordinator-dev`, `mc-pm-dev`,
+etc.). PR #133 made the gateway agent identity org-wide so operators
+could clone agent rosters between workspaces. The unintended downstream
+effects make this design indefensible:
+
+1. **Workspace ambiguity (the bug we just fixed).** A shared
+   `gateway_agent_id` legitimately maps to N workspace rows after
+   cloning, so `whoami({ agent_id: gateway_id })` returns
+   `ambiguous_gateway_id` ([tools.ts:172](../src/lib/mcp/tools.ts:172)),
+   the agent stalls hunting for its UUID, the PM dispatch reconciler
+   times out, and every PM Chat reply falls back to the synth-only
+   placeholder ([pm-dispatch.ts:329](../src/lib/agents/pm-dispatch.ts:329)).
+   Fixed by [pm-dispatch.ts:140](../src/lib/agents/pm-dispatch.ts:140) embedding the UUID, but the fix is a workaround for a deeper architectural mistake.
+2. **Session memory is mostly noise.** The PM dispatch session log shows
+   the agent reading old heartbeat memos trying to find its own UUID.
+   The real load-bearing state — deliverables, prior outcomes, task
+   history, learner snapshots — already lives in MC's database.
+   Per-agent openclaw session memory is an inferior place to store it:
+   per-machine, lossy via compaction, opaque, unqueryable.
+3. **Cross-workspace continuity is incoherent.** Drift detection
+   ([pm-standup.ts:142](../src/lib/agents/pm-standup.ts:142)) is a pure
+   function over the snapshot. Cross-task patterns (velocity, stall
+   detection, learner) are MC-resident. Nothing in MC actually depends
+   on agent-side session memory for cross-task reasoning. The "PM has
+   continuity" argument is a story we tell ourselves; the code disagrees.
+4. **Observability is poor.** Operators can see *what* an agent did
+   (deliverables, status changes), not *what it noticed, decided, or
+   struggled with* — that lives in session memory the operator can't
+   query. The notes spine in this spec is the load-bearing fix.
+
+The reframing: **everyone is scope-keyed**. No durable agents. Every
+session has a name (the `sessionKey`) that encodes the work it's doing.
+Resume comes free from openclaw's trajectory replay; sessions never
+"die" — they're inactive until the next dispatch with the same key.
+
+## Goals
+
+- Eliminate the `gateway_agent_id` ambiguity class entirely (no shared
+  gateway IDs across workspace rows).
+- Make every agent activity observable in real time on the
+  task/initiative card it relates to and in a workspace-wide live feed.
+- Move role definitions into source control (`agent-templates/`) so
+  authoring a new role = a PR, not filesystem surgery.
+- Support recurring jobs (researcher checks something every 2 days)
+  natively, not bolted on.
+- Preserve and improve task-stage hand-off via the notes spine instead
+  of session memory.
+
+## Non-Goals
+
+- Replacing the openclaw gateway. We still use openclaw to host
+  sessions; we just stop pretending each role-per-workspace combo is a
+  separate identity.
+- Replacing the synth fallback in dispatch. Offline / gateway-down
+  behavior stays as today.
+- Changing the workflow stage machine (planning → assigned →
+  in_progress → testing → review → verification → done).
+
+## Architecture Overview
+
+```
+~/.openclaw/workspaces/mc-runner-dev/         # ONE neutral session host
+                                              # (org-wide; symlinks shared docs;
+                                              #  generic SOUL/IDENTITY/AGENTS)
+
+agent-templates/<role>/                       # In-repo role definitions
+  SOUL.md, AGENTS.md, IDENTITY.md             # Source-controlled, reviewable
+
+agent_role_overrides table                    # Per-workspace customizations
+  (workspace_id, role, soul_md, ...)          # Operator edits via existing UI
+
+agent_notes table                             # Observability spine
+  (workspace_id, agent_id, task_id,           # Every meaningful agent moment
+   initiative_id, scope_key, kind, body,       # SSE-broadcast → UI cards + feed
+   audience, importance, run_group_id, ...)
+
+mc_sessions table                             # Bookkeeping for active scopes
+  (scope_key, session_key, scope_type,        # Lets MC list "active sessions
+   scope_ref_id, status, last_used_at)        #  for task X" or reap stale work
+
+recurring_jobs table                          # Native scheduled work
+  (scope_key_template, role, cadence_seconds, # Researcher checks every 2 days,
+   briefing_template, initiative_id, ...)     #  builder runs nightly check, etc.
+```
+
+Dispatch flow at high level:
+
+```
+Operator action / scheduler tick
+  → MC resolves a sessionKey (e.g. agent:mc-runner-dev:ws-<id>:task-<id>:builder:1)
+  → MC builds the briefing (template + override + task context + prior notes)
+  → openclaw chat.send to that sessionKey (replays trajectory if exists)
+  → Agent calls MCP tools (take_note, log_activity, register_deliverable, etc.)
+  → MC broadcasts SSE for every note → UI updates card / feed live
+  → Agent calls update_task_status to advance the workflow
+```
+
+No `agents` row dance. No promotion. No catalog sync for workers. Roles
+are templates; sessions are scopes.
+
+## 1. Scope-Keyed Sessions
+
+### 1.1 SessionKey grammar
+
+```
+agent:<gateway_agent_id>:<scope_segments>...
+```
+
+Each segment matches openclaw's `[a-z0-9][a-z0-9_-]{0,63}` and segments
+are joined by `:`. Reference: [openclaw session-key.ts:26].
+
+**Canonical scopes:**
+
+| Purpose | Pattern |
+|---|---|
+| PM disruption thread (per-thread, see Q1) | `agent:mc-runner-dev:ws-<wsid>:pm-chat-<thread_id>` |
+| plan_initiative refine loop | `agent:mc-runner-dev:ws-<wsid>:plan-<initiative_id>` |
+| decompose_initiative | `agent:mc-runner-dev:ws-<wsid>:decompose-<initiative_id>` |
+| decompose_story | `agent:mc-runner-dev:ws-<wsid>:decompose-story-<task_id>` |
+| notes intake (one-shot) | `agent:mc-runner-dev:ws-<wsid>:notes-<correlation_id>` |
+| Coordinator (optional, per task) | `agent:mc-runner-dev:ws-<wsid>:task-<task_id>:coord` |
+| Builder, attempt N | `agent:mc-runner-dev:ws-<wsid>:task-<task_id>:builder:<n>` |
+| Tester, attempt N | `agent:mc-runner-dev:ws-<wsid>:task-<task_id>:tester:<n>` |
+| Reviewer, attempt N | `agent:mc-runner-dev:ws-<wsid>:task-<task_id>:reviewer:<n>` |
+| Recurring job, run N | `agent:mc-runner-dev:ws-<wsid>:recurring-<job_id>` (reuse) or `:run-<n>` (fresh) |
+| Heartbeat coordinator (optional) | `agent:mc-runner-dev:ws-<wsid>:task-<task_id>:heartbeat` |
+
+`<wsid>` is the workspace UUID with hyphens preserved (36 chars, fits
+the 64-char segment limit). `<task_id>`, `<initiative_id>` likewise.
+The `mc-runner-dev` host name is the only org-wide gateway identifier;
+nothing else collides because everything else lives in the scope tail.
+
+### 1.2 Attempt-key strategies (Q3 A/B)
+
+For roles with retry semantics (builder, tester, reviewer), MC supports
+two strategies, pick-per-role at config time:
+
+- **`fresh`** — increment `:N` on each attempt. Each retry is a clean
+  session with a brand-new trajectory. Briefing carries forward via
+  notes from prior attempts.
+- **`reuse`** — same `:1` segment forever. Trajectory accumulates;
+  agent sees its own prior reasoning. Eventually compacts.
+
+Default per role:
+- `builder`, `tester`, `reviewer`: **fresh** (clean retries, no
+  fixation on prior failed approach).
+- `researcher`, `learner`: **reuse** (continuity is the value).
+- `coordinator` (when enabled): **reuse** for the duration of the task.
+
+The choice is a column on `agent_role_overrides`; per-workspace
+operator override is allowed.
+
+**Q3 validation harness** (defer real choice to data, not opinion):
+build a sweep that runs the same 6 synthetic tasks under both strategies
+against `spark-lb/agent`, scores via LLM-as-judge on a rubric (resume
+fidelity, hallucination rate, time-to-deliverable). Lock defaults from
+the result before declaring done.
+
+### 1.3 Lifecycle and the `mc_sessions` table
+
+```sql
+CREATE TABLE mc_sessions (
+  scope_key      TEXT PRIMARY KEY,             -- the openclaw sessionKey
+  workspace_id   TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  role           TEXT NOT NULL,                -- builder, tester, ..., pm
+  scope_type     TEXT NOT NULL CHECK (scope_type IN (
+                   'pm_chat','plan','decompose','decompose_story',
+                   'notes_intake','task_coord','task_role',
+                   'recurring','heartbeat')),
+  task_id        TEXT REFERENCES tasks(id) ON DELETE CASCADE,
+  initiative_id  TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
+  recurring_job_id TEXT REFERENCES recurring_jobs(id) ON DELETE CASCADE,
+  attempt        INTEGER DEFAULT 1,
+  status         TEXT NOT NULL DEFAULT 'active' CHECK (status IN (
+                   'active','idle','closed','failed')),
+  last_used_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  closed_at      TEXT
+);
+CREATE INDEX idx_mc_sessions_task ON mc_sessions(task_id);
+CREATE INDEX idx_mc_sessions_workspace ON mc_sessions(workspace_id, status);
+CREATE INDEX idx_mc_sessions_role ON mc_sessions(role, status);
+```
+
+The row exists for **bookkeeping only**. Openclaw owns the trajectory
+file; MC owns the metadata. On every dispatch:
+
+1. Upsert the `mc_sessions` row by `scope_key` (insert if new, bump
+   `last_used_at` if existing).
+2. Send the briefing via `chat.send`.
+3. Listen for tool calls and final frame as today.
+4. On task terminal status (done/cancelled), set `status='closed'`,
+   `closed_at=now()` for all sessions where `task_id` matches. Don't
+   delete; the row is the audit trail.
+
+### 1.4 Removing the durable agent rows
+
+Post-migration, the `agents` table contains only:
+
+- `mc-runner` and `mc-runner-dev` rows in workspace `default` (the
+  gateway hosts; `is_active=1`, `gateway_agent_id` set, no `is_pm`).
+- One PM row per workspace (the existing `is_pm=1` placeholder, now
+  *also* without `gateway_agent_id` — PM is just another role-templated
+  scope, see §2.4).
+
+All other `gateway_agent_id` values get nulled out. The existing
+catalog sync ([agent-catalog-sync.ts:114](../src/lib/agent-catalog-sync.ts:114))
+becomes a thin "ensure mc-runner-dev exists" check.
+
+## 2. Agent Templates
+
+### 2.1 Directory layout
+
+```
+agent-templates/
+├── README.md                     # Authoring guide
+├── _shared/
+│   ├── notetaker.md              # Appended to every role's briefing
+│   ├── messaging-protocol.md     # MC-side mirror of openclaw shared doc
+│   └── shared-rules.md           # Mirror of openclaw SHARED-RULES.md
+├── pm/
+│   ├── SOUL.md
+│   ├── AGENTS.md
+│   └── IDENTITY.md
+├── coordinator/
+├── builder/
+├── researcher/
+├── tester/
+├── reviewer/
+├── writer/
+├── learner/
+└── runner-host/                  # The neutral host docs for mc-runner-dev itself
+    ├── SOUL.md                   # "You assume whatever role the briefing assigns"
+    ├── AGENTS.md
+    └── IDENTITY.md
+```
+
+Initial seed: import via a one-shot script
+(`scripts/import-agent-templates.ts`) from
+`~/.openclaw/workspaces/mc-{role}-{env}/`, then the files are
+source-controlled and the openclaw workspaces become functionally dead.
+
+### 2.2 Per-workspace overrides
+
+```sql
+CREATE TABLE agent_role_overrides (
+  workspace_id   TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  role           TEXT NOT NULL,
+  soul_md        TEXT,
+  agents_md      TEXT,
+  identity_md    TEXT,
+  attempt_strategy TEXT CHECK (attempt_strategy IN ('fresh','reuse')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (workspace_id, role)
+);
+```
+
+Empty by default. Operator edits via the existing live agent prompt
+preview from PR #142 — but the editor now scopes to a *role* in a
+workspace, not a per-agent row.
+
+### 2.3 Briefing builder
+
+New module `src/lib/agents/briefing.ts` exposing:
+
+```ts
+function buildBriefing(input: {
+  workspace_id: string;
+  role: 'builder' | 'tester' | 'reviewer' | 'researcher' | 'writer'
+       | 'learner' | 'coordinator' | 'pm';
+  scope_key: string;
+  task_id?: string;
+  initiative_id?: string;
+  trigger_text?: string;
+  trigger_kind?: PmProposalTriggerKind;
+  agent_id: string;                 // the runner agent's MC UUID
+  gateway_agent_id: string;         // 'mc-runner-dev'
+  run_group_id: string;             // for note grouping
+  is_resume: boolean;               // whether this scope_key has prior trajectory
+}): string;
+```
+
+Composition order:
+
+1. **Identity preamble** (the [pm-dispatch.ts:140](../src/lib/agents/pm-dispatch.ts:140) header — `Your agent_id is: …`, `Your gateway_agent_id is: …`).
+2. **Role section.** From `agent_role_overrides` if a row exists for
+   `(workspace_id, role)`, else from `agent-templates/<role>/SOUL.md`.
+   Also load `AGENTS.md`, `IDENTITY.md` from same source.
+3. **Notetaker addendum** (`_shared/notetaker.md`).
+4. **Task context** (when `task_id` set):
+   - Title, description, acceptance criteria.
+   - Workspace snapshot summary (existing
+     `buildSnapshotSummary` in [pm-dispatch.ts:357](../src/lib/agents/pm-dispatch.ts:357)).
+   - Prior deliverables on this task.
+   - **Notes from prior stages** for this task and audience (see §3.4).
+5. **Prescribed verification commands** (existing
+   `getPrescribedCommandsForRole` from
+   [dispatch/route.ts:478](../src/app/api/tasks/[id]/dispatch/route.ts:478)).
+6. **Trigger payload** (the operator's actual ask, the scheduled job's
+   prompt, etc.).
+7. **Resume hint** if `is_resume`: a one-line "you may have prior
+   reasoning in this session; re-read recent turns before acting."
+
+This function replaces ad-hoc message construction in
+`runDisruptionDispatchInBackground`, `runNamedAgentDispatchInBackground`,
+and the existing dispatch route's prompt assembly.
+
+### 2.4 PM as a role, not a special agent
+
+The PM placeholder row stays (one per workspace, with `is_pm=1`) so
+existing UI queries that look up "the PM" still work. But it has no
+`gateway_agent_id`. Dispatching to the PM is now: pick role `'pm'`,
+build briefing from `agent-templates/pm/`, send to scope key
+`agent:mc-runner-dev:ws-<id>:pm-chat-<thread_id>`.
+
+This collapses the PM's special-case dispatch path. `dispatchPm` and
+`dispatchPmSynthesized` become thin wrappers around the same generic
+`dispatchScope()` primitive.
+
+## 3. The Notes Spine
+
+### 3.1 Schema
+
+```sql
+CREATE TABLE agent_notes (
+  id              TEXT PRIMARY KEY,
+  workspace_id    TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  agent_id        TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  task_id         TEXT REFERENCES tasks(id) ON DELETE CASCADE,
+  initiative_id   TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
+  scope_key       TEXT NOT NULL,
+  role            TEXT NOT NULL,
+  run_group_id    TEXT NOT NULL,             -- groups notes from one run/stage
+  kind            TEXT NOT NULL CHECK (kind IN (
+                    'discovery','blocker','uncertainty','decision',
+                    'observation','question','breadcrumb')),
+  audience        TEXT,                       -- 'pm'|'reviewer'|'next-stage'|'tester'|NULL
+  body            TEXT NOT NULL,              -- max 3000 chars
+  attached_files  TEXT,                       -- JSON array of paths
+  importance      INTEGER NOT NULL DEFAULT 0 CHECK (importance IN (0,1,2)),
+  consumed_by_stages TEXT,                    -- JSON array of stage_slugs
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_agent_notes_task ON agent_notes(task_id, created_at);
+CREATE INDEX idx_agent_notes_initiative ON agent_notes(initiative_id, created_at);
+CREATE INDEX idx_agent_notes_workspace ON agent_notes(workspace_id, created_at);
+CREATE INDEX idx_agent_notes_run_group ON agent_notes(run_group_id);
+CREATE INDEX idx_agent_notes_importance ON agent_notes(workspace_id, importance, created_at);
+```
+
+### 3.2 MCP tool family
+
+Four tools, all under the `sc-mission-control` server:
+
+- `take_note(agent_id, kind, body, task_id?, initiative_id?, audience?, attached_files?, importance?)` →
+  inserts a row, broadcasts `agent_note_created` SSE, returns the note id.
+  No evidence-gate side-effects. Cheap and spammable.
+- `read_notes(agent_id, task_id?, initiative_id?, audience?, kinds?, limit?)` →
+  query notes the agent can see. Used during work, not just at briefing
+  time. Ordered by importance DESC, created_at ASC.
+- `mark_note_consumed(agent_id, note_id)` → records that this stage has
+  read this note (appends to `consumed_by_stages`). Used by briefing
+  builder to suppress already-shown notes on the next briefing.
+- `archive_note(agent_id, note_id, reason?)` → soft-delete; the note
+  stays in DB but won't surface in future briefings or feeds. For
+  resolved blockers, stale observations.
+
+The `agent_id` argument follows the existing FK convention. Since the
+`agents` table only has `mc-runner-dev` + per-workspace PM rows, every
+non-PM scope-keyed session passes the `mc-runner-dev` UUID. This is
+fine — `agent_notes.role` carries the role-of-the-moment.
+
+### 3.3 SSE broadcast on `take_note`
+
+```ts
+broadcast({
+  type: 'agent_note_created',
+  payload: {
+    workspace_id, note_id, agent_id, role,
+    task_id, initiative_id, scope_key,
+    kind, audience, importance, body, attached_files,
+    run_group_id, created_at,
+  }
+});
+```
+
+If `importance === 2`, also post to PM Chat as an assistant-style
+message (existing `postPmChatMessage` from
+[pm-dispatch.ts:174](../src/lib/agents/pm-dispatch.ts:174)) so the
+operator sees high-stakes findings in their primary chat surface.
+
+### 3.4 Briefing integration
+
+Inside `buildBriefing()` step 4, query notes:
+
+```sql
+SELECT id, kind, role, body, audience, attached_files, importance, created_at
+  FROM agent_notes
+ WHERE (task_id = :task_id OR (task_id IS NULL AND initiative_id = :initiative_id))
+   AND archived_at IS NULL
+   AND (audience IS NULL OR audience = :next_role OR audience = 'next-stage')
+   AND (consumed_by_stages IS NULL OR :stage_slug NOT IN consumed_by_stages)
+ ORDER BY importance DESC, created_at ASC
+ LIMIT 50;
+```
+
+Format as a "Notes from prior work" section in the briefing, grouped by
+`run_group_id`. The agent is instructed (via the notetaker addendum) to
+call `mark_note_consumed` for each one as it processes them so the next
+session doesn't re-show it.
+
+### 3.5 Role-soul addendum (`agent-templates/_shared/notetaker.md`)
+
+```markdown
+# You are an obsessive notetaker
+
+Notes are free; forgotten reasoning is not. Every meaningful moment of
+your work should leave a trail in `take_note`.
+
+## When to call `take_note`
+
+- You read something non-obvious in the code → `kind: discovery`
+- You're stuck or unsure about an approach → `kind: uncertainty` or `blocker`
+- You chose A over B → `kind: decision` (name *both* alternatives in the body)
+- Something surprised you → `kind: observation`
+- You have a question you can't answer here → `kind: question` (set `audience: 'pm'`)
+- You're about to hand off → `kind: breadcrumb`, `audience: 'next-stage'`
+
+## How to write a good note
+
+- Concrete > aspirational. "Updated `migrations.ts:063` to add `role` column" beats "Made schema changes".
+- Reference file paths in `attached_files` so the next session can navigate without re-reading the world.
+- One thought per note. Ten short notes beat one long essay.
+- Set `importance: 2` only for genuinely high-stakes findings (security issues, broken assumptions, unrecoverable choices). The PM sees these in real time.
+
+## When to call `read_notes`
+
+Before you commit to an approach, check:
+- `read_notes(task_id: <self>, audience: 'next-stage')` — what did the prior stage want me to know?
+- `read_notes(task_id: <self>, kinds: ['decision','blocker'])` — what's already been decided or stuck?
+
+After you make progress, scan for any `kind: question` you can now answer.
+
+## Closing a note
+
+When a `blocker` is resolved or an `uncertainty` clarified, call
+`archive_note(note_id, reason: '<one line>')`. Don't leave stale
+worries in the feed.
+```
+
+### 3.6 UI surfaces (the observability win)
+
+Five subscribers to the SSE stream, each filtering differently:
+
+1. **Task detail panel** — filter `task_id === current.id`. New "Notes"
+   rail next to deliverables, grouped by `run_group_id`, reverse-chrono,
+   importance-pinned.
+2. **Initiative detail panel** — filter `initiative_id === current.id`
+   OR `task_id IN getInitiativeTaskIds(current.id)`. Rollup view of
+   activity across all child tasks.
+3. **Cards in lists** — small dot-badge with note count + most-recent
+   timestamp; hover shows latest body excerpt. Live-updates when SSE
+   arrives for a card on screen.
+4. **Workspace live feed** (new page at `/feed`) — full unfiltered
+   stream, filter chips by kind/role/agent/importance, "Follow" toggle
+   to subscribe to a specific task or recurring job.
+5. **PM Chat** — `importance: 2` notes auto-post (existing wire-up).
+
+Implementation: shared SSE hook `useAgentNotes(filter)` that any
+component can use. Notes Rail component is reused across Task and
+Initiative detail panels.
+
+## 4. Recurring Jobs
+
+### 4.1 Schema
+
+```sql
+CREATE TABLE recurring_jobs (
+  id                   TEXT PRIMARY KEY,
+  workspace_id         TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  name                 TEXT NOT NULL,                    -- "Watch DGX Spark forum"
+  role                 TEXT NOT NULL,                    -- 'researcher', 'builder', etc.
+  scope_key_template   TEXT NOT NULL,                    -- substitutes {wsid}, {job_id}, {run_n}
+  briefing_template    TEXT NOT NULL,                    -- prompt body, can interpolate MC state
+  initiative_id        TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
+  task_id              TEXT REFERENCES tasks(id) ON DELETE CASCADE,
+  cadence_seconds      INTEGER NOT NULL,                 -- 172800 = 2 days
+  attempt_strategy     TEXT NOT NULL DEFAULT 'reuse' CHECK (attempt_strategy IN ('reuse','fresh')),
+  status               TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','paused','done')),
+  last_run_at          TEXT,
+  last_run_scope_key   TEXT,
+  next_run_at          TEXT NOT NULL,
+  consecutive_failures INTEGER NOT NULL DEFAULT 0,
+  run_count            INTEGER NOT NULL DEFAULT 0,
+  created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+  created_by_agent_id  TEXT REFERENCES agents(id) ON DELETE SET NULL
+);
+CREATE INDEX idx_recurring_jobs_next_run ON recurring_jobs(next_run_at, status);
+CREATE INDEX idx_recurring_jobs_workspace ON recurring_jobs(workspace_id, status);
+```
+
+### 4.2 Scheduler
+
+Add to `instrumentation.ts` alongside the existing `pm_pending_notes`
+drain. 60-second `setInterval`:
+
+```ts
+function dispatchRecurringJobs(): void {
+  const now = new Date().toISOString();
+  const due = queryAll<RecurringJob>(
+    `SELECT * FROM recurring_jobs
+      WHERE status = 'active' AND next_run_at <= ?
+      ORDER BY next_run_at ASC LIMIT 50`,
+    [now]
+  );
+  for (const job of due) {
+    void dispatchRecurringJobOnce(job).catch(err =>
+      console.error(`[recurring] job ${job.id} failed:`, err)
+    );
+  }
+}
+```
+
+Each dispatch:
+1. Render `scope_key_template` with current `run_count`.
+2. Build briefing via the same `buildBriefing()`, passing the
+   `briefing_template` as `trigger_text`.
+3. Send via `chat.send`. Same SSE / note flow.
+4. On agent's final frame: bump `last_run_at`, `next_run_at = now() +
+   cadence_seconds`, `run_count++`, `consecutive_failures = 0`.
+5. On error or timeout: `consecutive_failures++`. If > 3, flip
+   `status='paused'` and post an `importance: 2` note for the operator.
+
+### 4.3 Notes-back semantics for recurring jobs
+
+The researcher example: every 2 days, check the DGX Spark forum,
+report what's new.
+
+- Each run takes 1–N notes via `take_note(kind: 'observation' or
+  'discovery', task_id: <linked>, audience: 'pm')`.
+- Same `run_group_id` across all notes from one run; UI groups them.
+- If the researcher concludes the roadmap should change, *also* call
+  `propose_changes` to draft a `pm_proposals` row.
+- "Nothing new this time" is still a note (`kind: 'observation'`,
+  `body: 'No new posts since last check'`). Silence is signal too.
+
+## 5. Optional Heartbeat Coordinator
+
+### 5.1 Opt-in per task or per workspace
+
+Workspace setting + per-task override: `coordinator_mode: 'off' |
+'reactive' | 'heartbeat'`. Reactive (today) = coordinator dispatches on
+stage transitions only. Heartbeat = additionally, every N minutes the
+coordinator checks in on its tasks.
+
+### 5.2 Schema (additive)
+
+```sql
+ALTER TABLE workspaces ADD COLUMN coordinator_mode TEXT NOT NULL DEFAULT 'reactive'
+  CHECK (coordinator_mode IN ('off','reactive','heartbeat'));
+ALTER TABLE workspaces ADD COLUMN coordinator_heartbeat_seconds INTEGER NOT NULL DEFAULT 1800;
+
+ALTER TABLE tasks ADD COLUMN coordinator_mode TEXT
+  CHECK (coordinator_mode IN ('off','reactive','heartbeat')); -- NULL = inherit workspace
+```
+
+### 5.3 Behavior
+
+When heartbeat is enabled for a task: a `recurring_jobs` row is
+auto-created at task assignment with:
+- `role: 'coordinator'`
+- `scope_key_template: 'agent:mc-runner-dev:ws-{wsid}:task-{task_id}:heartbeat'`
+- `cadence_seconds: <coordinator_heartbeat_seconds>`
+- `attempt_strategy: 'reuse'` (continuity is the value)
+- `briefing_template: 'Check on task {task_id}. Read recent notes via
+  read_notes. If there's a blocker that needs escalation, take_note
+  with audience=pm and importance=2. If a stage is stalled or going
+  off-track, take_note with audience=next-stage. If everything is fine,
+  take_note kind=observation body="ok".'`
+
+Auto-deleted on task terminal status. The coordinator becomes "the
+agent that watches the watchers" — purely observational, never writes
+deliverables, never moves status.
+
+This isn't a separate code path — it's `recurring_jobs` with a special
+template. Confirms the design: the recurring jobs primitive subsumes
+all "scheduled agent work".
+
+## 6. Migration Plan
+
+### 6.1 Phases (each independently deployable)
+
+**Phase A — Foundations (no behavioral change):**
+- A1. Add `agent-templates/` directory + import script + seed contents from openclaw workspaces.
+- A2. Add `agent_role_overrides`, `agent_notes`, `mc_sessions`, `recurring_jobs` tables (new migrations).
+- A3. Add MCP tools: `take_note`, `read_notes`, `mark_note_consumed`, `archive_note`. No agents call them yet.
+- A4. Add SSE event type `agent_note_created`. Add `useAgentNotes` hook (unused).
+
+Ships behind a feature flag. Tests pass; nothing user-facing changes.
+
+**Phase B — Briefing builder + scope-keyed dispatch primitive:**
+- B1. Implement `buildBriefing()` from `agent-templates/` + overrides.
+- B2. Add `dispatchScope()` primitive that takes a sessionKey and role, builds briefing, sends. Wraps existing `sendChatAndAwaitReply`.
+- B3. Add `mc_sessions` upsert in `dispatchScope`.
+- B4. Wire PM dispatch (disruption, plan, decompose, notes-intake) to use the new primitive. Verify behavior matches today via the existing `pm.test.ts` suite.
+
+**Phase C — Workers via scope-keyed dispatch:**
+- C1. Add the `runner-host/` template + neutralize `~/.openclaw/workspaces/mc-runner-dev/` SOUL/AGENTS/IDENTITY.
+- C2. Switch task dispatch ([dispatch/route.ts:42](../src/app/api/tasks/[id]/dispatch/route.ts:42)) to compute scope keys against `mc-runner-dev` and call `dispatchScope`. Keep the legacy path behind a feature flag for one PR's worth of testing.
+- C3. Update agent role-souls to include the notetaker addendum. Run real-agent eval against `spark-lb/agent` to verify notes are produced at expected rate.
+
+**Phase D — Observability surfaces:**
+- D1. Notes Rail component (Task detail).
+- D2. Notes Rail on Initiative detail (rollup query).
+- D3. Card badges in list views.
+- D4. Workspace `/feed` page.
+- D5. `importance: 2` auto-post to PM Chat.
+
+**Phase E — Recurring jobs + optional heartbeat coordinator:**
+- E1. Recurring jobs scheduler + UI (create/pause/resume).
+- E2. Workspace + task `coordinator_mode` setting + auto-create heartbeat job.
+- E3. Real-agent smoke for both: 2-day cadence forum-watcher (compressed to 5min in test), and a heartbeat coord that tests escalation.
+
+**Phase F — Decommission durable workers:**
+- F1. Run a script that nulls `gateway_agent_id` on all worker rows
+  (everything except the runner agents and PM placeholders).
+- F2. Drop the catalog sync's worker discovery path (it now only ensures `mc-runner-dev`).
+- F3. Update settings UI: "Agents" tab becomes "Roles", scoped to `agent_role_overrides`.
+- F4. Run another script to mark old worker `~/.openclaw/workspaces/mc-{role}-{env}/` as archived (move to `~/.openclaw/workspaces/.archive/`). Openclaw's 30-day pruner handles the rest.
+
+### 6.2 Rollback
+
+Each phase has a feature flag. Disable the flag = old path resumes. The
+schema additions are all additive (new tables, nullable columns); no
+destructive migrations until F1, which is reversible by re-running the
+agent catalog sync.
+
+### 6.3 What's removed
+
+After Phase F:
+- The promotion UI (operator-promotes-PM-to-gateway flow) goes away.
+- `cloneAgentsFromWorkspace` ([bootstrap-agents.ts:123](../src/lib/bootstrap-agents.ts:123)) becomes a no-op (only PM is per-workspace; PM is auto-seeded).
+- The `is_pm` resolver fallback path ([pm-resolver.ts:30](../src/lib/agents/pm-resolver.ts:30)) — the `LOWER(role)='pm'` branch — can be deleted once PM is universally `is_pm=1`.
+- The "AVAILABLE PERSISTENT AGENTS" roster in coordinator dispatches ([dispatch/route.ts:494](../src/app/api/tasks/[id]/dispatch/route.ts:494)) — coordinators now fan out via the scope-key dispatcher, not by enumerating peers.
+- The dispatch-message preamble fix from this morning ([pm-dispatch.ts:140](../src/lib/agents/pm-dispatch.ts:140)) becomes universal (every briefing has it).
+
+## 7. Validation Strategy
+
+### 7.1 Per-slice gates
+
+Every phase's PR must pass:
+- `yarn tsc --noEmit` (zero errors; pre-existing pm-decompose.test.ts errors are tracked and unrelated).
+- `yarn test` (existing suite + new tests for the slice).
+- `yarn mcp:smoke` (extended with new tools in Phase A).
+- For UI phases: `preview_*` smoke run with the browser tooling.
+- For dispatch phases: real-agent round-trip against `spark-lb/agent`,
+  asserting the agent reaches the expected terminal state in the DB.
+
+### 7.2 New test additions
+
+- `briefing.test.ts` — pure function tests for `buildBriefing()` over a synthetic snapshot. Asserts the role section, notes section, and identity preamble all appear.
+- `scope-key.test.ts` — round-trips parsing/formatting; asserts no legal scope exceeds the 64-char segment limit.
+- `agent-notes.test.ts` — schema CRUD, SSE broadcast, FK behavior on workspace deletion, filter queries.
+- `recurring-jobs.test.ts` — scheduler picks due jobs; updates `next_run_at`; trips into `paused` after 3 failures; correctly renders `scope_key_template`.
+- `dispatch-scope.test.ts` — uses existing `__setOpenClawClientForTests` to assert the briefing reaches the agent and the agent's tool calls are routed correctly.
+- `pm-eval.ts` (new harness) — runs synthetic disruptions through `dispatchScope` against `spark-lb/agent`, scores via LLM-as-judge.
+
+### 7.3 LLM-as-judge eval harness
+
+Built in Phase B, run automatically in CI for Phase C+:
+
+```
+specs/evals/scope-keyed-sessions/
+├── tasks/
+│   ├── 01-builder-add-feature.json
+│   ├── 02-tester-find-regression.json
+│   ├── 03-researcher-watch-forum.json
+│   └── ...
+├── rubrics/
+│   ├── note-quality.md          # does the agent take well-structured notes?
+│   ├── briefing-fidelity.md     # does the agent ingest prior notes correctly?
+│   └── handoff-cohesion.md      # does next-stage build on prior-stage notes?
+└── runner.ts                    # invokes spark-lb/agent, scores, prints table
+```
+
+Halt criteria (stop the autonomous build, surface to operator):
+- Type errors on any phase.
+- Test regressions in any phase.
+- Real-agent smoke fails with non-flake error.
+- LLM-as-judge rubric scores fall below threshold (define per rubric).
+- A phase's PR has no CHANGELOG entry.
+
+### 7.4 Q3 attempt-strategy decision
+
+The `fresh` vs `reuse` defaults are codified after running the harness
+against both strategies on each role's synthetic tasks. The defaults
+land in `agent_role_overrides` seed data. Document the win-rate per
+strategy per role in the spec's appendix when the data lands.
+
+## 8. Open Questions and Risks
+
+### 8.1 Open
+
+- **Coordinator collapse into PM?** Today coordinator and PM have
+  separate role definitions. With workers ephemeral and MC owning
+  convoy state, the coordinator's job is mostly thin orchestration. We
+  could either (a) keep the role definition for cases where mid-task
+  judgment matters, or (b) fold "decompose + dispatch + react" into
+  the PM at planning time. This spec keeps coordinator as a role for
+  Phase E flexibility; revisit after Phase E validation.
+
+- **Note retention.** Notes never delete. For a busy workspace running
+  for years, this is a lot of rows. Add a 90-day archival pass (move
+  to `agent_notes_archive`) in a follow-up if it becomes an issue.
+  Indexes are designed to keep recent-time queries fast regardless.
+
+### 8.2 Risks
+
+- **Briefing length.** Concatenating role-soul + AGENTS.md + IDENTITY
+  + notetaker addendum + task context + N notes can balloon. The
+  briefing builder caps notes at 50 and the addendum at 1500 chars; if
+  total exceeds 12,000 chars, truncate the notes block first (oldest
+  first). Add a metric: median + p95 briefing size per role.
+
+- **Trajectory file growth.** A long-lived recurring researcher session
+  with `attempt_strategy: 'reuse'` could grow large over months.
+  Openclaw's 30-day prune doesn't trigger if the session is touched
+  every 2 days. Mitigation: when `compactionCount > 5`, mint a new
+  attempt key (`run-N+1`) and start fresh, briefing from notes. Add as
+  Phase E2.5.
+
+- **Note spam.** Roles instructed to be "obsessive notetakers" might
+  fire too many `take_note` calls. The harness in Phase C will measure
+  notes-per-minute; if pathological, tighten the addendum guidance and
+  potentially rate-limit at the MCP layer.
+
+- **Operator note-fatigue.** Five notes per task across five tasks =
+  the live feed becomes noise. Mitigation: importance levels are real
+  (importance 0 doesn't surface in feed by default; importance 2 pings
+  PM Chat). Filter chips on `/feed` make the firehose tractable.
+
+## Appendix A — Where the bug we just fixed lives in the new model
+
+The [pm-dispatch.ts:140](../src/lib/agents/pm-dispatch.ts:140)
+`buildIdentityPreamble` becomes part of the universal briefing builder
+(§2.3 step 1). Every dispatch — PM, worker, coordinator, recurring —
+opens with the agent's UUID. The `whoami` ambiguity case
+([tools.ts:166](../src/lib/mcp/tools.ts:166)) becomes unreachable in
+practice because no two `agents` rows share a `gateway_agent_id` after
+Phase F (only `mc-runner-dev` carries one). The error path stays as
+defense-in-depth.
+
+## Appendix B — File inventory
+
+New files:
+- `agent-templates/` (directory + `_shared/` + 8 role subdirectories)
+- `scripts/import-agent-templates.ts`
+- `src/lib/agents/briefing.ts`
+- `src/lib/agents/dispatch-scope.ts`
+- `src/lib/db/migrations/064-agent-role-overrides.ts` (or next available)
+- `src/lib/db/migrations/065-agent-notes.ts`
+- `src/lib/db/migrations/066-mc-sessions.ts`
+- `src/lib/db/migrations/067-recurring-jobs.ts`
+- `src/lib/db/migrations/068-coordinator-mode.ts`
+- `src/lib/db/agent-notes.ts`
+- `src/lib/db/recurring-jobs.ts`
+- `src/lib/agents/recurring-scheduler.ts`
+- `src/components/notes/NotesRail.tsx`
+- `src/components/notes/NoteCard.tsx`
+- `src/components/notes/useAgentNotes.ts`
+- `src/app/feed/page.tsx`
+- `specs/evals/scope-keyed-sessions/`
+- Tests for each.
+
+Modified files:
+- [pm-dispatch.ts](../src/lib/agents/pm-dispatch.ts) — wraps `dispatchScope`
+- [dispatch/route.ts](../src/app/api/tasks/[id]/dispatch/route.ts) — uses `dispatchScope`
+- [agent-catalog-sync.ts](../src/lib/agent-catalog-sync.ts) — only ensures runner exists
+- [bootstrap-agents.ts](../src/lib/bootstrap-agents.ts) — `cloneAgentsFromWorkspace` becomes no-op
+- [pm-resolver.ts](../src/lib/agents/pm-resolver.ts) — drops legacy fallback (Phase F)
+- [tools.ts](../src/lib/mcp/tools.ts) — adds notes family
+- [instrumentation.ts](../instrumentation.ts) — adds recurring scheduler
+
+Removed (Phase F):
+- The `gateway_agent_id` column on most `agents` rows (data, not schema).
+- Coordinator dispatch's "AVAILABLE PERSISTENT AGENTS" roster section.
+- Older per-role openclaw workspaces archived (filesystem move only).
+
+## Status
+
+- [x] Audit complete (openclaw session internals + MC planning flows)
+- [x] Architecture locked
+- [x] Spec drafted (this document)
+- [ ] Phase A implementation
+- [ ] Phase B implementation
+- [ ] Phase C implementation
+- [ ] Phase D implementation
+- [ ] Phase E implementation
+- [ ] Phase F implementation


### PR DESCRIPTION
## Summary
- Architecture spec replacing durable per-role-per-workspace gateway agents with **scope-keyed sessions** on a single org-wide runner. Trajectory replay is the resume mechanism; openclaw's existing storage is the durable record.
- **Notes spine** (`take_note` MCP family + `agent_notes` table + SSE broadcast) — every meaningful agent moment becomes queryable, auditable, surfaced on cards/feed/PM Chat.
- **Recurring jobs** for native scheduled work (researcher every 2 days, optional heartbeat coordinator).
- **Source-controlled role templates** at `agent-templates/<role>/` with per-workspace overrides.
- **Six-phase migration plan**, each phase deployable behind a feature flag.
- **Validation pack** with runbook + test plan + 17 global gates + halt criteria for autonomous milestone gating against `spark-lb/agent`.

## Files
- `specs/scope-keyed-sessions.md` — full architecture (804 lines, 8 sections + 2 appendices).
- `specs/scope-keyed-sessions-validation/` — 4-file validation pack (baseline + pre-check + test plan + criteria).
- `scripts/seed-foia-fixture.ts` — idempotent FOIA initiative tree fixture for tests.

## What this PR is NOT
- No runtime code changes — design and validation infrastructure only.
- No migrations land here. Phase A starts after merge.

## Test plan
- [x] `scripts/seed-foia-fixture.ts` typechecks clean (`yarn tsc --noEmit` total errors unchanged at 2 — pre-existing pm-decompose noise).
- [x] Spec reviewed end-to-end by author; design questions in §8 surfaced rather than buried.
- [ ] Spec reviewed by operator before Phase A implementation begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)