### PR TITLE
feat(research): delete briefs + brief-mode override (no register_deliverable)

### DIFF
--- a/src/app/(app)/research/briefs/[id]/page.tsx
+++ b/src/app/(app)/research/briefs/[id]/page.tsx
@@ -3,11 +3,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { ArrowLeft, ExternalLink, RefreshCw, RotateCw } from 'lucide-react';
+import { ArrowLeft, ExternalLink, RefreshCw, RotateCw, Trash2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useMissionControl } from '@/lib/store';
 import { formatDistanceToNow } from 'date-fns';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 
 interface Brief {
   id: string;
@@ -57,6 +58,9 @@ export default function BriefDetailPage() {
   const [showCitations, setShowCitations] = useState(false);
   const [rerunning, setRerunning] = useState(false);
   const [rerunError, setRerunError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (!params.id) return;
@@ -106,6 +110,24 @@ export default function BriefDetailPage() {
       setRerunning(false);
     }
   }, [brief, rerunning, router]);
+
+  const doDelete = useCallback(async () => {
+    if (!brief || deleting) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const res = await fetch(`/api/briefs/${brief.id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `Delete failed (${res.status})`);
+      }
+      router.push(brief.topic_id ? `/research/topics/${brief.topic_id}` : '/research');
+    } catch (e) {
+      setDeleteError(e instanceof Error ? e.message : 'Delete failed');
+      setDeleting(false);
+      setConfirmDelete(false);
+    }
+  }, [brief, deleting, router]);
 
   if (error) return <div className="p-6 text-red-300">{error}</div>;
   if (!brief || !run) return <div className="p-6 text-mc-text-secondary">{loading ? 'Loading…' : 'Brief not found.'}</div>;
@@ -164,6 +186,16 @@ export default function BriefDetailPage() {
             <RotateCw className={`w-3.5 h-3.5 ${rerunning ? 'animate-spin' : ''}`} />
             {rerunning ? 'Re-running…' : 'Re-run'}
           </button>
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(true)}
+            disabled={deleting}
+            title="Delete this brief"
+            aria-label="Delete brief"
+            className="p-2 rounded-sm border border-mc-border text-red-300/80 hover:bg-red-900/20 hover:text-red-300 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+          </button>
         </div>
       </header>
 
@@ -177,6 +209,12 @@ export default function BriefDetailPage() {
       {rerunError && (
         <div className="mb-4 px-3 py-2 rounded-sm bg-red-900/20 border border-red-500/30 text-red-300 text-sm">
           {rerunError}
+        </div>
+      )}
+
+      {deleteError && (
+        <div className="mb-4 px-3 py-2 rounded-sm bg-red-900/20 border border-red-500/30 text-red-300 text-sm">
+          {deleteError}
         </div>
       )}
 
@@ -226,6 +264,16 @@ export default function BriefDetailPage() {
           )}
         </section>
       )}
+
+      <ConfirmDialog
+        open={confirmDelete}
+        title="Delete this brief?"
+        body={`The brief "${brief.title}" and its agent run will be permanently removed. This cannot be undone.`}
+        confirmLabel={deleting ? 'Deleting…' : 'Delete'}
+        destructive
+        onConfirm={doDelete}
+        onCancel={() => setConfirmDelete(false)}
+      />
     </div>
   );
 }

--- a/src/app/api/briefs/[id]/route.ts
+++ b/src/app/api/briefs/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getBrief } from '@/lib/db/briefs';
+import { deleteBrief, getBrief } from '@/lib/db/briefs';
 import { getAgentRun } from '@/lib/db/agent-runs';
+import { broadcast } from '@/lib/events';
 
 export const dynamic = 'force-dynamic';
 
@@ -20,4 +21,40 @@ export async function GET(
   if (!brief) return NextResponse.json({ error: 'Brief not found' }, { status: 404 });
   const agent_run = getAgentRun(brief.agent_run_id);
   return NextResponse.json({ brief, agent_run });
+}
+
+/**
+ * DELETE /api/briefs/[id]
+ *
+ * Hard-deletes the brief and its 1:1 agent_run. Allowed in any state
+ * (incorrect prompt, no longer relevant, mid-flight) — the
+ * orchestrator's writes after deletion silently no-op.
+ */
+export async function DELETE(
+  _request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  const brief = getBrief(id);
+  if (!brief) return NextResponse.json({ error: 'Brief not found' }, { status: 404 });
+  const ok = deleteBrief(id);
+  if (!ok) return NextResponse.json({ error: 'Brief not found' }, { status: 404 });
+  // Tell the hub + topic detail to refresh.
+  try {
+    broadcast({
+      type: 'brief_failed', // re-using the existing channel to trigger
+                            // the hub's "RELEVANT_EVENTS" refetch path
+                            // without minting a brand-new event type.
+      payload: {
+        brief_id: id,
+        agent_run_id: brief.agent_run_id,
+        workspace_id: brief.workspace_id,
+        topic_id: brief.topic_id,
+        deleted: true,
+      },
+    });
+  } catch {
+    // SSE broadcast failure must not block deletion.
+  }
+  return NextResponse.json({ deleted: true, brief_id: id });
 }

--- a/src/lib/db/briefs.test.ts
+++ b/src/lib/db/briefs.test.ts
@@ -231,3 +231,17 @@ test('FK SET NULL: archiving topic does not affect existing briefs; deleting top
   run(`DELETE FROM topics WHERE id = ?`, [topic.id]);
   assert.equal(getBrief(brief.id)?.topic_id, null);
 });
+
+test('deleteBrief: removes the brief and its agent_run via FK cascade', async () => {
+  const { deleteBrief } = await import('./briefs');
+  const ws = freshWorkspace();
+  const { brief, agent_run } = createBriefWithRun(baseInput(ws));
+  assert.equal(deleteBrief(brief.id), true);
+  assert.equal(getBrief(brief.id), null);
+  assert.equal(getAgentRun(agent_run.id), null);
+});
+
+test('deleteBrief: returns false for unknown id', async () => {
+  const { deleteBrief } = await import('./briefs');
+  assert.equal(deleteBrief('does-not-exist'), false);
+});

--- a/src/lib/db/briefs.ts
+++ b/src/lib/db/briefs.ts
@@ -226,6 +226,30 @@ export function setBriefResult(id: string, input: SetBriefResultInput): Brief | 
   return getBrief(id);
 }
 
+/**
+ * Hard-delete a brief and its 1:1 agent_run.
+ *
+ * Schema is `briefs.agent_run_id REFERENCES agent_runs(id) ON DELETE
+ * CASCADE` — so deleting the agent_run cascades into the brief. We
+ * delete the agent_run as the entry point (the brief goes with it
+ * via cascade) so we don't leave orphan run rows behind.
+ *
+ * No status guard — operators can delete a brief in any state,
+ * including mid-flight. The orchestrator's writes after deletion
+ * (setBriefResult / markComplete / setBriefError) all do
+ * `getBrief(id)` first and silently no-op when the row is gone.
+ *
+ * Returns `true` when the brief existed (and was removed), `false`
+ * when the id was unknown.
+ */
+export function deleteBrief(id: string): boolean {
+  const brief = getBrief(id);
+  if (!brief) return false;
+  // Cascade: deleting the agent_run row removes the brief too.
+  run(`DELETE FROM agent_runs WHERE id = ?`, [brief.agent_run_id]);
+  return true;
+}
+
 export function setBriefError(id: string, errorMd: string): Brief | null {
   const current = getBrief(id);
   if (!current) return null;

--- a/src/lib/research/run-brief.test.ts
+++ b/src/lib/research/run-brief.test.ts
@@ -201,6 +201,25 @@ test('buildBriefPrompt: omits topic section when not supplied', () => {
   assert.doesNotMatch(prompt, /Topic context/);
 });
 
+test('buildBriefPrompt: includes the brief-mode override (no register_deliverable / update_task_status)', () => {
+  // Pinning the contract: the researcher persona's AGENTS.md tells the
+  // agent to call register_deliverable + update_task_status as its
+  // closing sequence. Briefs aren't tasks, so those calls fail. The
+  // assembled prompt MUST include an explicit override telling the
+  // agent to deliver via reply text instead. Drift in this string
+  // re-introduces the old "couldn't find that task" failure mode.
+  const prompt = buildBriefPrompt({
+    template: 'general_brief',
+    title: 't',
+    prompt: 'p',
+    topicContext: null,
+  });
+  assert.match(prompt, /NOT a Mission Control task/i);
+  assert.match(prompt, /register_deliverable/);
+  assert.match(prompt, /update_task_status/);
+  assert.match(prompt, /replying with the brief body/i);
+});
+
 // ─── orchestrator: happy path ───────────────────────────────────────
 
 test('runBrief: happy path → running → complete with parsed citations', async () => {

--- a/src/lib/research/run-brief.ts
+++ b/src/lib/research/run-brief.ts
@@ -130,6 +130,25 @@ export interface BuildPromptInput {
 export function buildBriefPrompt(input: BuildPromptInput): string {
   const sections: string[] = [];
   sections.push(`# Research Brief request: ${input.title}`);
+  // Override the persona's task-completion sequence. The researcher
+  // AGENTS.md instructs the agent to call `register_deliverable` /
+  // `update_task_status` keyed on `task_id` — but briefs aren't
+  // tasks, so those calls fail. The orchestrator captures the agent's
+  // reply text directly via sendChatAndAwaitReply. Tell the agent
+  // explicitly so it doesn't waste tokens (and produce a confused
+  // "couldn't find that task" trail) on the deliverable flow.
+  sections.push(
+    `## How to deliver this brief\n\n` +
+    `**This is a Research Brief, NOT a Mission Control task.** Do NOT call ` +
+    `\`register_deliverable\`, \`update_task_status\`, or \`log_activity\`. ` +
+    `The \`task_id\` you see in your briefing is a synthetic scope key — ` +
+    `there is no underlying task row, and these tool calls will fail.\n\n` +
+    `**Deliver by replying with the brief body as your final assistant ` +
+    `message.** The orchestrator captures whatever text you reply with as ` +
+    `the brief's \`result_md\` and parses citations from inline markdown ` +
+    `links. No \`take_note\` / breadcrumb chain is needed — there is no ` +
+    `next stage; the operator reads your reply directly.`,
+  );
   if (input.topicContext) {
     sections.push(
       `## Topic context\n` +


### PR DESCRIPTION
Stacked on **#169** (\`fix/research-resilience\`). Two related fixes from operator dogfood.

## 1. Delete briefs
- **\`deleteBrief()\` DAO** removes the brief and its 1:1 agent_run via FK cascade (\`briefs.agent_run_id REFERENCES agent_runs(id) ON DELETE CASCADE\` — so we delete the agent_run as the entry point, the brief goes with it).
- **\`DELETE /api/briefs/[id]\`** wired to it. Allowed in any state including mid-flight; orchestrator's writes after deletion silently no-op because \`getBrief\` returns null.
- **Brief detail UI**: small red trash icon next to Re-run, gated by \`ConfirmDialog\` (destructive). On success → navigate back to the parent topic if attached, else the hub.
- Broadcasts a \`brief_failed\` SSE event with \`deleted: true\` so the hub re-fetches.

## 2. Brief-mode briefing override
The session log the operator attached to this request ends with:
> ⚠️ Note: The task ID from the dispatch (\`brief-1cff7fc3-...\`) wasn't recognized as a valid MC task in this workspace, so I couldn't complete the standard \`register_deliverable\`/\`update_task_status\` flow.

Researcher persona's AGENTS.md instructs the agent to close out with \`register_deliverable\` + \`update_task_status\` keyed on \`task_id\`. Briefs aren't tasks — those tool calls fail with "task not found" and the agent wastes tokens on a confused trail (visible in the SoTA brief result body before this fix).

\`buildBriefPrompt\` now prepends a **"How to deliver this brief"** section that explicitly:
- tells the agent this is NOT a task
- says don't call \`register_deliverable\` / \`update_task_status\` / \`log_activity\`
- points at "deliver by replying with the brief body" (which is what the orchestrator already captures)

Test pinned so the contract doesn't drift silently — re-introducing the failure mode would break a unit test.

## Test plan
- [x] **DAO tests**: 17 (was 15; +2 for deleteBrief — happy path + unknown id)
- [x] **Orchestrator tests**: 19 (was 18; +1 pins the brief-mode override text)
- [x] \`yarn tsc --noEmit\` — only the 2 pre-existing \`pm-decompose.test.ts\` failures
- [x] **Preview-verified live**:
  - Trash icon visible on brief detail page
  - Click → \`ConfirmDialog\` "Delete this brief?" with destructive (red) styling
  - Confirm → brief + cascaded agent_run row both gone from DB
  - Navigated back to parent topic page
  - No console errors
- [ ] Brief-mode override behavior verifiable on next live brief run; test pin is the regression bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)