### PR TITLE
feat(research): runner-dispatched briefs via dispatchScope; researcher is a roster-only role

### DIFF
--- a/specs/research-area-validation/00-baseline-observations.md
+++ b/specs/research-area-validation/00-baseline-observations.md
@@ -16,12 +16,19 @@
 - **Latest migration:** _(paste from `sqlite3 $DATABASE_PATH "SELECT MAX(id) FROM _migrations"`)_
 - **Confirm absent (will be added by slice 1):** `agent_runs`, `topics`, `briefs`
 
-## 2. Researcher persona state
+## 2. Researcher roster + runner state
 
-> Capture with: `sqlite3 $DATABASE_PATH "SELECT id, name, role, runtime_kind FROM agents WHERE role='researcher' OR name LIKE '%researcher%';"`
+**Updated for phase 2:** the researcher is a **role-only roster entry** (no gateway binding). The actual chat session is hosted by the workspace runner via `dispatchScope`, which composes the researcher persona from `agent-templates/researcher/{SOUL,AGENTS,IDENTITY}.md` at briefing time.
 
-- **Researcher rows present:** _(paste)_
-- **Per-workspace presence:** confirm `mc-researcher-dev` exists in the workspaces we'll use for validation (default + at least one secondary).
+> Capture with:
+> ```
+> sqlite3 $DATABASE_PATH \
+>   "SELECT name, role, source, gateway_agent_id FROM agents
+>      WHERE workspace_id = '<ws_id>' AND role IN ('researcher','runner','pm');"
+> ```
+
+- **Researcher roster entries:** _(paste — should be `source='local'`, `gateway_agent_id=NULL`; provisioned via the Add Agents picker)_
+- **Runner present:** _(paste — single `mc-runner-dev` row in `default` workspace)_
 - **Persona files on disk:**
   - `agent-templates/researcher/SOUL.md` ✅
   - `agent-templates/researcher/AGENTS.md` ✅
@@ -29,15 +36,15 @@
 
 ## 3. Web-tool exposure (the main risk)
 
-The phase-1 dispatch path uses `openclaw/send-chat.ts` directly, not the worker-task pipeline. The researcher persona's `send-chat` session must surface web-fetch / web-search tools or briefs cannot cite real sources.
+The phase-2 dispatch path uses `dispatchScope` against the runner. The runner's `send-chat` session must surface web-fetch / web-search tools or briefs cannot cite real sources.
 
-> Capture by: dispatching a simple "what is the current price of GOOG?" probe to the researcher via existing PM chat or a manual `send-chat` invocation, and checking the response for evidence of web access. Document one of:
+> Capture by: dispatching a simple "what is the current price of GOOG?" probe to the runner via existing PM chat or a manual `send-chat` invocation, and checking the response for evidence of web access. Document one of:
 >
-> - **GREEN** — researcher returns a current-day-priced answer with citations, indicating live web access
-> - **YELLOW** — researcher returns a non-current answer but acknowledges the missing tool; we'll need to wire web tools into `send-chat` profile in slice 3
+> - **GREEN** — runner returns a current-day-priced answer with citations, indicating live web access
+> - **YELLOW** — runner returns a non-current answer but acknowledges the missing tool; web-tool wiring on the runner needs follow-up
 > - **BLOCKED** — `send-chat` itself fails or returns nothing usable; deeper fix needed before phase 1 can ship
 
-Result: _(fill in)_
+Result: _(fill in — Run 2 confirmed GREEN against `main` agent with web access)_
 
 ## 4. Recurring scheduler state
 

--- a/src/app/(app)/research/page.tsx
+++ b/src/app/(app)/research/page.tsx
@@ -11,12 +11,13 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Plus, RefreshCw, Search, FileText, Zap, Archive } from 'lucide-react';
+import { Plus, RefreshCw, Search, FileText, Zap, Archive, AlertTriangle } from 'lucide-react';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 import { useMissionControl } from '@/lib/store';
 import { formatDistanceToNow } from 'date-fns';
 import { CreateTopicDrawer } from '@/components/research/CreateTopicDrawer';
 import { RunBriefDrawer } from '@/components/research/RunBriefDrawer';
+import { useResearchPreflight } from '@/components/research/useResearchPreflight';
 
 interface TopicSummary {
   id: string;
@@ -69,6 +70,8 @@ export default function ResearchHubPage() {
   const [createTopicOpen, setCreateTopicOpen] = useState(false);
   const [runBriefOpen, setRunBriefOpen] = useState(false);
   const [activeTopicId, setActiveTopicId] = useState<string | null>(null);
+
+  const preflight = useResearchPreflight(workspaceId);
 
   const load = useCallback(async () => {
     if (!workspaceId) return;
@@ -191,13 +194,21 @@ export default function ResearchHubPage() {
             <button
               type="button"
               onClick={() => setRunBriefOpen(true)}
-              className="px-3 py-1.5 bg-mc-accent text-mc-bg rounded-sm text-sm font-medium hover:opacity-90 flex items-center gap-1.5"
+              disabled={!preflight.ok && !preflight.loading}
+              title={preflight.ok ? undefined : 'A researcher must be in this workspace before you can dispatch a brief'}
+              className="px-3 py-1.5 bg-mc-accent text-mc-bg rounded-sm text-sm font-medium hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1.5"
             >
               <Zap className="w-3.5 h-3.5" />
               Run a brief
             </button>
           </div>
         </header>
+
+        {/* Preflight warning. Renders only when something is missing —
+            staying GREEN keeps the chrome out of the operator's way. */}
+        {!preflight.loading && !preflight.ok && (
+          <PreflightBanner preflight={preflight} />
+        )}
 
         {error && (
           <div className="mb-4 px-3 py-2 rounded-sm bg-red-900/20 border border-red-500/30 text-red-300 text-sm">
@@ -236,6 +247,53 @@ export default function ResearchHubPage() {
         defaultTopicId={null}
         onLaunched={() => { setRunBriefOpen(false); load(); }}
       />
+    </div>
+  );
+}
+
+function PreflightBanner({
+  preflight,
+}: {
+  preflight: { hasResearcher: boolean; hasRunner: boolean };
+}) {
+  const messages: { title: string; body: React.ReactNode }[] = [];
+
+  if (!preflight.hasResearcher) {
+    messages.push({
+      title: 'No researcher in this workspace',
+      body: (
+        <>
+          A researcher must be in this workspace's roster before briefs can be dispatched. Add one via{' '}
+          <Link href="/agents" className="underline hover:text-mc-accent">
+            Agents → Add agents
+          </Link>{' '}
+          (the Researcher role, or the &ldquo;Research &amp; write&rdquo; team).
+        </>
+      ),
+    });
+  }
+  if (!preflight.hasRunner) {
+    messages.push({
+      title: 'No runner agent registered',
+      body: (
+        <>
+          A workspace runner (<code>mc-runner-dev</code>) hosts the actual chat sessions for role-scoped dispatches. Provision it via the openclaw gateway, then return here.
+        </>
+      ),
+    });
+  }
+
+  return (
+    <div className="mb-4 px-4 py-3 rounded-sm bg-amber-900/20 border border-amber-500/40 text-amber-100 text-sm flex gap-3">
+      <AlertTriangle className="w-5 h-5 text-amber-400 shrink-0 mt-0.5" />
+      <div className="flex-1 space-y-2">
+        {messages.map((m, i) => (
+          <div key={i}>
+            <div className="font-medium">{m.title}</div>
+            <div className="text-amber-100/80">{m.body}</div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/api/briefs/[id]/run/route.test.ts
+++ b/src/app/api/briefs/[id]/run/route.test.ts
@@ -30,10 +30,22 @@ function freshWorkspace(): string {
 }
 
 function ensureResearcher(workspaceId: string): void {
+  // Phase 2: researcher is a role-only roster marker (no gateway binding).
   run(
-    `INSERT INTO agents (id, name, role, avatar_emoji, status, is_master, workspace_id, source, gateway_agent_id, session_key_prefix, model, created_at, updated_at)
-     VALUES (?, 'mc-researcher-test', 'researcher', '🔍', 'standby', 0, ?, 'gateway', 'gw-r', 'agent:gw-r', 'spark-lb/agent', datetime('now'), datetime('now'))`,
+    `INSERT INTO agents (id, name, role, avatar_emoji, status, is_master, workspace_id, source, is_active, created_at, updated_at)
+     VALUES (?, 'mc-researcher-test', 'researcher', '🔍', 'standby', 0, ?, 'local', 1, datetime('now'), datetime('now'))`,
     [`ag-${uuidv4().slice(0, 8)}`, workspaceId],
+  );
+}
+
+function ensureRunner(): void {
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES ('default', 'default', 'default', datetime('now'))`,
+  );
+  run(
+    `INSERT OR IGNORE INTO agents
+       (id, name, role, avatar_emoji, status, is_master, workspace_id, source, gateway_agent_id, session_key_prefix, model, is_active, created_at, updated_at)
+       VALUES ('runner-route-test', 'MC Runner Dev', 'runner', '⚙️', 'standby', 0, 'default', 'gateway', 'mc-runner-dev', 'agent:mc-runner-dev:main', 'spark-lb/agent', 1, datetime('now'), datetime('now'))`,
   );
 }
 
@@ -70,6 +82,7 @@ test('POST /api/briefs/[id]/run: 404 for unknown', async () => {
 test('POST /api/briefs/[id]/run: 202 on accepted dispatch', async () => {
   const ws = freshWorkspace();
   ensureResearcher(ws);
+  ensureRunner();
   __setSendChatClientForTests(inertStub());
   const { brief } = createBriefWithRun({
     workspace_id: ws, template: 'general_brief',

--- a/src/components/research/useResearchPreflight.ts
+++ b/src/components/research/useResearchPreflight.ts
@@ -1,0 +1,99 @@
+'use client';
+
+/**
+ * Tiny hook that asks the existing /api/agents endpoint two questions
+ * the Research surface needs to answer before letting the operator
+ * dispatch a brief:
+ *
+ *   1. Does this workspace have a researcher in its roster?
+ *   2. Is there a runner agent registered (any workspace) so
+ *      dispatchScope can host the session?
+ *
+ * Both are needed for a brief to succeed; if either is missing we
+ * surface a banner on /research and a warning dot on the nav.
+ *
+ * Uses the same `useMissionControl().events` SSE stream the rest of
+ * the research surface uses, so the warning clears live when the
+ * operator adds a researcher via the picker.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMissionControl } from '@/lib/store';
+
+const RELEVANT_AGENT_EVENTS = [
+  'agent_spawned',
+  'agents_cleared',
+] as const;
+
+interface AgentRow {
+  id: string;
+  role: string;
+  is_active?: number;
+  source?: string;
+  gateway_agent_id?: string;
+  workspace_id: string;
+}
+
+export interface ResearchPreflight {
+  loading: boolean;
+  hasResearcher: boolean;
+  hasRunner: boolean;
+  /** True iff both prerequisites are met. */
+  ok: boolean;
+  refresh: () => void;
+}
+
+export function useResearchPreflight(workspaceId: string | null | undefined): ResearchPreflight {
+  const { events } = useMissionControl();
+  const [loading, setLoading] = useState(false);
+  const [hasResearcher, setHasResearcher] = useState(false);
+  const [hasRunner, setHasRunner] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!workspaceId) {
+      setHasResearcher(false);
+      setHasRunner(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      // Workspace-scoped fetch for the researcher check.
+      const wsRows: AgentRow[] = await fetch(`/api/agents?workspace_id=${encodeURIComponent(workspaceId)}`)
+        .then(r => r.ok ? r.json() : []);
+      setHasResearcher(
+        wsRows.some(a => a.role === 'researcher' && (a.is_active ?? 1) === 1),
+      );
+
+      // Runner check is global (single mc-runner-dev row in `default`
+      // hosts every workspace's sessions). Cheapest is to hit /api/agents
+      // unscoped and look for any runner row.
+      const allRows: AgentRow[] = await fetch(`/api/agents`)
+        .then(r => r.ok ? r.json() : []);
+      setHasRunner(
+        allRows.some(a =>
+          a.role === 'runner' &&
+          (a.gateway_agent_id === 'mc-runner-dev' || a.gateway_agent_id === 'mc-runner'),
+        ),
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  // Re-check when agent inventory changes.
+  const latestEventId = useMemo(
+    () => events.find(e => RELEVANT_AGENT_EVENTS.includes(e.type as typeof RELEVANT_AGENT_EVENTS[number]))?.id,
+    [events],
+  );
+  useEffect(() => { if (latestEventId) refresh(); }, [latestEventId, refresh]);
+
+  return {
+    loading,
+    hasResearcher,
+    hasRunner,
+    ok: hasResearcher && hasRunner,
+    refresh,
+  };
+}

--- a/src/components/shell/AppNav.tsx
+++ b/src/components/shell/AppNav.tsx
@@ -46,12 +46,14 @@ import {
   Lightbulb,
   Brain,
   Workflow,
+  AlertCircle,
 } from 'lucide-react';
 import {
   useCurrentWorkspaceId,
   useSetCurrentWorkspaceId,
   type WorkspaceLite,
 } from './workspace-context';
+import { useResearchPreflight } from '@/components/research/useResearchPreflight';
 import { CreateWorkspaceDrawer } from './CreateWorkspaceDrawer';
 import type { Workspace } from '@/lib/types';
 
@@ -268,13 +270,39 @@ function NavSectionView({
                 `}
               >
                 <Icon className="w-4 h-4 shrink-0" />
-                <span className="truncate">{item.label}</span>
+                <span className="truncate flex-1">{item.label}</span>
+                {item.href === '/research' && <ResearchPreflightDot />}
               </Link>
             </li>
           );
         })}
       </ul>
     </div>
+  );
+}
+
+/**
+ * Renders a small amber AlertCircle to the right of the Research nav
+ * label when the current workspace can't dispatch briefs (no
+ * researcher in roster, or no runner registered). Silent when
+ * everything's healthy so the nav stays quiet.
+ *
+ * Lives in AppNav rather than the page so the indicator is visible
+ * even when the operator is on another route — the whole point of
+ * surfacing it on the nav is "you don't have to be on /research to
+ * notice."
+ */
+function ResearchPreflightDot() {
+  const workspaceId = useCurrentWorkspaceId();
+  const preflight = useResearchPreflight(workspaceId);
+  if (preflight.loading || preflight.ok) return null;
+  const reason = !preflight.hasResearcher
+    ? 'No researcher in this workspace — add one in Agents'
+    : 'No runner agent registered';
+  return (
+    <span title={reason} aria-label={reason} className="ml-1 shrink-0">
+      <AlertCircle className="w-3.5 h-3.5 text-amber-400" />
+    </span>
   );
 }
 

--- a/src/lib/research/eval/runner.ts
+++ b/src/lib/research/eval/runner.ts
@@ -62,19 +62,23 @@ function ensureWorkspace(workspaceId?: string): string {
   return id;
 }
 
-function ensureResearcher(workspaceId: string): void {
-  const existing = run(
-    `SELECT 1 FROM agents WHERE workspace_id = ? AND role = 'researcher' LIMIT 1`,
-    [workspaceId],
-  );
-  // run() returns RunResult, not rows. Use a probe insert with OR IGNORE
-  // pattern instead — safer than depending on a select.
+function ensureResearcherAndRunner(workspaceId: string): void {
+  // Phase 2: researcher is a role-only roster marker (no gateway binding).
   run(
-    `INSERT OR IGNORE INTO agents (id, name, role, avatar_emoji, status, is_master, workspace_id, source, gateway_agent_id, session_key_prefix, model, created_at, updated_at)
-     VALUES (?, 'mc-researcher-eval', 'researcher', '🔍', 'standby', 0, ?, 'gateway', 'gw-eval', 'agent:gw-eval', 'spark-lb/agent', datetime('now'), datetime('now'))`,
+    `INSERT OR IGNORE INTO agents (id, name, role, avatar_emoji, status, is_master, workspace_id, source, is_active, created_at, updated_at)
+     VALUES (?, 'mc-researcher-eval', 'researcher', '🔍', 'standby', 0, ?, 'local', 1, datetime('now'), datetime('now'))`,
     [`agent-eval-${workspaceId.slice(-8)}`, workspaceId],
   );
-  void existing;
+  // The runner hosts the actual session via dispatchScope. One row in
+  // 'default' is enough — getRunnerAgent() resolves it for any workspace.
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES ('default', 'default', 'default', datetime('now'))`,
+  );
+  run(
+    `INSERT OR IGNORE INTO agents
+       (id, name, role, avatar_emoji, status, is_master, workspace_id, source, gateway_agent_id, session_key_prefix, model, is_active, created_at, updated_at)
+       VALUES ('runner-eval', 'MC Runner Dev', 'runner', '⚙️', 'standby', 0, 'default', 'gateway', 'mc-runner-dev', 'agent:mc-runner-dev:main', 'spark-lb/agent', 1, datetime('now'), datetime('now'))`,
+  );
 }
 
 /** Build a stub openclaw client that emits a canned reply once and
@@ -157,7 +161,7 @@ export async function runEval(opts: EvalRunOptions = {}): Promise<EvalRunReport>
   const runId = `${startedAt.replace(/[:.]/g, '-')}_${uuidv4().slice(0, 6)}`;
   const outputDir = opts.outputDir ?? path.join(process.cwd(), 'tmp', 'research-eval');
   const workspaceId = ensureWorkspace(opts.workspaceId);
-  ensureResearcher(workspaceId);
+  ensureResearcherAndRunner(workspaceId);
 
   const fixtures = opts.only
     ? FIXTURES.filter(f => opts.only!.includes(f.id))

--- a/src/lib/research/run-brief.test.ts
+++ b/src/lib/research/run-brief.test.ts
@@ -1,12 +1,20 @@
 /**
- * Brief orchestrator tests.
+ * Brief orchestrator tests (phase 2 — runner-dispatched via dispatchScope).
  *
  * Stubs the openclaw send-chat client via __setSendChatClientForTests
  * so we can drive the dispatch path deterministically without a live
- * gateway. Covers:
+ * gateway. dispatchScope uses sendChatAndAwaitReply under the hood,
+ * so the same stub continues to work — but two new failure modes
+ * appear because resolution now spans both a researcher roster entry
+ * AND a runner agent:
+ *   - missing researcher → failed with "add a researcher" message
+ *   - missing runner     → failed with "no runner registered" message
+ *
+ * Covers:
  *   - happy path: queued → running (event) → complete (event) +
- *     result_md + parsed citations
- *   - missing researcher → failed cleanly
+ *     result_md + parsed citations + scope_key in completion event
+ *   - missing researcher → failed with no_researcher_in_roster reason
+ *   - missing runner → failed with no_runner reason
  *   - send-chat returns no_session → failed with gateway-clear message
  *   - send-chat returns send_failed → failed
  *   - timeout → failed with timeout reason
@@ -44,30 +52,48 @@ function freshWorkspace(): string {
   return id;
 }
 
-function ensureResearcher(workspaceId: string): string {
+/**
+ * Adds a role-only "researcher" roster entry (no gateway binding).
+ * The actual chat session will be hosted by the runner; this row
+ * just signals "this workspace has opted in to research."
+ */
+function ensureResearcherRosterEntry(workspaceId: string): string {
   const id = `agent-${uuidv4().slice(0, 8)}`;
   run(
-    `INSERT INTO agents (id, name, role, avatar_emoji, status, is_master, workspace_id, source, gateway_agent_id, session_key_prefix, model, created_at, updated_at)
-     VALUES (?, ?, 'researcher', '🔍', 'standby', 0, ?, 'gateway', 'gw-researcher', 'agent:gw-researcher', 'spark-lb/agent', datetime('now'), datetime('now'))`,
+    `INSERT INTO agents (id, name, role, avatar_emoji, status, is_master, workspace_id, source, is_active, created_at, updated_at)
+     VALUES (?, ?, 'researcher', '🔍', 'standby', 0, ?, 'local', 1, datetime('now'), datetime('now'))`,
     [id, `mc-researcher-${workspaceId.slice(-4)}`, workspaceId],
   );
   return id;
 }
 
+/**
+ * Adds the runner agent. getRunnerAgent() resolves by gateway_agent_id
+ * in ('mc-runner-dev', 'mc-runner'); we use the dev variant since
+ * NODE_ENV=test selects dev candidates first. The session_key_prefix
+ * is the same shape dispatchScope expects.
+ */
+function ensureRunner(): string {
+  // Idempotent: only insert if no row already.
+  const existing = run(
+    `INSERT OR IGNORE INTO agents
+       (id, name, role, avatar_emoji, status, is_master, workspace_id, source, gateway_agent_id, session_key_prefix, model, is_active, created_at, updated_at)
+       VALUES ('runner-test', 'MC Runner Dev', 'runner', '⚙️', 'standby', 0, 'default', 'gateway', 'mc-runner-dev', 'agent:mc-runner-dev:main', 'spark-lb/agent', 1, datetime('now'), datetime('now'))`,
+  );
+  void existing;
+  // Make sure the 'default' workspace exists for the runner FK.
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES ('default', 'default', 'default', datetime('now'))`,
+  );
+  return 'runner-test';
+}
+
 interface StubOpts {
-  /** Whether the gateway is "connected." Default true. */
   connected?: boolean;
-  /** What the underlying chat.send call resolves with. Default {}. */
   sendResult?: unknown;
-  /** Throw inside chat.send. Default null. */
   sendError?: Error | null;
-  /** Events to emit AFTER chat.send resolves, in order. The default
-   *  emits a single final-state event with the supplied body. */
   events?: ChatEvent[];
-  /** Body to wrap in the default final-state event. */
   body?: string;
-  /** Skip emitting any events (forces sendChatAndAwaitReply to time
-   *  out at its caller-supplied deadline). */
   silent?: boolean;
 }
 
@@ -90,11 +116,7 @@ function makeStubClient(opts: StubOpts = {}): SendChatClient {
       if (method !== 'chat.send') return undefined;
       if (opts.sendError) throw opts.sendError;
       if (!opts.silent) {
-        // Emit events AFTER the send call resolves, attached to the
-        // requested sessionKey so the listener accepts them.
         const sessionKey = (params as { sessionKey?: string } | undefined)?.sessionKey;
-        // setImmediate so the await in the orchestrator picks them up
-        // after we've returned from the call.
         setImmediate(() => {
           for (const e of emitAfterSend) {
             const withKey = { ...e, sessionKey };
@@ -183,7 +205,8 @@ test('buildBriefPrompt: omits topic section when not supplied', () => {
 
 test('runBrief: happy path → running → complete with parsed citations', async () => {
   const ws = freshWorkspace();
-  ensureResearcher(ws);
+  ensureResearcherRosterEntry(ws);
+  ensureRunner();
   const { brief, agent_run } = createBriefWithRun({
     workspace_id: ws, template: 'general_brief',
     title: 'WebGPU support', prompt: 'Survey WebGPU support.',
@@ -211,9 +234,10 @@ test('runBrief: happy path → running → complete with parsed citations', asyn
 
 // ─── orchestrator: failure modes ────────────────────────────────────
 
-test('runBrief: missing researcher → failed cleanly', async () => {
+test('runBrief: missing researcher roster entry → failed with no_researcher_in_roster', async () => {
   const ws = freshWorkspace();
-  // No ensureResearcher() call — workspace has none.
+  ensureRunner();
+  // No ensureResearcherRosterEntry() call — workspace has no researcher.
   const { brief, agent_run } = createBriefWithRun({
     workspace_id: ws, template: 'general_brief',
     title: 'x', prompt: 'p',
@@ -223,15 +247,35 @@ test('runBrief: missing researcher → failed cleanly', async () => {
 
   const runRow = getAgentRun(agent_run.id);
   assert.equal(runRow?.status, 'failed');
-  assert.match(runRow?.error_md ?? '', /No active researcher/);
+  assert.match(runRow?.error_md ?? '', /no researcher in its roster/i);
+  assert.match(runRow?.error_md ?? '', /Add agents/);
 
   const reloaded = getBrief(brief.id);
-  assert.match(reloaded?.error_md ?? '', /No active researcher/);
+  assert.match(reloaded?.error_md ?? '', /no researcher in its roster/i);
+});
+
+test('runBrief: missing runner → failed with no_runner', async () => {
+  // Wipe any runner that earlier tests inserted.
+  run(`DELETE FROM agents WHERE gateway_agent_id IN ('mc-runner-dev', 'mc-runner')`);
+  const ws = freshWorkspace();
+  ensureResearcherRosterEntry(ws);
+  // No ensureRunner() — workspace has researcher but no runner.
+  const { brief, agent_run } = createBriefWithRun({
+    workspace_id: ws, template: 'general_brief',
+    title: 'x', prompt: 'p',
+  });
+
+  await runBrief(brief.id, { awaitCompletionForTesting: true });
+
+  const runRow = getAgentRun(agent_run.id);
+  assert.equal(runRow?.status, 'failed');
+  assert.match(runRow?.error_md ?? '', /No runner agent registered/);
 });
 
 test('runBrief: gateway not connected → failed with gateway message', async () => {
   const ws = freshWorkspace();
-  ensureResearcher(ws);
+  ensureResearcherRosterEntry(ws);
+  ensureRunner();
   const { brief, agent_run } = createBriefWithRun({
     workspace_id: ws, template: 'general_brief',
     title: 'x', prompt: 'p',
@@ -248,7 +292,8 @@ test('runBrief: gateway not connected → failed with gateway message', async ()
 
 test('runBrief: chat.send throws → failed', async () => {
   const ws = freshWorkspace();
-  ensureResearcher(ws);
+  ensureResearcherRosterEntry(ws);
+  ensureRunner();
   const { brief, agent_run } = createBriefWithRun({
     workspace_id: ws, template: 'general_brief',
     title: 'x', prompt: 'p',
@@ -267,7 +312,8 @@ test('runBrief: chat.send throws → failed', async () => {
 
 test('runBrief: gateway returns no events → fails with timeout message', async () => {
   const ws = freshWorkspace();
-  ensureResearcher(ws);
+  ensureResearcherRosterEntry(ws);
+  ensureRunner();
   const { brief, agent_run } = createBriefWithRun({
     workspace_id: ws, template: 'general_brief',
     title: 'x', prompt: 'p',
@@ -287,7 +333,8 @@ test('runBrief: gateway returns no events → fails with timeout message', async
 
 test('runBrief: empty body → fails with explicit message', async () => {
   const ws = freshWorkspace();
-  ensureResearcher(ws);
+  ensureResearcherRosterEntry(ws);
+  ensureRunner();
   const { brief, agent_run } = createBriefWithRun({
     workspace_id: ws, template: 'general_brief',
     title: 'x', prompt: 'p',
@@ -304,12 +351,12 @@ test('runBrief: empty body → fails with explicit message', async () => {
 
 test('runBrief: refuses to redispatch a brief that is already running', async () => {
   const ws = freshWorkspace();
-  ensureResearcher(ws);
+  ensureResearcherRosterEntry(ws);
+  ensureRunner();
   const { brief, agent_run } = createBriefWithRun({
     workspace_id: ws, template: 'general_brief',
     title: 'x', prompt: 'p',
   });
-  // Force the run into "running" state so a second dispatch must be rejected.
   markRunning(agent_run.id);
 
   const result = await runBrief(brief.id);
@@ -325,7 +372,8 @@ test('runBrief: returns rejected for unknown brief id', async () => {
 
 test('runBrief: topic context flows into the assembled prompt', async () => {
   const ws = freshWorkspace();
-  ensureResearcher(ws);
+  ensureResearcherRosterEntry(ws);
+  ensureRunner();
   const topic = createTopic({
     workspace_id: ws,
     name: 'Acme competitor',
@@ -351,8 +399,9 @@ test('runBrief: topic context flows into the assembled prompt', async () => {
     },
   });
 
-  // We don't care about the orchestrator's failure-on-empty path here;
-  // we just want the message that hit chat.send.
+  // dispatchScope packages the trigger_body into the briefing along
+  // with the role persona; the chat.send message is the full briefing
+  // (which includes our trigger_body — the assembled brief prompt).
   await runBrief(brief.id, { timeoutMs: 30, awaitCompletionForTesting: true });
 
   assert.match(capturedMessage, /Acme competitor/);

--- a/src/lib/research/run-brief.ts
+++ b/src/lib/research/run-brief.ts
@@ -1,31 +1,36 @@
 /**
  * Brief execution orchestrator.
  *
- * Slice 3 of feat/research-phase-1
- * (specs/research-area-build-plan.md §2.3).
+ * Phase 2 (feat/research-phase-2-runner-dispatch): briefs are now
+ * dispatched through the workspace runner via `dispatchScope`, the
+ * scope-keyed-sessions primitive that composes the role's briefing
+ * (SOUL.md + AGENTS.md + IDENTITY.md from `agent-templates/researcher/`)
+ * into the session BEFORE the prompt is sent.
  *
- * Runs as a direct openclaw send-chat to the workspace's researcher
- * persona — NOT through the worker-task pipeline. Briefs don't need
- * a workspace clone, git ops, deliverable storage, or coordinator
- * gates; sendChatAndAwaitReply gives us streaming for free via the
- * onEvent tap.
+ * This corrects phase 1's design mistake — phase 1 used raw
+ * `send-chat` directly against an `agents` row whose `gateway_agent_id`
+ * had to point at a real openclaw agent. The agent system is built
+ * around exactly two real gateway agents per workspace (the runner +
+ * the PM); every other "agent" is a *role-only roster entry* that the
+ * runner takes on via persona-scoped sessions.
  *
- * Responsibilities:
- *   1. Resolve the workspace researcher agent.
- *   2. Build the assembled prompt from template + topic context +
- *      user prompt.
+ * The roster entry must still exist — `resolveResearcherRosterEntry`
+ * verifies the workspace has opted in to research by adding a
+ * researcher row (operator does this via the Add Agents picker). If
+ * not, we surface a clean message instead of silently inventing one.
+ *
+ * Flow:
+ *   1. Verify workspace has a researcher roster entry.
+ *   2. Verify a runner agent exists.
  *   3. markRunning + emit brief_started.
- *   4. Drive sendChatAndAwaitReply, tapping onEvent → emit
- *      brief_progress (throttled).
- *   5. On reply: parse citations from the rendered markdown,
- *      setBriefResult, markComplete, emit brief_completed.
- *   6. On send-failure / timeout / no-session / thrown error:
- *      setBriefError, markFailed, emit brief_failed.
+ *   4. dispatchScope({ role: 'researcher', agent: runner, ... }) —
+ *      buildBriefing applies the researcher persona.
+ *   5. Tap onEvent for throttled brief_progress broadcasts.
+ *   6. On reply: parse citations, setBriefResult, markComplete,
+ *      emit brief_completed.
+ *   7. On any failure: setBriefError, markFailed, emit brief_failed.
  *
- * The orchestrator is fire-and-forget at the API boundary
- * (POST /api/briefs/[id]/run returns immediately after kicking
- * runBrief; the brief progresses asynchronously and the UI
- * subscribes to SSE for updates).
+ * Fire-and-forget at the API boundary; the UI subscribes to SSE.
  */
 
 import { queryOne } from '@/lib/db';
@@ -45,50 +50,43 @@ import {
 } from '@/lib/db/briefs';
 import { getTopic } from '@/lib/db/topics';
 import { broadcast } from '@/lib/events';
-import {
-  sendChatAndAwaitReply,
-  type ChatEvent,
-  type SendChatAgent,
-} from '@/lib/openclaw/send-chat';
+import { dispatchScope } from '@/lib/agents/dispatch-scope';
+import { getRunnerAgent } from '@/lib/agents/runner';
+import type { ChatEvent } from '@/lib/openclaw/send-chat';
 
-/** Default budget for a brief: 5 minutes. Configurable per-call. */
 const DEFAULT_BRIEF_TIMEOUT_MS = 5 * 60 * 1000;
-
-/** Throttle progress broadcasts to one per 750ms — enough for the UI
- *  to feel live without flooding SSE consumers with token chunks. */
 const PROGRESS_BROADCAST_INTERVAL_MS = 750;
 
 export interface RunBriefOptions {
   timeoutMs?: number;
   /** Test-only: when true, runBrief awaits the dispatch promise rather
-   *  than returning immediately. Production callers leave it unset
-   *  (fire-and-forget). */
+   *  than returning immediately. */
   awaitCompletionForTesting?: boolean;
 }
 
 export interface RunBriefResult {
   brief_id: string;
   agent_run_id: string;
-  /** "started" — orchestrator kicked dispatch. Consumers tail SSE for
-   *  the actual outcome. */
   state: 'started' | 'rejected';
-  /** Set when state === 'rejected'. */
   reason?: string;
 }
 
-interface ResearcherRow {
+/**
+ * The researcher roster entry — any agent row in the workspace with
+ * role='researcher'. The row may be `source='local'` with no
+ * `gateway_agent_id` (role-only ephemeral marker, the canonical
+ * shape) or a real gateway-bound row (legacy / hand-provisioned).
+ * We don't care which; presence is what matters.
+ */
+interface ResearcherRosterEntry {
   id: string;
   name: string;
-  session_key_prefix: string | null;
-  gateway_agent_id: string | null;
-  model: string | null;
 }
 
-function resolveResearcher(workspaceId: string): ResearcherRow | null {
+function resolveResearcherRosterEntry(workspaceId: string): ResearcherRosterEntry | null {
   return (
-    queryOne<ResearcherRow>(
-      `SELECT id, name, session_key_prefix, gateway_agent_id, model
-         FROM agents
+    queryOne<ResearcherRosterEntry>(
+      `SELECT id, name FROM agents
         WHERE workspace_id = ? AND role = 'researcher' AND COALESCE(is_active, 1) = 1
         LIMIT 1`,
       [workspaceId],
@@ -134,9 +132,7 @@ export function buildBriefPrompt(input: BuildPromptInput): string {
 /**
  * Best-effort citation extraction from a markdown body. Looks for
  * inline markdown links `[label](url)` and produces one citation per
- * unique URL. Phase 1 is intentionally unsophisticated — promote to
- * structured-output prompting in phase 2 once we have a corpus to
- * test against.
+ * unique URL.
  */
 export function parseCitations(markdown: string): BriefCitation[] {
   if (!markdown) return [];
@@ -155,11 +151,8 @@ export function parseCitations(markdown: string): BriefCitation[] {
 
 /**
  * Extract a single concatenated text body from the gateway's
- * collected ChatEvents. The gateway emits events with `message`
- * either as a string or as an object with role/content; we walk
- * both shapes and concatenate the assistant-side text. The final
- * "done" event typically carries the full reply but we fall back
- * to the concatenated stream if it's missing.
+ * collected ChatEvents. The done event typically carries the full
+ * reply but we fall back to the concatenated stream if missing.
  */
 export function extractReplyText(reply: ChatEvent[], doneEvent?: ChatEvent): string {
   const fromDone = readMessageText(doneEvent?.message);
@@ -177,7 +170,6 @@ function readMessageText(message: unknown): string | null {
     const content = (message as { content: unknown }).content;
     if (typeof content === 'string') return content;
     if (Array.isArray(content)) {
-      // Best-effort: concatenate any string entries.
       return content
         .map(c => (typeof c === 'string' ? c : typeof c === 'object' && c && 'text' in c && typeof (c as { text: unknown }).text === 'string' ? (c as { text: string }).text : ''))
         .filter(Boolean)
@@ -194,7 +186,6 @@ function emit(
   try {
     broadcast({ type, payload });
   } catch (err) {
-    // SSE failures must never sink the orchestrator. Log and continue.
     console.error(`[run-brief] failed to broadcast ${type}:`, err);
   }
 }
@@ -215,36 +206,51 @@ async function runBriefInternal(briefId: string, options: RunBriefOptions): Prom
     return;
   }
 
-  const researcher = resolveResearcher(brief.workspace_id);
+  // 1. Verify the workspace has opted in to research by adding a
+  //    researcher to its roster. The row is a roster marker only —
+  //    actual dispatch goes through the runner with the persona
+  //    applied at briefing time.
+  const researcher = resolveResearcherRosterEntry(brief.workspace_id);
   if (!researcher) {
-    const msg = `No active researcher agent found in workspace ${brief.workspace_id}`;
+    const msg =
+      `This workspace has no researcher in its roster. Add one via ` +
+      `Agents → "Add agents" → pick a team that includes a researcher ` +
+      `(e.g. "Research & write") or pick the Researcher role directly. ` +
+      `Then re-run this brief.`;
     setBriefError(briefId, msg);
     markFailed(brief.agent_run_id, { error_md: msg });
-    emit('brief_failed', briefShape(brief, { error: msg }));
+    emit('brief_failed', briefShape(brief, { error: msg, reason: 'no_researcher_in_roster' }));
+    return;
+  }
+
+  // 2. Resolve the workspace runner — the only gateway agent that
+  //    actually hosts the chat session.
+  const runner = getRunnerAgent();
+  if (!runner) {
+    const msg =
+      `No runner agent registered. The runner (mc-runner-dev) is the ` +
+      `gateway-bound host for all role-scoped sessions. Provision it ` +
+      `via the openclaw gateway, then re-run.`;
+    setBriefError(briefId, msg);
+    markFailed(brief.agent_run_id, { error_md: msg });
+    emit('brief_failed', briefShape(brief, { error: msg, reason: 'no_runner' }));
     return;
   }
 
   const topic = brief.topic_id ? getTopic(brief.topic_id) : null;
-  const assembledPrompt = buildBriefPrompt({
+  const triggerBody = buildBriefPrompt({
     template: brief.template,
     title: brief.title,
     prompt: brief.prompt,
     topicContext: topic ? { name: topic.name, description: topic.description } : null,
   });
 
-  // Move into running BEFORE we send so SSE consumers see the state
-  // transition as the source of truth for "this brief is alive."
+  // 3. Move into running BEFORE we send so SSE consumers see the
+  //    state transition as the source of truth for "this brief is alive."
   markRunning(brief.agent_run_id, {
-    model_used: researcher.model ?? null,
+    model_used: runner.model ?? null,
   });
   emit('brief_started', briefShape(brief, { workspace_id: brief.workspace_id }));
-
-  const agent: SendChatAgent = {
-    id: researcher.id,
-    name: researcher.name,
-    session_key_prefix: researcher.session_key_prefix ?? undefined,
-    gateway_agent_id: researcher.gateway_agent_id ?? undefined,
-  };
 
   let lastProgressBroadcastAt = 0;
   const onEvent = (event: ChatEvent) => {
@@ -257,19 +263,36 @@ async function runBriefInternal(briefId: string, options: RunBriefOptions): Prom
     }));
   };
 
-  let reply;
+  // 4. dispatchScope handles: scope_key derivation, mc_sessions
+  //    bookkeeping, briefing composition (researcher persona),
+  //    chat.send + reply collection.
+  let result;
   try {
-    reply = await sendChatAndAwaitReply({
-      agent,
-      message: assembledPrompt,
+    result = await dispatchScope({
+      workspace_id: brief.workspace_id,
+      role: 'researcher',
+      agent: runner,
+      session_suffix: `brief-${brief.id}`,
+      trigger_body: triggerBody,
       timeoutMs: options.timeoutMs ?? DEFAULT_BRIEF_TIMEOUT_MS,
       onEvent,
+      attempt_strategy: 'fresh',
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     setBriefError(briefId, msg);
     markFailed(brief.agent_run_id, { error_md: msg });
-    emit('brief_failed', briefShape(brief, { error: msg }));
+    emit('brief_failed', briefShape(brief, { error: msg, reason: 'dispatch_threw' }));
+    return;
+  }
+
+  const reply = result.reply;
+  if (!reply) {
+    // dry_run path — should not happen in production. Fail loudly.
+    const msg = 'dispatchScope returned no reply (dry-run?); cannot complete brief.';
+    setBriefError(briefId, msg);
+    markFailed(brief.agent_run_id, { error_md: msg });
+    emit('brief_failed', briefShape(brief, { error: msg, reason: 'no_reply' }));
     return;
   }
 
@@ -281,7 +304,7 @@ async function runBriefInternal(briefId: string, options: RunBriefOptions): Prom
         : `dispatch failed: ${reply.reason ?? 'unknown'}`;
     setBriefError(briefId, msg);
     markFailed(brief.agent_run_id, { error_md: msg });
-    emit('brief_failed', briefShape(brief, { error: msg, reason: reply.reason }));
+    emit('brief_failed', briefShape(brief, { error: msg, reason: reply.reason ?? 'dispatch_failed' }));
     return;
   }
 
@@ -305,7 +328,15 @@ async function runBriefInternal(briefId: string, options: RunBriefOptions): Prom
   const citations = parseCitations(body);
   setBriefResult(briefId, { result_md: body, citations });
   markComplete(brief.agent_run_id);
-  emit('brief_completed', briefShape(brief, { citation_count: citations.length }));
+  emit('brief_completed', briefShape(brief, {
+    citation_count: citations.length,
+    scope_key: result.scope_key,
+    briefing_bytes: result.briefing_bytes,
+  }));
+  // Touch researcher to mark "use" — silences unused-var lint while
+  // also providing a hook if we want to surface researcher attribution
+  // in completion events later.
+  void researcher;
 }
 
 function briefShape(brief: Brief, extras: Record<string, unknown> = {}): Record<string, unknown> {
@@ -319,12 +350,6 @@ function briefShape(brief: Brief, extras: Record<string, unknown> = {}): Record<
   };
 }
 
-/**
- * Public entry point. Kicks runBriefInternal asynchronously and
- * returns immediately so the API route doesn't block the request
- * cycle. Tests can pass `awaitCompletionForTesting: true` to await
- * the full dispatch.
- */
 export async function runBrief(
   briefId: string,
   options: RunBriefOptions = {},
@@ -347,9 +372,6 @@ export async function runBrief(
   }
 
   const promise = runBriefInternal(briefId, options).catch(err => {
-    // Belt-and-braces: any uncaught path inside the orchestrator
-    // should still mark the brief failed rather than leaving it
-    // running forever.
     console.error(`[run-brief] uncaught failure in orchestrator:`, err);
     const errMsg = err instanceof Error ? err.message : String(err);
     try {


### PR DESCRIPTION
## Summary
Phase-2 follow-up to the freshly merged research stack. Two related changes:

1. **Dispatch refactor.** Briefs now dispatch through the workspace runner via `dispatchScope` instead of raw `send-chat`. The researcher persona (SOUL/AGENTS/IDENTITY from `agent-templates/researcher/`) is composed into the briefing automatically. The agent system is built around exactly two real gateway agents per workspace (the runner + the PM); every other "agent" is a role-only roster entry that the runner takes on via persona-scoped sessions.
2. **Preflight UX.** The Research hub now surfaces a clear amber banner when the workspace is missing a researcher (or a runner), the "Run a brief" button is gated when preflight isn't OK, and the AppNav shows an `AlertCircle` next to "Research" so the operator notices from any route. Banner + nav dot clear live as soon as a researcher is added (SSE `agent_spawned` triggers re-check).

## Changes
### Dispatch (commit 1)
- `src/lib/research/run-brief.ts` — rewritten around `dispatchScope`. New failure modes: `no_researcher_in_roster` (points at Add Agents picker) and `no_runner` (points at runner provisioning). `brief_completed` payload now carries `scope_key` + `briefing_bytes`.
- `src/lib/research/run-brief.test.ts` — `ensureRunner` helper; missing-researcher and missing-runner cases. 18/18 pass.
- `src/lib/research/eval/runner.ts` — eval harness uses the same roster+runner shape.
- `src/app/api/briefs/[id]/run/route.test.ts` — 202 happy-path now ensures runner.
- `specs/research-area-validation/00-baseline-observations.md` — §2/§3 reflect the roster-marker model.

### Preflight UX (commit 2)
- `src/components/research/useResearchPreflight.ts` — hook checks `/api/agents` for researcher-in-workspace + runner-anywhere; re-runs on `agent_spawned`/`agents_cleared` SSE events.
- `src/app/(app)/research/page.tsx` — amber banner at top with inline link to `/agents`; "Run a brief" disabled when preflight isn't OK.
- `src/components/shell/AppNav.tsx` — `AlertCircle` next to "Research" label whenever preflight isn't OK; silent when healthy.

## Test plan
- [x] `NODE_ENV=test yarn tsx --test src/lib/research/run-brief.test.ts` → 18 / 18
- [x] `NODE_ENV=test yarn tsx --test src/lib/research/eval/{rubric,runner}.test.ts` → 12 / 12
- [x] `find src/app/api/briefs -name 'route.test.ts' -print0 | xargs -0 yarn tsx --test` → 8 / 8
- [x] `yarn test` → **671 / 671** (was 663 baseline; +8 net new from the dispatch slice)
- [x] `yarn tsc --noEmit` → only the 2 pre-existing `pm-decompose.test.ts` failures
- [x] **Preview-verified**: empty workspace shows banner + dimmed button + nav dot. Adding a researcher row + reload clears all three. No console errors.

## Operator notes
- Synthetic `researcher-default-validation` row dropped from the dev DB.
- Add a researcher to a workspace via **Agents → "Add agents" → Researcher** (or the "Research & write" team) — no openclaw provisioning needed.

## Pre-existing failures noted
- `pm-decompose.test.ts:169` TS2578 unused `@ts-expect-error`.
- `pm-decompose.test.ts:173` TS2322 type mismatch.
- `next build` on `/initiatives` — useSearchParams Suspense issue, predates this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)