### PR TITLE
feat(research): db slice — agent_runs + topics + briefs (migration 075)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,10 @@ For multi-layer changes (DB migration + service + MCP tool + UI), follow audit â
 
 For genuinely independent slices, consider fanning out parallel subagents (one per slice) in worktrees rather than sequencing by hand.
 
+## Long Unattended Feature Development
+
+When the operator says "go build this in a structured way, I won't review in between," follow the contract in [specs/long-unattended-feature-dev.md](specs/long-unattended-feature-dev.md). It codifies the 4-doc pattern (build plan + `<feature>-validation/` directory with baseline / pre-check / test plan / criteria / results) used successfully for `scope-keyed-sessions` and `autonomous-flow-tightening`. Use it for any feature that is multi-slice, real-agent-exercisable, and ships behind stacked PRs without per-slice operator review.
+
 ## MCP Server
 
 The MCP server wrapping this app's API for openclaw workers is named `sc-mission-control`. Use that exact name when referencing it in configs, prompts, or docs.

--- a/specs/long-unattended-feature-dev.md
+++ b/specs/long-unattended-feature-dev.md
@@ -1,0 +1,99 @@
+# Long Unattended Feature Development — Workflow Template
+
+A reusable pattern for shipping a multi-slice feature with **agent-driven validation** between slices, where the operator reviews the final result instead of every intermediate diff.
+
+This codifies what worked for `scope-keyed-sessions` (`specs/scope-keyed-sessions-validation/`) and `autonomous-flow-tightening` (`specs/autonomous-flow-validation-plan.md`). Use it as the contract for any feature where the operator says "go build this, I'll review at the end."
+
+## When to use this
+
+✅ Multi-slice features (DB → API → dispatch → UI), 3+ PRs deep
+✅ Operator opts into "stacked PRs, no in-between review"
+✅ The feature is exercisable by real-agent dispatches against the dev DB
+✅ A clear pass/fail bar can be defined up front
+
+❌ Single-PR changes — overhead exceeds benefit
+❌ Features whose correctness can't be probed end-to-end (pure refactors, type-only edits)
+❌ Anything touching prod systems or external sinks without explicit opt-in
+
+## The four documents
+
+For feature `<feature-name>`, create:
+
+```
+specs/<feature-name>.md                       # the spec (pre-existing or co-authored)
+specs/<feature-name>-build-plan.md            # this doc — design + slices + PR plan
+specs/<feature-name>-validation/
+  README.md                                    # index + how to read
+  00-baseline-observations.md                  # state before any slice lands
+  01-pre-check-initialization.md               # destructive runbook to reach known-good baseline
+  02-test-plan.md                              # concrete scenarios with setup/action/observation
+  03-validation-criteria.md                    # pass/fail gates per scenario + globals
+  04-e2e-run-results.md                        # written DURING/AFTER runs; verdict + evidence
+```
+
+## Build-plan doc contents
+
+1. **Audit** — what already exists in the codebase that this feature can reuse; what's missing.
+2. **Design decisions** — the load-bearing calls (data model, integration boundary, dispatch model). Each with options considered + rationale + reversibility note.
+3. **Slice plan** — ordered PR list. Each slice = one PR with: scope, files-touched estimate, dependencies on prior slices, what becomes testable after it lands.
+4. **Test strategy per slice** — unit tests added in-slice, plus which validation scenarios become exercisable.
+5. **Open questions** — things to confirm with operator before final slice merges.
+6. **Out of scope** — explicit non-goals so scope creep doesn't sneak in.
+
+## Validation directory conventions
+
+### `00-baseline-observations.md`
+Read-only snapshot of dev DB + relevant agent rows + open issues. Captured before any slice lands. Diffed against later milestones.
+
+### `01-pre-check-initialization.md`
+Destructive runbook to reach known-good baseline before each test-plan run. Every step has a command + expected output. Halt-on-failure. Common steps:
+- Repo clean, on feature branch
+- Migrations apply on fresh dev DB (`yarn db:reset`)
+- Backup taken (`yarn db:backup`)
+- Dev server restarted (so new MCP tools register)
+- Targeted test slice baseline pass
+
+### `02-test-plan.md`
+Concrete scenarios grouped by surface or dispatch path. Each scenario has:
+- ID (e.g. `R1.1`)
+- Setup (DB state, agent state, env)
+- Action (the dispatch / API call / UI action)
+- Observation (what to capture: SSE events, DB rows, transcripts, screenshots)
+- Capture path (`/tmp/mc-validation/<feature>/<scenario_id>/`)
+- Time budget (~5 min real-agent time per scenario)
+
+Convention: **all real-agent dispatches use `spark-lb/agent`** per `project_openclaw_model.md` memory.
+
+### `03-validation-criteria.md`
+Per-scenario gates table (AND-ed within a scenario). Plus global gates (e.g. "no unhandled SSE errors across the run"). A milestone passes only if all gates pass. `FLAKE` policy: re-run 3×, pass if ≥ 2/3.
+
+### `04-e2e-run-results.md`
+Written during/after runs. Top-level verdict (GREEN / YELLOW / BLOCKED / RED) with one-paragraph summary, then per-scenario results table, then evidence pointers. This is the single document the operator reads to decide "ship it."
+
+## Operator handoff contract
+
+When the operator says "go build this in a structured way, I won't review in between":
+
+1. **Confirm the feature qualifies** (use the ✅/❌ list above).
+2. **Write all four docs first.** No code until the operator OKs the build plan.
+3. **Cut a feature branch** (`feat/<feature-name>` or `feat/<feature-name>-phase-N`).
+4. **Slice into stacked PRs**, each targeting the previous slice's branch (not `main`). Per `feedback_stacked_pr_merges.md`: when ready to merge, retarget children to `main` BEFORE merging the parent with `--delete-branch`.
+5. **Per slice**: implement → unit tests → run targeted suite → push → open PR with `## Summary`/`## Changes`/`## Test plan` body, link the build-plan doc, list which validation scenarios are now exercisable.
+6. **After all slices**: run `01-pre-check-initialization.md` → execute `02-test-plan.md` → score against `03-validation-criteria.md` → write `04-e2e-run-results.md` with verdict.
+7. **Surface for review**: post the verdict + evidence pointers to the operator. If GREEN, ready to merge the stack; if BLOCKED/RED, surface what to fix and ask before continuing.
+
+## Quality bars
+
+- **Don't invent scenarios as you go** — if the test plan isn't written before the code, the feature isn't ready for unattended dev.
+- **Capture transcripts** for every real-agent dispatch (`/tmp/mc-validation/<feature>/<scenario_id>/`). Forensic value compounds when something fails.
+- **Per-PR test plan in body** isn't optional — the operator has to be able to spot-check any single slice independently.
+- **Pre-existing test failures**: list them in the verdict (file + reason) per CLAUDE.md, never silently work around them.
+- **Cost ceiling**: declare it up front in the build plan (per `project_openclaw_model.md` it's effectively unlimited for this project, but the discipline transfers if we ever shift models).
+
+## Anti-patterns this prevents
+
+- "I made a bunch of changes; here's a 2000-line PR" — sliced PRs make review tractable.
+- "I tested it manually" — without `02-test-plan.md`, "tested" means nothing reproducible.
+- "It works on my machine" — `01-pre-check-initialization.md` forces a clean baseline.
+- "I'll add tests later" — per-slice unit tests are the contract for that slice's PR.
+- "We can validate after merge" — validation runs against the stacked branches before merge so failures don't ship.

--- a/specs/research-area-build-plan.md
+++ b/specs/research-area-build-plan.md
@@ -1,0 +1,154 @@
+# Research Area — Build Plan (Phase 1)
+
+> **Spec:** [`research-area.md`](research-area.md)
+> **Validation:** [`research-area-validation/`](research-area-validation/)
+> **Workflow contract:** [`long-unattended-feature-dev.md`](long-unattended-feature-dev.md)
+> **Phase 1 scope:** Topics + Briefs tables, manual "run a brief" with `general_brief` template, hub dashboard skeleton. No schedules, no other templates, no proposals-from-briefs. Those are phase 2+.
+
+---
+
+## 1. Audit — what we lean on
+
+| Need | Existing primitive | Notes |
+|---|---|---|
+| Persistence | `better-sqlite3` + `src/lib/db/migrations.ts` (additive only) + per-feature DAO files | Migration 069+ free; DAO pattern: `src/lib/db/<feature>.ts` + colocated `<feature>.test.ts` |
+| Workspace scoping | `workspaces` table; `useCurrentWorkspaceId` hook on the client | Briefs/topics workspace-scoped |
+| Researcher persona | `agent-templates/researcher/{SOUL,AGENTS,IDENTITY}.md` + sync into `agents` rows via `agent-catalog-sync.ts` | Already has clean output format ("Executive summary, key findings with citations, gaps, next steps") — directly usable for `general_brief` |
+| Agent dispatch | Two paths exist: full-task pipeline (`/api/tasks/[id]/dispatch` via `internal-dispatch.ts`) and PM dispatch (`src/lib/agents/pm-dispatch.ts`) | Neither is a clean fit for "fire-and-forget agent run that produces a structured report" — see §2 |
+| Recurring schedules | `recurring_jobs` table + `src/lib/agents/recurring-scheduler.ts` | Not used in phase 1; phase 2 schedules will plug into it |
+| Streaming progress | `src/lib/events.ts` + activity log | Add a new `research.brief.*` event family |
+| Cost telemetry | `src/lib/costs/` + `src/components/costs/` | Surface per-brief cost in the brief detail view |
+| UI shell | `(app)/<route>/page.tsx` server components; `Drawer`, `ConfirmDialog`, `AlertDialog` per CLAUDE.md | Spec page already stubs `/research`; replace with real surface in slice 4 |
+| Markdown rendering | `react-markdown` + `remark-gfm` + `prose-invert` | Brief result rendering reuses this |
+
+## 2. Design decisions
+
+### 2.1 Don't reuse `tasks` for non-deliverable agent work
+
+The operator asked the meta-question: **does it make sense to widen `task_kind` to cover briefs, sweeps, calendar readiness checks, and comms drafts?**
+
+**No.** Tasks are an opinionated five-stage pipeline (coordinator → builder → tester → reviewer → ship → deliverable) with gates, evidence, role transitions, and deliverable file output. Briefs/sweeps/etc. are categorically different: single-stage, structured-data output, no PR, no kanban presence. Forcing them into `tasks` means:
+- Branching half the lifecycle code on `task_kind`
+- Bloating the kanban + coordinator gates with non-task work that has to be filtered out
+- Mixing "is this work" with "is this an agent invocation" — two distinct concepts
+
+### 2.2 Introduce `agent_runs` as the shared dispatch envelope
+
+The right factoring is one table for **the dispatch envelope** + per-kind tables for the **domain output**.
+
+```
+agent_runs                          briefs
+├─ id (uuid)                        ├─ id (uuid)
+├─ workspace_id                     ├─ workspace_id
+├─ kind ("brief" | "sweep" |        ├─ topic_id (nullable)
+│        "readiness_check" | …)     ├─ title
+├─ status (queued/running/           ├─ template
+│         complete/failed/            ├─ prompt
+│         cancelled)                 ├─ result_md (nullable)
+├─ started_at                       ├─ citations_json (nullable)
+├─ completed_at                     ├─ requested_by
+├─ error_md (nullable)              ├─ agent_run_id ─────► agent_runs.id (1:1)
+├─ openclaw_session_id (nullable)   ├─ created_at
+├─ cost_cents (nullable)            └─ updated_at
+├─ model_used (nullable)
+├─ source_kind ("manual" |
+│               "schedule" |
+│               "event" | …)
+├─ source_ref (nullable)
+└─ created_at
+```
+
+**What this buys us:**
+- A single cross-kind "what's the agent doing right now?" surface (filters on `agent_runs.status='running'`)
+- Centralized cost/model/session attribution
+- Per-kind tables stay narrow and domain-specific
+- New surfaces (sweeps, comms drafts, etc.) reuse the envelope without re-deriving lifecycle conventions
+
+**What this costs us:**
+- One extra `INSERT` per brief creation (in a transaction with the brief insert)
+- A small amount of join cost on the brief detail view
+
+**Reversibility:** high — additive tables, no existing data to migrate. If the abstraction proves wrong, drop `agent_runs` and inline its columns into each per-kind table.
+
+### 2.3 Brief execution = dispatched researcher mission, no openclaw worker container
+
+For phase 1, briefs run as a **direct openclaw `send-chat` call** to the researcher persona, NOT through the full worker-task pipeline. Rationale:
+- Briefs don't need a workspace clone, git ops, deliverable storage, or a coordinator — all of that is dead weight
+- The output is markdown + citations, returned in the model's response, parsed and persisted
+- Using `send-chat` means we get streaming via the existing event surface for free
+
+Implementation: `src/lib/research/run-brief.ts` — orchestrator that:
+1. Inserts `agent_runs` row (status `queued`)
+2. Builds the prompt from template + topic context + user prompt
+3. Calls `openclaw/send-chat.ts` against the researcher persona
+4. Streams chunks → updates `agent_runs.status` → emits `research.brief.progress` events
+5. On completion: parses response into `result_md` + `citations_json`, marks `agent_runs.status='complete'`, emits `research.brief.completed`
+6. On failure: writes `error_md`, marks `failed`, emits `research.brief.failed`
+
+Failures surface to the brief detail view; we do not auto-retry in phase 1.
+
+### 2.4 Citations format
+
+Researcher persona's output already includes citations in markdown form. Phase 1 stores the raw rendered `result_md` for display + a parsed `citations_json` (best-effort regex over markdown links + footnote refs) for downstream querying. If parsing fails, we keep `result_md` and leave `citations_json = null`. Don't block the brief on citation parse fidelity in phase 1.
+
+### 2.5 Web access
+
+The researcher persona has `web_search` listed in its `knowledge_role` enum (per `migrations.ts:972`). Openclaw worker tools include WebFetch by default. Phase 1 assumes the persona has functional web access via `send-chat`'s default tool surface; validation will confirm. If web access is gated separately, we surface that as a BLOCKED finding in `04-e2e-run-results.md` and treat web-tool-wiring as a phase-1.5 dependency.
+
+## 3. Slice plan (stacked PRs)
+
+Branch base: `feat/research-phase-1` off `main`. Each slice is its own branch off the previous; final merge order documented in `feedback_stacked_pr_merges.md`.
+
+| # | Branch | Scope | Files (approx) | Becomes testable |
+|---|---|---|---|---|
+| 1 | `feat/research-phase-1/db` | Migration 069: `agent_runs` + `topics` + `briefs` tables. DAO files with CRUD + transitions. Unit tests for DAOs (insert, status transitions, FK behavior). | `src/lib/db/{agent-runs,topics,briefs}.ts` + tests; `migrations.ts` | Schema correctness in isolation |
+| 2 | `feat/research-phase-1/api` | REST endpoints: `GET/POST /api/topics`, `GET /api/briefs`, `POST /api/briefs` (creates brief + agent_run, returns IDs without dispatching), `GET /api/briefs/[id]`, `GET /api/agent-runs?kind=brief&status=running`. Workspace-scoped via header/query. Tests: shape + auth. | `src/app/api/{topics,briefs,agent-runs}/...` + tests | API contract; shape stability |
+| 3 | `feat/research-phase-1/dispatch` | `src/lib/research/run-brief.ts` orchestrator. Wire `POST /api/briefs/[id]/run` to invoke it. Emit `research.brief.{started,progress,completed,failed}` events. Unit tests against a stubbed `send-chat`. | `src/lib/research/...`; `src/app/api/briefs/[id]/run/...`; `src/lib/events.ts` (additive) | Mock-LLM brief execution path |
+| 4 | `feat/research-phase-1/ui` | Replace `(app)/research/page.tsx` with the real hub: "In progress / Upcoming (placeholder) / Recent results" lanes + topic library. Topic detail at `/research/topics/[id]`. Brief detail at `/research/briefs/[id]`. "Run a brief" drawer with template chooser (only `general_brief` enabled). Live updates via SSE on `research.brief.*`. | `(app)/research/...`; `src/components/research/...` | Operator-driven brief creation + display |
+| 5 | `feat/research-phase-1/eval` | Eval harness: deterministic fixture topics + prompts + an LLM-judge rubric (citations present? structure correct? appropriate length?). Yarn script `yarn research:eval`. Captures results to `tmp/research-eval/`. Used in validation `S6.*` scenarios. | `src/lib/research/eval/...`; `package.json` script | LLM-output-quality regression bar |
+
+Per-slice PR body structure (per CLAUDE.md):
+```
+## Summary
+<1–3 bullets>
+## Changes
+<files + behavior delta>
+## Test plan
+- [ ] yarn test --tests src/lib/db/<files>
+- [ ] curl smoke (where applicable)
+- [ ] Manual UI walkthrough (slice 4 only)
+- [ ] Validation scenarios newly exercisable: <list>
+```
+
+## 4. Test strategy
+
+### Per-slice unit tests
+- Slice 1: DAO behavior (CRUD, status transitions, FK cascades, workspace isolation), 100% on the new modules.
+- Slice 2: API contract tests (status codes, payload shape, workspace scoping, auth). No DB mocking — use the test-isolation pattern from `src/lib/db/test-isolation.test.ts`.
+- Slice 3: Orchestrator tests against a stubbed `send-chat` (input prompt assembly, event emission order, error path).
+- Slice 4: Component snapshot + interaction tests where they exist; otherwise covered by validation scenarios.
+- Slice 5: Eval-harness self-test (fixtures load, judge runs, scoring stable across invocations on the same input).
+
+### Validation scenarios (real-agent)
+See [`research-area-validation/02-test-plan.md`](research-area-validation/02-test-plan.md). Run after slice 4 lands; slice 5 makes them automatable.
+
+### Pre-existing failures
+Per CLAUDE.md, baseline `yarn test` once before slice 1 lands and inventory failures in the build-plan PR description so we know what's our breakage vs. what's pre-existing.
+
+## 5. Open questions
+
+1. **Citations parser fidelity** — phase 1 ships best-effort regex. Worth promoting to a structured-output researcher prompt (return JSON alongside markdown) in phase 2?
+2. **Topic deletion semantics** — soft-delete (`archived_at`) keeps brief history readable. Confirm.
+3. **Cost cap per brief** — should we enforce a per-brief token ceiling? Default off in phase 1 (per `project_openclaw_model.md` model is self-hosted). Add the column now (`agent_runs.cost_ceiling_cents`) so we don't migrate later.
+4. **Eval rubric** — start with 3 axes (citations present, structure follows researcher SOUL output format, length 200–2000 words). Add factual-accuracy axis only when we have ground-truth fixtures.
+
+## 6. Out of scope (phase 1)
+
+- Schedules / recurring briefs (phase 2)
+- Templates beyond `general_brief` (phase 3)
+- Brief proposals → Calendar/Risks/Decisions (phase 4)
+- Diff view across recurring briefs (phase 5)
+- Memory integration (depends on Memory layer)
+- Cost ceilings enforced (column added, behavior off)
+- Multi-workspace topics (phase 1 is workspace-scoped; "global" is post-MVP)
+- Concurrent-brief throttling (phase 1 lets the operator fire as many as they want; throttling lands when we hit a real failure mode)

--- a/specs/research-area-validation/00-baseline-observations.md
+++ b/specs/research-area-validation/00-baseline-observations.md
@@ -1,0 +1,74 @@
+# Baseline Observations — Pre-Slice-1
+
+> **Purpose:** Snapshot of dev environment state before any Research-Area code lands. Read-only — no DB writes, no service restarts.
+>
+> **Captured:** _(fill in when build-plan PR is opened)_
+> **Branch:** `main` at the build-plan-PR base commit
+> **Dev DB:** `${DATABASE_PATH}` (default `./mission-control.db`)
+
+---
+
+## 1. Schema state
+
+> Capture with: `sqlite3 $DATABASE_PATH ".tables" | tr ' ' '\n' | sort | uniq -c | sort -rn`
+
+- **Existing tables:** _(paste output)_
+- **Latest migration:** _(paste from `sqlite3 $DATABASE_PATH "SELECT MAX(id) FROM _migrations"`)_
+- **Confirm absent (will be added by slice 1):** `agent_runs`, `topics`, `briefs`
+
+## 2. Researcher persona state
+
+> Capture with: `sqlite3 $DATABASE_PATH "SELECT id, name, role, runtime_kind FROM agents WHERE role='researcher' OR name LIKE '%researcher%';"`
+
+- **Researcher rows present:** _(paste)_
+- **Per-workspace presence:** confirm `mc-researcher-dev` exists in the workspaces we'll use for validation (default + at least one secondary).
+- **Persona files on disk:**
+  - `agent-templates/researcher/SOUL.md` ✅
+  - `agent-templates/researcher/AGENTS.md` ✅
+  - `agent-templates/researcher/IDENTITY.md` ✅
+
+## 3. Web-tool exposure (the main risk)
+
+The phase-1 dispatch path uses `openclaw/send-chat.ts` directly, not the worker-task pipeline. The researcher persona's `send-chat` session must surface web-fetch / web-search tools or briefs cannot cite real sources.
+
+> Capture by: dispatching a simple "what is the current price of GOOG?" probe to the researcher via existing PM chat or a manual `send-chat` invocation, and checking the response for evidence of web access. Document one of:
+>
+> - **GREEN** — researcher returns a current-day-priced answer with citations, indicating live web access
+> - **YELLOW** — researcher returns a non-current answer but acknowledges the missing tool; we'll need to wire web tools into `send-chat` profile in slice 3
+> - **BLOCKED** — `send-chat` itself fails or returns nothing usable; deeper fix needed before phase 1 can ship
+
+Result: _(fill in)_
+
+## 4. Recurring scheduler state
+
+Phase 1 doesn't use the scheduler, but capture for diff:
+- `recurring_jobs` row count: _(paste)_
+- Scheduler currently active: _(yes/no — check `instrumentation.ts` or process status)_
+
+## 5. Test-suite baseline
+
+> Capture with: `yarn test 2>&1 | tail -40`
+
+- **Pass/fail counts:** _(paste)_
+- **Pre-existing failures (file + reason):** _(paste; CLAUDE.md requires we list these explicitly so they don't get blamed on our changes)_
+
+## 6. UI surfaces under change
+
+- `(app)/research/page.tsx` — currently the spec-renderer (`SpecPage`); will be replaced in slice 4
+- `src/components/shell/AppNav.tsx` — Research nav entry already present; no nav change required this phase
+
+## 7. Dev server state
+
+- Port 4010: _(in use? by what PID?)_
+- Operator using dev server actively: _(if yes, halt — `01-pre-check-initialization.md` is destructive)_
+
+---
+
+## Diff target
+
+After phase 1 lands, re-running this capture should show:
+- 3 new tables (`agent_runs`, `topics`, `briefs`)
+- Latest migration ID = previous + 1
+- New API routes mounted
+- New activity-log event family `research.brief.*` emitting on dispatch
+- `(app)/research/page.tsx` no longer using `SpecPage`

--- a/specs/research-area-validation/01-pre-check-initialization.md
+++ b/specs/research-area-validation/01-pre-check-initialization.md
@@ -1,0 +1,109 @@
+# Pre-Check Initialization — Research Area
+
+> **⚠️ DESTRUCTIVE.** Wipes dev DB. Confirm operator is not using `localhost:4010` or `192.168.50.95:4010` before running.
+>
+> **When to run:** before each execution of [`02-test-plan.md`](02-test-plan.md). Halt-on-failure — do not skip steps.
+
+---
+
+## 0. Prerequisites
+
+| Check | Command | Expected |
+|---|---|---|
+| Repo on validation branch | `git rev-parse --abbrev-ref HEAD` | `feat/research-phase-1/...` (not `main`) |
+| Repo clean | `git status --porcelain` | empty |
+| Build plan present | `test -f specs/research-area-build-plan.md && echo ok` | `ok` |
+| Operator off dev server | _(ask)_ | confirmed |
+| Dev server stopped | `lsof -ti :4010 \|\| echo none` | `none` (kill if needed: `kill $(lsof -ti :4010)`) |
+| Openclaw gateway up | `lsof -ti :18789 \|\| echo none` | non-empty PID |
+| `spark-lb/agent` reachable | `curl -sS http://localhost:18789/health \|\| true` | non-error |
+
+If any prerequisite fails, fix it before continuing.
+
+## 1. Backup current dev DB
+
+```
+yarn db:backup
+yarn db:backup:list | tail -5
+```
+
+Expected: latest backup file is from the last few seconds.
+
+## 2. Reset dev DB
+
+```
+yarn db:reset
+```
+
+Expected log lines (substitute correct migration ID — should be previous-max + 1):
+```
+[Migration NNN] agent_runs created.
+[Migration NNN] topics created.
+[Migration NNN] briefs created.
+```
+
+Confirm:
+```
+sqlite3 $DATABASE_PATH "SELECT COUNT(*) FROM agent_runs;"   # → 0
+sqlite3 $DATABASE_PATH "SELECT COUNT(*) FROM topics;"       # → 0
+sqlite3 $DATABASE_PATH "SELECT COUNT(*) FROM briefs;"       # → 0
+```
+
+## 3. Restart MC dev server
+
+```
+yarn dev:start  # or whatever the dev-start skill resolves to
+```
+
+Wait for ready, then confirm:
+
+```
+curl -sS http://127.0.0.1:4010/api/topics     | head -c 200
+curl -sS http://127.0.0.1:4010/api/briefs     | head -c 200
+curl -sS http://127.0.0.1:4010/api/agent-runs | head -c 200
+```
+
+Expected: each returns `[]` (empty workspace) or workspace-scoped JSON.
+
+## 4. Sync agent rows for the workspaces under test
+
+```
+yarn dev:sync
+```
+
+Expected: `mc-researcher-dev` rows present in `default` and `foia` (or whichever secondary workspace the test plan uses):
+
+```
+sqlite3 $DATABASE_PATH "SELECT workspace_id, name, role FROM agents WHERE role='researcher';"
+```
+
+## 5. Targeted-test baseline pass
+
+Once slices 1–3 have landed:
+
+```
+NODE_ENV=test yarn tsx --test \
+  src/lib/db/agent-runs.test.ts \
+  src/lib/db/topics.test.ts \
+  src/lib/db/briefs.test.ts \
+  src/lib/research/run-brief.test.ts
+```
+
+Expected: 100% pass on the new files. Pre-existing failures unrelated to this work: list in `04-e2e-run-results.md` per CLAUDE.md.
+
+## 6. Prepare capture directory
+
+```
+mkdir -p /tmp/mc-validation/research
+rm -rf /tmp/mc-validation/research/*
+```
+
+## 7. Sign-off
+
+Mark in `04-e2e-run-results.md`:
+
+```
+Pre-check completed at <timestamp> on commit <sha>. STATUS: READY FOR TEST PLAN.
+```
+
+If any step above failed: STATUS: BLOCKED — <step> — <reason>. Do not proceed.

--- a/specs/research-area-validation/02-test-plan.md
+++ b/specs/research-area-validation/02-test-plan.md
@@ -1,0 +1,161 @@
+# Test Plan — Research Area Phase 1
+
+> **Purpose:** Concrete real-agent scenarios exercising every Phase 1 surface. Each captures setup, action, observation, and evidence for [`03-validation-criteria.md`](03-validation-criteria.md).
+>
+> **Pre-requisite:** [`01-pre-check-initialization.md`](01-pre-check-initialization.md) completed with status `READY FOR TEST PLAN`.
+>
+> **All real-agent dispatches use `spark-lb/agent`** (per `project_openclaw_model.md` memory — self-hosted, no budget cap).
+>
+> **Convention:** every scenario captures its raw transcript and DB snapshot to `/tmp/mc-validation/research/<scenario_id>/`.
+
+---
+
+## Scenario taxonomy
+
+- **§R1 Topic CRUD** — create, list, archive
+- **§R2 One-shot brief (no topic)** — minimal flow
+- **§R3 Topic-attached brief** — context propagation
+- **§R4 Streaming progress** — SSE / activity-log signal during run
+- **§R5 Failure handling** — agent error, malformed response, dispatched-session lost
+- **§R6 Eval harness** — fixture briefs scored against rubric
+- **§R7 UI surfaces** — hub dashboard, topic detail, brief detail
+- **§R8 Cross-workspace isolation** — workspace A cannot see workspace B's topics/briefs
+- **§R9 Regression** — bugs found during validation must stay fixed
+
+Each scenario ≤ 5 min real-agent time. Total ≤ 60 min.
+
+---
+
+## §R1 — Topic CRUD
+
+### R1.1 Create a topic via API
+- **Setup:** `default` workspace selected
+- **Action:** `POST /api/topics` with `{name: "GLP-1 regulation", description: "Watch for FDA actions and pricing pressure", tags: ["pharma", "regulation"]}`
+- **Observe:**
+  - HTTP 201, response body includes `id`, timestamps, `archived_at: null`
+  - `sqlite3 $DATABASE_PATH "SELECT id, name, workspace_id FROM topics;"` → 1 row
+- **Capture:** request, response, DB row → `/tmp/mc-validation/research/R1.1/`
+
+### R1.2 List topics is workspace-scoped
+- **Setup:** topic from R1.1 exists in `default`; create one in `foia`
+- **Action:** `GET /api/topics` with each workspace header
+- **Observe:** each call returns only that workspace's row
+- **Capture:** both responses
+
+### R1.3 Archive a topic
+- **Action:** `DELETE /api/topics/:id` (soft-delete via `archived_at`)
+- **Observe:** subsequent `GET /api/topics` does not include it; `GET /api/topics?include=archived` does
+- **Capture:** before/after responses
+
+---
+
+## §R2 — One-shot brief (no topic)
+
+### R2.1 Create + run a `general_brief` with no topic
+- **Setup:** clean DB after R1
+- **Action:**
+  - `POST /api/briefs` with `{template: "general_brief", title: "What is the current state of WebGPU browser support?", prompt: "Survey WebGPU support across Chrome/Safari/Firefox as of today, including what's still behind flags."}` → returns `brief_id` + `agent_run_id`
+  - `POST /api/briefs/:id/run` → kicks dispatch
+- **Observe:**
+  - Initial `agent_runs.status = queued`, then `running` within 5s
+  - `research.brief.started` event in activity log within 5s of dispatch call
+  - Brief completes within 5 min
+  - `agent_runs.status = complete`
+  - `briefs.result_md` non-empty, contains "Executive summary" / "Key findings" / "Citations" or similar (matches researcher SOUL output format)
+  - `briefs.citations_json` is non-null with ≥ 1 citation (or YELLOW with explicit "no web access" note in result)
+- **Capture:** brief detail page screenshot; raw `result_md`; DB row state at queued/running/complete; full event log
+
+---
+
+## §R3 — Topic-attached brief
+
+### R3.1 Brief inherits topic context
+- **Setup:** topic from R1.1 (GLP-1 regulation) present
+- **Action:** `POST /api/briefs` with `{topic_id: <id>, template: "general_brief", title: "Q4 2025 FDA actions on GLP-1 drugs", prompt: "What FDA enforcement or guidance touched GLP-1 drugs in Q4 2025?"}`; then `POST /api/briefs/:id/run`
+- **Observe:**
+  - The dispatched prompt fed to the researcher includes the topic's `description` as context
+  - Brief detail shows the topic linkage
+- **Capture:** assembled prompt (log via dispatch debug or DB column if persisted), final `result_md`
+
+---
+
+## §R4 — Streaming progress
+
+### R4.1 SSE events fire during run
+- **Setup:** SSE consumer subscribed to `research.brief.*` filter on the workspace
+- **Action:** dispatch any brief from R2/R3
+- **Observe:**
+  - `research.brief.started` within 5s of dispatch
+  - At least one `research.brief.progress` event (token chunk or status heartbeat) before completion
+  - `research.brief.completed` within 5s of `agent_runs.status = complete`
+- **Capture:** SSE event sequence as JSON
+
+---
+
+## §R5 — Failure handling
+
+### R5.1 Agent returns malformed response
+- **Setup:** stub the researcher persona to return `<empty>` for one dispatch (use a test-only persona override or a deliberately malformed prompt)
+- **Action:** dispatch; observe failure
+- **Observe:** `agent_runs.status = failed`; `briefs.error_md` populated with a usable error string; `research.brief.failed` event emitted; brief detail UI shows the failure cleanly with a "Retry" button (button non-functional in phase 1 but visible)
+- **Capture:** `error_md`, event payload, screenshot
+
+### R5.2 Dispatch fails (gateway down)
+- **Setup:** stop openclaw gateway temporarily
+- **Action:** dispatch a brief
+- **Observe:** brief enters `failed` quickly (≤ 30s); error message identifies gateway/connection issue clearly; no orphaned `running` rows after failure
+- **Capture:** `error_md`, timing, no orphan check (`SELECT * FROM agent_runs WHERE status='running' AND started_at < datetime('now','-2 minutes')` → empty)
+- **Cleanup:** restart gateway
+
+---
+
+## §R6 — Eval harness
+
+### R6.1 Fixture run produces stable scores
+- **Setup:** slice 5 landed; `yarn research:eval` script available; fixture topics + prompts checked in
+- **Action:** run `yarn research:eval` end-to-end
+- **Observe:** all fixture briefs complete, judge produces a per-brief score on each rubric axis (citations / structure / length), aggregate score reported, results saved to `tmp/research-eval/<run_id>/`
+- **Capture:** the `tmp/research-eval/...` output dir, copied into `/tmp/mc-validation/research/R6.1/`
+
+### R6.2 Eval rubric flags a deliberately bad brief
+- **Setup:** seed the fixture set with one brief whose result we know to be poor (no citations, single sentence)
+- **Action:** run eval
+- **Observe:** rubric flags the bad brief with a low score on the relevant axes; aggregate score for the run is dragged down accordingly
+- **Capture:** judge's per-axis scores for the bad fixture
+
+---
+
+## §R7 — UI surfaces
+
+### R7.1 Hub dashboard
+- **Action:** navigate to `/research`
+- **Observe:** "In progress / Upcoming (placeholder for phase 1) / Recent results" lanes; topic library on left; SSE updates the in-progress lane live during a brief run
+- **Capture:** screenshots before/during/after a brief run
+
+### R7.2 Topic detail
+- **Action:** navigate to `/research/topics/<id>`
+- **Observe:** topic metadata; brief history list; "Run a brief" affordance with template chooser (only `general_brief` enabled)
+- **Capture:** screenshot
+
+### R7.3 Brief detail
+- **Action:** navigate to `/research/briefs/<id>` for a complete brief
+- **Observe:** rendered markdown body; citations panel; status; cost (if telemetry hooked up); "Re-run" button (non-functional in phase 1)
+- **Capture:** screenshot
+
+---
+
+## §R8 — Cross-workspace isolation
+
+### R8.1 Workspace A cannot read workspace B briefs
+- **Setup:** brief in `default` (R2.1); separate brief in `foia`
+- **Action:** `GET /api/briefs` against each workspace
+- **Observe:** each call returns only its workspace's briefs; cross-workspace fetch by ID returns 404 or 403 (not 200)
+- **Capture:** both responses
+
+---
+
+## §R9 — Regression
+
+> Populated as bugs are found and fixed during phase 1 validation. Each entry: scenario ID + description + commit that fixed it. Re-runs must continue to pass.
+
+(empty at start)

--- a/specs/research-area-validation/03-validation-criteria.md
+++ b/specs/research-area-validation/03-validation-criteria.md
@@ -1,0 +1,181 @@
+# Validation Criteria — Research Area Phase 1
+
+> **Purpose:** Pass/fail gates for [`02-test-plan.md`](02-test-plan.md). Per-scenario gates AND-ed within a scenario; scenarios AND-ed within global gates.
+>
+> **`FLAKE` policy:** intermittent scenarios re-run up to 3×; pass if ≥ 2/3.
+
+---
+
+## How to read this
+
+Each scenario gate is a single yes/no question. A scenario passes only if all its gates pass. The phase passes only if all in-scope scenarios pass + all global gates pass.
+
+`N/A` allowed when the slice under test does not implement the scenario yet (e.g. `R6.*` is N/A pre-slice-5).
+
+---
+
+## §R1 — Topic CRUD
+
+### R1.1 — Create a topic via API
+| Gate | Pass condition |
+|---|---|
+| HTTP status | `201 Created` |
+| Body shape | Includes `id` (uuid), `name`, `description`, `tags` (array), `workspace_id`, `created_at`, `updated_at`, `archived_at: null` |
+| DB row | Single row inserted in correct workspace |
+| Prepared-statement safety | No SQL injection from `name`/`description` (test with `'; DROP TABLE topics; --`) |
+
+### R1.2 — List is workspace-scoped
+| Gate | Pass condition |
+|---|---|
+| Workspace A list | Returns only A's topic(s) |
+| Workspace B list | Returns only B's topic(s) |
+| No leakage | A's topic IDs do not appear in B's response |
+
+### R1.3 — Soft-delete
+| Gate | Pass condition |
+|---|---|
+| `archived_at` set | Non-null after `DELETE` |
+| Default list excludes | `GET /api/topics` does not include archived |
+| `?include=archived` includes | Returns archived rows |
+
+---
+
+## §R2 — One-shot brief
+
+### R2.1 — Create + run `general_brief` with no topic
+| Gate | Pass condition |
+|---|---|
+| Initial state | `agent_runs.status = queued` immediately after `POST /api/briefs` |
+| Dispatch | `agent_runs.status` transitions to `running` within 5s of `POST /api/briefs/:id/run` |
+| Event emission | `research.brief.started` event in activity log within 5s of dispatch |
+| Completion within budget | Brief reaches `complete` within 5 minutes (FLAKE eligible) |
+| Final state | `agent_runs.status = complete`, `agent_runs.completed_at` set |
+| Result body present | `briefs.result_md` non-empty, ≥ 200 characters |
+| Output structure | `result_md` contains a recognizable executive-summary / findings / citations structure (per researcher SOUL output format) |
+| Citations | `briefs.citations_json` non-null with ≥ 1 citation **OR** result body explicitly notes web access unavailable (YELLOW pass — surface in verdict) |
+| No orphan run | After completion, no other `agent_runs` row for this brief is in `running` |
+
+---
+
+## §R3 — Topic-attached brief
+
+### R3.1 — Brief inherits topic context
+| Gate | Pass condition |
+|---|---|
+| Topic linkage in DB | `briefs.topic_id` set correctly |
+| Prompt augmentation | Assembled prompt sent to researcher includes the topic `description` text (verifiable via dispatch debug log or persisted prompt column) |
+| UI shows linkage | Brief detail page shows topic name with link to topic detail |
+
+---
+
+## §R4 — Streaming progress
+
+### R4.1 — SSE events
+| Gate | Pass condition |
+|---|---|
+| `started` event | Fires within 5s of dispatch |
+| `progress` event | At least one fires during the run (token chunk OR heartbeat) |
+| `completed` event | Fires within 5s of `agent_runs.status = complete` |
+| Event payload | Each event includes `brief_id`, `agent_run_id`, `workspace_id` |
+
+---
+
+## §R5 — Failure handling
+
+### R5.1 — Malformed response
+| Gate | Pass condition |
+|---|---|
+| Status transition | `agent_runs.status = failed` |
+| Error captured | `briefs.error_md` non-empty, human-readable |
+| Event | `research.brief.failed` emitted |
+| UI | Brief detail shows failure clearly (red status pill, error excerpt) |
+| No silent retry | Phase 1 does not auto-retry; brief stays `failed` |
+
+### R5.2 — Gateway down
+| Gate | Pass condition |
+|---|---|
+| Fast-fail | Brief reaches `failed` within 30s |
+| Error specificity | `error_md` identifies gateway/connection issue (not generic "fetch failed") |
+| No orphans | No `agent_runs` row stuck in `running` after failure |
+
+---
+
+## §R6 — Eval harness
+
+### R6.1 — Fixture run stability
+| Gate | Pass condition |
+|---|---|
+| Script runs cleanly | `yarn research:eval` exits 0 |
+| Output structure | Per-brief scores on every rubric axis; aggregate score reported |
+| Score persisted | Output written to `tmp/research-eval/<run_id>/` with timestamps |
+| Stability | Re-running the eval on the same fixtures within the same hour produces aggregate scores within ±10% (judge stochasticity acceptable; below this gate indicates rubric or prompt is too unstable to be useful) |
+
+### R6.2 — Bad-brief detection
+| Gate | Pass condition |
+|---|---|
+| Low scores assigned | The deliberately bad fixture scores in the bottom quartile on relevant axes |
+| Aggregate impact | Bad fixture pulls aggregate score below the all-good baseline by a measurable amount (≥ 0.5 on a 0–5 scale) |
+
+---
+
+## §R7 — UI surfaces
+
+### R7.1 — Hub dashboard
+| Gate | Pass condition |
+|---|---|
+| Loads without errors | No console errors on page load (per `preview_console_logs`) |
+| Lanes render | "In progress" / "Upcoming" / "Recent results" present even when empty |
+| Live update | An in-flight brief appears in "In progress" within 5s of dispatch and moves to "Recent results" within 5s of completion |
+
+### R7.2 — Topic detail
+| Gate | Pass condition |
+|---|---|
+| Renders | All topic metadata displayed |
+| Brief history | Lists all briefs for that topic, newest first |
+| Run-a-brief affordance | Drawer opens; only `general_brief` enabled |
+
+### R7.3 — Brief detail
+| Gate | Pass condition |
+|---|---|
+| Markdown rendered | `result_md` rendered with `react-markdown` + `remark-gfm` styling |
+| Citations panel | Visible when present, collapsed by default |
+| Status pill | Reflects current `agent_runs.status` |
+| Re-run button | Visible (non-functional in phase 1; hover tooltip says "phase 2") |
+
+---
+
+## §R8 — Cross-workspace isolation
+
+### R8.1 — No leakage
+| Gate | Pass condition |
+|---|---|
+| List endpoints | A workspace's listing endpoints never include another workspace's rows |
+| Direct fetch | `GET /api/briefs/:id` for a brief in another workspace returns 404 or 403, never 200 |
+| Topic linkage | Briefs cannot be created with a `topic_id` that belongs to another workspace (returns 400) |
+
+---
+
+## Global gates
+
+These apply across the whole run.
+
+| Gate | Pass condition |
+|---|---|
+| No unhandled errors | Dev server log has no `[ERROR]` lines from research code paths during the run |
+| No DB lock errors | No `SQLITE_BUSY` / `SQLITE_LOCKED` in dev server log |
+| Migration idempotency | Re-running `yarn db:reset` produces the same schema (no drift) |
+| Test suite intact | `yarn test` passes the same set as `00-baseline-observations.md`'s baseline (any new failures attributed to research code = FAIL) |
+| Type check | `yarn tsc --noEmit` clean |
+| Cost reasonable | Sum of `agent_runs.cost_cents` across all phase-1 validation runs ≤ $5 (sanity check; not a hard gate) |
+| Capture completeness | Every scenario has its `/tmp/mc-validation/research/<scenario_id>/` directory with at minimum a `notes.md` and any cited transcripts |
+
+---
+
+## Verdict shape
+
+After running the test plan, write a top-level verdict in `04-e2e-run-results.md`:
+
+- **GREEN** — all in-scope scenarios PASS, all global gates PASS. Stack ready to merge.
+- **YELLOW** — all in-scope scenarios PASS but with caveats (e.g. R2.1 passed without citations because web tools are not wired). Operator must explicitly accept the YELLOW conditions before merge.
+- **BLOCKED** — at least one scenario blocked by infra outside this stack's control (e.g. gateway not reachable). Surface the blocker; do not change the verdict to RED.
+- **RED** — at least one in-scope scenario or global gate FAILED due to code in this stack. Stack does NOT merge; surface the failure with reproduction steps and proposed fix.

--- a/specs/research-area-validation/04-e2e-run-results.md
+++ b/specs/research-area-validation/04-e2e-run-results.md
@@ -1,0 +1,51 @@
+# Real-Agent E2E Run Results — Research Area Phase 1
+
+> **Format:** append a new dated section per validation milestone (after slice 4 lands; after slice 5 lands; after any later phase).
+>
+> Each section: top-level verdict, per-scenario results table, global gates table, evidence pointers.
+
+---
+
+## Run log
+
+_(empty — first entry written after slice 4 lands and `01-pre-check-initialization.md` is run for the first time)_
+
+---
+
+## Verdict template (copy per run)
+
+```
+### Run <N> — <date> — commit <sha> — slices in scope: <list>
+
+**Verdict: <GREEN | YELLOW | BLOCKED | RED>**
+
+<one-paragraph summary of what was validated, what passed, what didn't>
+
+#### Per-scenario results
+
+| Scenario | Result | Notes / evidence |
+|---|---|---|
+| R1.1 | PASS | `/tmp/mc-validation/research/R1.1/` |
+| R1.2 | PASS | … |
+| R2.1 | YELLOW | passed without citations (web tools not wired); see notes.md |
+| … | | |
+
+#### Global gates
+
+| Gate | Result | Notes |
+|---|---|---|
+| No unhandled errors | PASS | dev server log clean |
+| Test suite intact | PASS | same 0 baseline failures, no new |
+| Type check | PASS | |
+| Cost | PASS | $0.42 total |
+| Capture completeness | PASS | all scenario dirs populated |
+
+#### YELLOW conditions (if any) requiring operator sign-off
+- <condition> — <why we accept it for phase 1>
+
+#### Pre-existing failures noted (per CLAUDE.md)
+- <file>: <reason — confirmed unrelated to this stack>
+
+#### Action items (if RED or BLOCKED)
+- <issue> — <proposed fix> — <slice/PR to land in>
+```

--- a/specs/research-area-validation/README.md
+++ b/specs/research-area-validation/README.md
@@ -1,0 +1,32 @@
+# Research Area — Validation Suite
+
+Real-agent end-to-end validation for the Research Area phase 1 build (see [`../research-area-build-plan.md`](../research-area-build-plan.md)).
+
+Follows the [long-unattended-feature-dev](../long-unattended-feature-dev.md) workflow.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| [`00-baseline-observations.md`](00-baseline-observations.md) | Pre-slice-1 dev environment snapshot |
+| [`01-pre-check-initialization.md`](01-pre-check-initialization.md) | Destructive runbook to reach known-good baseline before each test-plan run |
+| [`02-test-plan.md`](02-test-plan.md) | Concrete real-agent dispatch scenarios |
+| [`03-validation-criteria.md`](03-validation-criteria.md) | Pass/fail gates per scenario + globals |
+| [`04-e2e-run-results.md`](04-e2e-run-results.md) | Verdict + evidence (written during/after runs) |
+
+## How to use
+
+1. **Before any code lands:** `00-baseline-observations.md` is captured (read-only, no DB writes). Done as part of the build-plan PR.
+2. **Per validation milestone** (after slice 4 lands; after slice 5 lands; after any later phase):
+   - Run `01-pre-check-initialization.md` end-to-end. Halt-on-failure.
+   - Execute `02-test-plan.md` scenario by scenario. Capture transcripts to `/tmp/mc-validation/research/<scenario_id>/`.
+   - Score against `03-validation-criteria.md`.
+   - Write findings into `04-e2e-run-results.md` (append a new dated section per milestone).
+3. **The operator reads `04-e2e-run-results.md`** to decide whether to merge the stack.
+
+## Conventions
+
+- All real-agent dispatches use `spark-lb/agent` (per `project_openclaw_model.md`).
+- Scenario IDs are prefixed `R<n>.<m>` (R = Research).
+- Every scenario captures input + output transcripts under `/tmp/mc-validation/research/<scenario_id>/`.
+- Each scenario has a ~5-minute time budget; full plan ≤ 60 minutes wall clock.

--- a/src/lib/db/agent-runs.test.ts
+++ b/src/lib/db/agent-runs.test.ts
@@ -1,0 +1,190 @@
+/**
+ * agent_runs DAO tests.
+ *
+ * Covers: create / get / list / lifecycle transitions
+ * (queued→running→complete|failed|cancelled), invalid-transition
+ * errors, workspace isolation, stale-running reaper, cost+session
+ * threading.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import {
+  createAgentRun,
+  getAgentRun,
+  listAgentRuns,
+  markCancelled,
+  markComplete,
+  markFailed,
+  markRunning,
+  reapStaleRunning,
+  AgentRunTransitionError,
+  AgentRunValidationError,
+} from './agent-runs';
+
+function freshWorkspace(): string {
+  const id = `ws-ar-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+test('createAgentRun: round-trip with defaults', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'brief' });
+  assert.equal(r.workspace_id, ws);
+  assert.equal(r.kind, 'brief');
+  assert.equal(r.status, 'queued');
+  assert.equal(r.source_kind, 'manual');
+  assert.equal(r.source_ref, null);
+  assert.equal(r.openclaw_session_id, null);
+  assert.equal(r.cost_cents, null);
+  assert.equal(r.error_md, null);
+  assert.equal(r.started_at, null);
+  assert.equal(r.completed_at, null);
+  assert.ok(r.created_at);
+  assert.ok(r.updated_at);
+});
+
+test('createAgentRun: rejects empty workspace_id', () => {
+  assert.throws(
+    () => createAgentRun({ workspace_id: '   ', kind: 'brief' }),
+    AgentRunValidationError,
+  );
+});
+
+test('createAgentRun: source_kind + source_ref + ceiling threaded through', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({
+    workspace_id: ws,
+    kind: 'brief',
+    source_kind: 'schedule',
+    source_ref: 'schedule:42',
+    cost_ceiling_cents: 500,
+  });
+  assert.equal(r.source_kind, 'schedule');
+  assert.equal(r.source_ref, 'schedule:42');
+  assert.equal(r.cost_ceiling_cents, 500);
+});
+
+test('lifecycle: queued → running → complete', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'brief' });
+
+  const running = markRunning(r.id, {
+    openclaw_session_id: 'sess-abc',
+    model_used: 'spark-lb/agent',
+  });
+  assert.equal(running.status, 'running');
+  assert.equal(running.openclaw_session_id, 'sess-abc');
+  assert.equal(running.model_used, 'spark-lb/agent');
+  assert.ok(running.started_at);
+  assert.equal(running.completed_at, null);
+
+  const done = markComplete(r.id, { cost_cents: 42 });
+  assert.equal(done.status, 'complete');
+  assert.equal(done.cost_cents, 42);
+  assert.ok(done.completed_at);
+});
+
+test('lifecycle: queued → running → failed records error_md', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'brief' });
+  markRunning(r.id);
+  const failed = markFailed(r.id, { error_md: 'gateway unreachable' });
+  assert.equal(failed.status, 'failed');
+  assert.equal(failed.error_md, 'gateway unreachable');
+  assert.ok(failed.completed_at);
+});
+
+test('lifecycle: queued → cancelled', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'brief' });
+  const cancelled = markCancelled(r.id, 'user aborted');
+  assert.equal(cancelled.status, 'cancelled');
+  assert.equal(cancelled.error_md, 'user aborted');
+});
+
+test('lifecycle: terminal states reject further transitions', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'brief' });
+  markRunning(r.id);
+  markComplete(r.id);
+  assert.throws(() => markFailed(r.id, { error_md: 'too late' }), AgentRunTransitionError);
+  assert.throws(() => markRunning(r.id), AgentRunTransitionError);
+  assert.throws(() => markCancelled(r.id), AgentRunTransitionError);
+});
+
+test('lifecycle: cannot complete from queued (must run first)', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'brief' });
+  assert.throws(() => markComplete(r.id), AgentRunTransitionError);
+});
+
+test('listAgentRuns: filters by status and kind, scoped to workspace', () => {
+  const wsA = freshWorkspace();
+  const wsB = freshWorkspace();
+  const a1 = createAgentRun({ workspace_id: wsA, kind: 'brief' });
+  const a2 = createAgentRun({ workspace_id: wsA, kind: 'brief' });
+  createAgentRun({ workspace_id: wsB, kind: 'brief' });
+
+  markRunning(a1.id);
+
+  const allA = listAgentRuns(wsA);
+  assert.equal(allA.length, 2);
+
+  const runningA = listAgentRuns(wsA, { status: 'running' });
+  assert.equal(runningA.length, 1);
+  assert.equal(runningA[0].id, a1.id);
+
+  const queuedA = listAgentRuns(wsA, { status: 'queued' });
+  assert.equal(queuedA.length, 1);
+  assert.equal(queuedA[0].id, a2.id);
+
+  // Workspace B is invisible from A.
+  const briefsA = listAgentRuns(wsA, { kind: 'brief' });
+  assert.equal(briefsA.length, 2);
+  assert.ok(briefsA.every(r => r.workspace_id === wsA));
+});
+
+test('reapStaleRunning: marks rows older than threshold as failed', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'brief' });
+  markRunning(r.id);
+
+  // Backdate updated_at so it appears stale.
+  run(
+    `UPDATE agent_runs SET updated_at = datetime('now', '-1 hour') WHERE id = ?`,
+    [r.id],
+  );
+
+  const reaped = reapStaleRunning(60, 'reaped: stale running');
+  assert.equal(reaped, 1);
+
+  const after = getAgentRun(r.id);
+  assert.equal(after?.status, 'failed');
+  assert.equal(after?.error_md, 'reaped: stale running');
+});
+
+test('reapStaleRunning: leaves fresh running rows alone', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'brief' });
+  markRunning(r.id);
+  // No backdate — updated_at is fresh.
+  const reaped = reapStaleRunning(60, 'should not fire');
+  assert.equal(reaped, 0);
+  const after = getAgentRun(r.id);
+  assert.equal(after?.status, 'running');
+});
+
+test('FK cascade: deleting workspace removes its agent_runs', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'brief' });
+  assert.ok(getAgentRun(r.id));
+  run(`DELETE FROM workspaces WHERE id = ?`, [ws]);
+  assert.equal(getAgentRun(r.id), null);
+});

--- a/src/lib/db/agent-runs.ts
+++ b/src/lib/db/agent-runs.ts
@@ -1,0 +1,227 @@
+/**
+ * agent_runs DAO.
+ *
+ * Schema added in migration 075. The shared dispatch envelope for
+ * non-task agent work; per-kind domain tables (briefs first;
+ * sweeps/readiness_checks/comms_drafts/workflow_node_runs later) link
+ * via agent_run_id. See specs/research-area-build-plan.md §2.2.
+ *
+ * Lifecycle: queued → running → (complete | failed | cancelled).
+ * Each transition stamps started_at / completed_at / updated_at as
+ * appropriate. Per-kind output (result_md, citations_json, etc.)
+ * lives on the per-kind row, not here.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+
+export type AgentRunKind = 'brief';
+export type AgentRunStatus = 'queued' | 'running' | 'complete' | 'failed' | 'cancelled';
+export type AgentRunSourceKind = 'manual' | 'schedule' | 'event';
+
+export interface AgentRun {
+  id: string;
+  workspace_id: string;
+  kind: AgentRunKind;
+  status: AgentRunStatus;
+  source_kind: AgentRunSourceKind;
+  source_ref: string | null;
+  openclaw_session_id: string | null;
+  model_used: string | null;
+  cost_cents: number | null;
+  cost_ceiling_cents: number | null;
+  error_md: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export class AgentRunValidationError extends Error {
+  constructor(public reason: string) {
+    super(`agent_run validation: ${reason}`);
+    this.name = 'AgentRunValidationError';
+  }
+}
+
+export class AgentRunTransitionError extends Error {
+  constructor(public from: AgentRunStatus, public to: AgentRunStatus) {
+    super(`agent_run transition not allowed: ${from} → ${to}`);
+    this.name = 'AgentRunTransitionError';
+  }
+}
+
+const ALLOWED_TRANSITIONS: Record<AgentRunStatus, ReadonlyArray<AgentRunStatus>> = {
+  queued:    ['running', 'cancelled', 'failed'],
+  running:   ['complete', 'failed', 'cancelled'],
+  complete:  [],
+  failed:    [],
+  cancelled: [],
+};
+
+export interface CreateAgentRunInput {
+  workspace_id: string;
+  kind: AgentRunKind;
+  source_kind?: AgentRunSourceKind;
+  source_ref?: string | null;
+  cost_ceiling_cents?: number | null;
+}
+
+export function createAgentRun(input: CreateAgentRunInput): AgentRun {
+  if (!input.workspace_id.trim()) {
+    throw new AgentRunValidationError('workspace_id is required');
+  }
+  const id = uuidv4();
+  run(
+    `INSERT INTO agent_runs (
+       id, workspace_id, kind, status, source_kind, source_ref,
+       cost_ceiling_cents, created_at, updated_at
+     ) VALUES (?, ?, ?, 'queued', ?, ?, ?, datetime('now'), datetime('now'))`,
+    [
+      id,
+      input.workspace_id,
+      input.kind,
+      input.source_kind ?? 'manual',
+      input.source_ref ?? null,
+      input.cost_ceiling_cents ?? null,
+    ],
+  );
+  const row = queryOne<AgentRun>(`SELECT * FROM agent_runs WHERE id = ?`, [id]);
+  if (!row) throw new Error('createAgentRun: insert succeeded but row missing');
+  return row;
+}
+
+export function getAgentRun(id: string): AgentRun | null {
+  return queryOne<AgentRun>(`SELECT * FROM agent_runs WHERE id = ?`, [id]) ?? null;
+}
+
+export interface ListAgentRunsOptions {
+  kind?: AgentRunKind;
+  status?: AgentRunStatus;
+  limit?: number;
+}
+
+export function listAgentRuns(workspaceId: string, opts: ListAgentRunsOptions = {}): AgentRun[] {
+  const where: string[] = ['workspace_id = ?'];
+  const params: unknown[] = [workspaceId];
+  if (opts.kind) {
+    where.push('kind = ?');
+    params.push(opts.kind);
+  }
+  if (opts.status) {
+    where.push('status = ?');
+    params.push(opts.status);
+  }
+  const limit = Math.min(opts.limit ?? 100, 500);
+  return queryAll<AgentRun>(
+    // rowid DESC tiebreaks created_at — see briefs.ts listBriefs.
+    `SELECT * FROM agent_runs WHERE ${where.join(' AND ')} ORDER BY created_at DESC, rowid DESC LIMIT ${limit}`,
+    params,
+  );
+}
+
+function assertTransition(from: AgentRunStatus, to: AgentRunStatus): void {
+  if (!ALLOWED_TRANSITIONS[from].includes(to)) {
+    throw new AgentRunTransitionError(from, to);
+  }
+}
+
+export interface MarkRunningInput {
+  openclaw_session_id?: string | null;
+  model_used?: string | null;
+}
+
+export function markRunning(id: string, input: MarkRunningInput = {}): AgentRun {
+  const current = getAgentRun(id);
+  if (!current) throw new Error(`markRunning: agent_run ${id} not found`);
+  assertTransition(current.status, 'running');
+  run(
+    `UPDATE agent_runs SET
+       status = 'running',
+       openclaw_session_id = COALESCE(?, openclaw_session_id),
+       model_used = COALESCE(?, model_used),
+       started_at = datetime('now'),
+       updated_at = datetime('now')
+     WHERE id = ?`,
+    [input.openclaw_session_id ?? null, input.model_used ?? null, id],
+  );
+  return getAgentRun(id)!;
+}
+
+export interface MarkCompleteInput {
+  cost_cents?: number | null;
+}
+
+export function markComplete(id: string, input: MarkCompleteInput = {}): AgentRun {
+  const current = getAgentRun(id);
+  if (!current) throw new Error(`markComplete: agent_run ${id} not found`);
+  assertTransition(current.status, 'complete');
+  run(
+    `UPDATE agent_runs SET
+       status = 'complete',
+       cost_cents = COALESCE(?, cost_cents),
+       completed_at = datetime('now'),
+       updated_at = datetime('now')
+     WHERE id = ?`,
+    [input.cost_cents ?? null, id],
+  );
+  return getAgentRun(id)!;
+}
+
+export interface MarkFailedInput {
+  error_md: string;
+  cost_cents?: number | null;
+}
+
+export function markFailed(id: string, input: MarkFailedInput): AgentRun {
+  const current = getAgentRun(id);
+  if (!current) throw new Error(`markFailed: agent_run ${id} not found`);
+  assertTransition(current.status, 'failed');
+  run(
+    `UPDATE agent_runs SET
+       status = 'failed',
+       error_md = ?,
+       cost_cents = COALESCE(?, cost_cents),
+       completed_at = datetime('now'),
+       updated_at = datetime('now')
+     WHERE id = ?`,
+    [input.error_md, input.cost_cents ?? null, id],
+  );
+  return getAgentRun(id)!;
+}
+
+export function markCancelled(id: string, reasonMd?: string): AgentRun {
+  const current = getAgentRun(id);
+  if (!current) throw new Error(`markCancelled: agent_run ${id} not found`);
+  assertTransition(current.status, 'cancelled');
+  run(
+    `UPDATE agent_runs SET
+       status = 'cancelled',
+       error_md = COALESCE(?, error_md),
+       completed_at = datetime('now'),
+       updated_at = datetime('now')
+     WHERE id = ?`,
+    [reasonMd ?? null, id],
+  );
+  return getAgentRun(id)!;
+}
+
+/**
+ * Reap stale `running` rows whose started_at is older than `staleSeconds`
+ * and mark them failed. The dispatch orchestrator updates `updated_at`
+ * on progress events; jobs whose updated_at hasn't moved in that window
+ * are presumed dead. Used by the dispatch failure recovery path.
+ */
+export function reapStaleRunning(staleSeconds: number, errorMd: string): number {
+  const result = run(
+    `UPDATE agent_runs SET
+       status = 'failed',
+       error_md = ?,
+       completed_at = datetime('now'),
+       updated_at = datetime('now')
+     WHERE status = 'running'
+       AND updated_at < datetime('now', ?)`,
+    [errorMd, `-${staleSeconds} seconds`],
+  );
+  return result.changes;
+}

--- a/src/lib/db/briefs.test.ts
+++ b/src/lib/db/briefs.test.ts
@@ -1,0 +1,233 @@
+/**
+ * briefs DAO tests.
+ *
+ * Covers: createBriefWithRun (transactional with agent_runs), topic
+ * validation (cross-workspace + archived), get/list, setBriefResult /
+ * setBriefError, citation JSON round-trip, FK cascades, workspace
+ * isolation.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, run } from '@/lib/db';
+import {
+  archiveTopic,
+  createTopic,
+} from './topics';
+import { getAgentRun } from './agent-runs';
+import {
+  BriefValidationError,
+  createBriefWithRun,
+  getBrief,
+  getBriefByAgentRun,
+  listBriefs,
+  setBriefError,
+  setBriefResult,
+} from './briefs';
+
+function freshWorkspace(): string {
+  const id = `ws-br-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+const baseInput = (workspaceId: string, overrides: Partial<Parameters<typeof createBriefWithRun>[0]> = {}) => ({
+  workspace_id: workspaceId,
+  template: 'general_brief' as const,
+  title: 'WebGPU support survey',
+  prompt: 'Summarize WebGPU browser support today.',
+  ...overrides,
+});
+
+test('createBriefWithRun: inserts brief + agent_run together', () => {
+  const ws = freshWorkspace();
+  const { brief, agent_run } = createBriefWithRun(baseInput(ws));
+  assert.equal(brief.workspace_id, ws);
+  assert.equal(brief.template, 'general_brief');
+  assert.equal(brief.title, 'WebGPU support survey');
+  assert.equal(brief.requested_by, 'manual');
+  assert.equal(brief.topic_id, null);
+  assert.equal(brief.result_md, null);
+  assert.deepEqual(brief.citations, []);
+  assert.equal(brief.error_md, null);
+
+  assert.equal(agent_run.kind, 'brief');
+  assert.equal(agent_run.status, 'queued');
+  assert.equal(agent_run.workspace_id, ws);
+
+  // 1:1 linkage.
+  assert.equal(brief.agent_run_id, agent_run.id);
+  assert.equal(getBriefByAgentRun(agent_run.id)?.id, brief.id);
+});
+
+test('createBriefWithRun: rejects blank title / prompt / workspace', () => {
+  const ws = freshWorkspace();
+  assert.throws(
+    () => createBriefWithRun(baseInput(ws, { title: '   ' })),
+    BriefValidationError,
+  );
+  assert.throws(
+    () => createBriefWithRun(baseInput(ws, { prompt: '' })),
+    BriefValidationError,
+  );
+  assert.throws(
+    () => createBriefWithRun(baseInput('   ')),
+    BriefValidationError,
+  );
+});
+
+test('createBriefWithRun: links to topic in same workspace', () => {
+  const ws = freshWorkspace();
+  const topic = createTopic({ workspace_id: ws, name: 'GLP-1' });
+  const { brief } = createBriefWithRun(baseInput(ws, { topic_id: topic.id }));
+  assert.equal(brief.topic_id, topic.id);
+});
+
+test('createBriefWithRun: rejects unknown topic_id', () => {
+  const ws = freshWorkspace();
+  assert.throws(
+    () => createBriefWithRun(baseInput(ws, { topic_id: 'not-a-real-topic' })),
+    BriefValidationError,
+  );
+});
+
+test('createBriefWithRun: rejects topic from another workspace', () => {
+  const wsA = freshWorkspace();
+  const wsB = freshWorkspace();
+  const topicB = createTopic({ workspace_id: wsB, name: 'B-topic' });
+  assert.throws(
+    () => createBriefWithRun(baseInput(wsA, { topic_id: topicB.id })),
+    BriefValidationError,
+  );
+});
+
+test('createBriefWithRun: rejects archived topic', () => {
+  const ws = freshWorkspace();
+  const topic = createTopic({ workspace_id: ws, name: 'Stale' });
+  archiveTopic(topic.id);
+  assert.throws(
+    () => createBriefWithRun(baseInput(ws, { topic_id: topic.id })),
+    BriefValidationError,
+  );
+});
+
+test('createBriefWithRun: failed topic validation does not insert agent_run', () => {
+  const ws = freshWorkspace();
+  const beforeCount = queryOne<{ c: number }>(
+    `SELECT COUNT(*) as c FROM agent_runs WHERE workspace_id = ?`,
+    [ws],
+  )?.c ?? 0;
+  assert.throws(
+    () => createBriefWithRun(baseInput(ws, { topic_id: 'nope' })),
+    BriefValidationError,
+  );
+  const afterCount = queryOne<{ c: number }>(
+    `SELECT COUNT(*) as c FROM agent_runs WHERE workspace_id = ?`,
+    [ws],
+  )?.c ?? 0;
+  assert.equal(afterCount, beforeCount);
+});
+
+test('listBriefs: workspace-scoped, newest first, optional topic filter', () => {
+  const wsA = freshWorkspace();
+  const wsB = freshWorkspace();
+  const topic = createTopic({ workspace_id: wsA, name: 't' });
+  createBriefWithRun(baseInput(wsA, { title: 'first' }));
+  createBriefWithRun(baseInput(wsA, { title: 'second', topic_id: topic.id }));
+  createBriefWithRun(baseInput(wsB, { title: 'B-only' }));
+
+  const allA = listBriefs(wsA);
+  assert.equal(allA.length, 2);
+  // Newest first.
+  assert.equal(allA[0].title, 'second');
+  assert.equal(allA[1].title, 'first');
+
+  const onTopic = listBriefs(wsA, { topic_id: topic.id });
+  assert.equal(onTopic.length, 1);
+  assert.equal(onTopic[0].title, 'second');
+
+  const allB = listBriefs(wsB);
+  assert.equal(allB.length, 1);
+  assert.equal(allB[0].title, 'B-only');
+});
+
+test('setBriefResult: persists markdown + citations', () => {
+  const ws = freshWorkspace();
+  const { brief } = createBriefWithRun(baseInput(ws));
+  const updated = setBriefResult(brief.id, {
+    result_md: '# Summary\n\nSome findings.',
+    citations: [
+      { url: 'https://example.com/a', title: 'A' },
+      { url: 'https://example.com/b' },
+    ],
+  });
+  assert.equal(updated?.result_md, '# Summary\n\nSome findings.');
+  assert.equal(updated?.citations.length, 2);
+  assert.equal(updated?.citations[0].url, 'https://example.com/a');
+  assert.equal(updated?.citations[1].url, 'https://example.com/b');
+});
+
+test('setBriefResult: returns null for unknown id', () => {
+  assert.equal(setBriefResult('nope', { result_md: 'x' }), null);
+});
+
+test('setBriefError: persists error markdown', () => {
+  const ws = freshWorkspace();
+  const { brief } = createBriefWithRun(baseInput(ws));
+  const updated = setBriefError(brief.id, 'gateway timed out');
+  assert.equal(updated?.error_md, 'gateway timed out');
+});
+
+test('citations JSON round-trip drops malformed entries', () => {
+  const ws = freshWorkspace();
+  const { brief } = createBriefWithRun(baseInput(ws));
+  // Manually corrupt the citations JSON.
+  run(
+    `UPDATE briefs SET citations_json = ? WHERE id = ?`,
+    [
+      JSON.stringify([
+        { url: 'https://ok.example' },
+        { title: 'no-url' },
+        null,
+        'string-not-object',
+        { url: 'https://also-ok.example', title: 'B' },
+      ]),
+      brief.id,
+    ],
+  );
+  const reloaded = getBrief(brief.id);
+  assert.equal(reloaded?.citations.length, 2);
+  assert.equal(reloaded?.citations[0].url, 'https://ok.example');
+  assert.equal(reloaded?.citations[1].url, 'https://also-ok.example');
+});
+
+test('FK cascade: deleting agent_run cascades to brief', () => {
+  const ws = freshWorkspace();
+  const { brief, agent_run } = createBriefWithRun(baseInput(ws));
+  run(`DELETE FROM agent_runs WHERE id = ?`, [agent_run.id]);
+  assert.equal(getBrief(brief.id), null);
+});
+
+test('FK cascade: deleting workspace removes briefs and their agent_runs', () => {
+  const ws = freshWorkspace();
+  const { brief, agent_run } = createBriefWithRun(baseInput(ws));
+  run(`DELETE FROM workspaces WHERE id = ?`, [ws]);
+  assert.equal(getBrief(brief.id), null);
+  assert.equal(getAgentRun(agent_run.id), null);
+});
+
+test('FK SET NULL: archiving topic does not affect existing briefs; deleting topic nulls topic_id', () => {
+  const ws = freshWorkspace();
+  const topic = createTopic({ workspace_id: ws, name: 't' });
+  const { brief } = createBriefWithRun(baseInput(ws, { topic_id: topic.id }));
+  // Archive: brief still has the topic_id (archive is soft).
+  archiveTopic(topic.id);
+  assert.equal(getBrief(brief.id)?.topic_id, topic.id);
+  // Hard delete: topic_id should null out per FK ON DELETE SET NULL.
+  run(`DELETE FROM topics WHERE id = ?`, [topic.id]);
+  assert.equal(getBrief(brief.id)?.topic_id, null);
+});

--- a/src/lib/db/briefs.ts
+++ b/src/lib/db/briefs.ts
@@ -1,0 +1,237 @@
+/**
+ * briefs DAO.
+ *
+ * Schema added in migration 075. Each brief owns a 1:1 agent_run row
+ * for execution state. Phase 1 ships only the `general_brief`
+ * template; the CHECK constraint at the schema level will need to
+ * widen as new templates land.
+ *
+ * createBriefWithRun() is the canonical entry point — it inserts the
+ * agent_run + brief in a single transaction so a brief never exists
+ * without its envelope. Setters mirror the agent_run lifecycle for
+ * the brief-side fields (result_md / citations_json / error_md);
+ * status itself lives on agent_runs.
+ *
+ * See specs/research-area.md "Brief" + specs/research-area-build-plan.md §2.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run, transaction } from '@/lib/db';
+import {
+  createAgentRun,
+  type AgentRun,
+  type AgentRunSourceKind,
+} from './agent-runs';
+
+export type BriefTemplate = 'general_brief';
+
+export interface BriefCitation {
+  url: string;
+  title?: string;
+  accessed_at?: string;
+  snippet?: string;
+}
+
+export interface Brief {
+  id: string;
+  workspace_id: string;
+  agent_run_id: string;
+  topic_id: string | null;
+  template: BriefTemplate;
+  title: string;
+  prompt: string;
+  requested_by: string;
+  result_md: string | null;
+  citations: BriefCitation[];
+  error_md: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface BriefRow {
+  id: string;
+  workspace_id: string;
+  agent_run_id: string;
+  topic_id: string | null;
+  template: BriefTemplate;
+  title: string;
+  prompt: string;
+  requested_by: string;
+  result_md: string | null;
+  citations_json: string | null;
+  error_md: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export class BriefValidationError extends Error {
+  constructor(public reason: string) {
+    super(`brief validation: ${reason}`);
+    this.name = 'BriefValidationError';
+  }
+}
+
+function parseCitations(json: string | null): BriefCitation[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((c): c is BriefCitation => !!c && typeof c.url === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function rowToBrief(row: BriefRow): Brief {
+  return {
+    id: row.id,
+    workspace_id: row.workspace_id,
+    agent_run_id: row.agent_run_id,
+    topic_id: row.topic_id,
+    template: row.template,
+    title: row.title,
+    prompt: row.prompt,
+    requested_by: row.requested_by,
+    result_md: row.result_md,
+    citations: parseCitations(row.citations_json),
+    error_md: row.error_md,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export interface CreateBriefInput {
+  workspace_id: string;
+  template: BriefTemplate;
+  title: string;
+  prompt: string;
+  topic_id?: string | null;
+  requested_by?: string;
+  source_kind?: AgentRunSourceKind;
+  source_ref?: string | null;
+}
+
+export interface CreateBriefResult {
+  brief: Brief;
+  agent_run: AgentRun;
+}
+
+export function createBriefWithRun(input: CreateBriefInput): CreateBriefResult {
+  if (!input.workspace_id.trim()) throw new BriefValidationError('workspace_id is required');
+  if (!input.title.trim()) throw new BriefValidationError('title is required');
+  if (!input.prompt.trim()) throw new BriefValidationError('prompt is required');
+
+  // Validate topic belongs to the same workspace if provided. Done
+  // outside the transaction so the FK error message is meaningful;
+  // the transaction below would otherwise fail with a generic FK
+  // violation that hides the workspace-mismatch reason.
+  if (input.topic_id) {
+    const topic = queryOne<{ workspace_id: string; archived_at: string | null }>(
+      `SELECT workspace_id, archived_at FROM topics WHERE id = ?`,
+      [input.topic_id],
+    );
+    if (!topic) {
+      throw new BriefValidationError(`topic ${input.topic_id} does not exist`);
+    }
+    if (topic.workspace_id !== input.workspace_id) {
+      throw new BriefValidationError(
+        `topic ${input.topic_id} belongs to a different workspace`,
+      );
+    }
+    if (topic.archived_at) {
+      throw new BriefValidationError(`topic ${input.topic_id} is archived`);
+    }
+  }
+
+  return transaction(() => {
+    const agent_run = createAgentRun({
+      workspace_id: input.workspace_id,
+      kind: 'brief',
+      source_kind: input.source_kind,
+      source_ref: input.source_ref,
+    });
+
+    const id = uuidv4();
+    run(
+      `INSERT INTO briefs (
+         id, workspace_id, agent_run_id, topic_id, template,
+         title, prompt, requested_by, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      [
+        id,
+        input.workspace_id,
+        agent_run.id,
+        input.topic_id ?? null,
+        input.template,
+        input.title.trim(),
+        input.prompt,
+        input.requested_by ?? 'manual',
+      ],
+    );
+    const row = queryOne<BriefRow>(`SELECT * FROM briefs WHERE id = ?`, [id]);
+    if (!row) throw new Error('createBriefWithRun: insert succeeded but row missing');
+    return { brief: rowToBrief(row), agent_run };
+  });
+}
+
+export function getBrief(id: string): Brief | null {
+  const row = queryOne<BriefRow>(`SELECT * FROM briefs WHERE id = ?`, [id]);
+  return row ? rowToBrief(row) : null;
+}
+
+export function getBriefByAgentRun(agentRunId: string): Brief | null {
+  const row = queryOne<BriefRow>(`SELECT * FROM briefs WHERE agent_run_id = ?`, [agentRunId]);
+  return row ? rowToBrief(row) : null;
+}
+
+export interface ListBriefsOptions {
+  topic_id?: string;
+  limit?: number;
+}
+
+export function listBriefs(workspaceId: string, opts: ListBriefsOptions = {}): Brief[] {
+  const where: string[] = ['workspace_id = ?'];
+  const params: unknown[] = [workspaceId];
+  if (opts.topic_id) {
+    where.push('topic_id = ?');
+    params.push(opts.topic_id);
+  }
+  const limit = Math.min(opts.limit ?? 100, 500);
+  const rows = queryAll<BriefRow>(
+    // rowid DESC tiebreaks created_at when two rows land in the same
+    // SQLite-second (datetime('now') has 1s resolution; rapid inserts
+    // collide). rowid increases monotonically per insert.
+    `SELECT * FROM briefs WHERE ${where.join(' AND ')} ORDER BY created_at DESC, rowid DESC LIMIT ${limit}`,
+    params,
+  );
+  return rows.map(rowToBrief);
+}
+
+export interface SetBriefResultInput {
+  result_md: string;
+  citations?: BriefCitation[];
+}
+
+export function setBriefResult(id: string, input: SetBriefResultInput): Brief | null {
+  const current = getBrief(id);
+  if (!current) return null;
+  run(
+    `UPDATE briefs SET
+       result_md = ?,
+       citations_json = ?,
+       updated_at = datetime('now')
+     WHERE id = ?`,
+    [input.result_md, JSON.stringify(input.citations ?? []), id],
+  );
+  return getBrief(id);
+}
+
+export function setBriefError(id: string, errorMd: string): Brief | null {
+  const current = getBrief(id);
+  if (!current) return null;
+  run(
+    `UPDATE briefs SET error_md = ?, updated_at = datetime('now') WHERE id = ?`,
+    [errorMd, id],
+  );
+  return getBrief(id);
+}

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4060,6 +4060,101 @@ const migrations: Migration[] = [
       console.log('[Migration 074] agents.{soul,user,agents}_header columns added.');
     },
   },
+  {
+    id: '075',
+    name: 'research_area_phase_1',
+    up: (db) => {
+      // Phase 1 of the Research Area (specs/research-area-build-plan.md).
+      //
+      // Three additive tables:
+      //   - agent_runs    — shared dispatch envelope for non-task agent
+      //                     work. Briefs are the first kind; later phases
+      //                     add sweeps / readiness_checks / comms_drafts /
+      //                     workflow_node_runs without re-deriving the
+      //                     lifecycle.
+      //   - topics        — long-lived research interests (workspace-scoped,
+      //                     soft-deleted via archived_at).
+      //   - briefs        — single research outputs, optionally attached to
+      //                     a topic; FK to agent_runs(id) for execution
+      //                     state. result_md + citations_json populated on
+      //                     completion; error_md on failure.
+      //
+      // We deliberately do NOT widen task_kind to cover briefs: tasks are
+      // an opinionated 5-stage pipeline (coordinator/builder/tester/
+      // reviewer/ship) producing deliverables, and briefs are single-
+      // stage structured-data agent runs with no PR/coordinator/
+      // deliverable concept. See spec §2.1–2.2.
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS agent_runs (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          kind TEXT NOT NULL CHECK (kind IN (
+            'brief'
+          )),
+          status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN (
+            'queued','running','complete','failed','cancelled'
+          )),
+          source_kind TEXT NOT NULL DEFAULT 'manual' CHECK (source_kind IN (
+            'manual','schedule','event'
+          )),
+          source_ref TEXT,
+          openclaw_session_id TEXT,
+          model_used TEXT,
+          cost_cents INTEGER,
+          cost_ceiling_cents INTEGER,
+          error_md TEXT,
+          started_at TEXT,
+          completed_at TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_runs_workspace_status ON agent_runs(workspace_id, status)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_runs_kind_status ON agent_runs(kind, status)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_runs_created ON agent_runs(created_at)`);
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS topics (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          name TEXT NOT NULL,
+          description TEXT NOT NULL DEFAULT '',
+          tags_json TEXT NOT NULL DEFAULT '[]',
+          default_brief_template TEXT,
+          archived_at TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_topics_workspace ON topics(workspace_id, archived_at)`);
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS briefs (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          agent_run_id TEXT NOT NULL UNIQUE REFERENCES agent_runs(id) ON DELETE CASCADE,
+          topic_id TEXT REFERENCES topics(id) ON DELETE SET NULL,
+          template TEXT NOT NULL CHECK (template IN (
+            'general_brief'
+          )),
+          title TEXT NOT NULL,
+          prompt TEXT NOT NULL,
+          requested_by TEXT NOT NULL DEFAULT 'manual',
+          result_md TEXT,
+          citations_json TEXT,
+          error_md TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_briefs_workspace ON briefs(workspace_id, created_at DESC)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_briefs_topic ON briefs(topic_id) WHERE topic_id IS NOT NULL`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_briefs_agent_run ON briefs(agent_run_id)`);
+
+      console.log('[Migration 075] agent_runs + topics + briefs tables created.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/topics.test.ts
+++ b/src/lib/db/topics.test.ts
@@ -1,0 +1,147 @@
+/**
+ * topics DAO tests.
+ *
+ * Covers: create / get / list / update / archive / unarchive,
+ * tags JSON round-trip, soft-delete behavior, workspace isolation,
+ * validation errors.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import {
+  archiveTopic,
+  createTopic,
+  getTopic,
+  listTopics,
+  TopicValidationError,
+  unarchiveTopic,
+  updateTopic,
+} from './topics';
+
+function freshWorkspace(): string {
+  const id = `ws-tp-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+test('createTopic: round-trip with defaults', () => {
+  const ws = freshWorkspace();
+  const t = createTopic({ workspace_id: ws, name: 'GLP-1 regulation' });
+  assert.equal(t.workspace_id, ws);
+  assert.equal(t.name, 'GLP-1 regulation');
+  assert.equal(t.description, '');
+  assert.deepEqual(t.tags, []);
+  assert.equal(t.default_brief_template, null);
+  assert.equal(t.archived_at, null);
+});
+
+test('createTopic: trims name, preserves tags + description', () => {
+  const ws = freshWorkspace();
+  const t = createTopic({
+    workspace_id: ws,
+    name: '  Acme competitor watch  ',
+    description: 'Track product + pricing changes',
+    tags: ['competitor', 'saas'],
+    default_brief_template: 'general_brief',
+  });
+  assert.equal(t.name, 'Acme competitor watch');
+  assert.equal(t.description, 'Track product + pricing changes');
+  assert.deepEqual(t.tags, ['competitor', 'saas']);
+  assert.equal(t.default_brief_template, 'general_brief');
+});
+
+test('createTopic: rejects blank name', () => {
+  const ws = freshWorkspace();
+  assert.throws(() => createTopic({ workspace_id: ws, name: '   ' }), TopicValidationError);
+});
+
+test('createTopic: rejects blank workspace_id', () => {
+  assert.throws(
+    () => createTopic({ workspace_id: '   ', name: 'x' }),
+    TopicValidationError,
+  );
+});
+
+test('listTopics: workspace-scoped, archived excluded by default', () => {
+  const wsA = freshWorkspace();
+  const wsB = freshWorkspace();
+  const t1 = createTopic({ workspace_id: wsA, name: 'A1' });
+  createTopic({ workspace_id: wsA, name: 'A2' });
+  createTopic({ workspace_id: wsB, name: 'B1' });
+
+  archiveTopic(t1.id);
+
+  const liveA = listTopics(wsA);
+  assert.equal(liveA.length, 1);
+  assert.equal(liveA[0].name, 'A2');
+
+  const allA = listTopics(wsA, { includeArchived: true });
+  assert.equal(allA.length, 2);
+
+  const liveB = listTopics(wsB);
+  assert.equal(liveB.length, 1);
+  assert.equal(liveB[0].name, 'B1');
+});
+
+test('updateTopic: partial updates only touch provided fields', () => {
+  const ws = freshWorkspace();
+  const t = createTopic({
+    workspace_id: ws,
+    name: 'Original',
+    description: 'orig desc',
+    tags: ['a'],
+  });
+  const updated = updateTopic(t.id, { description: 'new desc' });
+  assert.equal(updated?.name, 'Original');
+  assert.equal(updated?.description, 'new desc');
+  assert.deepEqual(updated?.tags, ['a']);
+});
+
+test('updateTopic: rejects blank name', () => {
+  const ws = freshWorkspace();
+  const t = createTopic({ workspace_id: ws, name: 'x' });
+  assert.throws(() => updateTopic(t.id, { name: '   ' }), TopicValidationError);
+});
+
+test('updateTopic: returns null for unknown id', () => {
+  assert.equal(updateTopic('does-not-exist', { name: 'x' }), null);
+});
+
+test('archive + unarchive: round-trip', () => {
+  const ws = freshWorkspace();
+  const t = createTopic({ workspace_id: ws, name: 'ToArchive' });
+  const archived = archiveTopic(t.id);
+  assert.ok(archived?.archived_at);
+  // Idempotent: archiving twice doesn't reset the timestamp.
+  const archivedAt = archived?.archived_at;
+  const archivedAgain = archiveTopic(t.id);
+  assert.equal(archivedAgain?.archived_at, archivedAt);
+
+  const restored = unarchiveTopic(t.id);
+  assert.equal(restored?.archived_at, null);
+});
+
+test('tags JSON round-trip survives non-string entries', () => {
+  const ws = freshWorkspace();
+  const t = createTopic({ workspace_id: ws, name: 'x', tags: ['ok', 'fine'] });
+  // Manually corrupt the JSON to include a non-string entry.
+  run(
+    `UPDATE topics SET tags_json = ? WHERE id = ?`,
+    [JSON.stringify(['ok', 42, null, 'fine']), t.id],
+  );
+  const reloaded = getTopic(t.id);
+  assert.deepEqual(reloaded?.tags, ['ok', 'fine']);
+});
+
+test('FK cascade: deleting workspace removes its topics', () => {
+  const ws = freshWorkspace();
+  const t = createTopic({ workspace_id: ws, name: 'Orphan' });
+  assert.ok(getTopic(t.id));
+  run(`DELETE FROM workspaces WHERE id = ?`, [ws]);
+  assert.equal(getTopic(t.id), null);
+});

--- a/src/lib/db/topics.ts
+++ b/src/lib/db/topics.ts
@@ -1,0 +1,184 @@
+/**
+ * topics DAO.
+ *
+ * Schema added in migration 075. Long-lived research interests,
+ * workspace-scoped, soft-deleted via archived_at. tags is stored as a
+ * JSON array string (`tags_json`); we round-trip to string[] at the
+ * DAO boundary so callers don't deal with serialization.
+ *
+ * See specs/research-area.md "Topic" + specs/research-area-build-plan.md §2.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+
+export interface Topic {
+  id: string;
+  workspace_id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  default_brief_template: string | null;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TopicRow {
+  id: string;
+  workspace_id: string;
+  name: string;
+  description: string;
+  tags_json: string;
+  default_brief_template: string | null;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export class TopicValidationError extends Error {
+  constructor(public reason: string) {
+    super(`topic validation: ${reason}`);
+    this.name = 'TopicValidationError';
+  }
+}
+
+function parseTags(json: string): string[] {
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed.filter((t): t is string => typeof t === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function rowToTopic(row: TopicRow): Topic {
+  return {
+    id: row.id,
+    workspace_id: row.workspace_id,
+    name: row.name,
+    description: row.description,
+    tags: parseTags(row.tags_json),
+    default_brief_template: row.default_brief_template,
+    archived_at: row.archived_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export interface CreateTopicInput {
+  workspace_id: string;
+  name: string;
+  description?: string;
+  tags?: string[];
+  default_brief_template?: string | null;
+}
+
+export function createTopic(input: CreateTopicInput): Topic {
+  if (!input.workspace_id.trim()) {
+    throw new TopicValidationError('workspace_id is required');
+  }
+  if (!input.name.trim()) {
+    throw new TopicValidationError('name is required');
+  }
+  const id = uuidv4();
+  run(
+    `INSERT INTO topics (
+       id, workspace_id, name, description, tags_json,
+       default_brief_template, created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+    [
+      id,
+      input.workspace_id,
+      input.name.trim(),
+      input.description ?? '',
+      JSON.stringify(input.tags ?? []),
+      input.default_brief_template ?? null,
+    ],
+  );
+  const row = queryOne<TopicRow>(`SELECT * FROM topics WHERE id = ?`, [id]);
+  if (!row) throw new Error('createTopic: insert succeeded but row missing');
+  return rowToTopic(row);
+}
+
+export function getTopic(id: string): Topic | null {
+  const row = queryOne<TopicRow>(`SELECT * FROM topics WHERE id = ?`, [id]);
+  return row ? rowToTopic(row) : null;
+}
+
+export interface ListTopicsOptions {
+  includeArchived?: boolean;
+}
+
+export function listTopics(workspaceId: string, opts: ListTopicsOptions = {}): Topic[] {
+  const where = opts.includeArchived
+    ? 'workspace_id = ?'
+    : 'workspace_id = ? AND archived_at IS NULL';
+  const rows = queryAll<TopicRow>(
+    // rowid DESC tiebreaks created_at — see briefs.ts listBriefs.
+    `SELECT * FROM topics WHERE ${where} ORDER BY created_at DESC, rowid DESC`,
+    [workspaceId],
+  );
+  return rows.map(rowToTopic);
+}
+
+export interface UpdateTopicInput {
+  name?: string;
+  description?: string;
+  tags?: string[];
+  default_brief_template?: string | null;
+}
+
+export function updateTopic(id: string, input: UpdateTopicInput): Topic | null {
+  const current = getTopic(id);
+  if (!current) return null;
+
+  const sets: string[] = [];
+  const params: unknown[] = [];
+  if (input.name !== undefined) {
+    if (!input.name.trim()) {
+      throw new TopicValidationError('name cannot be blank');
+    }
+    sets.push('name = ?');
+    params.push(input.name.trim());
+  }
+  if (input.description !== undefined) {
+    sets.push('description = ?');
+    params.push(input.description);
+  }
+  if (input.tags !== undefined) {
+    sets.push('tags_json = ?');
+    params.push(JSON.stringify(input.tags));
+  }
+  if (input.default_brief_template !== undefined) {
+    sets.push('default_brief_template = ?');
+    params.push(input.default_brief_template);
+  }
+  if (sets.length === 0) return current;
+
+  sets.push(`updated_at = datetime('now')`);
+  params.push(id);
+  run(`UPDATE topics SET ${sets.join(', ')} WHERE id = ?`, params);
+  return getTopic(id);
+}
+
+export function archiveTopic(id: string): Topic | null {
+  const current = getTopic(id);
+  if (!current) return null;
+  if (current.archived_at) return current;
+  run(
+    `UPDATE topics SET archived_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
+    [id],
+  );
+  return getTopic(id);
+}
+
+export function unarchiveTopic(id: string): Topic | null {
+  const current = getTopic(id);
+  if (!current) return null;
+  run(
+    `UPDATE topics SET archived_at = NULL, updated_at = datetime('now') WHERE id = ?`,
+    [id],
+  );
+  return getTopic(id);
+}


### PR DESCRIPTION
## Summary
- Slice 1 of `feat/research-phase-1` (see [research-area-build-plan.md](https://github.com/smb209/mission-control/blob/feat/research-phase-1/specs/research-area-build-plan.md) §3).
- Introduces the data layer for the Research Area phase 1: migration 075 + three DAOs + 38 unit tests.
- Establishes `agent_runs` as the shared dispatch envelope for non-task agent work; per-kind tables (briefs first; sweeps/readiness/comms later) FK to it. Reasoning in build plan §2.1–2.2.

## Changes
- `src/lib/db/migrations.ts` — migration 075: `agent_runs`, `topics`, `briefs` tables + indexes.
- `src/lib/db/agent-runs.ts` — DAO with explicit transition matrix (queued → running → complete | failed | cancelled). `reapStaleRunning()` for the dispatch failure recovery path (slice 3).
- `src/lib/db/topics.ts` — workspace-scoped CRUD + soft-delete via `archived_at`. Tags JSON round-trips at the DAO boundary.
- `src/lib/db/briefs.ts` — `createBriefWithRun()` inserts brief + agent_run transactionally so a brief never exists without its envelope. Topic linkage validated against workspace + archived state outside the transaction so error messages stay specific.
- 38 unit tests covering CRUD, transitions, JSON round-trips, FK cascades, workspace isolation, stale-running reaper.

## Test plan
- [x] `NODE_ENV=test yarn tsx --test src/lib/db/{agent-runs,topics,briefs}.test.ts` → 38 / 38 pass
- [x] `yarn test` (full suite) → 611 / 611 pass
- [x] Migration 075 applies cleanly on fresh template DB (`yarn test:setup`)
- [x] Validation scenarios newly exercisable (post-merge of full stack):
  - R1.1–R1.3 (Topic CRUD) — schema + DAO ready; API route still owed by slice 2
  - R8.1 (workspace isolation) — DAO-level isolation enforced

## Pre-existing failures noted
Per CLAUDE.md, listing pre-existing breakage observed during this slice's verification, **unrelated to this change**:
- `src/lib/agents/pm-decompose.test.ts:169` — TS2578 unused `@ts-expect-error` directive
- `src/lib/agents/pm-decompose.test.ts:173` — TS2322 type `"theme"` not assignable to `"epic" | "story"`

These predate `feat/research-phase-1` and are flagged for separate cleanup.

## Stack position
Base: `feat/research-phase-1` (docs only)
Next slice: `feat/research-phase-1-api` (REST endpoints over these DAOs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)