### PR TITLE
feat(research): phase-2 schema — recurring_jobs.topic_id + brief_template

### DIFF
--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4203,6 +4203,33 @@ const migrations: Migration[] = [
       console.log('[Migration 076] research_suggestions table created.');
     },
   },
+  {
+    id: '077',
+    name: 'recurring_jobs_research_columns',
+    up: (db) => {
+      // Research phase 2: bind a recurring_jobs row to a topic +
+      // brief template so the scheduler can dispatch via run-brief
+      // instead of dispatchScope. See
+      // specs/research-phase-2-schedules-build-plan.md §3.1.
+      //
+      // Both columns are nullable: a row whose topic_id IS NULL is a
+      // pre-phase-2 scope-keyed job and the scheduler keeps using
+      // dispatchScope. A row with topic_id set is a research schedule.
+      //
+      // FK has no ON DELETE clause: topics are soft-deleted via
+      // archived_at, never hard-deleted. Pause-on-archive will be
+      // plumbed at the application layer in slice 3.
+      const cols = db.prepare(`PRAGMA table_info(recurring_jobs)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'topic_id')) {
+        db.exec(`ALTER TABLE recurring_jobs ADD COLUMN topic_id TEXT REFERENCES topics(id)`);
+      }
+      if (!cols.some((c) => c.name === 'brief_template')) {
+        db.exec(`ALTER TABLE recurring_jobs ADD COLUMN brief_template TEXT`);
+      }
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_recurring_jobs_topic ON recurring_jobs(topic_id) WHERE topic_id IS NOT NULL`);
+      console.log('[Migration 077] recurring_jobs.topic_id + brief_template columns added.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/recurring-jobs.test.ts
+++ b/src/lib/db/recurring-jobs.test.ts
@@ -12,16 +12,29 @@ import { v4 as uuidv4 } from 'uuid';
 import { run } from '@/lib/db';
 import {
   createRecurringJob,
+  createResearchSchedule,
   getRecurringJob,
   listDueJobs,
   listForTask,
   listForWorkspace,
+  listResearchSchedulesForTopic,
+  listUpcomingResearch,
   markRunFailure,
   markRunSuccess,
   RecurringJobValidationError,
   renderScopeKey,
   setJobStatus,
 } from './recurring-jobs';
+
+function freshTopic(workspaceId: string, name = 'WAL on macOS'): string {
+  const id = `tp-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO topics (id, workspace_id, name, description, tags_json, created_at, updated_at)
+     VALUES (?, ?, ?, '', '[]', datetime('now'), datetime('now'))`,
+    [id, workspaceId, name],
+  );
+  return id;
+}
 
 function freshWorkspace(): string {
   const id = `ws-rj-${uuidv4().slice(0, 8)}`;
@@ -179,4 +192,77 @@ test('listForTask: returns jobs scoped to a task', () => {
   const taskJobs = listForTask(taskId);
   assert.equal(taskJobs.length, 1);
   assert.equal(taskJobs[0].id, a.id);
+});
+
+// --- Phase 2: research-bound schedules ----------------------------
+
+test('createRecurringJob: rejects half-set research binding', () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  assert.throws(
+    () => createRecurringJob(baseInput(ws, { topic_id: tp })),
+    RecurringJobValidationError,
+  );
+  assert.throws(
+    () => createRecurringJob(baseInput(ws, { brief_template: 'general_brief' })),
+    RecurringJobValidationError,
+  );
+});
+
+test('createResearchSchedule: round-trip + first_run defaults to one-cadence-out', () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  const before = Date.now();
+  const s = createResearchSchedule({
+    workspace_id: ws,
+    topic_id: tp,
+    brief_template: 'general_brief',
+    cadence_seconds: 604800, // weekly
+  });
+  const after = Date.now();
+  assert.equal(s.topic_id, tp);
+  assert.equal(s.brief_template, 'general_brief');
+  assert.equal(s.role, 'researcher');
+  assert.equal(s.cadence_seconds, 604800);
+  // next_run_at should be one cadence ahead, not 'now'.
+  const nextMs = Date.parse(s.next_run_at);
+  assert.ok(nextMs >= before + 604800 * 1000 - 50);
+  assert.ok(nextMs <= after + 604800 * 1000 + 50);
+});
+
+test('listResearchSchedulesForTopic: scopes to topic', () => {
+  const ws = freshWorkspace();
+  const a = freshTopic(ws, 'topic A');
+  const b = freshTopic(ws, 'topic B');
+  const sa = createResearchSchedule({ workspace_id: ws, topic_id: a, brief_template: 'general_brief', cadence_seconds: 60 });
+  createResearchSchedule({ workspace_id: ws, topic_id: b, brief_template: 'general_brief', cadence_seconds: 60 });
+
+  const onA = listResearchSchedulesForTopic(a);
+  assert.equal(onA.length, 1);
+  assert.equal(onA[0].id, sa.id);
+});
+
+test('listUpcomingResearch: orders by next_run_at and excludes paused / non-research', () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  // Three research schedules, different next_run_at offsets.
+  const earliest = createResearchSchedule({
+    workspace_id: ws, topic_id: tp, brief_template: 'general_brief',
+    cadence_seconds: 60, first_run_at: new Date(Date.now() + 1000).toISOString(),
+  });
+  createResearchSchedule({
+    workspace_id: ws, topic_id: tp, brief_template: 'general_brief',
+    cadence_seconds: 60, first_run_at: new Date(Date.now() + 60_000).toISOString(),
+  });
+  const paused = createResearchSchedule({
+    workspace_id: ws, topic_id: tp, brief_template: 'general_brief',
+    cadence_seconds: 60, first_run_at: new Date(Date.now() + 500).toISOString(),
+  });
+  setJobStatus(paused.id, 'paused');
+  // A non-research recurring_jobs row in the same workspace must not leak.
+  createRecurringJob(baseInput(ws, { name: 'scope-keyed-only' }));
+
+  const upcoming = listUpcomingResearch(ws, 10);
+  assert.equal(upcoming.length, 2);
+  assert.equal(upcoming[0].id, earliest.id);
 });

--- a/src/lib/db/recurring-jobs.ts
+++ b/src/lib/db/recurring-jobs.ts
@@ -32,6 +32,13 @@ export interface RecurringJob {
   run_count: number;
   created_at: string;
   created_by_agent_id: string | null;
+  /**
+   * Phase-2 research binding (migration 077). When set, this row is a
+   * research schedule and the scheduler dispatches via run-brief
+   * instead of dispatchScope.
+   */
+  topic_id: string | null;
+  brief_template: string | null;
 }
 
 export class RecurringJobValidationError extends Error {
@@ -54,6 +61,15 @@ export interface CreateRecurringJobInput {
   /** ISO datetime; defaults to now (fires immediately on first sweep). */
   first_run_at?: string;
   created_by_agent_id?: string | null;
+  /**
+   * Phase-2 research binding. Set both `topic_id` and `brief_template`
+   * to make this a research schedule. The scheduler will dispatch via
+   * run-brief; `scope_key_template` is unused in that path but the
+   * column remains NOT NULL, so callers can pass any placeholder
+   * (`createResearchSchedule` below fills one in for them).
+   */
+  topic_id?: string | null;
+  brief_template?: string | null;
 }
 
 export function createRecurringJob(input: CreateRecurringJobInput): RecurringJob {
@@ -74,6 +90,12 @@ export function createRecurringJob(input: CreateRecurringJobInput): RecurringJob
   if (!input.briefing_template.trim()) {
     throw new RecurringJobValidationError('briefing_template is required');
   }
+  // Research binding: both fields go together or neither.
+  if ((input.topic_id == null) !== (input.brief_template == null)) {
+    throw new RecurringJobValidationError(
+      'topic_id and brief_template must be set together or both omitted',
+    );
+  }
 
   const id = uuidv4();
   const nextRun = input.first_run_at ?? new Date().toISOString();
@@ -83,8 +105,9 @@ export function createRecurringJob(input: CreateRecurringJobInput): RecurringJob
        id, workspace_id, name, role, scope_key_template, briefing_template,
        initiative_id, task_id, cadence_seconds, attempt_strategy,
        status, last_run_at, last_run_scope_key, next_run_at,
-       consecutive_failures, run_count, created_at, created_by_agent_id
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', NULL, NULL, ?, 0, 0, datetime('now'), ?)`,
+       consecutive_failures, run_count, created_at, created_by_agent_id,
+       topic_id, brief_template
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', NULL, NULL, ?, 0, 0, datetime('now'), ?, ?, ?)`,
     [
       id,
       input.workspace_id,
@@ -98,6 +121,8 @@ export function createRecurringJob(input: CreateRecurringJobInput): RecurringJob
       input.attempt_strategy ?? 'reuse',
       nextRun,
       input.created_by_agent_id ?? null,
+      input.topic_id ?? null,
+      input.brief_template ?? null,
     ],
   );
 
@@ -128,6 +153,76 @@ export function listForTask(taskId: string): RecurringJob[] {
     `SELECT * FROM recurring_jobs WHERE task_id = ? ORDER BY created_at DESC`,
     [taskId],
   );
+}
+
+/**
+ * Research phase 2: list every recurring research schedule (topic_id
+ * IS NOT NULL) for a topic, newest first.
+ */
+export function listResearchSchedulesForTopic(topicId: string): RecurringJob[] {
+  return queryAll<RecurringJob>(
+    `SELECT * FROM recurring_jobs WHERE topic_id = ? ORDER BY created_at DESC`,
+    [topicId],
+  );
+}
+
+/**
+ * Research phase 2: the next ~N due research schedules in a workspace
+ * (active + topic-bound), ordered by next_run_at ASC. Drives the
+ * "Upcoming" lane on /research.
+ */
+export function listUpcomingResearch(workspaceId: string, limit = 10): RecurringJob[] {
+  const cap = Math.min(Math.max(limit, 1), 100);
+  return queryAll<RecurringJob>(
+    `SELECT * FROM recurring_jobs
+       WHERE workspace_id = ?
+         AND topic_id IS NOT NULL
+         AND status = 'active'
+       ORDER BY next_run_at ASC
+       LIMIT ${cap}`,
+    [workspaceId],
+  );
+}
+
+export interface CreateResearchScheduleInput {
+  workspace_id: string;
+  topic_id: string;
+  brief_template: string;
+  cadence_seconds: number;
+  /** Defaults to a topic+template-derived label if omitted. */
+  name?: string;
+  /**
+   * Defaults to `now() + cadence_seconds` (wait one full cadence on
+   * first run). Pass an earlier ISO timestamp to fire sooner; the
+   * `run-now` endpoint sets this to `now()` to dispatch on the next
+   * sweep. See build-plan §3.3.
+   */
+  first_run_at?: string;
+  created_by_agent_id?: string | null;
+}
+
+/**
+ * Convenience constructor for research schedules. Fills in the
+ * NOT-NULL columns (`scope_key_template`, `briefing_template`) that
+ * the run-brief dispatch path doesn't actually use, then delegates to
+ * `createRecurringJob`.
+ */
+export function createResearchSchedule(input: CreateResearchScheduleInput): RecurringJob {
+  const firstRun = input.first_run_at ?? new Date(Date.now() + input.cadence_seconds * 1000).toISOString();
+  return createRecurringJob({
+    workspace_id: input.workspace_id,
+    name: input.name ?? `research:${input.topic_id}:${input.brief_template}`,
+    role: 'researcher',
+    // Placeholder — the research dispatch path ignores it but the
+    // column is NOT NULL with the {job_id}/{wsid} validator.
+    scope_key_template: 'research-brief-{job_id}',
+    briefing_template: 'researcher',
+    cadence_seconds: input.cadence_seconds,
+    first_run_at: firstRun,
+    created_by_agent_id: input.created_by_agent_id ?? null,
+    topic_id: input.topic_id,
+    brief_template: input.brief_template,
+  });
 }
 
 /**


### PR DESCRIPTION
Slice 1/5 of [research-phase-2-schedules-build-plan.md](specs/research-phase-2-schedules-build-plan.md). See §3.1.

## Summary
- Migration 077 adds two nullable columns + a partial index to \`recurring_jobs\`. Existing scope-keyed rows keep working unchanged.
- DAO surfaces a research-aware constructor + listing helpers; both fields validated as a pair.
- No scheduler / API / UI behavior change yet — those follow in slices 2-4.

## Changes
- \`src/lib/db/migrations.ts\` — migration 077 (idempotent ALTER + index).
- \`src/lib/db/recurring-jobs.ts\` — \`topic_id\` / \`brief_template\` on \`RecurringJob\` and \`CreateRecurringJobInput\`; new \`createResearchSchedule\`, \`listResearchSchedulesForTopic\`, \`listUpcomingResearch\`.
- \`src/lib/db/recurring-jobs.test.ts\` — 4 new tests (half-set rejection, round-trip, topic scoping, upcoming ordering w/ paused + scope-keyed exclusion).

## Test plan
- [x] \`yarn tsc --noEmit\` clean (only pre-existing \`pm-decompose.test.ts\` errors remain).
- [x] \`tsx --test src/lib/db/recurring-jobs.test.ts\` — 13/13 pass.
- [ ] Validation scenarios newly exercisable: RP2.S1.1, RP2.S1.2 (per [02-test-plan.md](specs/research-phase-2-validation/02-test-plan.md)). RP2.S1.3 lands with the API slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)