### PR TITLE
fix(openclaw/connection): kick reconnect on poll when not connected

### DIFF
--- a/src/app/api/openclaw/connection/route.ts
+++ b/src/app/api/openclaw/connection/route.ts
@@ -6,19 +6,39 @@ export const dynamic = 'force-dynamic';
 /**
  * GET /api/openclaw/connection
  *
- * Tiny pollable endpoint for surfacing the gateway connection state
- * to the UI. Distinct from /api/openclaw/status (which actively tries
- * to reconnect + lists sessions). This one is read-only — it asks
- * `client.isConnected()` and returns. No side effects, fast enough
- * to call on a refresh tick.
+ * Pollable endpoint for surfacing the gateway connection state to the
+ * UI. Distinct from /api/openclaw/status, which is the heavyweight
+ * "verify connectivity AND list sessions" endpoint.
+ *
+ * Behavior:
+ *   - Reports the current `isConnected()` state immediately (no
+ *     blocking wait).
+ *   - When the client reports as NOT connected, fires `connect()` in
+ *     the background. The next poll (typically 5s later in the UI)
+ *     will then see `connected: true`.
+ *
+ * Why the lazy kick: the openclaw client is created lazily; on a
+ * fresh dev server boot the first read of `isConnected()` returns
+ * false because the client hasn't tried yet. Without this trigger
+ * the gateway only wakes up when something else (e.g. the agents
+ * page hitting a session call) hits the right endpoint, which is
+ * confusing UX. `connect()` dedupes in-flight attempts so calling
+ * it on every miss is safe.
  */
 export async function GET() {
   try {
     const client = getOpenClawClient();
-    return NextResponse.json({ connected: client.isConnected() });
+    const connected = client.isConnected();
+    if (!connected) {
+      // Fire-and-forget. We deliberately don't await — the UI polls
+      // again in a few seconds, and connect() can take longer than
+      // we want to keep the browser hanging on a single GET.
+      client.connect().catch(err => {
+        console.warn('[openclaw/connection] background reconnect failed:', err?.message ?? err);
+      });
+    }
+    return NextResponse.json({ connected });
   } catch {
-    // If the client itself can't be instantiated (e.g. malformed env),
-    // treat that as not-connected so the UI can surface the warning.
     return NextResponse.json({ connected: false });
   }
 }


### PR DESCRIPTION
## Summary
Operator reported: *"I have to swap to the agents page and then back before the openclaw connection resolves as online."*

**Root cause**: \`GET /api/openclaw/connection\` was a pure read of \`client.isConnected()\` — it never asked the client to reconnect when disconnected. The Agents page hits \`/api/openclaw/status\` which DOES trigger \`client.connect()\`, so swapping pages was the only way to wake the gateway.

## Fix
When the connection endpoint sees \`isConnected() === false\`, it fires \`client.connect()\` in the background (non-awaited so the GET stays fast) and returns the current state immediately. The next poll (5s later in \`useResearchPreflight\`) then sees \`connected: true\` and clears the banner without manual intervention.

\`client.connect()\` is safe to call repeatedly — it dedupes in-flight attempts and short-circuits when already connected ([client.ts:177-189](https://github.com/smb209/mission-control/blob/main/src/lib/openclaw/client.ts#L177-L189)).

## Test plan
- [x] **Preview-verified**: \`/api/openclaw/connection\` returns \`{connected: true}\` on a warm gateway. Research page renders without the gateway-disconnect banner. No console errors.
- [x] \`yarn tsc --noEmit\`: only the 2 pre-existing \`pm-decompose.test.ts\` failures.
- The lazy-kick path is exercised when the gateway disconnects post-boot (HMR, transient network blip, gateway restart). The operator's reported scenario was one such case — without this fix the page stays stuck on "reconnecting" until something else hits \`/api/openclaw/status\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)