### PR TITLE
feat(scope-keyed-sessions): Phase J2 — wire dispatchSubagent into worker dispatch (flag-gated)

### DIFF
--- a/agent-templates/_shared/pm-coordinator.md
+++ b/agent-templates/_shared/pm-coordinator.md
@@ -1,0 +1,88 @@
+# PM as Coordinator (Phase J)
+
+When you receive a message starting with `**MC subagent dispatch (...)**`,
+that's MC asking you to fan out to a worker subagent.  The message has
+a fixed shape; follow it verbatim.
+
+## What the dispatch envelope looks like
+
+```
+**MC subagent dispatch (workspace=<wsid> task=<task_id>)**
+
+Spawn a **<role>** subagent for this task. Attempt #<n>.
+
+Step 1: Call `sessions_spawn` (openclaw native MCP tool) with these arguments:
+
+```json
+{
+  "task": "<<see WORKER_BRIEFING below — pass the whole block verbatim>>",
+  "mode": "run",
+  "context": "isolated" | "fork",
+  "runTimeoutSeconds": <n>,
+  "label": "<role>-<task_short>-attempt<n>"
+}
+```
+
+Step 2: When `sessions_spawn` returns, call MC's `register_subagent_dispatch` ...
+
+WORKER_BRIEFING (pass this entire block as the `task` parameter ...):
+
+```text
+<the actual briefing — role-soul, identity preamble, notetaker, task context, trigger>
+```
+```
+
+## Your job, step by step
+
+1. **Spawn.** Call openclaw's `sessions_spawn` MCP tool with the JSON
+   shown in Step 1. Take the WORKER_BRIEFING block (everything inside
+   the ```text``` fence) and pass it verbatim as the `task:` parameter.
+   Do **not** rewrite, summarize, or augment it — it's already complete.
+
+2. **Register.** `sessions_spawn` returns immediately with `runId` +
+   `childSessionKey`. Call MC's `register_subagent_dispatch` MCP tool
+   with the values shown in Step 2 — substitute in the runId and
+   childSessionKey you just got. This writes a row in `mc_sessions` so
+   MC can correlate the subagent's eventual completion event with this
+   task. Without this call, MC has no way to attribute the subagent's
+   work.
+
+3. **Wait.** The subagent runs asynchronously. openclaw will
+   auto-announce its final reply back to you as a chat message when it
+   completes. The subagent will also call MC MCP tools directly
+   (`log_activity`, `take_note`, `register_deliverable`,
+   `update_task_status`) so MC's state is updated regardless of whether
+   the announcement reaches you.
+
+4. **React when the announcement arrives.**
+   - **Subagent succeeded** → do nothing. The work is recorded; MC has
+     advanced the task status. Your dispatch is done.
+   - **Subagent failed and a retry is warranted** → dispatch again.
+     MC will send you a new META envelope with `attempt=N+1`. Use a
+     different brief or guidance if the prior approach was wrong.
+   - **Subagent flagged a blocker requiring operator attention** →
+     `take_note(audience='pm', importance=2, body='<one-line summary>')`.
+     The high-importance note auto-surfaces in PM Chat.
+
+## Active-subagent manifest
+
+Before the META envelope, you may see a section labeled `**Active
+subagents for this task:**`. That's MC's authoritative record of which
+subagents are currently running (or were running) for this task. It's
+re-injected on every dispatch — **never try to remember it; always
+re-read the manifest**. Your session memory may compact at any time.
+
+Look up current notes via `read_notes(task_id=...)` to see what each
+subagent has noticed, decided, or struggled with.
+
+## Don't
+
+- Don't rewrite the WORKER_BRIEFING. It's already composed by MC's
+  briefing builder (template + workspace overrides + identity + notes).
+  Editing it loses workspace-specific persona configuration.
+- Don't skip `register_subagent_dispatch`. Without it, MC can't
+  correlate `subagent_ended` events with the right task.
+- Don't spawn a worker subagent without a META envelope from MC. If
+  you're tempted to spawn one off your own bat (e.g., for
+  exploratory work), use `take_note` to record what you'd want done
+  and let the operator dispatch it through MC.

--- a/specs/scope-keyed-sessions-phase-j.md
+++ b/specs/scope-keyed-sessions-phase-j.md
@@ -1,0 +1,243 @@
+# Phase J — Worker dispatch via openclaw `sessions_spawn`
+
+> Addendum to [`scope-keyed-sessions.md`](scope-keyed-sessions.md). Phase
+> I established per-workspace PMs with isolated memory pools (per-agent
+> openclaw storage). Phase J leans into openclaw's parent/child model:
+> **the workspace PM coordinates, subagents do the work.**
+
+## Why
+
+After Phase I, every workspace has its own PM agent
+(`mc-pm-<slug>-(dev)?`) with its own memory pool. The current worker
+dispatch path (`dispatchScope` from Phase B+C) opens a sibling session
+on the PM agent for each worker:
+
+```
+agent:mc-pm-foia-dev:task-<id>:builder:1
+agent:mc-pm-foia-dev:task-<id>:tester:1
+agent:mc-pm-foia-dev:task-<id>:reviewer:1
+```
+
+That works, but it's fundamentally dispatching cold. Each worker session
+starts with no context other than what MC injects in the briefing. The
+PM agent — which has the workspace-scoped memory — isn't actually
+*involved*; sessions are siblings, not children.
+
+openclaw's native primitive is `sessions_spawn`: a parent agent calls
+this MCP tool to fan out child agents that inherit the parent's MCP
+tools, optionally inherit context, and auto-announce results back. This
+matches the architectural claim "PM is the coordinator" much more
+closely than the sibling-sessions pattern does.
+
+## Goals
+
+- Move worker dispatch (builder, tester, reviewer, researcher, writer,
+  learner) from sibling sessions to subagent spawns from the workspace PM.
+- Preserve memory isolation (Phase I): subagents share the parent PM's
+  workspace-scoped memory pool. No cross-workspace leak surface.
+- Make orchestration state durable: MC's `mc_sessions` table is the
+  source of truth for "which subagent is running for which task." The
+  PM's session memory is not load-bearing.
+- Ship behind a feature flag so we can validate without breaking the
+  existing dispatch path.
+
+## Non-Goals
+
+- Replacing PM dispatches (PM Chat, plan, decompose, notes-intake) —
+  those stay on `dispatchScope`. They're operator → PM, not worker
+  fan-out.
+- Replacing the heartbeat coordinator (Phase E) — that's a recurring
+  observation job, not a worker spawn.
+- Eliminating the `dispatchScope` primitive — it remains for the PM-
+  level dispatches above and as the J2 fallback when the flag is off.
+
+## Architecture
+
+```
+Operator
+  ↓ POST /api/tasks/<id>/dispatch
+MC dispatch route
+  ↓ dispatchSubagent({task_id, role, brief, attempt, context_mode})
+  ↓ — builds the worker briefing (role-soul + identity + notetaker + task context)
+  ↓ — sends a META message to the PM's per-task coord session
+PM agent (workspace-scoped)
+  ↓ receives META: "spawn a builder subagent. Brief: <…>. After spawn
+  ↓                returns, call register_subagent_dispatch with run_id."
+  ↓ openclaw `sessions_spawn`({task: <briefing>, mode: 'run', context: 'isolated'})
+  ↓ openclaw fans out a child session on the same agent
+Subagent (child of PM, inherits PM's MCP + memory pool)
+  ↓ runs the work
+  ↓ MCP: log_activity, take_note, register_deliverable, update_task_status
+  ↓ exits
+openclaw
+  ↓ subagent_ended hook fires
+  ↓ subagent's final reply auto-announces to PM as a chat message
+PM agent
+  ↓ observes outcome
+  ↓ accepts / re-spawns with attempt+1 / escalates via take_note(audience='pm', importance=2)
+```
+
+## Locked design decisions
+
+### D1 — Subagent context mode is per-call
+
+`dispatchSubagent` takes `context_mode: 'isolated' | 'fork'`. Default
+per role:
+
+| Role | Default | Rationale |
+|---|---|---|
+| builder | isolated | clean retry, no PM chatter to drown out |
+| tester | isolated | ditto |
+| reviewer | isolated | ditto |
+| researcher | isolated | self-contained brief; uses `read_notes` for context |
+| writer | isolated | same |
+| learner | isolated | same |
+| (future) summarizer | fork | needs the parent's transcript as input |
+
+Per-role default lives in `agent_role_overrides.subagent_context_mode`
+(NULL = use the table above). Per-spawn override via the primitive.
+
+### D2 — Subagent agent_id stays as parent PM's id
+
+openclaw's default behavior: subagent inherits `targetAgentId` from
+parent. For MC's tracking (which subagent did what), we use
+`mc_sessions.run_id` + `scope_key` (the `childSessionKey`), NOT
+`agent_id`. The audit trail at the agent level shows "PM" for every
+subagent action — acceptable cost to avoid expanding named agents.
+
+Improving per-subagent audit detail is a follow-up (a separate
+`agent_subagent_runs` table or denormalized audit columns); not
+in scope for J1/J2.
+
+### D3 — `register_subagent_dispatch` MCP tool
+
+New tool the PM calls right after `sessions_spawn` returns. Writes a
+`mc_sessions` row with:
+
+```typescript
+{
+  scope_key: <childSessionKey>,        // returned by sessions_spawn
+  workspace_id: <workspace>,
+  role: 'builder' | 'tester' | …,
+  scope_type: 'task_role' | 'recurring',
+  task_id?: string,
+  initiative_id?: string,
+  recurring_job_id?: string,
+  attempt: number,
+  status: 'active',
+  run_id: <openclaw runId>,            // NEW in migration 072
+}
+```
+
+Without this row, MC can't attribute subagent activity (notes,
+deliverables, status changes) to the right (task, role, attempt) tuple.
+The PM's coord briefing in J2 explicitly instructs it to call this tool
+right after every `sessions_spawn`.
+
+### D4 — PM coordinates from a per-task `:coord-task-<id>` session
+
+```
+agent:mc-pm-foia-dev:coord-task-<task_id>
+```
+
+One coord session per task, persists across stages. Compaction pressure
+stays low (bounded scope). When a stage finishes, MC dispatches a "stage
+complete" meta-message to the same coord session, retaining the PM's
+short-term memory of the task's progression.
+
+The PM Chat session (`agent:mc-pm-foia-dev:pm-chat-<thread>`) stays
+separate. Same agent, separate sessions.
+
+### D5 — Compaction-resilient orchestration state
+
+PM session compaction or restart should NOT lose orchestration. MC's
+`mc_sessions` is the durable record. When a coord session dispatches
+cold (or after compaction), the briefing builder injects an
+**active-session manifest** into the task-context block:
+
+```
+**Active subagents for this task:**
+- builder (run abc12345, started 2h ago, last activity 3min ago) — scope_key=…
+- tester (queued, run not yet started)
+
+You may receive announcements from these subagents at any time. Look up
+their current state via `read_notes(task_id=…)` and `mc_sessions` if you
+need details.
+```
+
+The PM never has to remember what's running. It looks up MC's truth.
+
+### D6 — Failure detection via openclaw runtime hook
+
+`subagent_ended` is a runtime hook openclaw fires when a subagent's run
+completes (success, error, or timeout). MC subscribes to this via the
+gateway client (or polls `mc_sessions` rows that have `last_used_at`
+older than `runTimeoutSeconds + buffer` and `status='active'` — a
+liveness check). The PM also gets the auto-announcement as a chat message.
+
+Either path (hook OR announcement) triggers PM to decide retry vs accept.
+Not relying on the PM agent to "decide" the subagent has ended — the
+runtime tells everyone.
+
+### Handling PM crashes mid-orchestration
+
+The subagent keeps running after a PM session restart. Since the
+subagent calls MCP directly to record results (deliverables, status
+changes, notes), MC's view stays consistent regardless of whether the
+PM's session memory survives. Worst case: an orphaned announcement
+that no PM ever reads. Acceptable — the work landed, MC knows.
+
+### Heartbeat coordinator stays on `dispatchScope`
+
+Phase E's heartbeat coordinator is a recurring observation job, not a
+worker fan-out. It uses `dispatchScope` to its `:heartbeat` session.
+Phase J doesn't change this.
+
+## Phase split
+
+### J1 — Primitives + schema (this PR)
+
+**No behavior change.** Library code waiting for J2 to wire up.
+
+- Migration 072: `mc_sessions.run_id TEXT NULL`
+- Migration 073: `agent_role_overrides.subagent_context_mode TEXT CHECK ('isolated','fork')`
+- `mc_sessions.ts`: read/write `run_id`; per-role context-mode lookup helper
+- `register_subagent_dispatch` MCP tool — registers a subagent dispatch in `mc_sessions`
+- `dispatchSubagent` primitive — builds the worker briefing + meta-message format the PM will receive in J2
+- Tests for all of the above
+
+### J2 — Wiring + flag (next PR, stacked)
+
+- Active-session manifest in `buildBriefing` task context block
+- PM coord briefing template — instructs PM how to call `sessions_spawn`
+  + `register_subagent_dispatch`
+- `dispatch/route.ts`: when `MC_USE_SUBAGENT_SPAWN=1`, route worker
+  dispatches via `dispatchSubagent` instead of the existing scope-keyed
+  path. Default off.
+- Integration test: mock openclaw client, assert the PM receives the
+  meta-message with the right briefing, asserts `mc_sessions` row lands
+  after register_subagent_dispatch is called.
+- Real-agent smoke: deferred (still blocked on openclaw MCP server
+  activation gap from the Phase F e2e report).
+
+### Phase K (later, separate)
+
+Flip `MC_USE_SUBAGENT_SPAWN` default to on; remove the legacy worker
+scope-keyed branch from `dispatch/route.ts`. Same shape as the Phase F
+flag-removal cleanup.
+
+## Validation pack additions
+
+The validation pack at `specs/scope-keyed-sessions-validation/` already
+covers worker dispatch in §5. Phase J extends:
+
+- §5 worker scenarios get a `MC_USE_SUBAGENT_SPAWN=1` variant.
+- New §11 — subagent lifecycle: spawn → MC observes via `register_subagent_dispatch` → subagent works → `subagent_ended` lands → MC's `mc_sessions.status` flips to `closed` or `failed`.
+- New global gate: every worker dispatch produces exactly one `mc_sessions` row with `run_id NOT NULL`.
+
+## Status
+
+- [ ] J1: schema, MCP tool, primitive (this PR)
+- [ ] J2: PM briefing wiring + integration test (next PR)
+- [ ] Phase K: flip `MC_USE_SUBAGENT_SPAWN` default to on; remove legacy branch
+- [ ] Real-agent integration smoke once openclaw MCP activation lands

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -25,12 +25,15 @@ import {
 } from '@/lib/gates/config';
 import { formatRoleSoulSection } from '@/lib/agents/role-souls';
 import { dispatchScope } from '@/lib/agents/dispatch-scope';
+import { dispatchSubagent } from '@/lib/agents/dispatch-subagent';
 import {
   computeWorkerScopeSuffix,
   getRunnerAgent,
   isScopeKeyedDispatchEnabled,
+  isSubagentSpawnEnabled,
   nextWorkerAttempt,
 } from '@/lib/agents/runner';
+import { getPmAgent } from '@/lib/agents/pm-resolver';
 import type { BriefingRole } from '@/lib/agents/briefing';
 import { execSync } from 'child_process';
 import { existsSync } from 'fs';
@@ -945,13 +948,47 @@ If you need help or clarification, ask the orchestrator.`;
       // agent stays as the task's `assigned_agent_id` for the
       // operator UI (and remains the fallback when the runner is
       // missing).
+      const useSubagentSpawn = isSubagentSpawnEnabled();
       const useScopeKeyed = isScopeKeyedDispatchEnabled();
-      const runner = useScopeKeyed ? getRunnerAgent() : null;
-      const briefingRole = runner ? resolveBriefingRole(agent) : null;
+      const runner = useScopeKeyed && !useSubagentSpawn ? getRunnerAgent() : null;
+      const briefingRole = useSubagentSpawn || runner ? resolveBriefingRole(agent) : null;
+
+      // Phase J2: when MC_USE_SUBAGENT_SPAWN=1, the workspace PM
+      // becomes the parent of all worker subagents. MC dispatches a
+      // META envelope to the PM's per-task coord session (`coord-task-
+      // <id>`) telling it to call openclaw `sessions_spawn` + register
+      // the resulting runId via `register_subagent_dispatch`. The PM
+      // owns the spawn; MC owns the bookkeeping. See
+      // specs/scope-keyed-sessions-phase-j.md.
+      const workspacePm =
+        useSubagentSpawn && task.workspace_id
+          ? getPmAgent(task.workspace_id)
+          : null;
 
       let sendResult: Awaited<ReturnType<typeof sendChatToAgent>>;
 
-      if (useScopeKeyed && runner && briefingRole) {
+      if (useSubagentSpawn && workspacePm && briefingRole && briefingRole !== 'pm') {
+        // Subagent-spawn branch.
+        const attempt = nextWorkerAttempt(task.id, briefingRole);
+        const dispatchResult = dispatchSubagent({
+          workspace_id: task.workspace_id ?? '',
+          role: briefingRole,
+          pm: workspacePm,
+          task_id: task.id,
+          attempt,
+          trigger_body: finalMessage,
+        });
+        // The PM receives the META envelope at its per-task coord
+        // session; sendChatToAgent computes the same scope key via
+        // session_key_prefix + sessionSuffix.
+        const coordSessionSuffix = `coord-task-${task.id}`;
+        sendResult = await sendChatToAgent({
+          agent: workspacePm,
+          message: dispatchResult.meta_message,
+          idempotencyKey,
+          sessionSuffix: coordSessionSuffix,
+        });
+      } else if (useScopeKeyed && runner && briefingRole) {
         // Scope-keyed branch: the runner receives the briefing; the
         // briefing carries the role-soul + identity preamble carrying
         // the runner's UUID + a notetaker addendum + the legacy

--- a/src/lib/agents/briefing.test.ts
+++ b/src/lib/agents/briefing.test.ts
@@ -192,6 +192,109 @@ test('buildBriefing: role + addendum + trigger order is identity → role → ad
   }
 });
 
+// ─── Phase J2: active-subagent manifest ────────────────────────────
+
+test('Phase J2: buildBriefing injects active-subagent manifest when task_id set + active sessions exist', () => {
+  const fx = makeFixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  try {
+    const taskId = uuidv4();
+    // Seed a task + an active mc_session for it.
+    run(
+      `INSERT INTO tasks (id, workspace_id, title, status, created_at, updated_at)
+       VALUES (?, ?, 't', 'in_progress', datetime('now'), datetime('now'))`,
+      [taskId, ws],
+    );
+    run(
+      `INSERT INTO mc_sessions (scope_key, workspace_id, role, scope_type, task_id,
+                                  attempt, status, run_id, last_used_at, created_at)
+       VALUES (?, ?, 'builder', 'task_role', ?, 1, 'active', 'run-abc12345-xx',
+               datetime('now'), datetime('now'))`,
+      [`agent:mc-pm-test-dev:subagent:${uuidv4()}`, ws, taskId],
+    );
+
+    const out = buildBriefing({
+      workspace_id: ws,
+      role: 'pm',
+      scope_key: `agent:mc-pm-test-dev:coord-task-${taskId}`,
+      agent_id: 'pm-uuid',
+      gateway_agent_id: 'mc-pm-test-dev',
+      run_group_id: 'rg',
+      task_id: taskId,
+      trigger_body: 'TRIGGER',
+    });
+    assert.match(out, /Active subagents for this task:/);
+    assert.match(out, /\*\*builder\*\* attempt 1/);
+    assert.match(out, /run-abc12345/);
+    assert.match(out, /status=active/);
+    // Manifest precedes the trigger body.
+    const manifestIdx = out.indexOf('Active subagents');
+    const triggerIdx = out.indexOf('TRIGGER');
+    assert.ok(manifestIdx > 0 && manifestIdx < triggerIdx, 'manifest should come before trigger');
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});
+
+test('Phase J2: buildBriefing skips manifest when task_id missing', () => {
+  const fx = makeFixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  try {
+    const out = buildBriefing({
+      workspace_id: ws,
+      role: 'pm',
+      scope_key: 'sk',
+      agent_id: 'aid',
+      gateway_agent_id: 'mc-pm-test-dev',
+      run_group_id: 'rg',
+      trigger_body: 'body',
+    });
+    assert.doesNotMatch(out, /Active subagents/);
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});
+
+test('Phase J2: buildBriefing skips manifest when no active sessions for the task', () => {
+  const fx = makeFixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  try {
+    const taskId = uuidv4();
+    run(
+      `INSERT INTO tasks (id, workspace_id, title, status, created_at, updated_at)
+       VALUES (?, ?, 't', 'done', datetime('now'), datetime('now'))`,
+      [taskId, ws],
+    );
+    // Closed session shouldn't appear in the manifest.
+    run(
+      `INSERT INTO mc_sessions (scope_key, workspace_id, role, scope_type, task_id,
+                                  attempt, status, last_used_at, created_at, closed_at)
+       VALUES ('sk-closed', ?, 'builder', 'task_role', ?, 1, 'closed',
+               datetime('now'), datetime('now'), datetime('now'))`,
+      [ws, taskId],
+    );
+    const out = buildBriefing({
+      workspace_id: ws,
+      role: 'pm',
+      scope_key: 'sk',
+      agent_id: 'aid',
+      gateway_agent_id: 'mc-pm-test-dev',
+      run_group_id: 'rg',
+      task_id: taskId,
+      trigger_body: 'body',
+    });
+    assert.doesNotMatch(out, /Active subagents/);
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});
+
 test('briefingByteLength matches buildBriefing UTF-8 length', () => {
   const fx = makeFixtureTemplates();
   __setTemplatesDirForTests(fx.dir);

--- a/src/lib/agents/briefing.ts
+++ b/src/lib/agents/briefing.ts
@@ -25,7 +25,7 @@
 
 import path from 'node:path';
 import fs from 'node:fs';
-import { queryOne } from '@/lib/db';
+import { queryAll, queryOne } from '@/lib/db';
 
 export type BriefingRole =
   | 'pm'
@@ -141,6 +141,62 @@ function buildNotetakerAddendum(input: BuildBriefingInput): string {
   );
 }
 
+/**
+ * Phase J2: when the briefing is going to a workspace PM's per-task
+ * coord session, surface the active-subagent manifest from
+ * `mc_sessions` so the PM (post-compaction or cold-start) can recover
+ * orchestration state without remembering it.
+ *
+ * Returns empty string when:
+ *  - no `task_id` in the briefing input (not a per-task coord briefing)
+ *  - no active subagents for the task (nothing to surface)
+ *
+ * The manifest is informational — the PM uses it to decide whether to
+ * spawn more subagents, accept results, or escalate. Authoritative
+ * state lives in mc_sessions; the PM looks it up rather than
+ * remembering.
+ */
+function buildActiveSubagentManifest(input: BuildBriefingInput): string {
+  if (!input.task_id) return '';
+  interface Row {
+    scope_key: string;
+    role: string;
+    attempt: number;
+    status: string;
+    last_used_at: string;
+    created_at: string;
+    run_id: string | null;
+  }
+  const rows = queryAll<Row>(
+    `SELECT scope_key, role, attempt, status, last_used_at, created_at, run_id
+       FROM mc_sessions
+      WHERE task_id = ?
+        AND scope_type = 'task_role'
+        AND status IN ('active', 'idle')
+      ORDER BY created_at ASC`,
+    [input.task_id],
+  );
+  if (rows.length === 0) return '';
+  const lines = rows.map((r) => {
+    const runFragment = r.run_id ? ` (run ${r.run_id.slice(0, 12)})` : '';
+    const startedFragment = r.created_at ? `, started ${r.created_at}` : '';
+    const lastFragment = r.last_used_at ? `, last activity ${r.last_used_at}` : '';
+    return (
+      `- **${r.role}** attempt ${r.attempt}${runFragment} — status=${r.status}` +
+      `${startedFragment}${lastFragment}\n  scope_key: \`${r.scope_key}\``
+    );
+  });
+  return [
+    '**Active subagents for this task:**',
+    '',
+    ...lines,
+    '',
+    "Look up current notes via `read_notes(task_id=…)`. Don't try to",
+    'remember any of this — re-read the manifest each time the briefing',
+    'rolls in.',
+  ].join('\n');
+}
+
 function buildResumeHint(input: BuildBriefingInput): string {
   if (!input.is_resume) return '';
   return (
@@ -166,6 +222,14 @@ export function buildBriefing(input: BuildBriefingInput): string {
   const notetaker = buildNotetakerAddendum(input);
   if (notetaker) {
     parts.push(`---\n\n${notetaker}`);
+  }
+
+  // Phase J2: active-subagent manifest precedes the trigger body so
+  // the PM sees the orchestration state before it reads what MC is
+  // asking it to do next.
+  const manifest = buildActiveSubagentManifest(input);
+  if (manifest) {
+    parts.push(`---\n\n${manifest}`);
   }
 
   if (input.trigger_body && input.trigger_body.trim()) {

--- a/src/lib/agents/dispatch-subagent.test.ts
+++ b/src/lib/agents/dispatch-subagent.test.ts
@@ -1,0 +1,209 @@
+/**
+ * dispatchSubagent primitive tests (Phase J1).
+ *
+ * Pure-function tests on the META envelope shape + worker briefing
+ * composition + context-mode resolution. Doesn't exercise the openclaw
+ * round-trip — that's J2's territory once the dispatch route wires
+ * this in behind the feature flag.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import { __setTemplatesDirForTests } from './briefing';
+import { dispatchSubagent } from './dispatch-subagent';
+import type { Agent } from '@/lib/types';
+
+function freshWorkspace(): string {
+  const id = `ws-ds-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function makePmAgent(workspaceId: string): Agent {
+  const id = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, gateway_agent_id, source,
+                          session_key_prefix, is_pm, is_master, is_active, created_at, updated_at)
+     VALUES (?, 'MC PM (test)', 'pm', ?, ?, 'gateway', ?, 1, 1, 1, datetime('now'), datetime('now'))`,
+    [id, workspaceId, 'mc-pm-test-dev', 'agent:mc-pm-test-dev'],
+  );
+  return {
+    id,
+    name: 'MC PM (test)',
+    role: 'pm',
+    workspace_id: workspaceId,
+    gateway_agent_id: 'mc-pm-test-dev',
+    session_key_prefix: 'agent:mc-pm-test-dev',
+    is_pm: 1,
+    is_master: 1,
+    is_active: 1,
+  } as unknown as Agent;
+}
+
+function makeFixtureTemplates(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mc-dispatch-subagent-'));
+  for (const role of ['builder', 'tester', 'reviewer']) {
+    mkdirSync(path.join(dir, role), { recursive: true });
+    writeFileSync(path.join(dir, role, 'SOUL.md'), `# ${role} soul\n`);
+  }
+  mkdirSync(path.join(dir, '_shared'), { recursive: true });
+  writeFileSync(path.join(dir, '_shared', 'notetaker.md'), '# notetaker\n');
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+test('dispatchSubagent: META envelope contains task_id, role, attempt + sessions_spawn args', () => {
+  const fx = makeFixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  const pm = makePmAgent(ws);
+  try {
+    const taskId = uuidv4();
+    const result = dispatchSubagent({
+      workspace_id: ws,
+      role: 'builder',
+      pm,
+      task_id: taskId,
+      attempt: 1,
+      trigger_body: 'Build the FOIA agency profile schema.',
+    });
+    assert.match(result.meta_message, /MC subagent dispatch/);
+    assert.match(result.meta_message, new RegExp(`task=${taskId}`));
+    assert.match(result.meta_message, /Spawn a \*\*builder\*\* subagent/);
+    assert.match(result.meta_message, /sessions_spawn/);
+    assert.match(result.meta_message, /register_subagent_dispatch/);
+    assert.match(result.meta_message, /WORKER_BRIEFING/);
+    assert.match(result.meta_message, /Build the FOIA agency profile schema/);
+    assert.match(result.meta_message, /"context": "isolated"/, 'default context_mode for builder');
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});
+
+test('dispatchSubagent: pm_coord_scope_key uses agent.session_key_prefix + coord-task-<id>', () => {
+  const fx = makeFixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  const pm = makePmAgent(ws);
+  try {
+    const taskId = uuidv4();
+    const result = dispatchSubagent({
+      workspace_id: ws,
+      role: 'builder',
+      pm,
+      task_id: taskId,
+      attempt: 1,
+      trigger_body: 'body',
+    });
+    assert.equal(result.pm_coord_scope_key, `agent:mc-pm-test-dev:coord-task-${taskId}`);
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});
+
+test('dispatchSubagent: context_mode override beats per-role default', () => {
+  const fx = makeFixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  const pm = makePmAgent(ws);
+  try {
+    const result = dispatchSubagent({
+      workspace_id: ws,
+      role: 'builder',
+      pm,
+      task_id: uuidv4(),
+      attempt: 1,
+      trigger_body: 'body',
+      context_mode: 'fork',
+    });
+    assert.equal(result.context_mode, 'fork');
+    assert.match(result.meta_message, /"context": "fork"/);
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});
+
+test('dispatchSubagent: agent_role_overrides.subagent_context_mode flips role default', () => {
+  const fx = makeFixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  const pm = makePmAgent(ws);
+  try {
+    run(
+      `INSERT INTO agent_role_overrides (workspace_id, role, subagent_context_mode)
+       VALUES (?, 'builder', 'fork')`,
+      [ws],
+    );
+    const result = dispatchSubagent({
+      workspace_id: ws,
+      role: 'builder',
+      pm,
+      task_id: uuidv4(),
+      attempt: 1,
+      trigger_body: 'body',
+    });
+    assert.equal(result.context_mode, 'fork');
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});
+
+test('dispatchSubagent: worker_briefing carries identity preamble + role section + trigger body', () => {
+  const fx = makeFixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  const pm = makePmAgent(ws);
+  try {
+    const result = dispatchSubagent({
+      workspace_id: ws,
+      role: 'builder',
+      pm,
+      task_id: uuidv4(),
+      attempt: 1,
+      trigger_body: 'TRIGGER_MARKER',
+    });
+    assert.match(result.worker_briefing, new RegExp(`Your agent_id is: ${pm.id}`));
+    assert.match(result.worker_briefing, /Your gateway_agent_id is: mc-pm-test-dev/);
+    assert.match(result.worker_briefing, /# Role: builder/);
+    assert.match(result.worker_briefing, /TRIGGER_MARKER/);
+    assert.ok(result.worker_briefing_bytes > 0);
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});
+
+test('dispatchSubagent: attempt number flows into meta + label', () => {
+  const fx = makeFixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  const pm = makePmAgent(ws);
+  try {
+    const taskId = 'aabbccdd-1111-2222-3333-444455556666';
+    const result = dispatchSubagent({
+      workspace_id: ws,
+      role: 'tester',
+      pm,
+      task_id: taskId,
+      attempt: 3,
+      trigger_body: 'body',
+    });
+    assert.match(result.meta_message, /Attempt #3/);
+    assert.match(result.meta_message, /"label": "tester-aabbccdd-attempt3"/);
+    assert.match(result.meta_message, /"attempt": 3/);
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});

--- a/src/lib/agents/dispatch-subagent.ts
+++ b/src/lib/agents/dispatch-subagent.ts
@@ -1,0 +1,190 @@
+/**
+ * Phase J1: subagent-dispatch primitive (skeleton).
+ *
+ * In Phase J2, MC's worker dispatch path (src/app/api/tasks/[id]/dispatch/route.ts)
+ * will route through this primitive when MC_USE_SUBAGENT_SPAWN=1. The
+ * primitive's job is to:
+ *
+ *   1. Build the worker briefing (role-soul + identity preamble + notetaker +
+ *      task context + active-session manifest + trigger payload).
+ *   2. Wrap that briefing into a META message the PM agent receives in its
+ *      per-task coord session — telling the PM how to spawn (task=<briefing>,
+ *      mode=run, context=<isolated|fork>, runTimeoutSeconds=<n>) and how to
+ *      register the resulting runId via register_subagent_dispatch.
+ *   3. Compute the per-task coord scope_key and dispatch the META message via
+ *      `dispatchScope` (the PM acts on it).
+ *
+ * J1 ships the primitive without wiring it into the dispatch route. J2 wires
+ * it. K removes the legacy fallback path and the feature flag.
+ *
+ * Why a primitive instead of inline construction in dispatch/route.ts:
+ *  - The META envelope shape is stable contract for the PM's coord briefing.
+ *    Centralizing it here keeps the PM-side instructions and MC-side
+ *    construction in the same module's vicinity.
+ *  - Tests can exercise primitive output without spinning up the full route
+ *    handler.
+ *  - The recurring-job dispatcher and the heartbeat coordinator can use the
+ *    same primitive when (later) they want to spawn fan-out workers.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { Agent } from '@/lib/types';
+import { buildBriefing, type BriefingRole } from './briefing';
+import { resolveSubagentContextMode, type SubagentContextMode } from './subagent-context';
+import { computeScopeKey } from './dispatch-scope';
+
+/**
+ * Default runtime ceiling for a subagent. openclaw enforces this on its
+ * end via `runTimeoutSeconds`. Conservative — most worker dispatches
+ * complete in well under 30min; runaways get killed.
+ */
+const DEFAULT_RUN_TIMEOUT_SECONDS = 1800;
+
+export interface DispatchSubagentInput {
+  /** MC workspace UUID. */
+  workspace_id: string;
+  /** Worker role to spawn. */
+  role: Exclude<BriefingRole, 'pm'>;
+  /** The workspace's PM agent (the parent). */
+  pm: Agent;
+  /** Task this dispatch is for. */
+  task_id: string;
+  /** Optional initiative scope (some workers run against an initiative directly). */
+  initiative_id?: string;
+  /** Attempt number — 1 for first dispatch, 2+ for retries. */
+  attempt: number;
+  /**
+   * The trigger-specific body the worker needs (task description,
+   * acceptance criteria, prescribed commands, etc.). Caller composes
+   * the same content `dispatch/route.ts` would have built for the
+   * legacy worker session.
+   */
+  trigger_body: string;
+  /** Optional per-spawn override of the context-mode role default. */
+  context_mode?: SubagentContextMode;
+  /** Override the runtime ceiling (default 1800s). */
+  run_timeout_seconds?: number;
+}
+
+export interface DispatchSubagentResult {
+  /** The full openclaw-shaped briefing the subagent will receive as `task:`. */
+  worker_briefing: string;
+  /** Resolved context mode after applying overrides + workspace settings. */
+  context_mode: SubagentContextMode;
+  /** Scope key for the PM's per-task coord session (where META lands). */
+  pm_coord_scope_key: string;
+  /** Suggested run_group_id for take_note grouping inside the subagent. */
+  run_group_id: string;
+  /** META message MC sends to the PM's coord session — drives sessions_spawn. */
+  meta_message: string;
+  /**
+   * Length of the worker briefing in bytes — useful for the briefing-length
+   * p95 metric (validation pack global gate GG8).
+   */
+  worker_briefing_bytes: number;
+}
+
+/**
+ * Compose a subagent dispatch envelope. Pure function — no DB writes,
+ * no openclaw round-trip. The caller (J2 dispatch route) takes the
+ * meta_message and sends it through `dispatchScope` to the PM's coord
+ * session.
+ */
+export function dispatchSubagent(input: DispatchSubagentInput): DispatchSubagentResult {
+  const run_group_id = uuidv4();
+  const context_mode = resolveSubagentContextMode({
+    workspace_id: input.workspace_id,
+    role: input.role,
+    override: input.context_mode ?? null,
+  });
+
+  // The subagent itself receives this as `sessions_spawn({ task: … })`.
+  // Same content shape `buildBriefing` produces for any worker today.
+  const worker_briefing = buildBriefing({
+    workspace_id: input.workspace_id,
+    role: input.role,
+    scope_key: '(child session — assigned by openclaw at spawn time)',
+    agent_id: input.pm.id,
+    gateway_agent_id:
+      (input.pm as Agent & { gateway_agent_id?: string | null }).gateway_agent_id ?? '',
+    run_group_id,
+    is_resume: false,
+    task_id: input.task_id,
+    initiative_id: input.initiative_id,
+    trigger_body: input.trigger_body,
+  });
+
+  const pm_coord_scope_key = computeScopeKey(input.pm, `coord-task-${input.task_id}`);
+  const run_timeout = input.run_timeout_seconds ?? DEFAULT_RUN_TIMEOUT_SECONDS;
+
+  // META message addressed to the PM. Documents:
+  //  1) The exact sessions_spawn parameters MC wants applied.
+  //  2) The follow-up call to register_subagent_dispatch with the runId.
+  //  3) What the subagent's brief is (verbatim — no PM rewriting).
+  // The PM's coord briefing template (Phase J2) trains the agent to
+  // recognize this shape and act on it.
+  const meta_message = [
+    `**MC subagent dispatch (workspace=${input.workspace_id} task=${input.task_id})**`,
+    '',
+    `Spawn a **${input.role}** subagent for this task. Attempt #${input.attempt}.`,
+    '',
+    'Step 1: Call `sessions_spawn` (openclaw native MCP tool) with these arguments:',
+    '',
+    '```json',
+    JSON.stringify(
+      {
+        task: '<<see WORKER_BRIEFING below — pass the whole block verbatim>>',
+        mode: 'run',
+        context: context_mode,
+        runTimeoutSeconds: run_timeout,
+        label: `${input.role}-${input.task_id.slice(0, 8)}-attempt${input.attempt}`,
+      },
+      null,
+      2,
+    ),
+    '```',
+    '',
+    'Step 2: When `sessions_spawn` returns (it returns immediately with `runId` + `childSessionKey`), call MC\'s `register_subagent_dispatch` so MC can correlate `subagent_ended` events with this task:',
+    '',
+    '```json',
+    JSON.stringify(
+      {
+        agent_id: '<your MC agent_id>',
+        run_id: '<runId from sessions_spawn>',
+        child_session_key: '<childSessionKey from sessions_spawn>',
+        role: input.role,
+        scope_type: 'task_role',
+        task_id: input.task_id,
+        ...(input.initiative_id ? { initiative_id: input.initiative_id } : {}),
+        attempt: input.attempt,
+      },
+      null,
+      2,
+    ),
+    '```',
+    '',
+    'Step 3: Wait for the subagent. openclaw will auto-announce the subagent\'s final reply back to you as a chat message when it completes. The subagent will also call MCP tools directly (`log_activity`, `take_note`, `register_deliverable`, `update_task_status`) so MC\'s state is updated regardless of whether the announcement reaches you.',
+    '',
+    'Step 4: When the announcement lands:',
+    `- If the subagent succeeded and completed the work cleanly, do nothing — the work is recorded.`,
+    `- If the subagent failed and you judge a retry is warranted, dispatch again with attempt=${input.attempt + 1}. Use a different brief if the prior approach was wrong.`,
+    `- If the subagent flagged a blocker that needs the operator, take_note(audience='pm', importance=2, body='<one-line summary>').`,
+    '',
+    '---',
+    '',
+    'WORKER_BRIEFING (pass this entire block as the `task` parameter to `sessions_spawn`):',
+    '',
+    '```text',
+    worker_briefing,
+    '```',
+  ].join('\n');
+
+  return {
+    worker_briefing,
+    context_mode,
+    pm_coord_scope_key,
+    run_group_id,
+    meta_message,
+    worker_briefing_bytes: Buffer.byteLength(worker_briefing, 'utf8'),
+  };
+}

--- a/src/lib/agents/runner.test.ts
+++ b/src/lib/agents/runner.test.ts
@@ -15,6 +15,7 @@ import {
   computeWorkerScopeSuffix,
   getRunnerAgent,
   isScopeKeyedDispatchEnabled,
+  isSubagentSpawnEnabled,
   nextWorkerAttempt,
 } from './runner';
 
@@ -139,4 +140,18 @@ test('isScopeKeyedDispatchEnabled: defaults on, opt-out via env=0', () => {
   assert.equal(isScopeKeyedDispatchEnabled(), false);
   if (prev === undefined) delete process.env.MC_USE_SCOPE_KEYED_DISPATCH;
   else process.env.MC_USE_SCOPE_KEYED_DISPATCH = prev;
+});
+
+test('isSubagentSpawnEnabled: defaults off (Phase J2), opt-in via env=1', () => {
+  const prev = process.env.MC_USE_SUBAGENT_SPAWN;
+  delete process.env.MC_USE_SUBAGENT_SPAWN;
+  assert.equal(isSubagentSpawnEnabled(), false);
+  process.env.MC_USE_SUBAGENT_SPAWN = '1';
+  assert.equal(isSubagentSpawnEnabled(), true);
+  process.env.MC_USE_SUBAGENT_SPAWN = 'true';
+  assert.equal(isSubagentSpawnEnabled(), true);
+  process.env.MC_USE_SUBAGENT_SPAWN = '0';
+  assert.equal(isSubagentSpawnEnabled(), false);
+  if (prev === undefined) delete process.env.MC_USE_SUBAGENT_SPAWN;
+  else process.env.MC_USE_SUBAGENT_SPAWN = prev;
 });

--- a/src/lib/agents/runner.ts
+++ b/src/lib/agents/runner.ts
@@ -64,6 +64,21 @@ export function isScopeKeyedDispatchEnabled(): boolean {
 }
 
 /**
+ * Phase J2: feature flag for the openclaw `sessions_spawn`-based
+ * worker dispatch path. Default OFF. Set MC_USE_SUBAGENT_SPAWN=1 to
+ * route worker dispatches via the workspace PM's per-task coord
+ * session (which then calls openclaw's sessions_spawn) instead of the
+ * Phase C scope-keyed sibling-session path.
+ *
+ * Flips to default-on in Phase K once we've validated against
+ * spark-lb/agent.
+ */
+export function isSubagentSpawnEnabled(): boolean {
+  return process.env.MC_USE_SUBAGENT_SPAWN === '1' ||
+    process.env.MC_USE_SUBAGENT_SPAWN === 'true';
+}
+
+/**
  * Compute the scope_suffix for a worker dispatch.
  *
  * Format: `ws-<wsid>:task-<task_id>:<role>:<attempt>`

--- a/src/lib/agents/subagent-context.ts
+++ b/src/lib/agents/subagent-context.ts
@@ -1,0 +1,64 @@
+/**
+ * Phase J: per-role default for openclaw subagent `context` parameter.
+ *
+ * `isolated` — clean child session, no parent transcript inherited.
+ *              Cheap, naturally avoids parent-chatter leakage. Default
+ *              for builder/tester/reviewer/researcher/writer/learner.
+ * `fork`     — parent transcript forked into child for context. Useful
+ *              for summarization-style tasks where the parent's chat
+ *              IS the input. No worker role uses this by default;
+ *              future summarizer roles will opt in via
+ *              agent_role_overrides.subagent_context_mode='fork'.
+ *
+ * Resolution order:
+ *   1. Per-spawn override (caller passes `context_mode` directly).
+ *   2. Per-workspace per-role override
+ *      (`agent_role_overrides.subagent_context_mode` for this workspace + role).
+ *   3. Hard-coded role default below (the table).
+ */
+
+import { queryOne } from '@/lib/db';
+import type { BriefingRole } from './briefing';
+
+export type SubagentContextMode = 'isolated' | 'fork';
+
+const ROLE_DEFAULT: Record<BriefingRole, SubagentContextMode> = {
+  pm: 'isolated', // not actually used — PM dispatches don't go via subagents in J1/J2
+  coordinator: 'isolated',
+  builder: 'isolated',
+  researcher: 'isolated',
+  tester: 'isolated',
+  reviewer: 'isolated',
+  writer: 'isolated',
+  learner: 'isolated',
+};
+
+interface OverrideRow {
+  subagent_context_mode: string | null;
+}
+
+/**
+ * Resolve which context mode to use for a (workspace, role) spawn.
+ * Per-spawn arg wins; otherwise workspace-scoped override; otherwise
+ * the hard-coded role default.
+ */
+export function resolveSubagentContextMode(input: {
+  workspace_id: string;
+  role: BriefingRole;
+  override?: SubagentContextMode | null;
+}): SubagentContextMode {
+  if (input.override === 'isolated' || input.override === 'fork') {
+    return input.override;
+  }
+  const row = queryOne<OverrideRow>(
+    `SELECT subagent_context_mode
+       FROM agent_role_overrides
+      WHERE workspace_id = ? AND role = ?
+      LIMIT 1`,
+    [input.workspace_id, input.role],
+  );
+  if (row?.subagent_context_mode === 'isolated' || row?.subagent_context_mode === 'fork') {
+    return row.subagent_context_mode;
+  }
+  return ROLE_DEFAULT[input.role];
+}

--- a/src/lib/agents/subagent-flow.test.ts
+++ b/src/lib/agents/subagent-flow.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Phase J2 integration test — walks the full data flow without
+ * mocking Next.js or openclaw:
+ *
+ *   1. dispatchSubagent builds the META envelope for a builder.
+ *   2. Simulate the PM calling sessions_spawn (just generate a
+ *      runId + childSessionKey).
+ *   3. Call upsertSession (the work register_subagent_dispatch MCP
+ *      tool does internally).
+ *   4. Re-call dispatchSubagent for the same task — its briefing
+ *      input is the META, but the active-session manifest is on the
+ *      coord-task briefing the PM gets re-dispatched. So we also
+ *      call buildBriefing for the PM's coord session and assert the
+ *      manifest includes the prior dispatch.
+ *   5. Simulate subagent_ended via closeSessionByRunId. Verify
+ *      next coord briefing has the manifest empty.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import { __setTemplatesDirForTests, buildBriefing } from './briefing';
+import { dispatchSubagent } from './dispatch-subagent';
+import { closeSessionByRunId, upsertSession } from '@/lib/db/mc-sessions';
+import type { Agent } from '@/lib/types';
+
+function freshWorkspace(): string {
+  const id = `ws-flow-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function makePm(workspaceId: string): Agent {
+  const id = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, gateway_agent_id, source,
+                          session_key_prefix, is_pm, is_master, is_active, created_at, updated_at)
+     VALUES (?, 'PM', 'pm', ?, 'mc-pm-test-dev', 'gateway',
+             'agent:mc-pm-test-dev', 1, 1, 1, datetime('now'), datetime('now'))`,
+    [id, workspaceId],
+  );
+  return {
+    id,
+    name: 'PM',
+    role: 'pm',
+    workspace_id: workspaceId,
+    gateway_agent_id: 'mc-pm-test-dev',
+    session_key_prefix: 'agent:mc-pm-test-dev',
+    is_pm: 1,
+    is_master: 1,
+    is_active: 1,
+  } as unknown as Agent;
+}
+
+function fixtureTemplates(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mc-j2-flow-'));
+  for (const role of ['builder', 'tester', 'pm']) {
+    mkdirSync(path.join(dir, role), { recursive: true });
+    writeFileSync(path.join(dir, role, 'SOUL.md'), `# ${role} soul\n`);
+  }
+  mkdirSync(path.join(dir, '_shared'), { recursive: true });
+  writeFileSync(path.join(dir, '_shared', 'notetaker.md'), '# notetaker\n');
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+test('Phase J2 flow: dispatch → register → manifest visible → close → manifest empty', () => {
+  const fx = fixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  const pm = makePm(ws);
+  try {
+    // Seed a task.
+    const taskId = uuidv4();
+    run(
+      `INSERT INTO tasks (id, workspace_id, title, status, created_at, updated_at)
+       VALUES (?, ?, 'Build the schema', 'in_progress', datetime('now'), datetime('now'))`,
+      [taskId, ws],
+    );
+
+    // Step 1 — MC builds the META envelope for the PM.
+    const dispatch1 = dispatchSubagent({
+      workspace_id: ws,
+      role: 'builder',
+      pm,
+      task_id: taskId,
+      attempt: 1,
+      trigger_body: 'Build the FOIA agency profile schema.',
+    });
+    assert.match(dispatch1.meta_message, /sessions_spawn/);
+    assert.match(dispatch1.meta_message, /register_subagent_dispatch/);
+    assert.equal(
+      dispatch1.pm_coord_scope_key,
+      `agent:mc-pm-test-dev:coord-task-${taskId}`,
+    );
+
+    // Step 2 — simulate openclaw response.
+    const runId = `run-${uuidv4().slice(0, 12)}`;
+    const childSessionKey = `agent:mc-pm-test-dev:subagent:${uuidv4()}`;
+
+    // Step 3 — PM calls register_subagent_dispatch. We exercise the
+    // DAO directly (the MCP tool is just a wrapper around upsertSession).
+    upsertSession({
+      scope_key: childSessionKey,
+      workspace_id: ws,
+      role: 'builder',
+      scope_type: 'task_role',
+      task_id: taskId,
+      attempt: 1,
+      run_id: runId,
+    });
+
+    // Step 4 — re-dispatch a coord briefing for the PM. The active-
+    // subagent manifest in the briefing should now include this run.
+    const coordBriefing = buildBriefing({
+      workspace_id: ws,
+      role: 'pm',
+      scope_key: dispatch1.pm_coord_scope_key,
+      agent_id: pm.id,
+      gateway_agent_id: 'mc-pm-test-dev',
+      run_group_id: uuidv4(),
+      task_id: taskId,
+      trigger_body: 'Status check on builder progress.',
+    });
+    assert.match(coordBriefing, /Active subagents for this task:/);
+    assert.match(coordBriefing, /\*\*builder\*\* attempt 1/);
+    assert.match(coordBriefing, new RegExp(runId.slice(0, 12)));
+    assert.match(coordBriefing, /status=active/);
+
+    // Step 5 — subagent_ended fires. closeSessionByRunId is what the
+    // hook handler will call.
+    const closed = closeSessionByRunId(runId);
+    assert.equal(closed?.status, 'closed');
+
+    // After close, manifest should be empty (only filters active|idle).
+    const coordAfter = buildBriefing({
+      workspace_id: ws,
+      role: 'pm',
+      scope_key: dispatch1.pm_coord_scope_key,
+      agent_id: pm.id,
+      gateway_agent_id: 'mc-pm-test-dev',
+      run_group_id: uuidv4(),
+      task_id: taskId,
+      trigger_body: 'Are we done?',
+    });
+    assert.doesNotMatch(coordAfter, /Active subagents for this task:/);
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});
+
+test('Phase J2 flow: retry attempt produces a second mc_sessions row, manifest shows both', () => {
+  const fx = fixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  const pm = makePm(ws);
+  try {
+    const taskId = uuidv4();
+    run(
+      `INSERT INTO tasks (id, workspace_id, title, status, created_at, updated_at)
+       VALUES (?, ?, 't', 'in_progress', datetime('now'), datetime('now'))`,
+      [taskId, ws],
+    );
+
+    const runId1 = `run-${uuidv4().slice(0, 12)}`;
+    const key1 = `agent:mc-pm-test-dev:subagent:${uuidv4()}`;
+    upsertSession({
+      scope_key: key1,
+      workspace_id: ws,
+      role: 'builder',
+      scope_type: 'task_role',
+      task_id: taskId,
+      attempt: 1,
+      run_id: runId1,
+    });
+
+    // First builder failed; close it as failed.
+    closeSessionByRunId(runId1, 'failed');
+
+    // Retry: attempt 2.
+    const runId2 = `run-${uuidv4().slice(0, 12)}`;
+    const key2 = `agent:mc-pm-test-dev:subagent:${uuidv4()}`;
+    upsertSession({
+      scope_key: key2,
+      workspace_id: ws,
+      role: 'builder',
+      scope_type: 'task_role',
+      task_id: taskId,
+      attempt: 2,
+      run_id: runId2,
+    });
+
+    const coord = buildBriefing({
+      workspace_id: ws,
+      role: 'pm',
+      scope_key: `agent:mc-pm-test-dev:coord-task-${taskId}`,
+      agent_id: pm.id,
+      gateway_agent_id: 'mc-pm-test-dev',
+      run_group_id: uuidv4(),
+      task_id: taskId,
+      trigger_body: 'Coord check',
+    });
+    // Manifest filters by status active|idle, so the failed attempt-1
+    // row is excluded; only attempt-2 active row appears.
+    assert.match(coord, /\*\*builder\*\* attempt 2/);
+    assert.doesNotMatch(coord, /\*\*builder\*\* attempt 1/);
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});

--- a/src/lib/db/mc-sessions.test.ts
+++ b/src/lib/db/mc-sessions.test.ts
@@ -11,7 +11,9 @@ import assert from 'node:assert/strict';
 import { v4 as uuidv4 } from 'uuid';
 import { run } from '@/lib/db';
 import {
+  closeSessionByRunId,
   getSession,
+  getSessionByRunId,
   setSessionStatus,
   touchSession,
   upsertSession,
@@ -136,4 +138,109 @@ test('upsertSession: workspace cascade deletes the session row', () => {
 
   run(`DELETE FROM workspaces WHERE id = ?`, [ws]);
   assert.equal(getSession(key), null);
+});
+
+// ─── Phase J1: run_id ───────────────────────────────────────────────
+
+test('upsertSession: persists run_id on insert', () => {
+  const ws = freshWorkspace();
+  const key = `agent:mc-pm-test-dev:subagent:${uuidv4()}`;
+  const runId = `run-${uuidv4().slice(0, 12)}`;
+  const result = upsertSession({
+    scope_key: key,
+    workspace_id: ws,
+    role: 'builder',
+    scope_type: 'task_role',
+    run_id: runId,
+  });
+  assert.equal(result.is_new, true);
+  assert.equal(result.session.run_id, runId);
+});
+
+test('upsertSession: re-touch updates run_id when provided, preserves it when not', () => {
+  const ws = freshWorkspace();
+  const key = `agent:mc-pm-test-dev:subagent:${uuidv4()}`;
+  upsertSession({
+    scope_key: key,
+    workspace_id: ws,
+    role: 'tester',
+    scope_type: 'task_role',
+    run_id: 'run-original',
+  });
+  // Re-upsert without run_id — should preserve the original.
+  const second = upsertSession({
+    scope_key: key,
+    workspace_id: ws,
+    role: 'tester',
+    scope_type: 'task_role',
+  });
+  assert.equal(second.session.run_id, 'run-original');
+
+  // Re-upsert with new run_id — should overwrite.
+  const third = upsertSession({
+    scope_key: key,
+    workspace_id: ws,
+    role: 'tester',
+    scope_type: 'task_role',
+    run_id: 'run-replaced',
+  });
+  assert.equal(third.session.run_id, 'run-replaced');
+});
+
+test('getSessionByRunId / closeSessionByRunId: round-trip', () => {
+  const ws = freshWorkspace();
+  const key = `agent:mc-pm-test-dev:subagent:${uuidv4()}`;
+  const runId = `run-${uuidv4().slice(0, 12)}`;
+  upsertSession({
+    scope_key: key,
+    workspace_id: ws,
+    role: 'builder',
+    scope_type: 'task_role',
+    run_id: runId,
+  });
+
+  const fetched = getSessionByRunId(runId);
+  assert.equal(fetched?.scope_key, key);
+
+  const closed = closeSessionByRunId(runId);
+  assert.equal(closed?.status, 'closed');
+  assert.ok(closed?.closed_at);
+});
+
+test('closeSessionByRunId: failed status sticks closed_at', () => {
+  const ws = freshWorkspace();
+  const key = `agent:mc-pm-test-dev:subagent:${uuidv4()}`;
+  const runId = `run-${uuidv4().slice(0, 12)}`;
+  upsertSession({
+    scope_key: key,
+    workspace_id: ws,
+    role: 'builder',
+    scope_type: 'task_role',
+    run_id: runId,
+  });
+  const failed = closeSessionByRunId(runId, 'failed');
+  assert.equal(failed?.status, 'failed');
+  assert.ok(failed?.closed_at);
+});
+
+test('closeSessionByRunId: idempotent on already-closed', () => {
+  const ws = freshWorkspace();
+  const key = `agent:mc-pm-test-dev:subagent:${uuidv4()}`;
+  const runId = `run-${uuidv4().slice(0, 12)}`;
+  upsertSession({
+    scope_key: key,
+    workspace_id: ws,
+    role: 'builder',
+    scope_type: 'task_role',
+    run_id: runId,
+  });
+  const first = closeSessionByRunId(runId);
+  const firstClosedAt = first?.closed_at;
+  const second = closeSessionByRunId(runId);
+  assert.equal(second?.status, 'closed');
+  assert.equal(second?.closed_at, firstClosedAt, 'closed_at should not advance on no-op close');
+});
+
+test('getSessionByRunId: missing runId returns null', () => {
+  assert.equal(getSessionByRunId('run-does-not-exist'), null);
 });

--- a/src/lib/db/mc-sessions.ts
+++ b/src/lib/db/mc-sessions.ts
@@ -37,6 +37,13 @@ export interface McSession {
   last_used_at: string;
   created_at: string;
   closed_at: string | null;
+  /**
+   * Phase J: openclaw's `sessions_spawn` returns a runId distinct from
+   * the session_key. We persist it so MC can correlate `subagent_ended`
+   * events back to the originating dispatch row. NULL for sessions
+   * that didn't originate from a sessions_spawn call.
+   */
+  run_id: string | null;
 }
 
 export interface UpsertSessionInput {
@@ -48,6 +55,8 @@ export interface UpsertSessionInput {
   initiative_id?: string | null;
   recurring_job_id?: string | null;
   attempt?: number;
+  /** Phase J: openclaw runId for subagent dispatches. */
+  run_id?: string | null;
 }
 
 /**
@@ -66,14 +75,31 @@ export function upsertSession(input: UpsertSessionInput): { session: McSession; 
   );
 
   if (existing) {
-    run(
-      `UPDATE mc_sessions
-          SET status = 'active',
-              last_used_at = datetime('now'),
-              closed_at = NULL
-        WHERE scope_key = ?`,
-      [input.scope_key],
-    );
+    // If a run_id is provided on touch, persist it (subagent dispatches
+    // are registered after the session row already exists in some flows
+    // — e.g. Phase B's sibling-session worker dispatch that gets
+    // promoted to a subagent during transition). Otherwise leave the
+    // existing run_id alone.
+    if (input.run_id) {
+      run(
+        `UPDATE mc_sessions
+            SET status = 'active',
+                last_used_at = datetime('now'),
+                closed_at = NULL,
+                run_id = ?
+          WHERE scope_key = ?`,
+        [input.run_id, input.scope_key],
+      );
+    } else {
+      run(
+        `UPDATE mc_sessions
+            SET status = 'active',
+                last_used_at = datetime('now'),
+                closed_at = NULL
+          WHERE scope_key = ?`,
+        [input.scope_key],
+      );
+    }
     const refreshed = queryOne<McSession>(
       `SELECT * FROM mc_sessions WHERE scope_key = ?`,
       [input.scope_key],
@@ -85,9 +111,9 @@ export function upsertSession(input: UpsertSessionInput): { session: McSession; 
     `INSERT INTO mc_sessions (
        scope_key, workspace_id, role, scope_type,
        task_id, initiative_id, recurring_job_id,
-       attempt, status, last_used_at, created_at, closed_at
+       attempt, status, last_used_at, created_at, closed_at, run_id
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active',
-              datetime('now'), datetime('now'), NULL)`,
+              datetime('now'), datetime('now'), NULL, ?)`,
     [
       input.scope_key,
       input.workspace_id,
@@ -97,6 +123,7 @@ export function upsertSession(input: UpsertSessionInput): { session: McSession; 
       input.initiative_id ?? null,
       input.recurring_job_id ?? null,
       input.attempt ?? 1,
+      input.run_id ?? null,
     ],
   );
 
@@ -144,4 +171,32 @@ export function touchSession(scopeKey: string): void {
     `UPDATE mc_sessions SET last_used_at = datetime('now') WHERE scope_key = ?`,
     [scopeKey],
   );
+}
+
+/**
+ * Phase J: look up a session by openclaw runId. Used by
+ * `subagent_ended` event handling to mark the session closed without
+ * needing the session_key — runId is what openclaw's hooks emit.
+ */
+export function getSessionByRunId(runId: string): McSession | null {
+  return (
+    queryOne<McSession>(`SELECT * FROM mc_sessions WHERE run_id = ?`, [runId]) ?? null
+  );
+}
+
+/**
+ * Phase J: close a session keyed by runId (instead of scope_key).
+ * Idempotent — already-closed sessions stay closed.
+ */
+export function closeSessionByRunId(runId: string, status: 'closed' | 'failed' = 'closed'): McSession | null {
+  const existing = getSessionByRunId(runId);
+  if (!existing) return null;
+  run(
+    `UPDATE mc_sessions
+        SET status = ?,
+            closed_at = datetime('now')
+      WHERE run_id = ? AND status NOT IN ('closed', 'failed')`,
+    [status, runId],
+  );
+  return getSessionByRunId(runId);
 }

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4004,6 +4004,44 @@ const migrations: Migration[] = [
       );
     },
   },
+  {
+    id: '072',
+    name: 'mc_sessions_run_id',
+    up: (db) => {
+      // Phase J1: openclaw's `sessions_spawn` returns a `runId` distinct
+      // from the session_key. We need both to correlate subagent
+      // lifecycle events (subagent_ended hooks, retries, audit) back to
+      // the dispatch row in mc_sessions. Nullable column — only
+      // populated when register_subagent_dispatch writes the row.
+      const cols = db.prepare(`PRAGMA table_info(mc_sessions)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'run_id')) {
+        db.exec(`ALTER TABLE mc_sessions ADD COLUMN run_id TEXT`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_mc_sessions_run_id ON mc_sessions(run_id) WHERE run_id IS NOT NULL`);
+      }
+      console.log('[Migration 072] mc_sessions.run_id column added.');
+    },
+  },
+  {
+    id: '073',
+    name: 'agent_role_overrides_subagent_context_mode',
+    up: (db) => {
+      // Phase J1: per-role default for openclaw subagent context mode.
+      // 'isolated' = clean child session (default for builder/tester/etc.)
+      // 'fork'     = parent transcript forked into child (default for
+      //              future summarization-style roles that need PM context).
+      // NULL       = use the per-role baked default in
+      //              src/lib/agents/dispatch-subagent.ts.
+      const cols = db.prepare(`PRAGMA table_info(agent_role_overrides)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'subagent_context_mode')) {
+        db.exec(`
+          ALTER TABLE agent_role_overrides
+            ADD COLUMN subagent_context_mode TEXT
+            CHECK (subagent_context_mode IN ('isolated', 'fork'))
+        `);
+      }
+      console.log('[Migration 073] agent_role_overrides.subagent_context_mode column added.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -34,6 +34,7 @@ import { getOpenClawClient } from '@/lib/openclaw/client';
 import { spawnDelegationSubtask } from '@/lib/convoy';
 import { internalDispatch } from '@/lib/internal-dispatch';
 import { postPmChatMessage } from '@/lib/agents/pm-dispatch';
+import { upsertSession, type ScopeType } from '@/lib/db/mc-sessions';
 import {
   archiveNote as archiveNoteDb,
   createNote,
@@ -1898,6 +1899,93 @@ export function registerAllTools(server: McpServer): void {
         subtask_id: args.subtask_id,
         child_task_id: row.task_id,
       });
+    }),
+  );
+
+  // ── Phase J: subagent dispatch registration ──────────────────────
+  // register_subagent_dispatch
+  // Called by the workspace PM right after `sessions_spawn` returns.
+  // Writes a row in mc_sessions correlating the openclaw runId +
+  // childSessionKey with the (task | initiative | recurring_job, role,
+  // attempt) tuple. Without this, MC has no way to attribute subagent
+  // activity (notes, deliverables, status transitions) to the right
+  // dispatch.
+  // See specs/scope-keyed-sessions-phase-j.md §D3.
+  server.registerTool(
+    'register_subagent_dispatch',
+    {
+      title: 'Register an openclaw subagent dispatch in mc_sessions',
+      description:
+        "After calling openclaw `sessions_spawn`, call this with the runId + childSessionKey + scope context. MC records the subagent in mc_sessions so deliverables, notes, and status transitions land on the correct (task, role, attempt) tuple. Idempotent on scope_key.",
+      inputSchema: {
+        agent_id: agentIdArg,
+        run_id: z
+          .string()
+          .min(1)
+          .describe(
+            'The runId returned by openclaw `sessions_spawn`. Used to correlate `subagent_ended` events back to this dispatch.',
+          ),
+        child_session_key: z
+          .string()
+          .min(1)
+          .describe(
+            'The childSessionKey returned by openclaw `sessions_spawn` (shape: agent:<parentId>:subagent:<uuid>). Stored as mc_sessions.scope_key.',
+          ),
+        role: z
+          .enum([
+            'pm',
+            'coordinator',
+            'builder',
+            'researcher',
+            'tester',
+            'reviewer',
+            'writer',
+            'learner',
+          ])
+          .describe('Role the subagent is dispatched to perform.'),
+        scope_type: z
+          .enum(['task_role', 'recurring', 'heartbeat'])
+          .describe('Why this subagent was spawned. task_role = per-task worker dispatch.'),
+        task_id: z.string().min(1).optional().describe('Task UUID for task_role spawns.'),
+        initiative_id: z.string().min(1).optional().describe('Initiative UUID for initiative-scoped spawns.'),
+        recurring_job_id: z.string().min(1).optional().describe('Recurring job UUID for scope_type=recurring.'),
+        attempt: z
+          .number()
+          .int()
+          .positive()
+          .default(1)
+          .describe('Attempt number (1 = first dispatch, 2 = retry, etc.).'),
+      },
+      annotations: { destructiveHint: false, openWorldHint: false },
+    },
+    trace('register_subagent_dispatch', async (args) => {
+      assertAgentActive(args.agent_id);
+      const workspaceId = deriveWorkspaceFromAgent(args.agent_id);
+      const result = upsertSession({
+        scope_key: args.child_session_key,
+        workspace_id: workspaceId,
+        role: args.role,
+        scope_type: args.scope_type as ScopeType,
+        task_id: args.task_id ?? null,
+        initiative_id: args.initiative_id ?? null,
+        recurring_job_id: args.recurring_job_id ?? null,
+        attempt: args.attempt,
+        run_id: args.run_id,
+      });
+      const payload = {
+        scope_key: result.session.scope_key,
+        run_id: result.session.run_id,
+        workspace_id: result.session.workspace_id,
+        role: result.session.role,
+        scope_type: result.session.scope_type,
+        task_id: result.session.task_id,
+        initiative_id: result.session.initiative_id,
+        recurring_job_id: result.session.recurring_job_id,
+        attempt: result.session.attempt,
+        status: result.session.status,
+        is_new: result.is_new,
+      };
+      return textResult(JSON.stringify(payload, null, 2), payload);
     }),
   );
 }


### PR DESCRIPTION
## Summary
**Stacked on [#157 (Phase J1)](https://github.com/smb209/mission-control/pull/157).** Behavior change behind `MC_USE_SUBAGENT_SPAWN=1` — default off.

When the flag is on, MC's worker dispatch routes through the workspace PM instead of opening a sibling session on it. The PM receives a META envelope and calls openclaw `sessions_spawn` + the J1 `register_subagent_dispatch` MCP tool per the contract in [`agent-templates/_shared/pm-coordinator.md`](agent-templates/_shared/pm-coordinator.md).

## What changed
- **`buildBriefing()`** — when the briefing has a `task_id`, queries `mc_sessions` for active subagents on that task and prepends an `Active subagents for this task:` manifest. Filters `status IN ('active','idle')` so closed/failed runs don't clutter. The PM looks up state instead of remembering it; durable across session compaction or restart.
- **`pm-coordinator.md`** — PM-side instructions: META envelope shape + four-step orchestration flow (spawn → register → wait → react) + the manifest contract.
- **`isSubagentSpawnEnabled()`** — env-flag helper, defaults off.
- **`dispatch/route.ts`** — new branch ahead of the Phase C scope-keyed branch: when flag on AND workspace PM exists AND the agent maps to a worker role, `dispatchSubagent` builds the META and `sendChatToAgent` delivers it to the PM's `coord-task-<id>` session.

## Test plan
- [x] `yarn test` — 573/573 (was 567, +6 in `briefing.test.ts`, `runner.test.ts`, new `subagent-flow.test.ts`).
- [x] `yarn tsc --noEmit` — 2 pre-existing errors only.
- [x] `yarn db:reset && yarn tsx scripts/seed-foia-fixture.ts` — migrations 072+073 apply on fresh DB; FOIA tree loads.
- [x] Integration test (`subagent-flow.test.ts`): full dispatch → register → manifest visible → close → manifest empty cycle, plus retry-attempt scenario.
- [ ] Real-agent smoke against `spark-lb/agent` — deferred until openclaw MCP server activation gap closes (per [`04-e2e-run-results.md`](specs/scope-keyed-sessions-validation/04-e2e-run-results.md)).

## Phase K — flip default + cleanup
Once we've validated the flag-on path against `spark-lb/agent`, Phase K will:
1. Flip `MC_USE_SUBAGENT_SPAWN` default to true
2. Remove the legacy Phase C worker scope-keyed branch from `dispatch/route.ts`
3. Remove `nextWorkerAttempt` if not used elsewhere
4. Delete `MC_USE_SUBAGENT_SPAWN` env lever after a release cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)