### PR TITLE
feat(research): PM-driven topic + brief suggestions

### DIFF
--- a/src/app/(app)/research/page.tsx
+++ b/src/app/(app)/research/page.tsx
@@ -11,12 +11,13 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Plus, RefreshCw, Search, FileText, Zap, Archive, AlertTriangle } from 'lucide-react';
+import { Plus, RefreshCw, Search, FileText, Zap, Archive, AlertTriangle, Sparkles } from 'lucide-react';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 import { useMissionControl } from '@/lib/store';
 import { formatDistanceToNow } from 'date-fns';
 import { CreateTopicDrawer } from '@/components/research/CreateTopicDrawer';
 import { RunBriefDrawer } from '@/components/research/RunBriefDrawer';
+import { SuggestPickerDrawer } from '@/components/research/SuggestPickerDrawer';
 import { useResearchPreflight } from '@/components/research/useResearchPreflight';
 
 interface TopicSummary {
@@ -70,6 +71,7 @@ export default function ResearchHubPage() {
   const [createTopicOpen, setCreateTopicOpen] = useState(false);
   const [runBriefOpen, setRunBriefOpen] = useState(false);
   const [activeTopicId, setActiveTopicId] = useState<string | null>(null);
+  const [suggestKind, setSuggestKind] = useState<'topic' | 'brief' | null>(null);
 
   const preflight = useResearchPreflight(workspaceId);
 
@@ -134,14 +136,26 @@ export default function ResearchHubPage() {
       <aside className="w-64 border-r border-mc-border bg-mc-bg-secondary flex flex-col shrink-0">
         <div className="px-3 py-2 border-b border-mc-border flex items-center justify-between">
           <span className="text-[10px] uppercase tracking-wider text-mc-text-secondary">Topics</span>
-          <button
-            type="button"
-            onClick={() => setCreateTopicOpen(true)}
-            className="p-1 rounded-sm text-mc-accent hover:bg-mc-bg-tertiary"
-            aria-label="Create topic"
-          >
-            <Plus className="w-4 h-4" />
-          </button>
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              onClick={() => setSuggestKind('topic')}
+              className="p-1 rounded-sm text-mc-text-secondary hover:text-mc-accent hover:bg-mc-bg-tertiary"
+              aria-label="Suggest topics"
+              title="Suggest topics from project state"
+            >
+              <Sparkles className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setCreateTopicOpen(true)}
+              className="p-1 rounded-sm text-mc-accent hover:bg-mc-bg-tertiary"
+              aria-label="Create topic"
+              title="Create topic from scratch"
+            >
+              <Plus className="w-4 h-4" />
+            </button>
+          </div>
         </div>
         <ul className="flex-1 overflow-y-auto py-1">
           <li>
@@ -193,6 +207,15 @@ export default function ResearchHubPage() {
             </button>
             <button
               type="button"
+              onClick={() => setSuggestKind('brief')}
+              title="Suggest briefs from project state"
+              className="px-3 py-1.5 text-sm rounded-sm border border-mc-border text-mc-text hover:bg-mc-bg-tertiary flex items-center gap-1.5"
+            >
+              <Sparkles className="w-3.5 h-3.5" />
+              Suggest
+            </button>
+            <button
+              type="button"
               onClick={() => setRunBriefOpen(true)}
               disabled={!preflight.ok && !preflight.loading}
               title={preflight.ok ? undefined : 'A researcher must be in this workspace before you can dispatch a brief'}
@@ -239,6 +262,15 @@ export default function ResearchHubPage() {
         workspaceId={workspaceId}
         onCreated={() => { setCreateTopicOpen(false); load(); }}
       />
+      {suggestKind && (
+        <SuggestPickerDrawer
+          open={!!suggestKind}
+          onClose={() => setSuggestKind(null)}
+          workspaceId={workspaceId}
+          kind={suggestKind}
+          onAccepted={() => { setSuggestKind(null); load(); }}
+        />
+      )}
       <RunBriefDrawer
         open={runBriefOpen}
         onClose={() => setRunBriefOpen(false)}

--- a/src/app/api/research/suggestions/[id]/route.ts
+++ b/src/app/api/research/suggestions/[id]/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  getSuggestion,
+  markAccepted,
+  markDismissed,
+  markRejected,
+  type BriefSuggestionPayload,
+  type TopicSuggestionPayload,
+} from '@/lib/db/research-suggestions';
+import { createTopic } from '@/lib/db/topics';
+import { createBriefWithRun } from '@/lib/db/briefs';
+
+export const dynamic = 'force-dynamic';
+
+const ActionSchema = z.object({
+  action: z.enum(['accept', 'reject', 'dismiss']),
+});
+
+/**
+ * POST /api/research/suggestions/[id] { action: 'accept' | 'reject' | 'dismiss' }
+ *
+ * Accept: creates the real topic / brief from the suggestion's
+ * payload, marks the suggestion accepted with `accepted_as_id`
+ * pointing at the new row. Briefs land queued (no auto-dispatch).
+ *
+ * Reject: marks rejected (signal for the PM not to re-suggest).
+ * Dismiss: marks dismissed (just noise; weaker signal).
+ */
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  const suggestion = getSuggestion(id);
+  if (!suggestion) {
+    return NextResponse.json({ error: 'Suggestion not found' }, { status: 404 });
+  }
+  if (suggestion.status !== 'pending') {
+    return NextResponse.json(
+      { error: `Suggestion is ${suggestion.status}, not pending` },
+      { status: 409 },
+    );
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Body must be JSON' }, { status: 400 });
+  }
+  const parsed = ActionSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  if (parsed.data.action === 'reject') {
+    return NextResponse.json(markRejected(id));
+  }
+  if (parsed.data.action === 'dismiss') {
+    return NextResponse.json(markDismissed(id));
+  }
+
+  // Accept: materialize the suggestion into a real topic or brief.
+  try {
+    if (suggestion.kind === 'topic') {
+      const p = suggestion.payload as TopicSuggestionPayload;
+      const topic = createTopic({
+        workspace_id: suggestion.workspace_id,
+        name: p.name,
+        description: p.description,
+        tags: p.tags,
+        default_brief_template: p.default_brief_template ?? null,
+      });
+      const updated = markAccepted(id, topic.id);
+      return NextResponse.json({ suggestion: updated, created: { kind: 'topic', topic } }, { status: 201 });
+    }
+
+    if (suggestion.kind === 'brief') {
+      const p = suggestion.payload as BriefSuggestionPayload;
+      const created = createBriefWithRun({
+        workspace_id: suggestion.workspace_id,
+        template: p.template,
+        title: p.title,
+        prompt: p.prompt,
+        topic_id: p.topic_id ?? null,
+        requested_by: `suggestion:${suggestion.id}`,
+      });
+      const updated = markAccepted(id, created.brief.id);
+      return NextResponse.json(
+        { suggestion: updated, created: { kind: 'brief', brief: created.brief, agent_run: created.agent_run } },
+        { status: 201 },
+      );
+    }
+
+    // recurring_brief is reserved for phase-2 schedules.
+    return NextResponse.json(
+      { error: `Cannot accept suggestion of kind '${suggestion.kind}' yet` },
+      { status: 501 },
+    );
+  } catch (error) {
+    console.error('Failed to accept research suggestion:', error);
+    const msg = error instanceof Error ? error.message : 'Failed to accept suggestion';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/research/suggestions/route.ts
+++ b/src/app/api/research/suggestions/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  listSuggestions,
+  type SuggestionKind,
+  type SuggestionStatus,
+} from '@/lib/db/research-suggestions';
+import { generateSuggestions } from '@/lib/research/suggest';
+
+export const dynamic = 'force-dynamic';
+
+const ALLOWED_KINDS: SuggestionKind[] = ['topic', 'brief', 'recurring_brief'];
+const ALLOWED_STATUSES: SuggestionStatus[] = ['pending', 'accepted', 'rejected', 'dismissed'];
+
+const PostSchema = z.object({
+  workspace_id: z.string().min(1),
+  kind: z.enum(['topic', 'brief']),
+});
+
+/**
+ * GET /api/research/suggestions?workspace_id=...&kind=...&status=...
+ * Lists suggestions in the workspace (default: status=pending).
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const workspaceId = searchParams.get('workspace_id');
+    if (!workspaceId) {
+      return NextResponse.json({ error: 'workspace_id is required' }, { status: 400 });
+    }
+    const kindParam = searchParams.get('kind');
+    const statusParam = searchParams.get('status') ?? 'pending';
+    if (kindParam && !ALLOWED_KINDS.includes(kindParam as SuggestionKind)) {
+      return NextResponse.json({ error: `kind must be one of: ${ALLOWED_KINDS.join(', ')}` }, { status: 400 });
+    }
+    if (statusParam && !ALLOWED_STATUSES.includes(statusParam as SuggestionStatus)) {
+      return NextResponse.json({ error: `status must be one of: ${ALLOWED_STATUSES.join(', ')}` }, { status: 400 });
+    }
+    return NextResponse.json(listSuggestions(workspaceId, {
+      kind: (kindParam as SuggestionKind | null) ?? undefined,
+      status: statusParam as SuggestionStatus,
+    }));
+  } catch (error) {
+    console.error('Failed to list research_suggestions:', error);
+    return NextResponse.json({ error: 'Failed to list suggestions' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/research/suggestions { workspace_id, kind }
+ * Kicks the PM dispatch synchronously and returns the new pending
+ * suggestions. Long-running (30–90s typical) — caller should show a
+ * spinner. Prior pending suggestions of the same kind are dismissed.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = PostSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const result = await generateSuggestions({
+      workspace_id: parsed.data.workspace_id,
+      kind: parsed.data.kind,
+    });
+    if (result.state === 'rejected') {
+      return NextResponse.json(
+        { error: result.reason, suggestions: [] },
+        { status: 409 },
+      );
+    }
+    if (result.state === 'failed') {
+      return NextResponse.json(
+        { error: result.reason, suggestions: [], raw: result.raw },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json(
+      { state: 'ok', suggestions: result.suggestions },
+      { status: 201 },
+    );
+  } catch (error) {
+    console.error('Failed to generate research suggestions:', error);
+    const msg = error instanceof Error ? error.message : 'Failed to generate suggestions';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/components/research/SuggestPickerDrawer.tsx
+++ b/src/components/research/SuggestPickerDrawer.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+/**
+ * Suggestion picker drawer.
+ *
+ * Open with `kind` ('topic' | 'brief'). On open it kicks the PM
+ * dispatch (POST /api/research/suggestions) and shows a spinner.
+ * When candidates arrive, each is a checkbox row with the rationale
+ * underneath. Operator multi-selects → "Insert N selected" → each
+ * accepted suggestion creates a real topic/brief. Briefs land
+ * queued (the brief detail page's "Run a brief" affordance stays
+ * the explicit dispatch trigger).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Sparkles, AlertTriangle, RefreshCw } from 'lucide-react';
+import Drawer from '@/components/Drawer';
+
+interface TopicPayload { name: string; description: string; tags: string[] }
+interface BriefPayload { title: string; prompt: string; topic_id?: string | null }
+type Payload = TopicPayload | BriefPayload;
+
+interface Suggestion {
+  id: string;
+  kind: 'topic' | 'brief' | 'recurring_brief';
+  payload: Payload;
+  rationale: string | null;
+  status: 'pending' | 'accepted' | 'rejected' | 'dismissed';
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  workspaceId: string;
+  kind: 'topic' | 'brief';
+  /** Called after the operator accepts ≥ 1 suggestion. */
+  onAccepted: () => void;
+}
+
+export function SuggestPickerDrawer({ open, onClose, workspaceId, kind, onAccepted }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+
+  const dispatchSuggest = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setSuggestions([]);
+    setSelected(new Set());
+    try {
+      const res = await fetch('/api/research/suggestions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ workspace_id: workspaceId, kind }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(body.error ?? `Request failed (${res.status})`);
+      }
+      setSuggestions(body.suggestions ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch suggestions');
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId, kind]);
+
+  // Auto-kick on open.
+  useEffect(() => {
+    if (open) dispatchSuggest();
+  }, [open, dispatchSuggest]);
+
+  const toggle = (id: string) => {
+    setSelected(s => {
+      const next = new Set(s);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const insertSelected = useCallback(async () => {
+    if (selected.size === 0 || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const ids = Array.from(selected);
+      const results = await Promise.all(
+        ids.map(id =>
+          fetch(`/api/research/suggestions/${id}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: 'accept' }),
+          }),
+        ),
+      );
+      const failed = results.filter(r => !r.ok);
+      if (failed.length > 0) {
+        throw new Error(`${failed.length} of ${results.length} suggestions failed to insert`);
+      }
+      onAccepted();
+      handleClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Insert failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [selected, submitting, onAccepted]);
+
+  const handleClose = () => {
+    if (submitting) return;
+    setSuggestions([]);
+    setSelected(new Set());
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Drawer
+      open={open}
+      title={`Suggest ${kind === 'topic' ? 'topics' : 'briefs'}`}
+      onClose={handleClose}
+      footer={
+        <div className="flex items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={dispatchSuggest}
+            disabled={loading || submitting}
+            className="text-xs text-mc-text-secondary hover:text-mc-accent flex items-center gap-1.5 disabled:opacity-40"
+          >
+            <RefreshCw className={`w-3.5 h-3.5 ${loading ? 'animate-spin' : ''}`} />
+            Suggest again
+          </button>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleClose}
+              disabled={submitting}
+              className="px-3 py-1.5 text-sm rounded-sm text-mc-text-secondary hover:bg-mc-bg-tertiary"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={insertSelected}
+              disabled={selected.size === 0 || submitting || loading}
+              className="px-3 py-1.5 text-sm rounded-sm bg-mc-accent text-mc-bg disabled:opacity-40 hover:opacity-90"
+            >
+              {submitting
+                ? 'Inserting…'
+                : selected.size === 0
+                  ? 'Select to insert'
+                  : `Insert ${selected.size} selected`}
+            </button>
+          </div>
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        <p className="text-xs text-mc-text-secondary">
+          The PM is surveying the workspace's initiatives, in-flight tasks, existing topics, and recent briefs to propose candidates. Pick one or more to insert. {kind === 'brief' && 'Briefs land queued — you still hit "Run" to dispatch.'}
+        </p>
+
+        {loading && (
+          <div className="flex items-center gap-2 text-sm text-mc-text-secondary px-3 py-4 rounded-sm bg-mc-bg-tertiary border border-mc-border">
+            <Sparkles className="w-4 h-4 text-mc-accent animate-pulse" />
+            <span>PM is thinking…</span>
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="flex items-start gap-2 px-3 py-2 rounded-sm bg-red-900/20 border border-red-500/30 text-red-300 text-sm">
+            <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+            <div className="flex-1">{error}</div>
+          </div>
+        )}
+
+        {!loading && !error && suggestions.length === 0 && (
+          <p className="text-sm text-mc-text-secondary/70 italic px-3 py-4">
+            No candidates returned. Click "Suggest again" to retry.
+          </p>
+        )}
+
+        {!loading && suggestions.length > 0 && (
+          <ul className="space-y-2">
+            {suggestions.map(s => {
+              const isSelected = selected.has(s.id);
+              const title = kind === 'topic'
+                ? (s.payload as TopicPayload).name
+                : (s.payload as BriefPayload).title;
+              const body = kind === 'topic'
+                ? (s.payload as TopicPayload).description
+                : (s.payload as BriefPayload).prompt;
+              return (
+                <li key={s.id}>
+                  <label className={`block px-3 py-2 rounded-sm border cursor-pointer ${
+                    isSelected
+                      ? 'border-mc-accent/60 bg-mc-accent/5'
+                      : 'border-mc-border bg-mc-bg-secondary hover:bg-mc-bg-tertiary'
+                  }`}>
+                    <div className="flex items-start gap-2">
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => toggle(s.id)}
+                        className="mt-1 shrink-0 accent-mc-accent"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium text-mc-text">{title}</div>
+                        <div className="text-xs text-mc-text-secondary mt-1 whitespace-pre-wrap">{body}</div>
+                        {s.rationale && (
+                          <div className="mt-2 text-[11px] text-mc-accent/80 italic">
+                            Why: {s.rationale}
+                          </div>
+                        )}
+                        {kind === 'topic' && (s.payload as TopicPayload).tags?.length > 0 && (
+                          <div className="flex flex-wrap gap-1 mt-1.5">
+                            {(s.payload as TopicPayload).tags.map(t => (
+                              <span key={t} className="text-[10px] px-1.5 py-0.5 rounded-sm bg-mc-bg-tertiary text-mc-text-secondary border border-mc-border">{t}</span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4155,6 +4155,54 @@ const migrations: Migration[] = [
       console.log('[Migration 075] agent_runs + topics + briefs tables created.');
     },
   },
+  {
+    id: '076',
+    name: 'research_suggestions',
+    up: (db) => {
+      // PM-driven topic / brief suggestions. Operator clicks Suggest
+      // on the Research hub → PM dispatch surveys workspace state →
+      // returns a small set of candidate topics or briefs → operator
+      // multi-selects → accepted ones become real topics/briefs
+      // (briefs land queued, no auto-dispatch).
+      //
+      // payload_json shape varies per kind:
+      //   topic:
+      //     { name, description, tags, default_brief_template? }
+      //   brief:
+      //     { title, prompt, topic_id?, template }
+      //   recurring_brief (RESERVED — not generated until phase-2
+      //     schedules ship; left in the CHECK so we don't have to
+      //     migrate when it lands):
+      //     { title, prompt, topic_id?, template, cadence }
+      //
+      // rationale: short why-this-matters string from the PM, shown
+      // alongside the candidate in the picker so the operator knows
+      // why it was suggested.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS research_suggestions (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          kind TEXT NOT NULL CHECK (kind IN (
+            'topic', 'brief', 'recurring_brief'
+          )),
+          payload_json TEXT NOT NULL,
+          rationale TEXT,
+          status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN (
+            'pending', 'accepted', 'rejected', 'dismissed'
+          )),
+          source_run_id TEXT,
+          accepted_as_id TEXT,
+          decided_at TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_research_suggestions_workspace_status ON research_suggestions(workspace_id, status)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_research_suggestions_kind_status ON research_suggestions(kind, status)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_research_suggestions_source_run ON research_suggestions(source_run_id) WHERE source_run_id IS NOT NULL`);
+      console.log('[Migration 076] research_suggestions table created.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/research-suggestions.test.ts
+++ b/src/lib/db/research-suggestions.test.ts
@@ -1,0 +1,245 @@
+/**
+ * research_suggestions DAO tests.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import {
+  createSuggestion,
+  dismissPendingForWorkspaceKind,
+  getSuggestion,
+  listSuggestions,
+  markAccepted,
+  markDismissed,
+  markRejected,
+  SuggestionValidationError,
+} from './research-suggestions';
+
+function freshWorkspace(): string {
+  const id = `ws-rs-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+test('createSuggestion: round-trip topic kind', () => {
+  const ws = freshWorkspace();
+  const s = createSuggestion({
+    workspace_id: ws,
+    kind: 'topic',
+    payload: {
+      name: 'GLP-1 regulation',
+      description: 'Watch FDA actions',
+      tags: ['pharma'],
+    },
+    rationale: 'Three initiatives touch healthcare regulation; no topic exists.',
+  });
+  assert.equal(s.workspace_id, ws);
+  assert.equal(s.kind, 'topic');
+  assert.equal(s.status, 'pending');
+  assert.equal(s.rationale, 'Three initiatives touch healthcare regulation; no topic exists.');
+  const payload = s.payload as { name: string; description: string; tags: string[] };
+  assert.equal(payload.name, 'GLP-1 regulation');
+  assert.deepEqual(payload.tags, ['pharma']);
+});
+
+test('createSuggestion: round-trip brief kind', () => {
+  const ws = freshWorkspace();
+  const s = createSuggestion({
+    workspace_id: ws,
+    kind: 'brief',
+    payload: {
+      title: 'WebGPU survey',
+      prompt: 'Survey browser support',
+      template: 'general_brief',
+    },
+  });
+  assert.equal(s.kind, 'brief');
+  const payload = s.payload as { title: string; prompt: string };
+  assert.equal(payload.title, 'WebGPU survey');
+});
+
+test('createSuggestion: rejects empty workspace_id', () => {
+  assert.throws(
+    () => createSuggestion({
+      workspace_id: '   ',
+      kind: 'topic',
+      payload: { name: 'x', description: '', tags: [] },
+    }),
+    SuggestionValidationError,
+  );
+});
+
+test('createSuggestion: rejects topic without name', () => {
+  const ws = freshWorkspace();
+  assert.throws(
+    () => createSuggestion({
+      workspace_id: ws,
+      kind: 'topic',
+      payload: { name: '   ', description: '', tags: [] },
+    }),
+    SuggestionValidationError,
+  );
+});
+
+test('createSuggestion: rejects brief without title or prompt', () => {
+  const ws = freshWorkspace();
+  assert.throws(
+    () => createSuggestion({
+      workspace_id: ws,
+      kind: 'brief',
+      payload: { title: '', prompt: 'x', template: 'general_brief' },
+    }),
+    SuggestionValidationError,
+  );
+  assert.throws(
+    () => createSuggestion({
+      workspace_id: ws,
+      kind: 'brief',
+      payload: { title: 'x', prompt: '', template: 'general_brief' },
+    }),
+    SuggestionValidationError,
+  );
+});
+
+test('listSuggestions: workspace-scoped, filters by kind/status', () => {
+  const wsA = freshWorkspace();
+  const wsB = freshWorkspace();
+  createSuggestion({
+    workspace_id: wsA,
+    kind: 'topic',
+    payload: { name: 'A1', description: '', tags: [] },
+  });
+  const sBrief = createSuggestion({
+    workspace_id: wsA,
+    kind: 'brief',
+    payload: { title: 'A2', prompt: 'p', template: 'general_brief' },
+  });
+  createSuggestion({
+    workspace_id: wsB,
+    kind: 'topic',
+    payload: { name: 'B1', description: '', tags: [] },
+  });
+
+  const allA = listSuggestions(wsA);
+  assert.equal(allA.length, 2);
+
+  const topicsA = listSuggestions(wsA, { kind: 'topic' });
+  assert.equal(topicsA.length, 1);
+
+  const briefsA = listSuggestions(wsA, { kind: 'brief' });
+  assert.equal(briefsA.length, 1);
+  assert.equal(briefsA[0].id, sBrief.id);
+
+  const allB = listSuggestions(wsB);
+  assert.equal(allB.length, 1);
+  assert.equal((allB[0].payload as { name: string }).name, 'B1');
+});
+
+test('markAccepted: transitions pending → accepted with accepted_as_id', () => {
+  const ws = freshWorkspace();
+  const s = createSuggestion({
+    workspace_id: ws,
+    kind: 'topic',
+    payload: { name: 't', description: '', tags: [] },
+  });
+  const updated = markAccepted(s.id, 'real-topic-id');
+  assert.equal(updated?.status, 'accepted');
+  assert.equal(updated?.accepted_as_id, 'real-topic-id');
+  assert.ok(updated?.decided_at);
+});
+
+test('markAccepted: no-op when already terminal', () => {
+  const ws = freshWorkspace();
+  const s = createSuggestion({
+    workspace_id: ws,
+    kind: 'topic',
+    payload: { name: 't', description: '', tags: [] },
+  });
+  markRejected(s.id);
+  const reAccepted = markAccepted(s.id, 'x');
+  assert.equal(reAccepted?.status, 'rejected');
+});
+
+test('markRejected + markDismissed lifecycle', () => {
+  const ws = freshWorkspace();
+  const s1 = createSuggestion({
+    workspace_id: ws,
+    kind: 'topic',
+    payload: { name: 't1', description: '', tags: [] },
+  });
+  const s2 = createSuggestion({
+    workspace_id: ws,
+    kind: 'topic',
+    payload: { name: 't2', description: '', tags: [] },
+  });
+  assert.equal(markRejected(s1.id)?.status, 'rejected');
+  assert.equal(markDismissed(s2.id)?.status, 'dismissed');
+});
+
+test('dismissPendingForWorkspaceKind: bulk-dismisses pending in scope', () => {
+  const ws = freshWorkspace();
+  // Two pending topics, one accepted topic, one pending brief.
+  const t1 = createSuggestion({
+    workspace_id: ws,
+    kind: 'topic',
+    payload: { name: 'a', description: '', tags: [] },
+  });
+  const t2 = createSuggestion({
+    workspace_id: ws,
+    kind: 'topic',
+    payload: { name: 'b', description: '', tags: [] },
+  });
+  const t3 = createSuggestion({
+    workspace_id: ws,
+    kind: 'topic',
+    payload: { name: 'c', description: '', tags: [] },
+  });
+  markAccepted(t3.id, 'x');
+  const b1 = createSuggestion({
+    workspace_id: ws,
+    kind: 'brief',
+    payload: { title: 'br', prompt: 'p', template: 'general_brief' },
+  });
+
+  const changed = dismissPendingForWorkspaceKind(ws, 'topic');
+  assert.equal(changed, 2);
+  assert.equal(getSuggestion(t1.id)?.status, 'dismissed');
+  assert.equal(getSuggestion(t2.id)?.status, 'dismissed');
+  assert.equal(getSuggestion(t3.id)?.status, 'accepted'); // unchanged
+  assert.equal(getSuggestion(b1.id)?.status, 'pending');  // wrong kind, unchanged
+});
+
+test('FK cascade: deleting workspace removes its suggestions', () => {
+  const ws = freshWorkspace();
+  const s = createSuggestion({
+    workspace_id: ws,
+    kind: 'topic',
+    payload: { name: 't', description: '', tags: [] },
+  });
+  run(`DELETE FROM workspaces WHERE id = ?`, [ws]);
+  assert.equal(getSuggestion(s.id), null);
+});
+
+test('payload JSON survives round-trip', () => {
+  const ws = freshWorkspace();
+  const s = createSuggestion({
+    workspace_id: ws,
+    kind: 'brief',
+    payload: {
+      title: 'WebGPU support',
+      prompt: 'Survey browser support; quote spec authors where relevant.',
+      topic_id: 'some-topic-uuid',
+      template: 'general_brief',
+    },
+  });
+  const reloaded = getSuggestion(s.id);
+  const p = reloaded?.payload as { title: string; prompt: string; topic_id: string };
+  assert.equal(p.title, 'WebGPU support');
+  assert.equal(p.topic_id, 'some-topic-uuid');
+  assert.match(p.prompt, /quote spec authors/);
+});

--- a/src/lib/db/research-suggestions.ts
+++ b/src/lib/db/research-suggestions.ts
@@ -1,0 +1,263 @@
+/**
+ * research_suggestions DAO.
+ *
+ * Schema added in migration 076. Stores PM-generated candidate
+ * topics and briefs for operator review. Lifecycle:
+ *
+ *   pending → accepted (with accepted_as_id)
+ *           → rejected
+ *           → dismissed
+ *
+ * `dismissed` is distinct from `rejected`: rejected = "the PM was
+ * wrong, don't suggest this again"; dismissed = "I closed the
+ * picker without acting." Future PM runs can use rejected as
+ * negative training; dismissed is just noise.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+
+export type SuggestionKind = 'topic' | 'brief' | 'recurring_brief';
+export type SuggestionStatus = 'pending' | 'accepted' | 'rejected' | 'dismissed';
+
+export interface TopicSuggestionPayload {
+  name: string;
+  description: string;
+  tags: string[];
+  default_brief_template?: string | null;
+}
+
+export interface BriefSuggestionPayload {
+  title: string;
+  prompt: string;
+  topic_id?: string | null;
+  template: 'general_brief';
+}
+
+/** Reserved — not generated yet (phase-2 schedules). */
+export interface RecurringBriefSuggestionPayload {
+  title: string;
+  prompt: string;
+  topic_id?: string | null;
+  template: 'general_brief';
+  cadence: string;
+}
+
+export type SuggestionPayload =
+  | { kind: 'topic'; payload: TopicSuggestionPayload }
+  | { kind: 'brief'; payload: BriefSuggestionPayload }
+  | { kind: 'recurring_brief'; payload: RecurringBriefSuggestionPayload };
+
+export interface ResearchSuggestion {
+  id: string;
+  workspace_id: string;
+  kind: SuggestionKind;
+  payload: TopicSuggestionPayload | BriefSuggestionPayload | RecurringBriefSuggestionPayload;
+  rationale: string | null;
+  status: SuggestionStatus;
+  source_run_id: string | null;
+  accepted_as_id: string | null;
+  decided_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SuggestionRow {
+  id: string;
+  workspace_id: string;
+  kind: SuggestionKind;
+  payload_json: string;
+  rationale: string | null;
+  status: SuggestionStatus;
+  source_run_id: string | null;
+  accepted_as_id: string | null;
+  decided_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export class SuggestionValidationError extends Error {
+  constructor(public reason: string) {
+    super(`research_suggestion validation: ${reason}`);
+    this.name = 'SuggestionValidationError';
+  }
+}
+
+function rowToSuggestion(row: SuggestionRow): ResearchSuggestion {
+  let payload: ResearchSuggestion['payload'];
+  try {
+    payload = JSON.parse(row.payload_json) as ResearchSuggestion['payload'];
+  } catch {
+    // Corrupt payload: surface as empty payload of the right shape so
+    // callers don't crash; the operator can dismiss.
+    payload = row.kind === 'topic'
+      ? { name: '(corrupt payload)', description: '', tags: [] }
+      : { title: '(corrupt payload)', prompt: '', template: 'general_brief' as const };
+  }
+  return {
+    id: row.id,
+    workspace_id: row.workspace_id,
+    kind: row.kind,
+    payload,
+    rationale: row.rationale,
+    status: row.status,
+    source_run_id: row.source_run_id,
+    accepted_as_id: row.accepted_as_id,
+    decided_at: row.decided_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export interface CreateSuggestionInput {
+  workspace_id: string;
+  kind: SuggestionKind;
+  payload: TopicSuggestionPayload | BriefSuggestionPayload | RecurringBriefSuggestionPayload;
+  rationale?: string | null;
+  source_run_id?: string | null;
+}
+
+export function createSuggestion(input: CreateSuggestionInput): ResearchSuggestion {
+  if (!input.workspace_id.trim()) {
+    throw new SuggestionValidationError('workspace_id is required');
+  }
+  // Cheap shape validation per kind.
+  if (input.kind === 'topic') {
+    const p = input.payload as TopicSuggestionPayload;
+    if (!p.name?.trim()) throw new SuggestionValidationError('topic.name is required');
+  } else {
+    const p = input.payload as BriefSuggestionPayload | RecurringBriefSuggestionPayload;
+    if (!p.title?.trim()) throw new SuggestionValidationError('brief.title is required');
+    if (!p.prompt?.trim()) throw new SuggestionValidationError('brief.prompt is required');
+  }
+
+  const id = uuidv4();
+  run(
+    `INSERT INTO research_suggestions (
+       id, workspace_id, kind, payload_json, rationale,
+       source_run_id, created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+    [
+      id,
+      input.workspace_id,
+      input.kind,
+      JSON.stringify(input.payload),
+      input.rationale ?? null,
+      input.source_run_id ?? null,
+    ],
+  );
+  const row = queryOne<SuggestionRow>(
+    `SELECT * FROM research_suggestions WHERE id = ?`,
+    [id],
+  );
+  if (!row) throw new Error('createSuggestion: insert succeeded but row missing');
+  return rowToSuggestion(row);
+}
+
+export function getSuggestion(id: string): ResearchSuggestion | null {
+  const row = queryOne<SuggestionRow>(
+    `SELECT * FROM research_suggestions WHERE id = ?`,
+    [id],
+  );
+  return row ? rowToSuggestion(row) : null;
+}
+
+export interface ListSuggestionsOptions {
+  kind?: SuggestionKind;
+  status?: SuggestionStatus;
+  source_run_id?: string;
+  limit?: number;
+}
+
+export function listSuggestions(
+  workspaceId: string,
+  opts: ListSuggestionsOptions = {},
+): ResearchSuggestion[] {
+  const where: string[] = ['workspace_id = ?'];
+  const params: unknown[] = [workspaceId];
+  if (opts.kind) {
+    where.push('kind = ?');
+    params.push(opts.kind);
+  }
+  if (opts.status) {
+    where.push('status = ?');
+    params.push(opts.status);
+  }
+  if (opts.source_run_id) {
+    where.push('source_run_id = ?');
+    params.push(opts.source_run_id);
+  }
+  const limit = Math.min(opts.limit ?? 100, 500);
+  const rows = queryAll<SuggestionRow>(
+    `SELECT * FROM research_suggestions WHERE ${where.join(' AND ')}
+       ORDER BY created_at DESC, rowid DESC LIMIT ${limit}`,
+    params,
+  );
+  return rows.map(rowToSuggestion);
+}
+
+export function markAccepted(id: string, acceptedAsId: string): ResearchSuggestion | null {
+  const current = getSuggestion(id);
+  if (!current) return null;
+  if (current.status !== 'pending') return current;
+  run(
+    `UPDATE research_suggestions
+        SET status = 'accepted',
+            accepted_as_id = ?,
+            decided_at = datetime('now'),
+            updated_at = datetime('now')
+      WHERE id = ?`,
+    [acceptedAsId, id],
+  );
+  return getSuggestion(id);
+}
+
+export function markRejected(id: string): ResearchSuggestion | null {
+  const current = getSuggestion(id);
+  if (!current) return null;
+  if (current.status !== 'pending') return current;
+  run(
+    `UPDATE research_suggestions
+        SET status = 'rejected',
+            decided_at = datetime('now'),
+            updated_at = datetime('now')
+      WHERE id = ?`,
+    [id],
+  );
+  return getSuggestion(id);
+}
+
+export function markDismissed(id: string): ResearchSuggestion | null {
+  const current = getSuggestion(id);
+  if (!current) return null;
+  if (current.status !== 'pending') return current;
+  run(
+    `UPDATE research_suggestions
+        SET status = 'dismissed',
+            decided_at = datetime('now'),
+            updated_at = datetime('now')
+      WHERE id = ?`,
+    [id],
+  );
+  return getSuggestion(id);
+}
+
+/**
+ * Dismiss every pending suggestion in a workspace for a given kind.
+ * Used when the operator clicks "Suggest" again — old pending
+ * candidates are no longer interesting.
+ */
+export function dismissPendingForWorkspaceKind(
+  workspaceId: string,
+  kind: SuggestionKind,
+): number {
+  const result = run(
+    `UPDATE research_suggestions
+        SET status = 'dismissed',
+            decided_at = datetime('now'),
+            updated_at = datetime('now')
+      WHERE workspace_id = ? AND kind = ? AND status = 'pending'`,
+    [workspaceId, kind],
+  );
+  return result.changes;
+}

--- a/src/lib/research/suggest.test.ts
+++ b/src/lib/research/suggest.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Suggestion dispatcher tests.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import {
+  __setSendChatClientForTests,
+  type ChatEvent,
+  type SendChatClient,
+} from '@/lib/openclaw/send-chat';
+import { createTopic } from '@/lib/db/topics';
+import { listSuggestions } from '@/lib/db/research-suggestions';
+import {
+  buildSuggestPrompt,
+  gatherWorkspaceContext,
+  generateSuggestions,
+  parseSuggestionsResponse,
+} from './suggest';
+
+function freshWorkspace(): string {
+  const id = `ws-sg-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function ensurePm(workspaceId: string): void {
+  run(
+    `INSERT OR IGNORE INTO agents (id, name, role, avatar_emoji, status, is_master, is_pm, workspace_id, source, gateway_agent_id, session_key_prefix, model, is_active, created_at, updated_at)
+     VALUES (?, 'mc-pm-test', 'pm', '🧭', 'standby', 1, 1, ?, 'gateway', ?, ?, 'spark-lb/agent', 1, datetime('now'), datetime('now'))`,
+    [`pm-${uuidv4().slice(0, 8)}`, workspaceId, `mc-pm-${workspaceId.slice(-4)}`, `agent:mc-pm-${workspaceId.slice(-4)}:main`],
+  );
+}
+
+function makeStubClient(replyBody: string): SendChatClient {
+  const listeners = new Set<(p: ChatEvent) => void>();
+  return {
+    isConnected: () => true,
+    on: (event, listener) => { if (event === 'chat_event') listeners.add(listener); return undefined; },
+    off: (event, listener) => { if (event === 'chat_event') listeners.delete(listener); return undefined; },
+    call: async (method, params) => {
+      if (method !== 'chat.send') return undefined;
+      const sessionKey = (params as { sessionKey?: string } | undefined)?.sessionKey;
+      setImmediate(() => {
+        for (const l of listeners) l({ sessionKey, state: 'final', message: replyBody });
+      });
+      return {};
+    },
+  };
+}
+
+test.afterEach(() => {
+  __setSendChatClientForTests(null);
+});
+
+// ─── parseSuggestionsResponse ───────────────────────────────────────
+
+test('parseSuggestionsResponse: extracts fenced json topic block', () => {
+  const raw = `Sure! Here are my picks.
+
+\`\`\`json
+{
+  "suggestions": [
+    { "name": "Topic A", "description": "About A", "tags": ["a","b"], "rationale": "Initiative X needs this" },
+    { "name": "Topic B", "description": "About B", "tags": [], "rationale": "Recurring gap" }
+  ]
+}
+\`\`\`
+
+Hope that helps.`;
+  const out = parseSuggestionsResponse(raw, 'topic', new Set());
+  assert.equal(out.length, 2);
+  assert.equal((out[0].payload as { name: string }).name, 'Topic A');
+  assert.equal(out[0].rationale, 'Initiative X needs this');
+});
+
+test('parseSuggestionsResponse: extracts brief block + filters topic_id to known ids', () => {
+  const raw = `\`\`\`json
+{
+  "suggestions": [
+    { "title": "B1", "prompt": "p1", "topic_id": "known-id", "rationale": "r1" },
+    { "title": "B2", "prompt": "p2", "topic_id": "made-up-id", "rationale": "r2" },
+    { "title": "B3", "prompt": "p3", "topic_id": null, "rationale": "r3" }
+  ]
+}
+\`\`\``;
+  const out = parseSuggestionsResponse(raw, 'brief', new Set(['known-id']));
+  assert.equal(out.length, 3);
+  assert.equal((out[0].payload as { topic_id: string | null }).topic_id, 'known-id');
+  assert.equal((out[1].payload as { topic_id: string | null }).topic_id, null);
+  assert.equal((out[2].payload as { topic_id: string | null }).topic_id, null);
+});
+
+test('parseSuggestionsResponse: bare object fallback when fence is missing', () => {
+  const raw = `noise before
+{ "suggestions": [{ "name": "OK", "description": "", "tags": [], "rationale": "" }] }
+trailing prose`;
+  const out = parseSuggestionsResponse(raw, 'topic', new Set());
+  assert.equal(out.length, 1);
+  assert.equal((out[0].payload as { name: string }).name, 'OK');
+});
+
+test('parseSuggestionsResponse: drops malformed entries silently', () => {
+  const raw = `\`\`\`json
+{ "suggestions": [
+  { "name": "Good" },
+  { "name": "" },
+  { "rationale": "missing name" },
+  { "name": "Also good", "description": "x" }
+] }
+\`\`\``;
+  const out = parseSuggestionsResponse(raw, 'topic', new Set());
+  assert.equal(out.length, 2);
+});
+
+test('parseSuggestionsResponse: returns empty when reply has no JSON', () => {
+  assert.deepEqual(parseSuggestionsResponse('no json here', 'topic', new Set()), []);
+  assert.deepEqual(parseSuggestionsResponse('', 'topic', new Set()), []);
+});
+
+// ─── gatherWorkspaceContext ─────────────────────────────────────────
+
+test('gatherWorkspaceContext: empty workspace returns empty buckets', () => {
+  const ws = freshWorkspace();
+  const ctx = gatherWorkspaceContext(ws);
+  assert.equal(ctx.initiatives.length, 0);
+  assert.equal(ctx.recent_briefs.length, 0);
+  assert.equal(ctx.topics.length, 0);
+});
+
+test('gatherWorkspaceContext: includes existing topics', () => {
+  const ws = freshWorkspace();
+  createTopic({ workspace_id: ws, name: 'T1', description: 'd1' });
+  const ctx = gatherWorkspaceContext(ws);
+  assert.equal(ctx.topics.length, 1);
+  assert.equal(ctx.topics[0].name, 'T1');
+});
+
+// ─── buildSuggestPrompt ─────────────────────────────────────────────
+
+test('buildSuggestPrompt: includes reply-format instructions per kind', () => {
+  const ws = freshWorkspace();
+  const ctx = gatherWorkspaceContext(ws);
+  const topicPrompt = buildSuggestPrompt('topic', ctx);
+  // Use [\s\S] instead of the /s (dotAll) flag — older TS targets
+  // don't allow the flag in the source regex.
+  assert.match(topicPrompt, /name[\s\S]*description[\s\S]*tags[\s\S]*rationale/);
+  assert.match(topicPrompt, /topic/);
+
+  const briefPrompt = buildSuggestPrompt('brief', ctx);
+  assert.match(briefPrompt, /title[\s\S]*prompt[\s\S]*topic_id[\s\S]*rationale/);
+});
+
+test('buildSuggestPrompt: includes the NOT-a-task override', () => {
+  const ws = freshWorkspace();
+  const ctx = gatherWorkspaceContext(ws);
+  const prompt = buildSuggestPrompt('topic', ctx);
+  assert.match(prompt, /NOT a Mission Control task/i);
+  assert.match(prompt, /Do NOT call/);
+});
+
+// ─── generateSuggestions end-to-end ─────────────────────────────────
+
+test('generateSuggestions: rejects when no PM agent', async () => {
+  const ws = freshWorkspace();
+  const result = await generateSuggestions({ workspace_id: ws, kind: 'topic' });
+  assert.equal(result.state, 'rejected');
+  assert.match(result.reason ?? '', /No PM agent/);
+});
+
+test('generateSuggestions: happy path inserts pending rows', async () => {
+  const ws = freshWorkspace();
+  ensurePm(ws);
+  const reply = `\`\`\`json
+{
+  "suggestions": [
+    { "name": "Pricing watch", "description": "Track competitor pricing", "tags": ["competitor"], "rationale": "No topic exists" },
+    { "name": "Regulatory scan", "description": "Quarterly scan of industry rules", "tags": ["compliance"], "rationale": "Ship date relies on this" }
+  ]
+}
+\`\`\``;
+  __setSendChatClientForTests(makeStubClient(reply));
+
+  const result = await generateSuggestions({ workspace_id: ws, kind: 'topic' });
+  assert.equal(result.state, 'ok');
+  assert.equal(result.suggestions.length, 2);
+
+  const pending = listSuggestions(ws, { kind: 'topic', status: 'pending' });
+  assert.equal(pending.length, 2);
+});
+
+test('generateSuggestions: dismisses prior pending of same kind on rerun', async () => {
+  const ws = freshWorkspace();
+  ensurePm(ws);
+
+  __setSendChatClientForTests(makeStubClient(
+    `\`\`\`json
+{ "suggestions": [{ "name": "First", "description": "", "tags": [], "rationale": "" }] }
+\`\`\``,
+  ));
+  await generateSuggestions({ workspace_id: ws, kind: 'topic' });
+
+  __setSendChatClientForTests(makeStubClient(
+    `\`\`\`json
+{ "suggestions": [{ "name": "Second", "description": "", "tags": [], "rationale": "" }] }
+\`\`\``,
+  ));
+  await generateSuggestions({ workspace_id: ws, kind: 'topic' });
+
+  const pending = listSuggestions(ws, { kind: 'topic', status: 'pending' });
+  assert.equal(pending.length, 1);
+  assert.equal((pending[0].payload as { name: string }).name, 'Second');
+
+  const dismissed = listSuggestions(ws, { kind: 'topic', status: 'dismissed' });
+  assert.equal(dismissed.length, 1);
+  assert.equal((dismissed[0].payload as { name: string }).name, 'First');
+});
+
+test('generateSuggestions: returns failed when PM reply has no JSON', async () => {
+  const ws = freshWorkspace();
+  ensurePm(ws);
+  __setSendChatClientForTests(makeStubClient('I do not understand the request.'));
+  const result = await generateSuggestions({ workspace_id: ws, kind: 'topic' });
+  assert.equal(result.state, 'failed');
+  assert.match(result.reason ?? '', /JSON/i);
+});

--- a/src/lib/research/suggest.ts
+++ b/src/lib/research/suggest.ts
@@ -1,0 +1,430 @@
+/**
+ * PM-driven research suggestion dispatcher.
+ *
+ * Operator clicks Suggest on the Research hub → this module:
+ *   1. Gathers a workspace context snapshot (initiatives, tasks,
+ *      recent briefs, existing topics).
+ *   2. Builds a prompt asking the workspace PM to propose 3–5
+ *      candidate topics OR briefs (depending on `kind`).
+ *   3. Dispatches via dispatchScope({ role: 'pm', agent: pm, ... }).
+ *   4. Parses the PM's reply for a JSON block listing candidates.
+ *   5. Inserts each candidate as a `research_suggestion` row,
+ *      pending operator review.
+ *
+ * Synchronous from the API caller's perspective — returns the new
+ * suggestion rows once the PM responds. Wait time tracks PM's
+ * reply latency (typically 30–90 seconds).
+ */
+
+import { queryAll } from '@/lib/db';
+import { dispatchScope } from '@/lib/agents/dispatch-scope';
+import { getPmAgent } from '@/lib/agents/pm-resolver';
+import { listTopics } from '@/lib/db/topics';
+import { listBriefs } from '@/lib/db/briefs';
+import { listInitiatives } from '@/lib/db/initiatives';
+import {
+  createSuggestion,
+  dismissPendingForWorkspaceKind,
+  type ResearchSuggestion,
+  type SuggestionKind,
+  type TopicSuggestionPayload,
+  type BriefSuggestionPayload,
+} from '@/lib/db/research-suggestions';
+import { extractReplyText } from '@/lib/research/run-brief';
+import type { ChatEvent } from '@/lib/openclaw/send-chat';
+
+const DEFAULT_TIMEOUT_MS = 3 * 60 * 1000;
+const MAX_SUGGESTIONS_PER_RUN = 6;
+
+export interface SuggestOptions {
+  workspace_id: string;
+  /** Either 'topic' or 'brief'. recurring_brief is reserved (phase 2). */
+  kind: 'topic' | 'brief';
+  timeoutMs?: number;
+}
+
+export interface SuggestResult {
+  state: 'ok' | 'rejected' | 'failed';
+  reason?: string;
+  suggestions: ResearchSuggestion[];
+  /** Raw PM reply, useful for debugging when parsing fails. */
+  raw?: string;
+}
+
+interface InitiativeSummary {
+  id: string;
+  kind: string;
+  title: string;
+  status: string;
+  description?: string | null;
+  target_end?: string | null;
+}
+
+interface TaskSummary {
+  id: string;
+  title: string;
+  status: string;
+  initiative_id: string | null;
+  priority: string;
+}
+
+interface BriefSummary {
+  id: string;
+  title: string;
+  topic_name: string | null;
+  template: string;
+  created_at: string;
+}
+
+interface TopicSummary {
+  id: string;
+  name: string;
+  description: string;
+}
+
+interface WorkspaceContext {
+  initiatives: InitiativeSummary[];
+  blocked_or_at_risk_tasks: TaskSummary[];
+  needs_input_tasks: TaskSummary[];
+  recent_briefs: BriefSummary[];
+  topics: TopicSummary[];
+}
+
+/** Cap how much we feed the PM. Beyond a few dozen rows the prompt
+ *  bloats and the PM's signal-to-noise drops. Tune on real usage. */
+const MAX_INITIATIVES = 30;
+const MAX_TASKS_PER_BUCKET = 15;
+const MAX_BRIEFS = 20;
+const MAX_TOPICS = 30;
+
+export function gatherWorkspaceContext(workspaceId: string): WorkspaceContext {
+  const initiatives = listInitiatives({ workspace_id: workspaceId })
+    .slice(0, MAX_INITIATIVES)
+    .map(i => ({
+      id: i.id,
+      kind: i.kind,
+      title: i.title,
+      status: i.status,
+      description: i.description ?? null,
+      target_end: i.target_end ?? null,
+    }));
+
+  // Tasks: focus on the buckets a PM cares about for "what's stuck?"
+  // and "what's blocked on a decision?".
+  const blockedOrAtRisk = queryAll<TaskSummary>(
+    `SELECT id, title, status, initiative_id, priority FROM tasks
+       WHERE workspace_id = ? AND status IN ('assigned','in_progress','testing','review','verification')
+         AND COALESCE(is_archived, 0) = 0
+       ORDER BY updated_at DESC LIMIT ?`,
+    [workspaceId, MAX_TASKS_PER_BUCKET],
+  );
+  const needsInput = queryAll<TaskSummary>(
+    `SELECT id, title, status, initiative_id, priority FROM tasks
+       WHERE workspace_id = ? AND status = 'needs_user_input'
+         AND COALESCE(is_archived, 0) = 0
+       ORDER BY updated_at DESC LIMIT ?`,
+    [workspaceId, MAX_TASKS_PER_BUCKET],
+  );
+
+  const briefs = listBriefs(workspaceId, { limit: MAX_BRIEFS });
+  const topics = listTopics(workspaceId).slice(0, MAX_TOPICS);
+  const topicById = new Map(topics.map(t => [t.id, t]));
+
+  const recent_briefs: BriefSummary[] = briefs.map(b => ({
+    id: b.id,
+    title: b.title,
+    topic_name: b.topic_id ? topicById.get(b.topic_id)?.name ?? null : null,
+    template: b.template,
+    created_at: b.created_at,
+  }));
+
+  return {
+    initiatives,
+    blocked_or_at_risk_tasks: blockedOrAtRisk,
+    needs_input_tasks: needsInput,
+    recent_briefs,
+    topics: topics.map(t => ({
+      id: t.id,
+      name: t.name,
+      description: t.description,
+    })),
+  };
+}
+
+export function buildSuggestPrompt(
+  kind: 'topic' | 'brief',
+  ctx: WorkspaceContext,
+): string {
+  const sections: string[] = [];
+  sections.push(
+    `# Research suggestion request`,
+    `\nYou are being asked to survey the workspace's current state and propose ` +
+    `up to ${MAX_SUGGESTIONS_PER_RUN} candidate **research ${kind === 'topic' ? 'topics' : 'briefs'}** ` +
+    `that would meaningfully reduce uncertainty or unlock a decision the team is sitting on.\n` +
+    `\n**This is NOT a Mission Control task.** Do NOT call \`register_deliverable\` / ` +
+    `\`update_task_status\` / \`log_activity\` / \`propose_changes\`. Reply with the ` +
+    `JSON block specified at the bottom of this prompt and nothing else after it.`,
+  );
+
+  sections.push(
+    `## What's a good ${kind}?`,
+    kind === 'topic'
+      ? `A topic is a **long-lived area of interest** — something worth tracking ` +
+        `over weeks or months because the workspace will care about its evolution. ` +
+        `Examples: "FDA enforcement on GLP-1", "Acme competitor watch", ` +
+        `"DE/CA filing obligations". Avoid: one-off questions (those are briefs).`
+      : `A brief is a **single research output** — a specific question whose ` +
+        `answer would change a decision or reduce risk. Examples: "Survey VLMs ` +
+        `that fit on 8GB Jetson", "Compare Postgres vector ext vs pinecone for ` +
+        `our RAG load". Avoid: vague areas (those are topics).`,
+  );
+
+  sections.push(
+    `## Workspace context\n`,
+    `### Initiatives (${ctx.initiatives.length})`,
+    ctx.initiatives.length === 0
+      ? '_(none)_'
+      : ctx.initiatives
+          .map(i => `- **${i.kind}** \`${i.status}\` — ${i.title}` +
+                    (i.description ? `\n  ${i.description.slice(0, 200)}` : ''))
+          .join('\n'),
+  );
+
+  if (ctx.blocked_or_at_risk_tasks.length || ctx.needs_input_tasks.length) {
+    sections.push(`### Tasks needing attention`);
+    if (ctx.needs_input_tasks.length) {
+      sections.push(
+        `**Awaiting operator input:**\n` +
+        ctx.needs_input_tasks.map(t => `- ${t.title}`).join('\n'),
+      );
+    }
+    if (ctx.blocked_or_at_risk_tasks.length) {
+      sections.push(
+        `**In flight:**\n` +
+        ctx.blocked_or_at_risk_tasks.map(t => `- \`${t.status}\` — ${t.title}`).join('\n'),
+      );
+    }
+  }
+
+  sections.push(
+    `### Existing topics (${ctx.topics.length})`,
+    ctx.topics.length === 0
+      ? '_(none — you may suggest foundational ones)_'
+      : ctx.topics.map(t => `- **${t.name}** — ${t.description.slice(0, 200) || '(no description)'}`).join('\n'),
+  );
+
+  sections.push(
+    `### Recent briefs (${ctx.recent_briefs.length})`,
+    ctx.recent_briefs.length === 0
+      ? '_(none)_'
+      : ctx.recent_briefs
+          .map(b => `- "${b.title}"${b.topic_name ? ` (topic: ${b.topic_name})` : ''}`)
+          .join('\n'),
+  );
+
+  sections.push(
+    `## Reply format`,
+    `\nReply with a single fenced JSON code block (\`\`\`json … \`\`\`) and nothing else after it. ` +
+    `Shape:\n` +
+    (kind === 'topic'
+      ? `\n\`\`\`json
+{
+  "suggestions": [
+    {
+      "name": "Short topic name (≤ 80 chars)",
+      "description": "Why this topic matters; what we'd track over time (1–3 sentences).",
+      "tags": ["short", "tags"],
+      "rationale": "1 sentence: WHY you suggested this, referencing specific initiatives/tasks/gaps you saw."
+    }
+  ]
+}
+\`\`\`\n`
+      : `\n\`\`\`json
+{
+  "suggestions": [
+    {
+      "title": "Short brief title (≤ 100 chars)",
+      "prompt": "Specific research question. Be precise about scope, depth, and what would make the answer useful.",
+      "topic_id": null,
+      "rationale": "1 sentence: WHY you suggested this, referencing specific initiatives/tasks/gaps you saw."
+    }
+  ]
+}
+\`\`\`\n` +
+        `If a brief naturally belongs to one of the existing topics above, set \`topic_id\` to that topic's id; otherwise leave null.\n`),
+    `\nReturn between 1 and ${MAX_SUGGESTIONS_PER_RUN} candidates. Quality over quantity — fewer good ` +
+    `suggestions beat many shallow ones. Skip anything that duplicates an existing topic or recent brief.`,
+  );
+
+  return sections.join('\n\n');
+}
+
+interface RawTopicSuggestion {
+  name?: unknown;
+  description?: unknown;
+  tags?: unknown;
+  rationale?: unknown;
+}
+interface RawBriefSuggestion {
+  title?: unknown;
+  prompt?: unknown;
+  topic_id?: unknown;
+  rationale?: unknown;
+}
+interface RawResponse {
+  suggestions?: Array<RawTopicSuggestion | RawBriefSuggestion>;
+}
+
+interface ParsedCandidate {
+  payload: TopicSuggestionPayload | BriefSuggestionPayload;
+  rationale: string | null;
+}
+
+/**
+ * Best-effort JSON extraction from a reply that may include prose
+ * around the fenced code block. Tries fenced ```json blocks first,
+ * then a bare top-level object.
+ */
+export function parseSuggestionsResponse(
+  raw: string,
+  kind: 'topic' | 'brief',
+  validTopicIds: Set<string>,
+): ParsedCandidate[] {
+  if (!raw) return [];
+
+  const fenced = /```json\s*([\s\S]*?)\s*```/i.exec(raw);
+  const candidate = fenced ? fenced[1] : raw;
+
+  let obj: RawResponse;
+  try {
+    obj = JSON.parse(candidate) as RawResponse;
+  } catch {
+    // Try a bare-object pass: find the first '{' to last '}' span.
+    const start = candidate.indexOf('{');
+    const end = candidate.lastIndexOf('}');
+    if (start === -1 || end === -1 || end <= start) return [];
+    try {
+      obj = JSON.parse(candidate.slice(start, end + 1)) as RawResponse;
+    } catch {
+      return [];
+    }
+  }
+
+  if (!obj || !Array.isArray(obj.suggestions)) return [];
+
+  const out: ParsedCandidate[] = [];
+  for (const s of obj.suggestions.slice(0, MAX_SUGGESTIONS_PER_RUN)) {
+    if (kind === 'topic') {
+      const t = s as RawTopicSuggestion;
+      if (typeof t.name !== 'string' || !t.name.trim()) continue;
+      out.push({
+        payload: {
+          name: t.name.trim().slice(0, 500),
+          description: typeof t.description === 'string' ? t.description.trim() : '',
+          tags: Array.isArray(t.tags)
+            ? t.tags.filter((x): x is string => typeof x === 'string').slice(0, 16)
+            : [],
+        },
+        rationale: typeof t.rationale === 'string' ? t.rationale.trim() : null,
+      });
+    } else {
+      const b = s as RawBriefSuggestion;
+      if (typeof b.title !== 'string' || !b.title.trim()) continue;
+      if (typeof b.prompt !== 'string' || !b.prompt.trim()) continue;
+      const topicId =
+        typeof b.topic_id === 'string' && validTopicIds.has(b.topic_id) ? b.topic_id : null;
+      out.push({
+        payload: {
+          title: b.title.trim().slice(0, 500),
+          prompt: b.prompt.trim(),
+          topic_id: topicId,
+          template: 'general_brief',
+        },
+        rationale: typeof b.rationale === 'string' ? b.rationale.trim() : null,
+      });
+    }
+  }
+  return out;
+}
+
+/** Public entry point used by the API route. */
+export async function generateSuggestions(opts: SuggestOptions): Promise<SuggestResult> {
+  const pm = getPmAgent(opts.workspace_id);
+  if (!pm) {
+    return {
+      state: 'rejected',
+      reason: 'No PM agent in this workspace. The PM is the gateway-bound master agent — provision it via the openclaw catalog.',
+      suggestions: [],
+    };
+  }
+
+  const ctx = gatherWorkspaceContext(opts.workspace_id);
+  const triggerBody = buildSuggestPrompt(opts.kind, ctx);
+  const validTopicIds = new Set(ctx.topics.map(t => t.id));
+
+  let result;
+  try {
+    result = await dispatchScope({
+      workspace_id: opts.workspace_id,
+      role: 'pm',
+      agent: pm,
+      session_suffix: `research-suggest-${opts.kind}-${Date.now()}`,
+      trigger_body: triggerBody,
+      timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      attempt_strategy: 'fresh',
+    });
+  } catch (err) {
+    return {
+      state: 'failed',
+      reason: err instanceof Error ? err.message : String(err),
+      suggestions: [],
+    };
+  }
+
+  const reply = result.reply;
+  if (!reply || !reply.sent) {
+    return {
+      state: 'failed',
+      reason: reply?.reason === 'no_session'
+        ? 'Openclaw gateway not connected; cannot reach PM.'
+        : reply?.reason === 'send_failed'
+          ? `chat.send failed: ${reply.error?.message ?? 'unknown error'}`
+          : `dispatch failed: ${reply?.reason ?? 'unknown'}`,
+      suggestions: [],
+    };
+  }
+  if (reply.timedOut) {
+    return {
+      state: 'failed',
+      reason: `PM did not respond within ${(opts.timeoutMs ?? DEFAULT_TIMEOUT_MS) / 1000}s`,
+      suggestions: [],
+    };
+  }
+
+  const body = extractReplyText(reply.reply ?? [], reply.doneEvent);
+  const candidates = parseSuggestionsResponse(body, opts.kind, validTopicIds);
+
+  if (candidates.length === 0) {
+    return {
+      state: 'failed',
+      reason: 'PM reply did not contain a parseable JSON block of suggestions.',
+      raw: body,
+      suggestions: [],
+    };
+  }
+
+  // Dismiss any prior pending suggestions of this kind so the picker
+  // shows only the latest batch.
+  dismissPendingForWorkspaceKind(opts.workspace_id, opts.kind);
+
+  const inserted = candidates.map(c =>
+    createSuggestion({
+      workspace_id: opts.workspace_id,
+      kind: opts.kind as SuggestionKind,
+      payload: c.payload,
+      rationale: c.rationale,
+    }),
+  );
+
+  return { state: 'ok', suggestions: inserted, raw: body };
+}


### PR DESCRIPTION
Operator clicks **Suggest** on the Research hub → PM surveys workspace state → returns 1–6 candidate topics or briefs → operator multi-selects → accepted candidates become real topics/briefs (briefs land queued, no auto-dispatch).

## Components
### DB
- **Migration 076**: \`research_suggestions\` table. \`kind\` enum: \`topic | brief | recurring_brief\` (last reserved for phase-2 schedules so we don't widen the CHECK later). Status lifecycle: \`pending → accepted | rejected | dismissed\`. \`accepted_as_id\` points at the materialized topic/brief.
- **\`src/lib/db/research-suggestions.ts\`** — DAO with create/list/get + per-status setters + \`dismissPendingForWorkspaceKind\` for bulk-dismissing prior pending on rerun.

### Dispatcher
- **\`src/lib/research/suggest.ts\`** — gathers a workspace context snapshot (initiatives + status, in-flight + needs-input tasks, existing topics, recent briefs), builds a kind-specific prompt with explicit reply-format instructions and the same "NOT a Mission Control task" override the brief flow uses, dispatches via \`dispatchScope({ role: 'pm', agent: pm, ... })\` (the workspace's gateway-bound PM, not the runner), parses the PM's fenced JSON reply, dismisses prior pending of the same kind, inserts new ones.

### API
- **POST \`/api/research/suggestions\`** \`{ workspace_id, kind }\` — synchronous PM dispatch (~30–90s). Returns the new pending suggestions.
- **POST \`/api/research/suggestions/[id]\`** \`{ action }\` — \`accept | reject | dismiss\`. Accept materializes the suggestion (\`createTopic\` / \`createBriefWithRun\`) and stamps \`accepted_as_id\`.

### UI
- **\`SuggestPickerDrawer\`** — auto-kicks the PM dispatch on open, shows "PM is thinking" spinner, then renders candidates as checkbox cards with rationale and tags. "Insert N selected" accepts each in parallel. "Suggest again" re-runs.
- **Research hub** gets two Suggest entry points:
  - Sparkles button next to **+** in the Topics rail header
  - "Suggest" button next to **Run a brief** in the main header

## Test plan
- [x] **DAO tests**: 12 (round-trip per kind, validation errors, lifecycle, bulk-dismiss, FK cascade)
- [x] **Dispatcher tests**: 13 (parser shape, fenced/bare/malformed handling, context gathering, prompt assembly, end-to-end with stubbed PM including dismiss-on-rerun)
- [x] \`yarn test\`: **705 / 705** (was 671; +34 net new)
- [x] \`yarn tsc --noEmit\`: only the 2 pre-existing pm-decompose failures
- [x] **Preview-verified live**: Suggest controls visible in both the Topics rail and main header. Click → drawer opens, explainer text + dispatch fires + gateway-disconnect error path renders cleanly. No console errors. Live happy-path verification needs the openclaw gateway connected; the test pin covers the parser + dispatch shape.

## Reserved
The \`recurring_brief\` kind is reserved in the schema and union types but no code path generates it yet — ships when phase-2 schedules land. Avoids a migration-to-widen-CHECK later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)