### PR TITLE
fix(workspace:provision): seed role-templated workspace files after openclaw agents add

### DIFF
--- a/scripts/provision-workspace-runner.ts
+++ b/scripts/provision-workspace-runner.ts
@@ -3,34 +3,47 @@
  *
  * Uses openclaw's native CLI bindings (not raw config-file editing) so
  * the script rides along with openclaw upgrades and config schema
- * changes:
+ * changes. Then seeds the workspace dir with the role-templated
+ * SOUL.md / AGENTS.md / IDENTITY.md from `agent-templates/<role>/`,
+ * overwriting openclaw's defaults — without those, the PM's first-turn
+ * context comes from openclaw's generic templates instead of the MC
+ * role guidance.
  *
+ * Steps:
  *   1. `openclaw agents add <id> --workspace <dir> --model <m> --non-interactive --json`
  *      Creates the agent record + workspace dir + writes the basic
  *      entry into ~/.openclaw/openclaw.json.
  *   2. `openclaw config get agents.list` to find the new entry's index.
- *   3. `openclaw config set --batch-json [...]` to enrich with tools
- *      profile / skills / heartbeat / display name.
+ *   3. `openclaw config set --batch-json [...]` to enrich with display
+ *      name / skills / heartbeat / tools profile (allow sc-mission-
+ *      control-<env>__*, deny opposite).
+ *   4. Seed role-templated files into the workspace dir
+ *      (SOUL.md, AGENTS.md, IDENTITY.md from agent-templates/<role>/).
+ *      AGENTS.md gets the pm-coordinator addendum appended so the PM
+ *      knows how to handle MC's META envelopes from Phase J2.
  *
- * Idempotent — if the agent already exists (id collision), bails with
- * a clear message instead of creating a duplicate. Use
- * `openclaw agents delete <id> --force` first to recreate.
+ * Idempotency:
+ *   - If the agent already exists in openclaw config, bails with a
+ *     clear "already exists" message instead of stacking duplicates.
+ *   - `--reseed-templates` re-runs step 4 only (skips agents add +
+ *     config enrich), useful for picking up template updates without
+ *     touching the openclaw record.
  *
  * Usage:
- *   yarn workspace:provision <slug> [--prod]
+ *   yarn workspace:provision <slug> [--prod] [--reseed-templates]
  *
  * Examples:
  *   yarn workspace:provision foia
- *     → creates `mc-pm-foia-dev` with sc-mission-control-dev MCP scope
+ *     → creates `mc-pm-foia-dev`; seeds workspace dir with PM templates
  *   yarn workspace:provision foia --prod
  *     → creates `mc-pm-foia` with sc-mission-control MCP scope
- *
- * MCP scope is derived from --prod flag and openclaw.json must already
- * have both `sc-mission-control` and `sc-mission-control-dev` MCP
- * server entries (run `openclaw mcp show <name>` to verify).
+ *   yarn workspace:provision foia --reseed-templates
+ *     → existing agent: just re-seed SOUL.md/AGENTS.md/IDENTITY.md
+ *       from agent-templates/pm/. No openclaw config changes.
  */
 
 import { spawnSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -52,27 +65,39 @@ const DEFAULT_SKILLS = [
   'taskflow',
 ];
 const DEFAULT_MODEL = 'spark-lb/agent';
+const REPO_ROOT = path.resolve(__dirname, '..');
+const TEMPLATES_DIR = path.join(REPO_ROOT, 'agent-templates');
+
+/**
+ * Files we manage from the role template. Anything outside this list
+ * (HEARTBEAT.md, BOOTSTRAP.md, TOOLS.md, USER.md, MC-CONTEXT.json)
+ * stays as openclaw provided it — those are operator state, not role
+ * identity.
+ */
+const TEMPLATED_FILES = ['SOUL.md', 'AGENTS.md', 'IDENTITY.md'];
 
 function fail(msg: string): never {
   process.stderr.write(`ERROR: ${msg}\n`);
   process.exit(1);
 }
 
-function parseArgs(): { slug: string; isProd: boolean } {
+function parseArgs(): { slug: string; isProd: boolean; reseedOnly: boolean } {
   const args = process.argv.slice(2).filter((a) => !!a);
   if (args.length === 0) {
-    fail('usage: yarn workspace:provision <slug> [--prod]');
+    fail('usage: yarn workspace:provision <slug> [--prod] [--reseed-templates]');
   }
   let isProd = false;
+  let reseedOnly = false;
   let slug: string | null = null;
   for (const a of args) {
     if (a === '--prod') isProd = true;
+    else if (a === '--reseed-templates') reseedOnly = true;
     else if (a.startsWith('--')) fail(`unknown flag: ${a}`);
     else if (slug === null) slug = a;
     else fail(`unexpected positional arg: ${a}`);
   }
   if (!slug) fail('slug is required');
-  return { slug: slug!, isProd };
+  return { slug: slug!, isProd, reseedOnly };
 }
 
 function validateSlug(slug: string): void {
@@ -132,7 +157,68 @@ function findAgentIndex(list: AgentListEntry[], id: string): number {
   return list.findIndex((a) => a.id === id);
 }
 
-function provision(slug: string, isProd: boolean): void {
+/**
+ * Step 4: seed the workspace dir with role-templated content.
+ * Always overwrites the three templated files regardless of prior
+ * content. The pm-coordinator addendum is appended to AGENTS.md so
+ * the PM knows how to handle MC's META envelopes (Phase J2).
+ *
+ * Returns true if any file changed.
+ */
+async function seedRoleTemplates(role: string, workspaceDir: string): Promise<boolean> {
+  const roleDir = path.join(TEMPLATES_DIR, role);
+  let changed = 0;
+
+  for (const file of TEMPLATED_FILES) {
+    const src = path.join(roleDir, file);
+    const dest = path.join(workspaceDir, file);
+    let content: string;
+    try {
+      content = await fs.readFile(src, 'utf8');
+    } catch (err) {
+      // Some roles may not have all three files — that's fine.
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        process.stderr.write(`  ${file.padEnd(15)} skipped (template missing in agent-templates/${role}/)\n`);
+        continue;
+      }
+      throw err;
+    }
+
+    // PM AGENTS.md gets the coordinator addendum appended so the
+    // operator-side workspace dir mirrors what the briefing builder
+    // injects on dispatch. Without this, the agent's first-turn
+    // context (read from these files at session start) wouldn't
+    // include META-envelope handling.
+    if (role === 'pm' && file === 'AGENTS.md') {
+      const addendumPath = path.join(TEMPLATES_DIR, '_shared', 'pm-coordinator.md');
+      try {
+        const addendum = await fs.readFile(addendumPath, 'utf8');
+        content = content.trimEnd() + '\n\n---\n\n' + addendum;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        // pm-coordinator.md is optional; skip silently if absent.
+      }
+    }
+
+    let prior: string | null = null;
+    try {
+      prior = await fs.readFile(dest, 'utf8');
+    } catch {
+      // missing destination — that's fine, we'll create it.
+    }
+    if (prior === content) {
+      process.stderr.write(`  ${file.padEnd(15)} unchanged\n`);
+      continue;
+    }
+    await fs.writeFile(dest, content);
+    process.stderr.write(`  ${file.padEnd(15)} ${prior === null ? 'created' : 'overwrote openclaw default'}\n`);
+    changed++;
+  }
+
+  return changed > 0;
+}
+
+async function provision(slug: string, isProd: boolean, reseedOnly: boolean): Promise<void> {
   const env = isProd ? '' : '-dev';
   const gatewayId = `mc-pm-${slug}${env}`;
   if (gatewayId.length > 64) {
@@ -143,13 +229,37 @@ function provision(slug: string, isProd: boolean): void {
   const mcpServer = isProd ? 'sc-mission-control' : 'sc-mission-control-dev';
   const otherMcp = isProd ? 'sc-mission-control-dev' : 'sc-mission-control';
   const workspaceDir = path.join(os.homedir(), '.openclaw', 'workspaces', gatewayId);
+  const role = 'pm'; // mc-pm-<slug>-* always maps to the PM role.
 
   // 1. Idempotency check.
   const before = getAgentsList();
-  if (findAgentIndex(before, gatewayId) >= 0) {
+  const exists = findAgentIndex(before, gatewayId) >= 0;
+
+  if (reseedOnly) {
+    if (!exists) {
+      fail(
+        `--reseed-templates requires the agent to already exist; ` +
+          `${gatewayId} is not in agents.list. Drop the flag to provision fresh.`,
+      );
+    }
+    process.stderr.write(`Re-seeding templates only for ${gatewayId}…\n`);
+    const wsExists = await fs
+      .stat(workspaceDir)
+      .then(() => true)
+      .catch(() => false);
+    if (!wsExists) {
+      fail(`workspace dir ${workspaceDir} doesn't exist; can't reseed templates`);
+    }
+    const changed = await seedRoleTemplates(role, workspaceDir);
+    process.stderr.write(`\n${changed ? '✓ templates reseeded' : '✓ templates already up-to-date'}\n`);
+    return;
+  }
+
+  if (exists) {
     process.stderr.write(
       `agent "${gatewayId}" already exists in openclaw.json — nothing to do.\n` +
-        `(to recreate: openclaw agents delete ${gatewayId} --force)\n`,
+        `(to recreate: openclaw agents delete ${gatewayId} --force)\n` +
+        `(to re-seed templates only: yarn workspace:provision ${slug}${isProd ? ' --prod' : ''} --reseed-templates)\n`,
     );
     return;
   }
@@ -185,6 +295,7 @@ function provision(slug: string, isProd: boolean): void {
     { path: `agents.list[${idx}].skills`, value: DEFAULT_SKILLS },
     { path: `agents.list[${idx}].heartbeat.every`, value: '4h' },
     { path: `agents.list[${idx}].heartbeat.model`, value: DEFAULT_MODEL },
+    { path: `agents.list[${idx}].heartbeat.includeSystemPromptSection`, value: false },
     { path: `agents.list[${idx}].tools.profile`, value: 'coding' },
     { path: `agents.list[${idx}].tools.alsoAllow`, value: ['browser', `${mcpServer}__*`] },
     {
@@ -202,7 +313,11 @@ function provision(slug: string, isProd: boolean): void {
     );
   }
 
-  // 5. Verify final shape.
+  // 5. Seed role-templated workspace files.
+  process.stderr.write(`→ seeding role templates from agent-templates/${role}/\n`);
+  await seedRoleTemplates(role, workspaceDir);
+
+  // 6. Verify final shape.
   const verifyResult = runOpenclaw(['config', 'get', `agents.list[${idx}]`]);
   if (verifyResult.status !== 0) {
     fail(`verification read failed:\n${verifyResult.stderr || verifyResult.stdout}`);
@@ -218,10 +333,13 @@ function provision(slug: string, isProd: boolean): void {
   process.stderr.write(`     # expect: 1 row, pm=1, master=1, workspace_id=<workspace whose slug='${slug}'>\n`);
 }
 
-function main(): void {
-  const { slug, isProd } = parseArgs();
+async function main(): Promise<void> {
+  const { slug, isProd, reseedOnly } = parseArgs();
   validateSlug(slug);
-  provision(slug, isProd);
+  await provision(slug, isProd, reseedOnly);
 }
 
-main();
+main().catch((err) => {
+  console.error('[provision-workspace-runner] fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Fix-up for [#156 (Phase I)](https://github.com/smb209/mission-control/pull/156). `openclaw agents add` populates the workspace dir with generic openclaw default markdown — the PM agent ended up with stub files instead of the role-templated SOUL/AGENTS/IDENTITY.

## What changed
- **Step 4 added to provision flow:** after `openclaw agents add` + config-enrich, copies `SOUL.md` / `AGENTS.md` / `IDENTITY.md` from `agent-templates/<role>/` into the workspace dir, overwriting openclaw defaults.
- **PM `AGENTS.md` gets the Phase J2 coordinator addendum appended** (`agent-templates/_shared/pm-coordinator.md`) — META-envelope handling instructions ride with the operating instructions.
- **`--reseed-templates` flag** for existing agents: re-runs only step 4. Useful for picking up template updates without re-provisioning.
- **`heartbeat.includeSystemPromptSection: false`** added to config-enrich to match the existing `mc-runner-dev` shape.
- Files outside the role-templated set (HEARTBEAT.md, BOOTSTRAP.md, TOOLS.md, USER.md, MC-CONTEXT.json) stay untouched — those are operator state, not role identity.

## Demonstrated
```
$ yarn workspace:provision testws
→ openclaw agents add mc-pm-testws-dev …
→ openclaw config set --batch-json (8 ops)
→ seeding role templates from agent-templates/pm/
  SOUL.md         overwrote openclaw default
  AGENTS.md       overwrote openclaw default
  IDENTITY.md     overwrote openclaw default
✓ provisioned

$ head -1 ~/.openclaw/workspaces/mc-pm-testws-dev/SOUL.md
# SOUL.md — PM (Project Manager)
```

```
$ yarn workspace:provision foia --reseed-templates
Re-seeding templates only for mc-pm-foia-dev…
  SOUL.md         overwrote openclaw default
  AGENTS.md       overwrote openclaw default
  IDENTITY.md     overwrote openclaw default
✓ templates reseeded

$ yarn workspace:provision foia --reseed-templates
  SOUL.md         unchanged
  AGENTS.md       unchanged
  IDENTITY.md     unchanged
✓ templates already up-to-date
```

## Test plan
- [x] `yarn test` — 573/573 pass.
- [x] `yarn tsc --noEmit` — 2 pre-existing errors only.
- [x] Fresh provision against new slug — workspace dir gets templated files.
- [x] `--reseed-templates` on existing agent — flips defaults to PM templates.
- [x] Idempotent re-seed reports unchanged.
- [x] Existing-agent fresh-provision bails with `--reseed-templates` hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)