### PR TITLE
feat(scope-keyed-sessions): Phase H — runner IS the PM

### DIFF
--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -53,6 +53,20 @@ function compileGlobList(env: string | undefined): ((id: string) => boolean) | n
 }
 
 /**
+ * Phase H: pick the runner gateway id this MC instance prefers, mirroring
+ * `src/lib/agents/runner.ts:getRunnerAgent` selection logic. Dev MCs
+ * use `mc-runner-dev`; prod uses `mc-runner`. The opposite is
+ * auto-excluded from catalog sync so a dev DB never grows a prod
+ * runner row (and vice versa).
+ */
+function preferredRunnerGatewayId(env: NodeJS.ProcessEnv = process.env): 'mc-runner' | 'mc-runner-dev' {
+  const explicit = env.MC_RUNNER_GATEWAY_ID;
+  if (explicit === 'mc-runner' || explicit === 'mc-runner-dev') return explicit;
+  const isDev = env.NODE_ENV === 'development' || env.MC_ENV === 'dev';
+  return isDev ? 'mc-runner-dev' : 'mc-runner';
+}
+
+/**
  * Decide which gateway agent ids should sync into the catalog. Returns
  * the included subset and the set of gateway ids that were filtered
  * out, so the caller can mark previously-synced excluded rows offline.
@@ -62,13 +76,16 @@ function compileGlobList(env: string | undefined): ((id: string) => boolean) | n
  */
 export function selectGatewayAgents(
   gatewayAgents: GatewayAgent[],
-  env: { include?: string; exclude?: string } = {
+  env: { include?: string; exclude?: string; processEnv?: NodeJS.ProcessEnv } = {
     include: process.env.MC_AGENT_SYNC_INCLUDE,
     exclude: process.env.MC_AGENT_SYNC_EXCLUDE,
+    processEnv: process.env,
   },
 ): { included: GatewayAgent[]; excludedGatewayIds: Set<string> } {
   const includeMatch = compileGlobList(env.include);
   const excludeMatch = compileGlobList(env.exclude);
+  const preferredRunner = preferredRunnerGatewayId(env.processEnv ?? process.env);
+  const otherRunner = preferredRunner === 'mc-runner' ? 'mc-runner-dev' : 'mc-runner';
 
   const included: GatewayAgent[] = [];
   const excludedGatewayIds = new Set<string>();
@@ -76,6 +93,13 @@ export function selectGatewayAgents(
   for (const ga of gatewayAgents) {
     const id = ga.id || ga.name;
     if (!id) continue;
+    // Phase H: auto-exclude the non-preferred runner so a dev DB never
+    // grows a `mc-runner` row (and vice versa for prod). Operator-set
+    // INCLUDE/EXCLUDE still apply on top of this default.
+    if (id === otherRunner) {
+      excludedGatewayIds.add(id);
+      continue;
+    }
     // Include defaults to match-all when not configured. Exclude is then
     // applied on top — so an id can be in the include list and still be
     // dropped if exclude matches it.
@@ -183,29 +207,53 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
           // workspace that has an agent linked to it). Flip status off
           // 'offline' if a previous sync had marked it filtered-out and
           // the operator has now included it again.
-          run(
-            `UPDATE agents
-                SET name = ?,
-                    role = CASE WHEN role IS NULL OR role = 'builder' THEN ? ELSE role END,
-                    model = COALESCE(?, model),
-                    source = 'gateway',
-                    status = CASE WHEN status = 'offline' THEN 'standby' ELSE status END,
-                    updated_at = ?
-              WHERE gateway_agent_id = ?`,
-            [name, role, normaliseModel(ga.model), ts, gatewayId]
-          );
+          //
+          // Phase H: runner rows are also re-asserted as is_pm=1 +
+          // is_master=1 so a stale row that lost the flags (manual DB
+          // edit, partial migration) self-heals on the next sync.
+          const isRunner = gatewayId === 'mc-runner' || gatewayId === 'mc-runner-dev';
+          if (isRunner) {
+            run(
+              `UPDATE agents
+                  SET name = ?,
+                      role = CASE WHEN role IS NULL OR role = 'builder' THEN ? ELSE role END,
+                      model = COALESCE(?, model),
+                      source = 'gateway',
+                      status = CASE WHEN status = 'offline' THEN 'standby' ELSE status END,
+                      is_pm = 1,
+                      is_master = 1,
+                      is_active = 1,
+                      updated_at = ?
+                WHERE gateway_agent_id = ?`,
+              [name, role, normaliseModel(ga.model), ts, gatewayId]
+            );
+          } else {
+            run(
+              `UPDATE agents
+                  SET name = ?,
+                      role = CASE WHEN role IS NULL OR role = 'builder' THEN ? ELSE role END,
+                      model = COALESCE(?, model),
+                      source = 'gateway',
+                      status = CASE WHEN status = 'offline' THEN 'standby' ELSE status END,
+                      updated_at = ?
+                WHERE gateway_agent_id = ?`,
+              [name, role, normaliseModel(ga.model), ts, gatewayId]
+            );
+          }
           changed += 1;
         } else if (gatewayId === 'mc-runner' || gatewayId === 'mc-runner-dev') {
           // Phase F: only auto-create rows for the org-wide runner.
           // Per-role workers (mc-builder, mc-tester, etc.) are no
           // longer durable agents — work routes through the runner
-          // with role-specific briefings. Discovering a per-role
-          // gateway agent here is a no-op so we don't recreate the
-          // durable rows the decommission script just nulled.
+          // with role-specific briefings.
+          //
+          // Phase H: the runner IS the PM. Insert with is_pm=1 +
+          // is_master=1 so a fresh DB has a working PM the moment
+          // catalog sync completes.
           run(
-            `INSERT INTO agents (id, name, role, description, avatar_emoji, is_master, workspace_id, model, source, gateway_agent_id, created_at, updated_at)
-             VALUES (lower(hex(randomblob(16))), ?, ?, ?, '🎯', 0, 'default', ?, 'gateway', ?, ?, ?)`,
-            [name, role, `Org-wide scope-keyed-session host (${gatewayId})`, normaliseModel(ga.model), gatewayId, ts, ts]
+            `INSERT INTO agents (id, name, role, description, avatar_emoji, is_master, is_pm, is_active, workspace_id, model, source, gateway_agent_id, created_at, updated_at)
+             VALUES (lower(hex(randomblob(16))), ?, 'pm', ?, '🎯', 1, 1, 1, 'default', ?, 'gateway', ?, ?, ?)`,
+            [name, `Org-wide PM + scope-keyed-session host (${gatewayId})`, normaliseModel(ga.model), gatewayId, ts, ts]
           );
           changed += 1;
         } else {
@@ -224,10 +272,28 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
       // will flip status back to 'idle' automatically (above).
       for (const gatewayId of excludedGatewayIds) {
         if (!existingGatewayIds.has(gatewayId)) continue;
-        const result = run(
-          `UPDATE agents SET status = 'offline', updated_at = ? WHERE gateway_agent_id = ? AND status != 'offline'`,
-          [ts, gatewayId]
-        );
+        // Phase H: when a runner is excluded (the non-preferred one
+        // for this MC instance's env), also demote it from PM/master
+        // and deactivate so hasWorkspacePm / getPmAgent don't pick
+        // it up as the PM. Workers that were previously synced fall
+        // back to the legacy status='offline' update.
+        const isRunner = gatewayId === 'mc-runner' || gatewayId === 'mc-runner-dev';
+        const result = isRunner
+          ? run(
+              `UPDATE agents
+                  SET status = 'offline',
+                      is_active = 0,
+                      is_pm = 0,
+                      is_master = 0,
+                      updated_at = ?
+                WHERE gateway_agent_id = ?
+                  AND (status != 'offline' OR is_active = 1 OR is_pm = 1 OR is_master = 1)`,
+              [ts, gatewayId]
+            )
+          : run(
+              `UPDATE agents SET status = 'offline', updated_at = ? WHERE gateway_agent_id = ? AND status != 'offline'`,
+              [ts, gatewayId]
+            );
         if (result.changes > 0) markedOffline += result.changes;
       }
 

--- a/src/lib/agents/pm-resolver.ts
+++ b/src/lib/agents/pm-resolver.ts
@@ -20,6 +20,22 @@ import { queryOne } from '@/lib/db';
 import type { Agent } from '@/lib/types';
 
 export function getPmAgent(workspaceId: string): Agent | null {
+  // Phase H: the org-wide runner agent is the PM for every workspace.
+  // It carries is_pm=1 + is_master=1 and lives in the 'default'
+  // workspace as a singleton (mc-runner / mc-runner-dev). All
+  // workspace-scoped dispatches resolve to it.
+  const runner = queryOne<Agent>(
+    `SELECT * FROM agents
+       WHERE gateway_agent_id IN ('mc-runner', 'mc-runner-dev')
+         AND is_pm = 1
+         AND is_master = 1
+         AND COALESCE(is_active, 1) = 1
+       LIMIT 1`,
+  );
+  if (runner) return runner;
+
+  // Backwards-compat for DBs that haven't run migration 070 yet:
+  // fall back to the legacy per-workspace placeholder.
   const flagged = queryOne<Agent>(
     `SELECT * FROM agents
        WHERE workspace_id = ? AND is_pm = 1

--- a/src/lib/bootstrap-agents.test.ts
+++ b/src/lib/bootstrap-agents.test.ts
@@ -134,3 +134,79 @@ test('assertWorkspacePm: silent when PM is correctly configured', () => {
 // tests. The migration's effect is logged at template-build time
 // (`[Migration 069] is_master=1 backfilled on N PM agent row(s).`)
 // and exercised in the production migration suite.
+
+// ─── Phase H: runner-as-PM ─────────────────────────────────────────
+
+function ensureRunner(gatewayId: 'mc-runner' | 'mc-runner-dev'): string {
+  const id = uuidv4();
+  run(
+    `INSERT OR IGNORE INTO agents (
+       id, name, role, workspace_id, gateway_agent_id, source,
+       is_pm, is_master, is_active, created_at, updated_at
+     ) VALUES (?, ?, 'pm', 'default', ?, 'gateway', 1, 1, 1,
+              datetime('now'), datetime('now'))`,
+    [id, `Runner ${gatewayId}`, gatewayId],
+  );
+  return id;
+}
+
+function dropRunners(): void {
+  run(`DELETE FROM agents WHERE gateway_agent_id IN ('mc-runner', 'mc-runner-dev')`);
+}
+
+test('hasWorkspacePm: runner with both flags satisfies any workspace', () => {
+  dropRunners();
+  ensureRunner('mc-runner-dev');
+  const ws = freshWorkspace();
+  // The workspace has no per-workspace PM placeholder, but the runner does.
+  assert.equal(hasWorkspacePm(ws), true);
+});
+
+test('hasWorkspacePm: runner without flags does NOT satisfy', () => {
+  dropRunners();
+  // Insert runner with is_pm=0 (pre-Phase-H state).
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, gateway_agent_id, source,
+                          is_pm, is_master, is_active, created_at, updated_at)
+     VALUES (?, 'rn', 'runner', 'default', 'mc-runner-dev', 'gateway',
+             0, 0, 1, datetime('now'), datetime('now'))`,
+    [uuidv4()],
+  );
+  const ws = freshWorkspace();
+  assert.equal(hasWorkspacePm(ws), false);
+});
+
+test('ensurePmAgent: short-circuits to runner when present', () => {
+  dropRunners();
+  const runnerId = ensureRunner('mc-runner-dev');
+  const ws = freshWorkspace();
+  const result = ensurePmAgent(ws);
+  assert.equal(result.id, runnerId);
+  assert.equal(result.created, false);
+  // Should NOT have inserted a per-workspace placeholder.
+  const placeholders = queryOne<{ n: number }>(
+    `SELECT COUNT(*) AS n FROM agents WHERE workspace_id = ? AND source = 'local'`,
+    [ws],
+  );
+  assert.equal(placeholders?.n, 0);
+});
+
+test('getPmAgent: returns the runner regardless of workspace_id', async () => {
+  dropRunners();
+  const runnerId = ensureRunner('mc-runner-dev');
+  const wsA = freshWorkspace();
+  const wsB = freshWorkspace();
+  const { getPmAgent } = await import('./agents/pm-resolver');
+  assert.equal(getPmAgent(wsA)?.id, runnerId);
+  assert.equal(getPmAgent(wsB)?.id, runnerId);
+});
+
+test('migration 070: legacy mc-project-manager artifact is dropped on apply', () => {
+  // After migration 070 runs (template-build time), no rows should
+  // exist with the legacy gateway_agent_id values.
+  const legacy = queryOne<{ n: number }>(
+    `SELECT COUNT(*) AS n FROM agents
+       WHERE gateway_agent_id IN ('mc-project-manager', 'mc-project-manager-dev')`,
+  );
+  assert.equal(legacy?.n, 0);
+});

--- a/src/lib/bootstrap-agents.ts
+++ b/src/lib/bootstrap-agents.ts
@@ -78,6 +78,22 @@ export class WorkspacePmRequiredError extends Error {
 
 export function ensurePmAgent(workspaceId: string): { id: string; created: boolean } {
   const db = getDb();
+
+  // Phase H: if the org-wide runner is registered with is_pm=1 +
+  // is_master=1, that's the workspace's PM. Don't seed a per-workspace
+  // placeholder — it'd duplicate the role and confuse hasWorkspacePm.
+  // Returns the runner's id so callers that record "the PM" get a
+  // valid FK target.
+  const runner = db.prepare(
+    `SELECT id FROM agents
+       WHERE gateway_agent_id IN ('mc-runner', 'mc-runner-dev')
+         AND is_pm = 1 AND is_master = 1 AND COALESCE(is_active, 1) = 1
+       LIMIT 1`,
+  ).get() as { id: string } | undefined;
+  if (runner) return { id: runner.id, created: false };
+
+  // Pre-Phase-H fallback: scan for an existing per-workspace PM and
+  // backfill is_master if it's a legacy is_master=0 row.
   const existing = db.prepare(
     `SELECT id, COALESCE(is_master, 0) AS is_master
        FROM agents
@@ -248,13 +264,32 @@ export function cloneWorkflowTemplates(db: Database.Database, targetWorkspaceId:
 
 /**
  * Cheap presence check used by request handlers and pre-dispatch
- * guards. Returns true iff the workspace has at least one row with
- * `is_pm = 1` AND `is_master = 1`. Phase G makes this the canonical
- * "is this workspace operational?" signal.
+ * guards. Returns true iff EITHER:
+ *   - The org-wide runner agent (mc-runner / mc-runner-dev) exists with
+ *     is_pm=1 AND is_master=1 AND is_active=1 — Phase H state. The
+ *     runner serves every workspace as PM; one row covers them all.
+ *   - A pre-Phase-H per-workspace PM placeholder exists in this
+ *     workspace with the same flags. Backwards compatibility for DBs
+ *     that haven't run migration 070 yet.
+ *
+ * The argument is named `workspaceId` for source-stability — Phase H
+ * makes it advisory only.
  */
 export function hasWorkspacePm(workspaceId: string): boolean {
   const db = getDb();
-  const row = db.prepare(
+  // Phase H: org-wide runner row. Any workspace can dispatch through it.
+  const runner = db.prepare(
+    `SELECT 1 FROM agents
+       WHERE gateway_agent_id IN ('mc-runner', 'mc-runner-dev')
+         AND is_pm = 1
+         AND is_master = 1
+         AND COALESCE(is_active, 1) = 1
+       LIMIT 1`,
+  ).get();
+  if (runner) return true;
+
+  // Backwards-compat: pre-Phase-H per-workspace PM placeholder.
+  const ws = db.prepare(
     `SELECT 1 FROM agents
        WHERE workspace_id = ?
          AND is_pm = 1
@@ -262,7 +297,7 @@ export function hasWorkspacePm(workspaceId: string): boolean {
          AND COALESCE(is_active, 1) = 1
        LIMIT 1`,
   ).get(workspaceId);
-  return Boolean(row);
+  return Boolean(ws);
 }
 
 /**

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -3912,6 +3912,70 @@ const migrations: Migration[] = [
       );
     },
   },
+  {
+    id: '070',
+    name: 'runner_is_pm',
+    up: (db) => {
+      // Phase H: the runner agent IS the PM. Single org-wide row
+      // (mc-runner for prod, mc-runner-dev for dev) carries is_pm=1 +
+      // is_master=1. The pre-Phase-F per-workspace PM placeholders
+      // are retired in place, and the migration-049 'Margaret /
+      // mc-project-manager' artifact is dropped.
+      //
+      // Selection: MC_RUNNER_GATEWAY_ID env var wins; otherwise
+      // dev-vs-prod is inferred from NODE_ENV / MC_ENV. Both runner
+      // gateway rows are promoted when both exist (idempotent — the
+      // ones not actively used stay flagged but inert).
+
+      // 1. Retire pre-Phase-F per-workspace PM placeholders. Don't
+      //    delete (FK refs from pm_proposals etc. need to stay valid)
+      //    — flip is_pm/is_master to 0 and is_active to 0 so they
+      //    don't show up in any "is the workspace operational" check.
+      const retired = db.prepare(
+        `UPDATE agents
+            SET is_pm = 0,
+                is_master = 0,
+                is_active = 0,
+                updated_at = datetime('now')
+          WHERE is_pm = 1
+            AND gateway_agent_id NOT IN ('mc-runner', 'mc-runner-dev')`,
+      ).run();
+      console.log(
+        `[Migration 070] retired ${retired.changes} pre-runner-as-PM placeholder agent row(s).`,
+      );
+
+      // 2. Drop the migration-049 'mc-project-manager' artifact.
+      //    These rows have gateway_agent_id='mc-project-manager' but
+      //    that gateway agent no longer exists in openclaw config
+      //    (Phase F decommissioned the per-role agents). The row is
+      //    a dead breadcrumb. Delete is safe because the only FK
+      //    references are ON DELETE SET NULL or ON DELETE CASCADE
+      //    workspace-scoped (no orphan rows after delete).
+      const dropped = db.prepare(
+        `DELETE FROM agents
+          WHERE gateway_agent_id IN ('mc-project-manager', 'mc-project-manager-dev')`,
+      ).run();
+      console.log(
+        `[Migration 070] dropped ${dropped.changes} legacy mc-project-manager artifact row(s).`,
+      );
+
+      // 3. Promote runner rows to PM + master. Both runner pairs get
+      //    flagged so dev and prod each have a single PM in their
+      //    catalog. The MC_RUNNER_GATEWAY_ID env knob (read at
+      //    request time) decides which one this MC instance prefers.
+      const promoted = db.prepare(
+        `UPDATE agents
+            SET is_pm = 1,
+                is_master = 1,
+                is_active = 1,
+                updated_at = datetime('now')
+          WHERE gateway_agent_id IN ('mc-runner', 'mc-runner-dev')`,
+      ).run();
+      console.log(
+        `[Migration 070] promoted ${promoted.changes} runner row(s) to is_pm=1 + is_master=1.`,
+      );
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */


### PR DESCRIPTION
## Summary
**Stacked on [#154 (Phase G)](https://github.com/smb209/mission-control/pull/154).**

Per operator clarification: **the runner agent IS the PM for every workspace.** Single org-wide row (`mc-runner` / `mc-runner-dev`) carries `is_pm=1 + is_master=1`. No per-workspace PM placeholder. The opposite-environment runner is auto-excluded from catalog sync.

### What changed
- **Migration 070** — retires pre-Phase-F per-workspace PM placeholders, drops the migration-049 `Margaret / mc-project-manager` artifact rows entirely, promotes runner rows to `is_pm=1, is_master=1, is_active=1`.
- **`agent-catalog-sync.ts`** — auto-excludes the non-preferred runner via `MC_RUNNER_GATEWAY_ID` env or `NODE_ENV`/`MC_ENV` heuristic; runner INSERT/UPDATE branches re-assert PM+master flags; excluded-runner path also flips `is_active=0, is_pm=0, is_master=0` so the demoted row can't be picked up as PM.
- **`hasWorkspacePm` / `ensurePmAgent` / `getPmAgent`** — runner-first lookup; legacy per-workspace fallback preserved for pre-migration-070 DBs.

### Demonstrated
After `yarn db:reset && yarn dev` on the dev branch, the agent roster is exactly:
```
name           | gateway_agent_id | pm | master | active | status
MC Runner      | mc-runner        |  0 |   0    |   0    | offline
MC Runner Dev  | mc-runner-dev    |  1 |   1    |   1    | standby
```
No Margaret. No legacy `mc-project-manager` rows. Dev's PM is the dev runner; prod runner is inert on dev.

### Test plan
- [x] `yarn test` — 550/550 pass (was 545, +5).
- [x] `yarn tsc --noEmit` — 2 errors, both pre-existing (CLAUDE.md).
- [x] `yarn db:reset && yarn dev` — catalog sync produces the exact roster above.
- [ ] Real-agent dispatch (still blocked by openclaw-side MCP server activation per [`04-e2e-run-results.md`](specs/scope-keyed-sessions-validation/04-e2e-run-results.md)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)