### PR TITLE
feat(scope-keyed-sessions): Phase G — PM is the workspace's only required agent

### DIFF
--- a/specs/scope-keyed-sessions-validation/04-e2e-run-results.md
+++ b/specs/scope-keyed-sessions-validation/04-e2e-run-results.md
@@ -92,6 +92,17 @@ implement this conversion in `pm-resolver.ts` — left as a Phase G
 follow-up item. The manual repoint sidesteps it for the e2e.
 
 ### 4. **The actual blocker — MCP tools not surfaced to runner sessions**
+
+**Note (post-run, per operator confirmation):** the openclaw config is
+correct. Both MCP servers are configured and the runner's tool profile
+allow/deny scopes them properly (dev runner allows
+`sc-mission-control-dev__*`, denies `sc-mission-control__*`; prod
+runner is the inverse). The dev runner used for this run was
+`mc-runner-dev` — verified end-to-end (FOIA PM was repointed at
+`mc-runner-dev`, dev MC runs on port 4010, MCP launcher's `MC_URL`
+points at port 4010). The remaining gap is openclaw-side MCP server
+*activation* at session start — not configuration.
+
 **Symptom:** Runner agent receives the dispatch, reasons through it,
 tries `browser`, `exec`, every available tool, then concludes:
 > "I'm in an isolated session without MCP tool access. The PM tools

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
-import { bootstrapCoreAgents, cloneAgentsFromWorkspace, cloneWorkflowTemplates, ensurePmAgent } from '@/lib/bootstrap-agents';
+import { bootstrapCoreAgents, cloneAgentsFromWorkspace, cloneWorkflowTemplates, ensurePmAgent, hasWorkspacePm, WorkspacePmRequiredError } from '@/lib/bootstrap-agents';
 import type { Workspace, WorkspaceStats, TaskStatus } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -106,35 +106,63 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'A workspace with this name already exists' }, { status: 400 });
     }
 
-    db.prepare(`
-      INSERT INTO workspaces (id, name, slug, description, icon)
-      VALUES (?, ?, ?, ?, ?)
-    `).run(id, name.trim(), slug, description || null, icon || '📁');
+    // Phase G: workspace creation atomically seeds + verifies the PM.
+    // If any of the steps fail (PM placeholder couldn't insert, clone
+    // returned without bringing a PM across, etc.), the whole
+    // workspace is rolled back. The PM is the workspace's only required
+    // agent — without it, no dispatch / proposal / planning works.
+    const tx = db.transaction(() => {
+      db.prepare(`
+        INSERT INTO workspaces (id, name, slug, description, icon)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(id, name.trim(), slug, description || null, icon || '📁');
 
-    // Clone workflow templates and bootstrap core agents for the new workspace
-    cloneWorkflowTemplates(db, id);
-    bootstrapCoreAgents(id);
+      cloneWorkflowTemplates(db, id);
+      bootstrapCoreAgents(id);
 
-    // Optional: copy the agent roster from another workspace. Useful when
-    // gateway sync only keys to one workspace and a fresh row would
-    // otherwise start empty. ensurePmAgent below is a no-op if any
-    // cloned agent already has is_pm=1.
-    if (clone_agents_from && typeof clone_agents_from === 'string') {
-      const source = db.prepare(
-        'SELECT id FROM workspaces WHERE id = ?',
-      ).get(clone_agents_from);
-      if (!source) {
+      // Optional: copy the agent roster from another workspace.
+      if (clone_agents_from && typeof clone_agents_from === 'string') {
+        const source = db.prepare(
+          'SELECT id FROM workspaces WHERE id = ?',
+        ).get(clone_agents_from);
+        if (!source) {
+          throw new Error(`SOURCE_NOT_FOUND:${clone_agents_from}`);
+        }
+        cloneAgentsFromWorkspace(clone_agents_from, id);
+      }
+
+      ensurePmAgent(id);
+
+      // Final gate: workspace MUST have a PM with is_pm=1 AND is_master=1
+      // before we commit. ensurePmAgent throws on insert failure but a
+      // legacy code path (e.g. clone source missing PM) could still
+      // leave the workspace PM-less; the assertion catches that.
+      if (!hasWorkspacePm(id)) {
+        throw new WorkspacePmRequiredError(
+          id,
+          'workspace creation completed but no PM is present after seeding',
+        );
+      }
+    });
+
+    try {
+      tx();
+    } catch (err) {
+      if (err instanceof WorkspacePmRequiredError) {
         return NextResponse.json(
-          { error: `Source workspace not found: ${clone_agents_from}` },
+          { error: 'PM required', message: err.message },
+          { status: 500 },
+        );
+      }
+      const msg = (err as Error).message ?? '';
+      if (msg.startsWith('SOURCE_NOT_FOUND:')) {
+        return NextResponse.json(
+          { error: `Source workspace not found: ${msg.slice('SOURCE_NOT_FOUND:'.length)}` },
           { status: 400 },
         );
       }
-      cloneAgentsFromWorkspace(clone_agents_from, id);
+      throw err;
     }
-
-    // Seed the workspace's PM agent (planning layer, role='pm'). Idempotent
-    // — bails out if cloneAgentsFromWorkspace already brought a PM across.
-    ensurePmAgent(id);
 
     const workspace = db.prepare('SELECT * FROM workspaces WHERE id = ?').get(id);
     return NextResponse.json(workspace, { status: 201 });

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -53,6 +53,7 @@ import {
 import { buildNotesIntakeMessage } from './pm-prompts/notes-intake';
 import { getPmAgent } from './pm-resolver';
 import { dispatchScope } from './dispatch-scope';
+import { assertWorkspacePm } from '@/lib/bootstrap-agents';
 import type { Agent } from '@/lib/types';
 
 // ─── Public API ─────────────────────────────────────────────────────
@@ -168,6 +169,12 @@ function buildIdentityPreamble(pm: Agent): string {
  * `PmDispatchGatewayUnavailableError` instead of persisting a synth row.
  */
 export function dispatchPm(input: DispatchPmInput): DispatchPmResult {
+  // Phase G: every dispatch path is gated on the workspace having a
+  // PM agent (is_pm=1 AND is_master=1). The workspace's POST handler
+  // enforces this on creation; the gate here protects against late
+  // operator actions (manual DB edits, demoted PM, etc.) that would
+  // otherwise leave dispatch undefined.
+  assertWorkspacePm(input.workspace_id);
   const snapshot = getRoadmapSnapshot({ workspace_id: input.workspace_id });
   const pm = lookupPmAgent(input.workspace_id);
   const allowFallback = input.allowFallback ?? true;
@@ -498,6 +505,9 @@ const RECONCILER_POLL_MS = 2_000;
 export function dispatchPmSynthesized(
   input: DispatchSynthesizedInput,
 ): DispatchSynthesizedResult {
+  // Phase G: gate every PM dispatch on the workspace having a PM. See
+  // dispatchPm above for the rationale.
+  assertWorkspacePm(input.workspace_id);
   const pm = lookupPmAgent(input.workspace_id);
   const gw = gatewayClient();
   const gatewayUp = !!(pm && pm.gateway_agent_id && gw.isConnected());

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -937,3 +937,20 @@ test('dispatchPmSynthesized: plan_initiative — agent omits target dates → re
     __setNamedAgentTimeoutForTests(null);
   }
 });
+
+// ─── Phase G: PM-required gating ────────────────────────────────────
+
+test('dispatchPm: throws WorkspacePmRequiredError when workspace has no PM', async () => {
+  // Fresh workspace, no ensurePmAgent — bootstrapCoreAgents is a no-op
+  // and we never seeded a PM. Phase G gates dispatch on PM presence.
+  const id = `ws-no-pm-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  const { WorkspacePmRequiredError } = await import('@/lib/bootstrap-agents');
+  assert.throws(
+    () => dispatchPm({ workspace_id: id, trigger_text: 'no pm here' }),
+    WorkspacePmRequiredError,
+  );
+});

--- a/src/lib/bootstrap-agents.test.ts
+++ b/src/lib/bootstrap-agents.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Phase G: PM is the workspace's only required agent and is the
+ * master orchestrator (is_pm=1 AND is_master=1).
+ *
+ * Coverage:
+ *  - ensurePmAgent on a fresh workspace inserts with is_master=1.
+ *  - ensurePmAgent on a legacy workspace (PM with is_master=0)
+ *    upgrades the existing row in place.
+ *  - hasWorkspacePm requires both flags + is_active.
+ *  - assertWorkspacePm throws WorkspacePmRequiredError when missing.
+ *  - migration 069 backfills is_master on legacy PM rows
+ *    (verified by running the test-template setup which applies all
+ *    migrations).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, run } from '@/lib/db';
+import {
+  assertWorkspacePm,
+  ensurePmAgent,
+  hasWorkspacePm,
+  WorkspacePmRequiredError,
+} from './bootstrap-agents';
+
+function freshWorkspace(): string {
+  const id = `ws-pm-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+test('ensurePmAgent: fresh workspace gets PM with is_pm=1 AND is_master=1', () => {
+  const ws = freshWorkspace();
+  const result = ensurePmAgent(ws);
+  assert.equal(result.created, true);
+  const row = queryOne<{ id: string; is_pm: number; is_master: number; role: string; name: string }>(
+    `SELECT id, is_pm, COALESCE(is_master,0) AS is_master, role, name
+       FROM agents WHERE workspace_id = ? AND is_pm = 1 LIMIT 1`,
+    [ws],
+  );
+  assert.ok(row);
+  assert.equal(row?.is_pm, 1);
+  assert.equal(row?.is_master, 1);
+  assert.equal(row?.role, 'pm');
+  assert.equal(row?.name, 'PM');
+});
+
+test('ensurePmAgent: idempotent — second call returns same id, created=false', () => {
+  const ws = freshWorkspace();
+  const first = ensurePmAgent(ws);
+  const second = ensurePmAgent(ws);
+  assert.equal(second.created, false);
+  assert.equal(second.id, first.id);
+});
+
+test('ensurePmAgent: upgrades legacy is_master=0 PM to is_master=1', () => {
+  const ws = freshWorkspace();
+  // Simulate a pre-Phase-G workspace: PM with is_master=0.
+  const id = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_pm, is_master, is_active, created_at, updated_at)
+     VALUES (?, 'PM', 'pm', ?, 1, 0, 1, datetime('now'), datetime('now'))`,
+    [id, ws],
+  );
+  // Sanity: legacy row is is_master=0.
+  let row = queryOne<{ is_master: number }>(
+    `SELECT COALESCE(is_master,0) AS is_master FROM agents WHERE id = ?`,
+    [id],
+  );
+  assert.equal(row?.is_master, 0);
+
+  const result = ensurePmAgent(ws);
+  assert.equal(result.id, id);
+  assert.equal(result.created, false);
+
+  row = queryOne<{ is_master: number }>(
+    `SELECT COALESCE(is_master,0) AS is_master FROM agents WHERE id = ?`,
+    [id],
+  );
+  assert.equal(row?.is_master, 1, 'ensurePmAgent should backfill is_master on legacy PMs');
+});
+
+test('hasWorkspacePm: returns false for an empty workspace', () => {
+  const ws = freshWorkspace();
+  assert.equal(hasWorkspacePm(ws), false);
+});
+
+test('hasWorkspacePm: requires both is_pm=1 AND is_master=1', () => {
+  const ws = freshWorkspace();
+  // is_pm=1, is_master=0 — not a master orchestrator yet.
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_pm, is_master, is_active, created_at, updated_at)
+     VALUES (?, 'PM', 'pm', ?, 1, 0, 1, datetime('now'), datetime('now'))`,
+    [uuidv4(), ws],
+  );
+  assert.equal(hasWorkspacePm(ws), false);
+});
+
+test('hasWorkspacePm: requires is_active=1', () => {
+  const ws = freshWorkspace();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_pm, is_master, is_active, created_at, updated_at)
+     VALUES (?, 'PM', 'pm', ?, 1, 1, 0, datetime('now'), datetime('now'))`,
+    [uuidv4(), ws],
+  );
+  assert.equal(hasWorkspacePm(ws), false);
+});
+
+test('hasWorkspacePm: returns true after ensurePmAgent', () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  assert.equal(hasWorkspacePm(ws), true);
+});
+
+test('assertWorkspacePm: throws WorkspacePmRequiredError when missing', () => {
+  const ws = freshWorkspace();
+  assert.throws(() => assertWorkspacePm(ws), WorkspacePmRequiredError);
+});
+
+test('assertWorkspacePm: silent when PM is correctly configured', () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  assert.doesNotThrow(() => assertWorkspacePm(ws));
+});
+
+// Note: the migration-069 backfill assertion isn't a meaningful test
+// at this scope — other tests in the file deliberately insert
+// is_pm=1 + is_master=0 rows to exercise hasWorkspacePm's flag
+// requirements, and node:test shares a single template DB across
+// tests. The migration's effect is logged at template-build time
+// (`[Migration 069] is_master=1 backfilled on N PM agent row(s).`)
+// and exercised in the production migration suite.

--- a/src/lib/bootstrap-agents.ts
+++ b/src/lib/bootstrap-agents.ts
@@ -69,14 +69,33 @@ export function bootstrapCoreAgentsRaw(
  * untouched — operators may have customized it, and migration 061
  * backfilled is_pm for legacy rows.
  */
+export class WorkspacePmRequiredError extends Error {
+  constructor(public workspaceId: string, reason: string) {
+    super(`workspace ${workspaceId} requires a PM: ${reason}`);
+    this.name = 'WorkspacePmRequiredError';
+  }
+}
+
 export function ensurePmAgent(workspaceId: string): { id: string; created: boolean } {
   const db = getDb();
   const existing = db.prepare(
-    `SELECT id FROM agents
+    `SELECT id, COALESCE(is_master, 0) AS is_master
+       FROM agents
        WHERE workspace_id = ? AND (is_pm = 1 OR LOWER(role) = 'pm')
        LIMIT 1`,
-  ).get(workspaceId) as { id: string } | undefined;
-  if (existing) return { id: existing.id, created: false };
+  ).get(workspaceId) as { id: string; is_master: number } | undefined;
+  if (existing) {
+    // Phase G: the PM is the workspace's master orchestrator. Forgive
+    // legacy rows that pre-date that contract by upgrading them in
+    // place; treat this as not-created so callers don't double-emit
+    // setup events.
+    if (existing.is_master !== 1) {
+      db.prepare(
+        `UPDATE agents SET is_master = 1, updated_at = datetime('now') WHERE id = ?`,
+      ).run(existing.id);
+    }
+    return { id: existing.id, created: false };
+  }
 
   // Lazy-import to avoid circular deps during migration startup.
   // pm-agent.ts is plain TS with no DB imports so it's safe everywhere.
@@ -89,20 +108,29 @@ export function ensurePmAgent(workspaceId: string): { id: string; created: boole
   // either edits this row to point at a gateway PM, or (more likely)
   // promotes a different existing gateway agent via the AgentModal
   // checkbox, which clears is_pm here and sets it on the new target.
-  db.prepare(`
-    INSERT INTO agents (
-      id, name, role, description, avatar_emoji, status, is_master, is_pm,
-      workspace_id, soul_md, source,
-      is_active, created_at, updated_at
-    ) VALUES (?, 'PM', 'pm', ?, '📋', 'standby', 0, 1, ?, ?, 'local', 1, ?, ?)
-  `).run(
-    id,
-    PM_AGENT_DESCRIPTION,
-    workspaceId,
-    getPmSoulMd(),
-    now,
-    now,
-  );
+  // Phase G: is_master=1 so the PM is the master orchestrator from
+  // the moment the workspace is born.
+  try {
+    db.prepare(`
+      INSERT INTO agents (
+        id, name, role, description, avatar_emoji, status, is_master, is_pm,
+        workspace_id, soul_md, source,
+        is_active, created_at, updated_at
+      ) VALUES (?, 'PM', 'pm', ?, '📋', 'standby', 1, 1, ?, ?, 'local', 1, ?, ?)
+    `).run(
+      id,
+      PM_AGENT_DESCRIPTION,
+      workspaceId,
+      getPmSoulMd(),
+      now,
+      now,
+    );
+  } catch (err) {
+    throw new WorkspacePmRequiredError(
+      workspaceId,
+      `PM placeholder insert failed: ${(err as Error).message}`,
+    );
+  }
   return { id, created: true };
 }
 
@@ -214,4 +242,43 @@ export function cloneWorkflowTemplates(db: Database.Database, targetWorkspaceId:
   }
 
   console.log(`[Bootstrap] Cloned ${templates.length} workflow template(s) to workspace ${targetWorkspaceId}`);
+}
+
+// ─── PM presence gating (Phase G) ───────────────────────────────────
+
+/**
+ * Cheap presence check used by request handlers and pre-dispatch
+ * guards. Returns true iff the workspace has at least one row with
+ * `is_pm = 1` AND `is_master = 1`. Phase G makes this the canonical
+ * "is this workspace operational?" signal.
+ */
+export function hasWorkspacePm(workspaceId: string): boolean {
+  const db = getDb();
+  const row = db.prepare(
+    `SELECT 1 FROM agents
+       WHERE workspace_id = ?
+         AND is_pm = 1
+         AND is_master = 1
+         AND COALESCE(is_active, 1) = 1
+       LIMIT 1`,
+  ).get(workspaceId);
+  return Boolean(row);
+}
+
+/**
+ * Throws WorkspacePmRequiredError if the workspace doesn't have a
+ * configured PM. Call from request handlers before kicking off any
+ * dispatch / proposal / decompose / planning flow — these all assume
+ * a PM exists; without one, MC's behavior is undefined.
+ *
+ * The PM is the only required agent per workspace. Workers come and
+ * go; the PM is the workspace's spine.
+ */
+export function assertWorkspacePm(workspaceId: string): void {
+  if (!hasWorkspacePm(workspaceId)) {
+    throw new WorkspacePmRequiredError(
+      workspaceId,
+      'no agent with is_pm=1 AND is_master=1 found',
+    );
+  }
 }

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3894,6 +3894,24 @@ const migrations: Migration[] = [
       console.log('[Migration 068] coordinator_mode columns added to workspaces + tasks.');
     },
   },
+  {
+    id: '069',
+    name: 'pm_is_master_required',
+    up: (db) => {
+      // Phase G: the PM is the workspace's only required agent and is
+      // also the master orchestrator (is_master=1). Backfill the flag
+      // on every existing PM placeholder so legacy workspaces converge
+      // without operator intervention. New PMs are created with both
+      // flags by ensurePmAgent (see src/lib/bootstrap-agents.ts).
+      const result = db.prepare(
+        `UPDATE agents SET is_master = 1, updated_at = datetime('now')
+          WHERE is_pm = 1 AND COALESCE(is_master, 0) = 0`,
+      ).run();
+      console.log(
+        `[Migration 069] is_master=1 backfilled on ${result.changes} PM agent row(s).`,
+      );
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */


### PR DESCRIPTION
## Summary
**Stacked on [#153 (Phase F)](https://github.com/smb209/mission-control/pull/153).**

Per operator clarification: the PM is the workspace's spine — the only required agent — and is also the master orchestrator (`is_master=1`). Workspace creation must enforce this; downstream functionality must gate on it.

- **Migration 069** — backfills `is_master=1` on every existing PM placeholder so legacy workspaces converge automatically.
- **`ensurePmAgent`** — new PMs insert with `is_master=1`; legacy `is_master=0` PMs upgrade in place; insert failure throws `WorkspacePmRequiredError`.
- **`hasWorkspacePm` / `assertWorkspacePm`** — new exports. `hasWorkspacePm` requires `is_pm=1 AND is_master=1 AND is_active=1`. `assertWorkspacePm` throws `WorkspacePmRequiredError` when missing.
- **`POST /api/workspaces`** — entire creation (templates, bootstrap, optional clone, PM ensure) runs inside a transaction. Final `hasWorkspacePm` gate rolls back the transaction if no PM lands; operator gets a 500 with `{error: 'PM required', message: ...}`.
- **`dispatchPm` + `dispatchPmSynthesized`** — first line of every dispatch path is `assertWorkspacePm`. Throws cleanly when missing instead of producing undefined behavior.

## Phase applicability
Phase G adds a new gate that activates at every PM dispatch entry point. No new validation-pack scenarios required; existing S1–S4 + S10 still apply (they all run against workspaces that have PMs by setup).

## Test plan
- [x] `yarn test` — 545/545 (was 535, +10).
- [x] `yarn tsc --noEmit` — 2 errors, both pre-existing (CLAUDE.md).
- [x] `yarn db:reset && yarn tsx scripts/seed-foia-fixture.ts` — both default + FOIA PMs land with `is_pm=1, is_master=1`.
- [x] Migration 069 backfill verified (log: `[Migration 069] is_master=1 backfilled on N PM agent row(s).`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)