### PR TITLE
fix(dialogs): stop focus-trap effects from re-running on every parent render

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -52,16 +52,24 @@ export function ConfirmDialog({
 }: ConfirmDialogProps) {
   const confirmRef = useRef<HTMLButtonElement | null>(null);
 
+  // Stash onCancel in a ref so the open/setup effect can depend on
+  // `open` ALONE. Including onCancel in the dep array re-ran the
+  // effect on every parent render (most callers pass a fresh closure
+  // for onCancel), which re-stole focus to the confirm button.
+  // Same fix as Drawer.tsx.
+  const onCancelRef = useRef(onCancel);
+  useEffect(() => { onCancelRef.current = onCancel; }, [onCancel]);
+
   // Focus the primary button on open + close on Escape.
   useEffect(() => {
     if (!open) return;
     confirmRef.current?.focus();
     const onKey = (ev: KeyboardEvent) => {
-      if (ev.key === 'Escape') onCancel();
+      if (ev.key === 'Escape') onCancelRef.current();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [open, onCancel]);
+  }, [open]);
 
   if (!open) return null;
 

--- a/src/components/DecomposeStoryToTasksModal.tsx
+++ b/src/components/DecomposeStoryToTasksModal.tsx
@@ -16,7 +16,7 @@
  *   - POST /api/pm/proposals/[id]/accept    (apply transactionally)
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Sparkles, Send, RefreshCw, Plus, Trash2, ArrowUp, ArrowDown, X } from 'lucide-react';
 
 interface InitiativeLite {
@@ -165,16 +165,20 @@ export default function DecomposeStoryToTasksModal({
     };
   }, [proposalId, dispatchState, initiative.id, initiative.workspace_id]);
 
+  // Stash onClose in a ref so the keydown subscription doesn't churn
+  // on every parent render — same fix as Drawer.tsx.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
-        onClose();
+        onCloseRef.current();
       }
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
-  }, [onClose]);
+  }, []);
 
   const refine = async () => {
     if (!proposalId || !refineText.trim()) return;

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -29,7 +29,7 @@
  * superseded chain — the modal swaps in the new proposal's diffs.
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Sparkles, Send, RefreshCw, Plus, Trash2, ArrowUp, ArrowDown, X } from 'lucide-react';
 
 interface InitiativeLite {
@@ -183,17 +183,21 @@ export default function DecomposeWithPmModal({
     };
   }, [proposalId, dispatchState, initiative.id, initiative.workspace_id]);
 
-  // Esc to close.
+  // Esc to close. Stash onClose in a ref so the keydown subscription
+  // doesn't churn on every parent render (caller-supplied onClose is
+  // typically a fresh closure). Same fix as Drawer.tsx.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
-        onClose();
+        onCloseRef.current();
       }
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
-  }, [onClose]);
+  }, []);
 
   const refine = async () => {
     if (!proposalId || !refineText.trim()) return;

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -28,6 +28,16 @@ export default function Drawer({
 }) {
   const panelRef = useRef<HTMLDivElement | null>(null);
   const previouslyFocused = useRef<HTMLElement | null>(null);
+  // Stash onClose in a ref so the open/setup effect can depend on
+  // `open` ALONE. Including onClose in the dep array re-ran the
+  // effect on every parent render (typical onClose props are fresh
+  // closures), which re-stole focus to the first focusable element
+  // (the X close button) on every keystroke in form fields. The
+  // keydown handler reads from the ref, so it always sees the
+  // current onClose without needing a re-subscription.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
+
   // Render via portal so the fixed-positioned panel can't get trapped by
   // an ancestor that creates a containing block (e.g. a parent flex column,
   // CSS containment, or future transform). Mount-gated to keep SSR happy.
@@ -40,19 +50,27 @@ export default function Drawer({
 
     previouslyFocused.current = (document.activeElement as HTMLElement) || null;
 
-    // Move focus into the drawer.
+    // Move focus into the drawer. Prefer an autoFocus'd input over
+    // the close button so opening the drawer lands the cursor where
+    // the operator most likely wants it. Falls back to the first
+    // focusable if no autofocus target exists.
     const panel = panelRef.current;
     if (panel) {
-      const focusable = panel.querySelector<HTMLElement>(
-        'input, textarea, select, button, [tabindex]:not([tabindex="-1"])',
-      );
-      focusable?.focus();
+      const autofocus =
+        panel.querySelector<HTMLElement>('[autofocus]') ??
+        panel.querySelector<HTMLElement>(
+          'input, textarea, select, [tabindex]:not([tabindex="-1"])',
+        ) ??
+        panel.querySelector<HTMLElement>(
+          'button, [tabindex]:not([tabindex="-1"])',
+        );
+      autofocus?.focus();
     }
 
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
-        onClose();
+        onCloseRef.current();
         return;
       }
       if (e.key === 'Tab' && panel) {
@@ -85,7 +103,9 @@ export default function Drawer({
       document.body.style.overflow = prevOverflow;
       previouslyFocused.current?.focus?.();
     };
-  }, [open, onClose]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onClose
+    // deliberately excluded; see onCloseRef above.
+  }, [open]);
 
   if (!open || !mounted) return null;
 


### PR DESCRIPTION
## Summary
Sweep for an anti-pattern in dialog/drawer components: \`useEffect\` that subscribes a keydown listener (and sometimes calls \`.focus()\`) with \`onClose\` / \`onCancel\` in its dep array. Most callers pass a fresh closure each render (\`onClose={() => setOpen(false)}\`), so the effect re-ran on every parent render — which re-stole focus when the effect calls \`.focus()\`, and otherwise churned listener subscriptions for no reason.

User-reported on the Create Topic drawer: typing in the Name field made focus jump to the X close button, dropping every keystroke after the first.

## Components fixed
| File | Symptom |
|---|---|
| \`Drawer.tsx\` | Focus-stealing — first focusable in panel was the X. Visible bug. |
| \`ConfirmDialog.tsx\` | Re-focuses confirm button on every parent render. |
| \`DecomposeWithPmModal.tsx\` | Keydown-only; listener thrash, no focus theft. Preventative fix. |
| \`DecomposeStoryToTasksModal.tsx\` | Same as above. |

\`AlertDialog.tsx\` already depended only on \`[state.open]\` and is fine.

## Pattern applied
- Stash the callback in a \`useRef\`, refresh on prop change.
- Effect deps narrowed to \`[open]\` (or \`[]\` where appropriate).
- Keydown handler reads from the ref so it always sees the current callback without re-subscribing.
- In \`Drawer\`: when picking what to focus on open, prefer \`[autofocus]\` then inputs/selects, then buttons — avoids the close button grabbing initial focus by accident.

## Test plan
- [x] **Create Topic drawer (Drawer + bug repro)**: scripted-typed 5 chars into Name field; focus stayed on input every keystroke; value reads \`"hello"\`. Previously, every keystroke jumped focus to X.
- [x] **Topic detail Archive (ConfirmDialog)**: opened dialog, focus landed on Archive button and stayed; cancelled cleanly.
- [x] No console errors throughout.
- [x] \`yarn tsc --noEmit\` — only the 2 pre-existing \`pm-decompose.test.ts\` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)