### PR TITLE
fix(research): Run button for queued briefs + clearer Suggest labels

### DIFF
--- a/src/app/(app)/research/briefs/[id]/page.tsx
+++ b/src/app/(app)/research/briefs/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { ArrowLeft, ExternalLink, RefreshCw, RotateCw, Trash2 } from 'lucide-react';
+import { ArrowLeft, ExternalLink, RefreshCw, RotateCw, Trash2, Zap } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useMissionControl } from '@/lib/store';
@@ -60,6 +60,8 @@ export default function BriefDetailPage() {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (!params.id) return;
@@ -90,6 +92,26 @@ export default function BriefDetailPage() {
     [events],
   );
   useEffect(() => { if (latestRelevantId) load(); }, [latestRelevantId, load]);
+
+  const dispatchQueued = useCallback(async () => {
+    if (!brief || running) return;
+    setRunning(true);
+    setRunError(null);
+    try {
+      const res = await fetch(`/api/briefs/${brief.id}/run`, { method: 'POST' });
+      if (!res.ok && res.status !== 202) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `Run failed (${res.status})`);
+      }
+      // SSE will move the status pill to RUNNING shortly; refresh
+      // immediately so the operator gets feedback even if SSE is slow.
+      load();
+    } catch (e) {
+      setRunError(e instanceof Error ? e.message : 'Run failed');
+    } finally {
+      setRunning(false);
+    }
+  }, [brief, running, load]);
 
   const rerun = useCallback(async () => {
     if (!brief || rerunning) return;
@@ -131,6 +153,7 @@ export default function BriefDetailPage() {
   if (error) return <div className="p-6 text-red-300">{error}</div>;
   if (!brief || !run) return <div className="p-6 text-mc-text-secondary">{loading ? 'Loading…' : 'Brief not found.'}</div>;
 
+  const isQueued = run.status === 'queued';
   const isTerminal = run.status === 'complete' || run.status === 'failed' || run.status === 'cancelled';
   const stamp = run.completed_at ?? run.started_at ?? brief.created_at;
 
@@ -171,6 +194,18 @@ export default function BriefDetailPage() {
           >
             <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
           </button>
+          {isQueued && (
+            <button
+              type="button"
+              onClick={dispatchQueued}
+              disabled={running}
+              title="Dispatch this queued brief now"
+              className="px-3 py-1.5 text-sm bg-mc-accent text-mc-bg rounded-sm hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1.5"
+            >
+              <Zap className={`w-3.5 h-3.5 ${running ? 'animate-pulse' : ''}`} />
+              {running ? 'Dispatching…' : 'Run'}
+            </button>
+          )}
           <button
             type="button"
             onClick={rerun}
@@ -217,6 +252,12 @@ export default function BriefDetailPage() {
         </div>
       )}
 
+      {runError && (
+        <div className="mb-4 px-3 py-2 rounded-sm bg-red-900/20 border border-red-500/30 text-red-300 text-sm">
+          {runError}
+        </div>
+      )}
+
       <section className="mb-4">
         <h2 className="text-[11px] uppercase tracking-wider text-mc-text-secondary mb-2">Prompt</h2>
         <pre className="px-3 py-2 bg-mc-bg-secondary border border-mc-border rounded-sm text-xs text-mc-text whitespace-pre-wrap font-sans">{brief.prompt}</pre>
@@ -230,7 +271,11 @@ export default function BriefDetailPage() {
           </article>
         ) : (
           <p className="text-sm text-mc-text-secondary/70 italic">
-            {isTerminal ? 'No result body.' : 'Brief is still running…'}
+            {isTerminal
+              ? 'No result body.'
+              : isQueued
+                ? 'Brief is queued — hit "Run" to dispatch it.'
+                : 'Brief is still running…'}
           </p>
         )}
       </section>

--- a/src/app/(app)/research/page.tsx
+++ b/src/app/(app)/research/page.tsx
@@ -142,7 +142,7 @@ export default function ResearchHubPage() {
               onClick={() => setSuggestKind('topic')}
               className="p-1 rounded-sm text-mc-text-secondary hover:text-mc-accent hover:bg-mc-bg-tertiary"
               aria-label="Suggest topics"
-              title="Suggest topics from project state"
+              title="Suggest topics — ask the PM to propose long-lived areas to track based on workspace state"
             >
               <Sparkles className="w-4 h-4" />
             </button>
@@ -208,11 +208,11 @@ export default function ResearchHubPage() {
             <button
               type="button"
               onClick={() => setSuggestKind('brief')}
-              title="Suggest briefs from project state"
+              title="Suggest briefs — ask the PM to propose specific research questions based on workspace state"
               className="px-3 py-1.5 text-sm rounded-sm border border-mc-border text-mc-text hover:bg-mc-bg-tertiary flex items-center gap-1.5"
             >
               <Sparkles className="w-3.5 h-3.5" />
-              Suggest
+              Suggest briefs
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Summary
Operator hit this in a real session: accepted a brief suggestion (which inserts the brief in \`queued\` state, matching the agreed manual-dispatch model), then clicked into the brief and saw "still running" — but the brief was actually queued and stalled, with no way to dispatch it from the UI.

## Three fixes on the brief detail page
1. **Run button when status === 'queued'.** Calls \`POST /api/briefs/[id]/run\` (the same endpoint \`RunBriefDrawer\` uses post-create). Visible only for queued briefs.
2. **Status text differentiates queued vs running.** Was always *"Brief is still running…"* for any non-terminal state. Now:
   - \`queued\`    → *"Brief is queued — hit \"Run\" to dispatch it."*
   - \`running\`   → *"Brief is still running…"*
   - terminal   → *"No result body."*
3. **Header label \"Suggest\" → \"Suggest briefs\"** in the Research hub, parallel to "Run a brief" next to it. Topics rail sparkles icon stays icon-only (contextual placement carries the meaning) but its tooltip is now sharper.

### Why a queued path exists at all
Per the agreed suggestion-flow design, accepted suggestions create briefs in \`queued\` state — the operator hits Run deliberately, no auto-dispatch. The bug was that the brief detail page assumed every non-terminal brief got there through "Run a brief" (which immediately dispatches), so the queued-with-no-Run-affordance state was unreachable from the suggestion flow until now.

## Test plan
- [x] **Preview-verified live**: queued brief shows Run button. Click → API confirms \`agent_run\` flips to running with \`started_at\` set. Status pill updates to RUNNING. Run button disappears. Result text updates. No console errors.
- [x] "Suggest briefs" label visible in header.
- [x] \`yarn tsc --noEmit\`: only the 2 pre-existing \`pm-decompose.test.ts\` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)