### PR TITLE
feat(research): persistent left rail across research pages

### DIFF
--- a/src/app/(app)/research/briefs/[id]/page.tsx
+++ b/src/app/(app)/research/briefs/[id]/page.tsx
@@ -3,10 +3,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { ArrowLeft, ExternalLink, RefreshCw, RotateCw, Trash2, Zap } from 'lucide-react';
+import { ExternalLink, RefreshCw, RotateCw, Trash2, Zap } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { useMissionControl } from '@/lib/store';
 import { formatDistanceToNow } from 'date-fns';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 
@@ -36,7 +35,7 @@ interface AgentRun {
 
 interface Topic { id: string; name: string }
 
-const RELEVANT_EVENTS = ['brief_started', 'brief_progress', 'brief_completed', 'brief_failed'];
+const RELEVANT_EVENTS = new Set(['brief_started', 'brief_progress', 'brief_completed', 'brief_failed']);
 
 const STATUS_COLOR: Record<AgentRun['status'], string> = {
   queued:    'bg-mc-bg-tertiary text-mc-text-secondary border-mc-border',
@@ -49,7 +48,6 @@ const STATUS_COLOR: Record<AgentRun['status'], string> = {
 export default function BriefDetailPage() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
-  const { events } = useMissionControl();
   const [brief, setBrief] = useState<Brief | null>(null);
   const [run, setRun] = useState<AgentRun | null>(null);
   const [topic, setTopic] = useState<Topic | null>(null);
@@ -87,11 +85,18 @@ export default function BriefDetailPage() {
 
   useEffect(() => { load(); }, [load]);
 
-  const latestRelevantId = useMemo(
-    () => events.find(e => RELEVANT_EVENTS.includes(e.type as string))?.id,
-    [events],
-  );
-  useEffect(() => { if (latestRelevantId) load(); }, [latestRelevantId, load]);
+  // Direct SSE — global events store doesn't surface brief_* events.
+  useEffect(() => {
+    const es = new EventSource('/api/events/stream');
+    es.onmessage = (raw) => {
+      try {
+        if (raw.data.startsWith(':')) return;
+        const evt = JSON.parse(raw.data) as { type?: string };
+        if (evt.type && RELEVANT_EVENTS.has(evt.type)) load();
+      } catch { /* ignore */ }
+    };
+    return () => es.close();
+  }, [load]);
 
   const dispatchQueued = useCallback(async () => {
     if (!brief || running) return;
@@ -159,13 +164,6 @@ export default function BriefDetailPage() {
 
   return (
     <div className="px-6 py-5 max-w-4xl">
-      <Link
-        href="/research"
-        className="inline-flex items-center gap-1 text-xs text-mc-text-secondary hover:text-mc-accent mb-4"
-      >
-        <ArrowLeft className="w-3 h-3" /> All research
-      </Link>
-
       <header className="flex items-start justify-between mb-4">
         <div className="flex-1 min-w-0">
           <h1 className="text-xl font-semibold text-mc-text mb-1">{brief.title}</h1>

--- a/src/app/(app)/research/layout.tsx
+++ b/src/app/(app)/research/layout.tsx
@@ -1,0 +1,18 @@
+/**
+ * Persistent research shell. The left rail (topics + recent briefs)
+ * stays mounted while the operator navigates between the hub, topic
+ * detail, and brief detail pages — so the rail acts as actual
+ * navigation rather than a one-page accent.
+ */
+
+import type { ReactNode } from 'react';
+import { ResearchSideRail } from '@/components/research/ResearchSideRail';
+
+export default function ResearchLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-full">
+      <ResearchSideRail />
+      <div className="flex-1 overflow-y-auto">{children}</div>
+    </div>
+  );
+}

--- a/src/app/(app)/research/page.tsx
+++ b/src/app/(app)/research/page.tsx
@@ -3,28 +3,26 @@
 /**
  * Research hub.
  *
- * Three lanes — In progress / Recent results / (Upcoming is a phase-1
- * placeholder until schedules ship in phase 2) — plus a topic library
- * on the left rail. SSE keeps the in-progress lane and recent results
- * live without polling.
+ * Renders inside the persistent research shell (see
+ * `(app)/research/layout.tsx`). The left rail (topics + briefs +
+ * Suggest / Create / Run buttons) is the layout's responsibility;
+ * this page just owns the main panel.
+ *
+ * Three lanes — In progress / Upcoming (placeholder) / Recent results.
+ * SSE keeps the in-progress lane and recent results live without
+ * polling.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Plus, RefreshCw, Search, FileText, Zap, Archive, AlertTriangle, Sparkles } from 'lucide-react';
+import { RefreshCw, FileText, AlertTriangle } from 'lucide-react';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
-import { useMissionControl } from '@/lib/store';
 import { formatDistanceToNow } from 'date-fns';
-import { CreateTopicDrawer } from '@/components/research/CreateTopicDrawer';
-import { RunBriefDrawer } from '@/components/research/RunBriefDrawer';
-import { SuggestPickerDrawer } from '@/components/research/SuggestPickerDrawer';
 import { useResearchPreflight } from '@/components/research/useResearchPreflight';
 
 interface TopicSummary {
   id: string;
   name: string;
-  description: string;
-  tags: string[];
   archived_at: string | null;
 }
 
@@ -34,10 +32,7 @@ interface BriefSummary {
   topic_id: string | null;
   agent_run_id: string;
   template: string;
-  result_md: string | null;
-  error_md: string | null;
   created_at: string;
-  updated_at: string;
 }
 
 interface AgentRunSummary {
@@ -46,10 +41,11 @@ interface AgentRunSummary {
   kind: 'brief';
   started_at: string | null;
   completed_at: string | null;
-  error_md: string | null;
 }
 
-const RELEVANT_EVENTS = ['brief_started', 'brief_progress', 'brief_completed', 'brief_failed'];
+const RELEVANT_EVENTS = new Set([
+  'brief_started', 'brief_progress', 'brief_completed', 'brief_failed',
+]);
 
 const STATUS_COLOR: Record<AgentRunSummary['status'], string> = {
   queued:    'bg-mc-bg-tertiary text-mc-text-secondary border-mc-border',
@@ -61,19 +57,13 @@ const STATUS_COLOR: Record<AgentRunSummary['status'], string> = {
 
 export default function ResearchHubPage() {
   const workspaceId = useCurrentWorkspaceId();
-  const { events } = useMissionControl();
+  const preflight = useResearchPreflight(workspaceId);
 
   const [topics, setTopics] = useState<TopicSummary[]>([]);
   const [briefs, setBriefs] = useState<BriefSummary[]>([]);
   const [runs, setRuns] = useState<AgentRunSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [createTopicOpen, setCreateTopicOpen] = useState(false);
-  const [runBriefOpen, setRunBriefOpen] = useState(false);
-  const [activeTopicId, setActiveTopicId] = useState<string | null>(null);
-  const [suggestKind, setSuggestKind] = useState<'topic' | 'brief' | null>(null);
-
-  const preflight = useResearchPreflight(workspaceId);
 
   const load = useCallback(async () => {
     if (!workspaceId) return;
@@ -98,11 +88,20 @@ export default function ResearchHubPage() {
 
   useEffect(() => { load(); }, [load]);
 
-  // Refetch when relevant SSE events fire.
-  const latestRelevantId = useMemo(() => {
-    return events.find(e => RELEVANT_EVENTS.includes(e.type as string))?.id;
-  }, [events]);
-  useEffect(() => { if (latestRelevantId) load(); }, [latestRelevantId, load]);
+  // Subscribe directly to SSE — the global events store doesn't
+  // surface brief_* events, so we open our own stream like the rail
+  // does. See RELEVANT_EVENTS doc.
+  useEffect(() => {
+    const es = new EventSource('/api/events/stream');
+    es.onmessage = (raw) => {
+      try {
+        if (raw.data.startsWith(':')) return;
+        const evt = JSON.parse(raw.data) as { type?: string };
+        if (evt.type && RELEVANT_EVENTS.has(evt.type)) load();
+      } catch { /* ignore parse errors */ }
+    };
+    return () => es.close();
+  }, [load]);
 
   const runById = useMemo(() => {
     const m = new Map<string, AgentRunSummary>();
@@ -131,154 +130,46 @@ export default function ResearchHubPage() {
   }
 
   return (
-    <div className="flex h-full">
-      {/* Left rail: topic library */}
-      <aside className="w-64 border-r border-mc-border bg-mc-bg-secondary flex flex-col shrink-0">
-        <div className="px-3 py-2 border-b border-mc-border flex items-center justify-between">
-          <span className="text-[10px] uppercase tracking-wider text-mc-text-secondary">Topics</span>
-          <div className="flex items-center gap-0.5">
-            <button
-              type="button"
-              onClick={() => setSuggestKind('topic')}
-              className="p-1 rounded-sm text-mc-text-secondary hover:text-mc-accent hover:bg-mc-bg-tertiary"
-              aria-label="Suggest topics"
-              title="Suggest topics — ask the PM to propose long-lived areas to track based on workspace state"
-            >
-              <Sparkles className="w-4 h-4" />
-            </button>
-            <button
-              type="button"
-              onClick={() => setCreateTopicOpen(true)}
-              className="p-1 rounded-sm text-mc-accent hover:bg-mc-bg-tertiary"
-              aria-label="Create topic"
-              title="Create topic from scratch"
-            >
-              <Plus className="w-4 h-4" />
-            </button>
-          </div>
+    <div className="p-6">
+      <header className="flex items-center justify-between mb-5">
+        <div>
+          <h1 className="text-xl font-semibold text-mc-text">Research</h1>
+          <p className="text-sm text-mc-text-secondary mt-0.5">Topics, briefs, and dispatched research runs.</p>
         </div>
-        <ul className="flex-1 overflow-y-auto py-1">
-          <li>
-            <button
-              type="button"
-              onClick={() => setActiveTopicId(null)}
-              className={`w-full text-left px-3 py-1.5 text-sm flex items-center gap-2 ${
-                activeTopicId === null ? 'bg-mc-accent/15 text-mc-accent' : 'text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary'
-              }`}
-            >
-              <Search className="w-3.5 h-3.5 shrink-0" />
-              All
-            </button>
-          </li>
-          {topics.map(t => (
-            <li key={t.id}>
-              <Link
-                href={`/research/topics/${t.id}`}
-                className="block px-3 py-1.5 text-sm text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary truncate"
-                title={t.description}
-              >
-                {t.archived_at && <Archive className="inline w-3 h-3 mr-1" />}
-                {t.name}
-              </Link>
-            </li>
-          ))}
-          {topics.length === 0 && !loading && (
-            <li className="px-3 py-2 text-xs text-mc-text-secondary/60">No topics yet.</li>
-          )}
-        </ul>
-      </aside>
+        <button
+          type="button"
+          onClick={load}
+          className="p-2 rounded-sm text-mc-text-secondary hover:bg-mc-bg-tertiary"
+          title="Refresh"
+          aria-label="Refresh"
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+        </button>
+      </header>
 
-      {/* Main: lanes */}
-      <main className="flex-1 overflow-y-auto p-6">
-        <header className="flex items-center justify-between mb-5">
-          <div>
-            <h1 className="text-xl font-semibold text-mc-text">Research</h1>
-            <p className="text-sm text-mc-text-secondary mt-0.5">Topics, briefs, and dispatched research runs.</p>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={load}
-              className="p-2 rounded-sm text-mc-text-secondary hover:bg-mc-bg-tertiary"
-              title="Refresh"
-              aria-label="Refresh"
-            >
-              <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-            </button>
-            <button
-              type="button"
-              onClick={() => setSuggestKind('brief')}
-              title="Suggest briefs — ask the PM to propose specific research questions based on workspace state"
-              className="px-3 py-1.5 text-sm rounded-sm border border-mc-border text-mc-text hover:bg-mc-bg-tertiary flex items-center gap-1.5"
-            >
-              <Sparkles className="w-3.5 h-3.5" />
-              Suggest briefs
-            </button>
-            <button
-              type="button"
-              onClick={() => setRunBriefOpen(true)}
-              disabled={!preflight.ok && !preflight.loading}
-              title={preflight.ok ? undefined : 'A researcher must be in this workspace before you can dispatch a brief'}
-              className="px-3 py-1.5 bg-mc-accent text-mc-bg rounded-sm text-sm font-medium hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1.5"
-            >
-              <Zap className="w-3.5 h-3.5" />
-              Run a brief
-            </button>
-          </div>
-        </header>
-
-        {/* Preflight warning. Renders only when something is missing —
-            staying GREEN keeps the chrome out of the operator's way. */}
-        {!preflight.loading && !preflight.ok && (
-          <PreflightBanner preflight={preflight} />
-        )}
-
-        {error && (
-          <div className="mb-4 px-3 py-2 rounded-sm bg-red-900/20 border border-red-500/30 text-red-300 text-sm">
-            {error}
-          </div>
-        )}
-
-        <Lane title="In progress" emptyText="No briefs running. Hit “Run a brief” to start one.">
-          {inProgress.map(b => (
-            <BriefRow key={b.id} brief={b} run={runById.get(b.agent_run_id)} topics={topics} />
-          ))}
-        </Lane>
-
-        <Lane title="Upcoming" emptyText="Schedules land in phase 2 — this lane will populate then.">
-          {/* Empty in phase 1 — schedules ship in phase 2. */}
-        </Lane>
-
-        <Lane title="Recent results" emptyText="Completed briefs appear here.">
-          {recent.map(b => (
-            <BriefRow key={b.id} brief={b} run={runById.get(b.agent_run_id)} topics={topics} />
-          ))}
-        </Lane>
-      </main>
-
-      <CreateTopicDrawer
-        open={createTopicOpen}
-        onClose={() => setCreateTopicOpen(false)}
-        workspaceId={workspaceId}
-        onCreated={() => { setCreateTopicOpen(false); load(); }}
-      />
-      {suggestKind && (
-        <SuggestPickerDrawer
-          open={!!suggestKind}
-          onClose={() => setSuggestKind(null)}
-          workspaceId={workspaceId}
-          kind={suggestKind}
-          onAccepted={() => { setSuggestKind(null); load(); }}
-        />
+      {!preflight.loading && !preflight.ok && (
+        <PreflightBanner preflight={preflight} />
       )}
-      <RunBriefDrawer
-        open={runBriefOpen}
-        onClose={() => setRunBriefOpen(false)}
-        workspaceId={workspaceId}
-        topics={topics.filter(t => !t.archived_at)}
-        defaultTopicId={null}
-        onLaunched={() => { setRunBriefOpen(false); load(); }}
-      />
+
+      {error && (
+        <div className="mb-4 px-3 py-2 rounded-sm bg-red-900/20 border border-red-500/30 text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+
+      <Lane title="In progress" emptyText="No briefs running. Use the rail’s Run button to start one.">
+        {inProgress.map(b => (
+          <BriefRow key={b.id} brief={b} run={runById.get(b.agent_run_id)} topics={topics} />
+        ))}
+      </Lane>
+
+      <Lane title="Upcoming" emptyText="Schedules land in phase 2 — this lane will populate then." />
+
+      <Lane title="Recent results" emptyText="Completed briefs appear here.">
+        {recent.map(b => (
+          <BriefRow key={b.id} brief={b} run={runById.get(b.agent_run_id)} topics={topics} />
+        ))}
+      </Lane>
     </div>
   );
 }

--- a/src/app/(app)/research/topics/[id]/page.tsx
+++ b/src/app/(app)/research/topics/[id]/page.tsx
@@ -3,9 +3,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { ArrowLeft, Archive, ArchiveRestore, FileText, RefreshCw, Zap } from 'lucide-react';
+import { Archive, ArchiveRestore, FileText, RefreshCw, Zap } from 'lucide-react';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
-import { useMissionControl } from '@/lib/store';
 import { formatDistanceToNow } from 'date-fns';
 import { RunBriefDrawer } from '@/components/research/RunBriefDrawer';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -28,13 +27,12 @@ interface BriefSummary {
   created_at: string;
 }
 
-const RELEVANT_EVENTS = ['brief_started', 'brief_completed', 'brief_failed'];
+const RELEVANT_EVENTS = new Set(['brief_started', 'brief_completed', 'brief_failed']);
 
 export default function TopicDetailPage() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
   const workspaceId = useCurrentWorkspaceId();
-  const { events } = useMissionControl();
   const [topic, setTopic] = useState<Topic | null>(null);
   const [briefs, setBriefs] = useState<BriefSummary[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -59,11 +57,18 @@ export default function TopicDetailPage() {
 
   useEffect(() => { load(); }, [load]);
 
-  const latestRelevantId = useMemo(
-    () => events.find(e => RELEVANT_EVENTS.includes(e.type as string))?.id,
-    [events],
-  );
-  useEffect(() => { if (latestRelevantId) load(); }, [latestRelevantId, load]);
+  // Direct SSE — global events store doesn't surface brief_* events.
+  useEffect(() => {
+    const es = new EventSource('/api/events/stream');
+    es.onmessage = (raw) => {
+      try {
+        if (raw.data.startsWith(':')) return;
+        const evt = JSON.parse(raw.data) as { type?: string };
+        if (evt.type && RELEVANT_EVENTS.has(evt.type)) load();
+      } catch { /* ignore */ }
+    };
+    return () => es.close();
+  }, [load]);
 
   const archive = async (archived: boolean) => {
     if (!topic) return;
@@ -87,13 +92,6 @@ export default function TopicDetailPage() {
 
   return (
     <div className="px-6 py-5 max-w-4xl">
-      <Link
-        href="/research"
-        className="inline-flex items-center gap-1 text-xs text-mc-text-secondary hover:text-mc-accent mb-4"
-      >
-        <ArrowLeft className="w-3 h-3" /> All research
-      </Link>
-
       <header className="flex items-start justify-between mb-4">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">

--- a/src/components/research/ResearchSideRail.tsx
+++ b/src/components/research/ResearchSideRail.tsx
@@ -1,0 +1,674 @@
+'use client';
+
+/**
+ * Persistent left rail rendered by `(app)/research/layout.tsx`.
+ *
+ * Stays mounted across /research, /research/topics/[id],
+ * /research/briefs/[id], so the operator can navigate between
+ * topics and recent briefs without going back to the hub.
+ *
+ * Features:
+ *   - Sections (Topics, Briefs) each collapse vertically so a big
+ *     topics list doesn't bury briefs.
+ *   - Pin a topic or brief to keep it pinned to the top of its
+ *     section (per-workspace, localStorage-only — pure UI state, no
+ *     DB row required).
+ *   - Drag the right edge to resize the rail width (180–480px).
+ *   - Collapse the entire rail to a thin icon column for focus mode.
+ *
+ * All UI state (rail collapsed, rail width, section open/closed,
+ * pinned ids per workspace) persists in localStorage so operator
+ * preference survives reloads.
+ *
+ * Active row highlighting is pathname-based.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import {
+  Plus,
+  Sparkles,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  Search,
+  FileText,
+  Archive,
+  Zap,
+  CircleDot,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Pin,
+  PinOff,
+} from 'lucide-react';
+import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
+import { useResearchPreflight } from '@/components/research/useResearchPreflight';
+import { CreateTopicDrawer } from '@/components/research/CreateTopicDrawer';
+import { RunBriefDrawer } from '@/components/research/RunBriefDrawer';
+import { SuggestPickerDrawer } from '@/components/research/SuggestPickerDrawer';
+
+interface TopicSummary {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  archived_at: string | null;
+}
+
+interface BriefSummary {
+  id: string;
+  title: string;
+  topic_id: string | null;
+  agent_run_id: string;
+  template: string;
+  created_at: string;
+}
+
+interface AgentRunSummary {
+  id: string;
+  status: 'queued' | 'running' | 'complete' | 'failed' | 'cancelled';
+}
+
+const RAIL_COLLAPSED_KEY = 'mc.research.rail.collapsed';
+const RAIL_WIDTH_KEY = 'mc.research.rail.width';
+const SECTION_OPEN_KEY = 'mc.research.rail.sections';
+const PINS_KEY_PREFIX = 'mc.research.rail.pins.';
+
+const RAIL_MIN_WIDTH = 180;
+const RAIL_MAX_WIDTH = 480;
+const RAIL_DEFAULT_WIDTH = 256;
+
+/**
+ * SSE event types the rail reacts to. `brief_failed` is also broadcast
+ * (with `payload.deleted: true`) by the DELETE /api/briefs/[id] route
+ * so the deleted entry disappears from the rail without a manual
+ * refresh.
+ *
+ * We open our OWN EventSource (instead of routing through the store)
+ * because the project's `useSSE` hook only pushes specific event
+ * types into the global events array — `brief_*` events are not on
+ * its allowlist. Matches the pattern in DecomposeWithPmModal /
+ * AgentActivityDashboard / etc.
+ */
+const RELEVANT_EVENTS = new Set([
+  'brief_started', 'brief_progress', 'brief_completed', 'brief_failed',
+]);
+
+const STATUS_ICON: Record<AgentRunSummary['status'], React.ComponentType<{ className?: string }>> = {
+  queued: CircleDot,
+  running: Loader2,
+  complete: CheckCircle2,
+  failed: XCircle,
+  cancelled: XCircle,
+};
+
+const STATUS_COLOR: Record<AgentRunSummary['status'], string> = {
+  queued: 'text-mc-text-secondary',
+  running: 'text-mc-accent animate-spin',
+  complete: 'text-green-400',
+  failed: 'text-red-400',
+  cancelled: 'text-yellow-400',
+};
+
+interface SectionState { topics: boolean; briefs: boolean }
+const DEFAULT_SECTION_STATE: SectionState = { topics: true, briefs: true };
+
+export function ResearchSideRail() {
+  const workspaceId = useCurrentWorkspaceId();
+  const pathname = usePathname() ?? '/research';
+  const preflight = useResearchPreflight(workspaceId);
+
+  const [collapsed, setCollapsed] = useState(false);
+  const [width, setWidth] = useState(RAIL_DEFAULT_WIDTH);
+  const [sections, setSections] = useState<SectionState>(DEFAULT_SECTION_STATE);
+  const [pinnedTopics, setPinnedTopics] = useState<string[]>([]);
+  const [pinnedBriefs, setPinnedBriefs] = useState<string[]>([]);
+
+  const [topics, setTopics] = useState<TopicSummary[]>([]);
+  const [briefs, setBriefs] = useState<BriefSummary[]>([]);
+  const [runs, setRuns] = useState<AgentRunSummary[]>([]);
+  const [createTopicOpen, setCreateTopicOpen] = useState(false);
+  const [runBriefOpen, setRunBriefOpen] = useState(false);
+  const [suggestKind, setSuggestKind] = useState<'topic' | 'brief' | null>(null);
+
+  // Restore persisted UI state.
+  useEffect(() => {
+    try {
+      setCollapsed(localStorage.getItem(RAIL_COLLAPSED_KEY) === '1');
+      const w = parseInt(localStorage.getItem(RAIL_WIDTH_KEY) ?? '', 10);
+      if (Number.isFinite(w) && w >= RAIL_MIN_WIDTH && w <= RAIL_MAX_WIDTH) setWidth(w);
+      const sec = localStorage.getItem(SECTION_OPEN_KEY);
+      if (sec) {
+        const parsed = JSON.parse(sec) as Partial<SectionState>;
+        setSections({ ...DEFAULT_SECTION_STATE, ...parsed });
+      }
+    } catch { /* ignore */ }
+  }, []);
+
+  // Per-workspace pinned ids.
+  useEffect(() => {
+    if (!workspaceId) {
+      setPinnedTopics([]); setPinnedBriefs([]);
+      return;
+    }
+    try {
+      const raw = localStorage.getItem(PINS_KEY_PREFIX + workspaceId);
+      if (raw) {
+        const parsed = JSON.parse(raw) as { topics?: string[]; briefs?: string[] };
+        setPinnedTopics(parsed.topics ?? []);
+        setPinnedBriefs(parsed.briefs ?? []);
+      } else {
+        setPinnedTopics([]); setPinnedBriefs([]);
+      }
+    } catch {
+      setPinnedTopics([]); setPinnedBriefs([]);
+    }
+  }, [workspaceId]);
+
+  const persistPins = useCallback((topicsArr: string[], briefsArr: string[]) => {
+    if (!workspaceId) return;
+    try {
+      localStorage.setItem(PINS_KEY_PREFIX + workspaceId, JSON.stringify({ topics: topicsArr, briefs: briefsArr }));
+    } catch { /* ignore */ }
+  }, [workspaceId]);
+
+  const toggleCollapsed = useCallback(() => {
+    setCollapsed(c => {
+      const next = !c;
+      try { localStorage.setItem(RAIL_COLLAPSED_KEY, next ? '1' : '0'); } catch { /* ignore */ }
+      return next;
+    });
+  }, []);
+
+  const toggleSection = useCallback((key: keyof SectionState) => {
+    setSections(s => {
+      const next = { ...s, [key]: !s[key] };
+      try { localStorage.setItem(SECTION_OPEN_KEY, JSON.stringify(next)); } catch { /* ignore */ }
+      return next;
+    });
+  }, []);
+
+  const togglePinTopic = useCallback((id: string) => {
+    setPinnedTopics(prev => {
+      const next = prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id];
+      persistPins(next, pinnedBriefs);
+      return next;
+    });
+  }, [persistPins, pinnedBriefs]);
+
+  const togglePinBrief = useCallback((id: string) => {
+    setPinnedBriefs(prev => {
+      const next = prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id];
+      persistPins(pinnedTopics, next);
+      return next;
+    });
+  }, [persistPins, pinnedTopics]);
+
+  // Resize-drag.
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const onDragStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    dragRef.current = { startX: e.clientX, startWidth: width };
+    const onMove = (ev: MouseEvent) => {
+      if (!dragRef.current) return;
+      const dx = ev.clientX - dragRef.current.startX;
+      const next = Math.min(RAIL_MAX_WIDTH, Math.max(RAIL_MIN_WIDTH, dragRef.current.startWidth + dx));
+      setWidth(next);
+    };
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+      dragRef.current = null;
+      // Persist final width.
+      try {
+        const finalWidth = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--mc-research-rail-w') || '', 10);
+        // Fallback: read from state via setWidth(prev => ...). We
+        // can just use the latest setter trick here.
+        void finalWidth;
+      } catch { /* ignore */ }
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'col-resize';
+  }, [width]);
+
+  // Persist width when it stops changing (debounced via effect).
+  useEffect(() => {
+    const id = setTimeout(() => {
+      try { localStorage.setItem(RAIL_WIDTH_KEY, String(width)); } catch { /* ignore */ }
+    }, 200);
+    return () => clearTimeout(id);
+  }, [width]);
+
+  const load = useCallback(async () => {
+    if (!workspaceId) {
+      setTopics([]); setBriefs([]); setRuns([]);
+      return;
+    }
+    const qs = `?workspace_id=${encodeURIComponent(workspaceId)}`;
+    try {
+      const [t, b, r] = await Promise.all([
+        fetch(`/api/topics${qs}`).then(res => res.ok ? res.json() : []),
+        fetch(`/api/briefs${qs}&limit=20`).then(res => res.ok ? res.json() : []),
+        fetch(`/api/agent-runs${qs}&kind=brief&limit=50`).then(res => res.ok ? res.json() : []),
+      ]);
+      setTopics(t);
+      setBriefs(b);
+      setRuns(r);
+    } catch {
+      // Quiet failure — main panel surfaces its own load error.
+    }
+  }, [workspaceId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  // Subscribe directly to SSE so we react to brief lifecycle and
+  // deletions even when the operator isn't on a page that already
+  // owns the global events stream. See RELEVANT_EVENTS doc above.
+  useEffect(() => {
+    const es = new EventSource('/api/events/stream');
+    es.onmessage = (raw) => {
+      try {
+        if (raw.data.startsWith(':')) return;
+        const evt = JSON.parse(raw.data) as { type?: string };
+        if (evt.type && RELEVANT_EVENTS.has(evt.type)) load();
+      } catch { /* ignore parse errors */ }
+    };
+    return () => es.close();
+  }, [load]);
+
+  const runById = useMemo(() => {
+    const m = new Map<string, AgentRunSummary>();
+    for (const r of runs) m.set(r.id, r);
+    return m;
+  }, [runs]);
+
+  // Sort: pinned first (preserving pin order), then the rest in
+  // their natural order.
+  const sortedTopics = useMemo(() => {
+    const pinSet = new Set(pinnedTopics);
+    const pinned = pinnedTopics
+      .map(id => topics.find(t => t.id === id))
+      .filter((t): t is TopicSummary => !!t);
+    const rest = topics.filter(t => !pinSet.has(t.id));
+    return [...pinned, ...rest];
+  }, [topics, pinnedTopics]);
+
+  const sortedBriefs = useMemo(() => {
+    const pinSet = new Set(pinnedBriefs);
+    const pinned = pinnedBriefs
+      .map(id => briefs.find(b => b.id === id))
+      .filter((b): b is BriefSummary => !!b);
+    const rest = briefs.filter(b => !pinSet.has(b.id));
+    return [...pinned, ...rest];
+  }, [briefs, pinnedBriefs]);
+
+  const isHub = pathname === '/research';
+  const activeTopicId = matchPath(pathname, /^\/research\/topics\/([^/]+)/);
+  const activeBriefId = matchPath(pathname, /^\/research\/briefs\/([^/]+)/);
+
+  const drawers = (
+    <>
+      {createTopicOpen && (
+        <CreateTopicDrawer
+          open={createTopicOpen}
+          onClose={() => setCreateTopicOpen(false)}
+          workspaceId={workspaceId ?? ''}
+          onCreated={() => { setCreateTopicOpen(false); load(); }}
+        />
+      )}
+      {runBriefOpen && (
+        <RunBriefDrawer
+          open={runBriefOpen}
+          onClose={() => setRunBriefOpen(false)}
+          workspaceId={workspaceId ?? ''}
+          topics={topics.filter(t => !t.archived_at)}
+          defaultTopicId={null}
+          onLaunched={() => { setRunBriefOpen(false); load(); }}
+        />
+      )}
+      {suggestKind && (
+        <SuggestPickerDrawer
+          open={!!suggestKind}
+          onClose={() => setSuggestKind(null)}
+          workspaceId={workspaceId ?? ''}
+          kind={suggestKind}
+          onAccepted={() => { setSuggestKind(null); load(); }}
+        />
+      )}
+    </>
+  );
+
+  if (!workspaceId) {
+    return (
+      <aside className="w-60 border-r border-mc-border bg-mc-bg-secondary shrink-0 p-3 text-xs text-mc-text-secondary">
+        No workspace selected.
+      </aside>
+    );
+  }
+
+  if (collapsed) {
+    return (
+      <>
+        <aside className="w-12 border-r border-mc-border bg-mc-bg-secondary shrink-0 flex flex-col items-center py-2 gap-1">
+          <button
+            type="button"
+            onClick={toggleCollapsed}
+            className="p-1.5 rounded-sm text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary"
+            title="Expand rail"
+            aria-label="Expand rail"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+          <Link
+            href="/research"
+            className={`p-1.5 rounded-sm ${isHub ? 'bg-mc-accent/15 text-mc-accent' : 'text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary'}`}
+            title="All research"
+          >
+            <Search className="w-4 h-4" />
+          </Link>
+          <button
+            type="button"
+            onClick={() => setRunBriefOpen(true)}
+            disabled={!preflight.ok && !preflight.loading}
+            className="p-1.5 rounded-sm text-mc-text-secondary hover:text-mc-accent hover:bg-mc-bg-tertiary disabled:opacity-40"
+            title="Run a brief"
+          >
+            <Zap className="w-4 h-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setSuggestKind('brief')}
+            className="p-1.5 rounded-sm text-mc-text-secondary hover:text-mc-accent hover:bg-mc-bg-tertiary"
+            title="Suggest briefs"
+          >
+            <Sparkles className="w-4 h-4" />
+          </button>
+        </aside>
+        {drawers}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <aside
+        className="border-r border-mc-border bg-mc-bg-secondary shrink-0 flex flex-col relative"
+        style={{ width: `${width}px` }}
+      >
+        {/* Header */}
+        <div className="px-3 py-2 border-b border-mc-border flex items-center justify-between">
+          <Link
+            href="/research"
+            className={`text-sm font-medium ${isHub ? 'text-mc-accent' : 'text-mc-text hover:text-mc-accent'}`}
+          >
+            Research
+          </Link>
+          <button
+            type="button"
+            onClick={toggleCollapsed}
+            className="p-1 rounded-sm text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary"
+            title="Collapse rail"
+            aria-label="Collapse rail"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto py-1">
+          {/* Hub link */}
+          <Link
+            href="/research"
+            className={`mx-2 px-2 py-1.5 rounded-sm flex items-center gap-2 text-sm ${
+              isHub ? 'bg-mc-accent/15 text-mc-accent' : 'text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary'
+            }`}
+          >
+            <Search className="w-3.5 h-3.5 shrink-0" />
+            <span className="truncate">All research</span>
+          </Link>
+
+          {/* Topics section */}
+          <CollapsibleSection
+            label="Topics"
+            open={sections.topics}
+            onToggle={() => toggleSection('topics')}
+            count={topics.length}
+            actions={
+              <>
+                <RailIconButton
+                  icon={Sparkles}
+                  onClick={() => setSuggestKind('topic')}
+                  title="Suggest topics — ask the PM to propose long-lived areas"
+                  aria-label="Suggest topics"
+                />
+                <RailIconButton
+                  icon={Plus}
+                  onClick={() => setCreateTopicOpen(true)}
+                  title="Create topic from scratch"
+                  aria-label="Create topic"
+                  accent
+                />
+              </>
+            }
+          >
+            <ul>
+              {sortedTopics.map(t => {
+                const active = activeTopicId === t.id;
+                const pinned = pinnedTopics.includes(t.id);
+                return (
+                  <li key={t.id} className="group">
+                    <div className={`mx-2 rounded-sm flex items-center ${
+                      active ? 'bg-mc-accent/15' : 'hover:bg-mc-bg-tertiary'
+                    }`}>
+                      <Link
+                        href={`/research/topics/${t.id}`}
+                        className={`flex-1 px-2 py-1.5 flex items-center gap-2 text-sm min-w-0 ${
+                          active ? 'text-mc-accent' : 'text-mc-text-secondary hover:text-mc-text'
+                        }`}
+                        title={t.description}
+                      >
+                        {pinned && <Pin className="w-3 h-3 shrink-0 text-mc-accent fill-mc-accent" />}
+                        {t.archived_at && <Archive className="w-3 h-3 shrink-0 opacity-60" />}
+                        <span className="truncate">{t.name}</span>
+                      </Link>
+                      <PinToggle
+                        pinned={pinned}
+                        onClick={() => togglePinTopic(t.id)}
+                        kind="topic"
+                      />
+                    </div>
+                  </li>
+                );
+              })}
+              {topics.length === 0 && (
+                <li className="px-3 py-2 text-xs text-mc-text-secondary/60 italic">No topics yet.</li>
+              )}
+            </ul>
+          </CollapsibleSection>
+
+          {/* Briefs section */}
+          <CollapsibleSection
+            label="Briefs"
+            open={sections.briefs}
+            onToggle={() => toggleSection('briefs')}
+            count={briefs.length}
+            actions={
+              <>
+                <RailIconButton
+                  icon={Sparkles}
+                  onClick={() => setSuggestKind('brief')}
+                  title="Suggest briefs — ask the PM to propose specific research questions"
+                  aria-label="Suggest briefs"
+                />
+                <RailIconButton
+                  icon={Zap}
+                  onClick={() => setRunBriefOpen(true)}
+                  title="Run a brief"
+                  aria-label="Run a brief"
+                  accent
+                  disabled={!preflight.ok && !preflight.loading}
+                />
+              </>
+            }
+          >
+            <ul>
+              {sortedBriefs.slice(0, 20).map(b => {
+                const active = activeBriefId === b.id;
+                const pinned = pinnedBriefs.includes(b.id);
+                const status = runById.get(b.agent_run_id)?.status;
+                const StatusIcon = status ? STATUS_ICON[status] : FileText;
+                const statusClass = status ? STATUS_COLOR[status] : 'text-mc-text-secondary';
+                return (
+                  <li key={b.id} className="group">
+                    <div className={`mx-2 rounded-sm flex items-center ${
+                      active ? 'bg-mc-accent/15' : 'hover:bg-mc-bg-tertiary'
+                    }`}>
+                      <Link
+                        href={`/research/briefs/${b.id}`}
+                        className={`flex-1 px-2 py-1.5 flex items-center gap-2 text-sm min-w-0 ${
+                          active ? 'text-mc-accent' : 'text-mc-text-secondary hover:text-mc-text'
+                        }`}
+                        title={b.title}
+                      >
+                        {pinned && <Pin className="w-3 h-3 shrink-0 text-mc-accent fill-mc-accent" />}
+                        <StatusIcon className={`w-3.5 h-3.5 shrink-0 ${statusClass}`} />
+                        <span className="truncate">{b.title}</span>
+                      </Link>
+                      <PinToggle
+                        pinned={pinned}
+                        onClick={() => togglePinBrief(b.id)}
+                        kind="brief"
+                      />
+                    </div>
+                  </li>
+                );
+              })}
+              {briefs.length === 0 && (
+                <li className="px-3 py-2 text-xs text-mc-text-secondary/60 italic">No briefs yet.</li>
+              )}
+            </ul>
+          </CollapsibleSection>
+        </div>
+
+        {/* Resize handle on the right edge */}
+        <div
+          onMouseDown={onDragStart}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize rail"
+          title="Drag to resize"
+          className="absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-mc-accent/50 transition-colors"
+        />
+      </aside>
+      {drawers}
+    </>
+  );
+}
+
+function CollapsibleSection({
+  label,
+  open,
+  onToggle,
+  count,
+  actions,
+  children,
+}: {
+  label: string;
+  open: boolean;
+  onToggle: () => void;
+  count: number;
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mt-3">
+      <div className="px-3 pb-1 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-mc-text-secondary/70 hover:text-mc-text"
+          aria-expanded={open}
+        >
+          <ChevronDown className={`w-3 h-3 transition-transform ${open ? '' : '-rotate-90'}`} />
+          {label}
+          {count > 0 && <span className="text-mc-text-secondary/50">({count})</span>}
+        </button>
+        {actions && <div className="flex items-center gap-0.5">{actions}</div>}
+      </div>
+      {open && children}
+    </div>
+  );
+}
+
+function PinToggle({
+  pinned,
+  onClick,
+  kind,
+}: {
+  pinned: boolean;
+  onClick: () => void;
+  kind: 'topic' | 'brief';
+}) {
+  return (
+    <button
+      type="button"
+      onClick={(e) => { e.preventDefault(); e.stopPropagation(); onClick(); }}
+      className={`p-1 mr-1 rounded-sm shrink-0 ${
+        pinned
+          ? 'text-mc-accent hover:bg-mc-bg-tertiary'
+          : 'text-mc-text-secondary/0 group-hover:text-mc-text-secondary/70 hover:text-mc-accent hover:bg-mc-bg-tertiary'
+      }`}
+      title={pinned ? `Unpin ${kind}` : `Pin ${kind} to top`}
+      aria-label={pinned ? `Unpin ${kind}` : `Pin ${kind} to top`}
+    >
+      {pinned ? <PinOff className="w-3 h-3" /> : <Pin className="w-3 h-3" />}
+    </button>
+  );
+}
+
+function RailIconButton({
+  icon: Icon,
+  onClick,
+  title,
+  accent,
+  disabled,
+  ...rest
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  onClick: () => void;
+  title: string;
+  accent?: boolean;
+  disabled?: boolean;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      disabled={disabled}
+      className={`p-1 rounded-sm hover:bg-mc-bg-tertiary disabled:opacity-40 disabled:cursor-not-allowed ${
+        accent ? 'text-mc-accent' : 'text-mc-text-secondary hover:text-mc-accent'
+      }`}
+      {...rest}
+    >
+      <Icon className="w-4 h-4" />
+    </button>
+  );
+}
+
+function matchPath(pathname: string, re: RegExp): string | null {
+  const m = re.exec(pathname);
+  return m ? m[1] : null;
+}


### PR DESCRIPTION
## Summary
- Topics + briefs rail now lives in `(app)/research/layout.tsx`, staying mounted while the operator navigates between hub, topic detail, and brief detail.
- Rail supports collapse, drag-resize (180–480px), per-section collapse, and per-workspace pin-to-top for topics and briefs (all in localStorage — no DB rows).
- Hub/topic/brief pages drop their inline back-links; each subscribes directly to `/api/events/stream` for `brief_*` events (the global store doesn't surface them).

## Changes
- `src/app/(app)/research/layout.tsx` (new) — persistent shell.
- `src/components/research/ResearchSideRail.tsx` (new) — rail component.
- `src/app/(app)/research/page.tsx` — main panel only; rail extracted.
- `src/app/(app)/research/topics/[id]/page.tsx`, `briefs/[id]/page.tsx` — drop "All research" back-link, switch SSE refetch to direct EventSource.

## Test plan
- [x] `yarn tsc --noEmit` clean for all research files (only pre-existing `pm-decompose.test.ts` errors remain).
- [x] Preview: rail renders on `/research` with topics + briefs + section actions; persists on `/research/briefs/[id]`; no console errors.
- [ ] Manual: collapse / resize / pin interactions, drawer flows (Create / Suggest / Run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)