### PR TITLE
feat(research): phase-2 scheduler — research dispatch branch

### DIFF
--- a/src/lib/agents/recurring-scheduler.test.ts
+++ b/src/lib/agents/recurring-scheduler.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Recurring scheduler — research dispatch branch.
+ *
+ * These tests exercise the failure paths of the slice-2 research
+ * binding (topic missing/archived, researcher missing, runner missing,
+ * pause-after-3). The success path requires a live gateway dispatch
+ * through `runBrief` and is deferred to the slice-5 eval harness.
+ *
+ * Pre-existing scope-keyed scheduler behavior is unchanged by slice 2
+ * and is exercised end-to-end by `recurring-jobs.test.ts` plus the
+ * dispatchScope tests; we don't re-cover it here.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import {
+  createResearchSchedule,
+  getRecurringJob,
+} from '@/lib/db/recurring-jobs';
+import { dispatchRecurringJobOnce } from './recurring-scheduler';
+
+function freshWorkspace(): string {
+  const id = `ws-rs-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function freshTopic(workspaceId: string, name = 'Topic'): string {
+  const id = `tp-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT INTO topics (id, workspace_id, name, description, tags_json, created_at, updated_at)
+     VALUES (?, ?, ?, '', '[]', datetime('now'), datetime('now'))`,
+    [id, workspaceId, name],
+  );
+  return id;
+}
+
+function archiveTopic(topicId: string): void {
+  run(`UPDATE topics SET archived_at = datetime('now') WHERE id = ?`, [topicId]);
+}
+
+function addResearcher(workspaceId: string): void {
+  run(
+    `INSERT INTO agents (id, workspace_id, name, role, source, status, created_at, updated_at, is_active)
+     VALUES (?, ?, ?, 'researcher', 'local', 'standby', datetime('now'), datetime('now'), 1)`,
+    [`agent-${uuidv4().slice(0, 8)}`, workspaceId, 'Test Researcher'],
+  );
+}
+
+test('research schedule: topic archived → markRunFailure', async () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  addResearcher(ws);
+  const sched = createResearchSchedule({
+    workspace_id: ws,
+    topic_id: tp,
+    brief_template: 'general_brief',
+    cadence_seconds: 60,
+    first_run_at: new Date().toISOString(),
+  });
+  archiveTopic(tp);
+
+  await dispatchRecurringJobOnce(sched);
+  const after = getRecurringJob(sched.id);
+  assert.equal(after?.consecutive_failures, 1);
+  assert.equal(after?.run_count, 0);
+  assert.equal(after?.status, 'active'); // not yet paused (1 < 3)
+});
+
+test('research schedule: missing researcher → markRunFailure', async () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  // No addResearcher call.
+  const sched = createResearchSchedule({
+    workspace_id: ws,
+    topic_id: tp,
+    brief_template: 'general_brief',
+    cadence_seconds: 60,
+    first_run_at: new Date().toISOString(),
+  });
+
+  await dispatchRecurringJobOnce(sched);
+  const after = getRecurringJob(sched.id);
+  assert.equal(after?.consecutive_failures, 1);
+  assert.equal(after?.run_count, 0);
+});
+
+test('research schedule: pauses after 3 consecutive failures', async () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  // Researcher present but no runner — every dispatch will fail at
+  // the runner check.
+  addResearcher(ws);
+  const sched = createResearchSchedule({
+    workspace_id: ws,
+    topic_id: tp,
+    brief_template: 'general_brief',
+    cadence_seconds: 60,
+    first_run_at: new Date().toISOString(),
+  });
+
+  // We don't stub the runner — production code returns null when no
+  // runner agent row exists, which is the default in tests.
+  await dispatchRecurringJobOnce(sched);
+  await dispatchRecurringJobOnce(sched);
+  await dispatchRecurringJobOnce(sched);
+
+  const after = getRecurringJob(sched.id);
+  assert.equal(after?.consecutive_failures, 3);
+  assert.equal(after?.status, 'paused');
+});
+

--- a/src/lib/agents/recurring-scheduler.ts
+++ b/src/lib/agents/recurring-scheduler.ts
@@ -19,6 +19,9 @@ import {
   renderScopeKey,
   type RecurringJob,
 } from '@/lib/db/recurring-jobs';
+import { createBriefWithRun, type BriefTemplate } from '@/lib/db/briefs';
+import { queryOne } from '@/lib/db';
+import { runBrief } from '@/lib/research/run-brief';
 import { dispatchScope } from './dispatch-scope';
 import { getRunnerAgent } from './runner';
 import type { BriefingRole } from './briefing';
@@ -41,7 +44,127 @@ function isBriefingRole(role: string): role is BriefingRole {
   );
 }
 
+/**
+ * Phase 2 research schedules. When a recurring_jobs row has `topic_id`
+ * set, the dispatch flow uses the topic + brief_template to spin up a
+ * fresh brief row and call `runBrief` (the same orchestrator the
+ * /api/briefs POST path uses). The scope-keyed `dispatchScope` path
+ * is bypassed entirely — research dispatches are brief-shaped, not
+ * task-shaped.
+ *
+ * On rejected start (topic missing/archived, runner missing,
+ * researcher missing) we mark the run failed so the auto-pause logic
+ * applies after `PAUSE_THRESHOLD` consecutive failures. On a started
+ * dispatch we mark the run successful — the brief itself surfaces
+ * its own outcome via `brief_completed` / `brief_failed` SSE events.
+ */
+async function dispatchResearchScheduleOnce(job: RecurringJob): Promise<void> {
+  if (!job.topic_id || !job.brief_template) {
+    // Defensive: caller already gated on these.
+    return;
+  }
+
+  const topic = queryOne<{ id: string; name: string; description: string; archived_at: string | null }>(
+    `SELECT id, name, description, archived_at FROM topics WHERE id = ?`,
+    [job.topic_id],
+  );
+  if (!topic) {
+    failResearchSchedule(job, 'topic missing');
+    return;
+  }
+  if (topic.archived_at) {
+    failResearchSchedule(job, 'topic archived');
+    return;
+  }
+
+  // Preflight: matches the API's createBriefWithRun + runBrief flow.
+  // Quick checks here let us mark a clean fail-and-pause without
+  // creating an orphan brief row.
+  const researcher = queryOne<{ id: string }>(
+    `SELECT id FROM agents WHERE workspace_id = ? AND role = 'researcher' AND COALESCE(is_active, 1) = 1 LIMIT 1`,
+    [job.workspace_id],
+  );
+  if (!researcher) {
+    failResearchSchedule(job, 'no researcher in workspace roster');
+    return;
+  }
+  const runner = getRunnerAgent();
+  if (!runner) {
+    failResearchSchedule(job, 'no runner agent registered');
+    return;
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const title = `${topic.name} · ${today}`;
+  // The brief's prompt is the topic description by default. If the
+  // operator left description empty, a minimal directive keeps the
+  // researcher productive.
+  const prompt = topic.description.trim()
+    ? topic.description
+    : `Survey "${topic.name}" and produce a research brief.`;
+
+  let result: { brief_id: string; agent_run_id: string; state: 'started' | 'rejected'; reason?: string };
+  try {
+    const created = createBriefWithRun({
+      workspace_id: job.workspace_id,
+      template: job.brief_template as BriefTemplate,
+      title,
+      prompt,
+      topic_id: job.topic_id,
+      requested_by: 'schedule',
+      source_kind: 'schedule',
+      source_ref: job.id,
+    });
+    result = await runBrief(created.brief.id);
+  } catch (err) {
+    failResearchSchedule(job, `brief create/run threw: ${(err as Error).message}`);
+    return;
+  }
+
+  if (result.state === 'rejected') {
+    failResearchSchedule(job, `runBrief rejected: ${result.reason ?? 'unknown'}`);
+    return;
+  }
+
+  markRunSuccess(job.id, `research-brief-${result.brief_id}`);
+}
+
+function failResearchSchedule(job: RecurringJob, reason: string): void {
+  console.warn(`[recurring/research] job ${job.id}: ${reason}`);
+  const next = markRunFailure(job.id, { pauseThreshold: PAUSE_THRESHOLD });
+  if (next?.status === 'paused') {
+    try {
+      createNote({
+        workspace_id: job.workspace_id,
+        agent_id: null,
+        task_id: null,
+        initiative_id: null,
+        scope_key: 'mc:recurring-scheduler',
+        role: 'system',
+        run_group_id: `recurring-pause-${job.id}`,
+        kind: 'blocker',
+        audience: 'pm',
+        body:
+          `Recurring research schedule "${job.name}" auto-paused after ` +
+          `${PAUSE_THRESHOLD} consecutive failures. Last reason: ${reason}.`,
+        importance: 2,
+      });
+    } catch (noteErr) {
+      console.warn(
+        `[recurring/research] failed to write pause note for job ${job.id}:`,
+        (noteErr as Error).message,
+      );
+    }
+  }
+}
+
 export async function dispatchRecurringJobOnce(job: RecurringJob): Promise<void> {
+  // Phase 2: research-bound rows take a different dispatch path.
+  if (job.topic_id) {
+    await dispatchResearchScheduleOnce(job);
+    return;
+  }
+
   const runner = getRunnerAgent();
   if (!runner) {
     console.warn(`[recurring] job ${job.id}: no runner agent registered; skipping`);

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4203,6 +4203,33 @@ const migrations: Migration[] = [
       console.log('[Migration 076] research_suggestions table created.');
     },
   },
+  {
+    id: '077',
+    name: 'recurring_jobs_research_columns',
+    up: (db) => {
+      // Research phase 2: bind a recurring_jobs row to a topic +
+      // brief template so the scheduler can dispatch via run-brief
+      // instead of dispatchScope. See
+      // specs/research-phase-2-schedules-build-plan.md §3.1.
+      //
+      // Both columns are nullable: a row whose topic_id IS NULL is a
+      // pre-phase-2 scope-keyed job and the scheduler keeps using
+      // dispatchScope. A row with topic_id set is a research schedule.
+      //
+      // FK has no ON DELETE clause: topics are soft-deleted via
+      // archived_at, never hard-deleted. Pause-on-archive will be
+      // plumbed at the application layer in slice 3.
+      const cols = db.prepare(`PRAGMA table_info(recurring_jobs)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'topic_id')) {
+        db.exec(`ALTER TABLE recurring_jobs ADD COLUMN topic_id TEXT REFERENCES topics(id)`);
+      }
+      if (!cols.some((c) => c.name === 'brief_template')) {
+        db.exec(`ALTER TABLE recurring_jobs ADD COLUMN brief_template TEXT`);
+      }
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_recurring_jobs_topic ON recurring_jobs(topic_id) WHERE topic_id IS NOT NULL`);
+      console.log('[Migration 077] recurring_jobs.topic_id + brief_template columns added.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/recurring-jobs.test.ts
+++ b/src/lib/db/recurring-jobs.test.ts
@@ -12,16 +12,29 @@ import { v4 as uuidv4 } from 'uuid';
 import { run } from '@/lib/db';
 import {
   createRecurringJob,
+  createResearchSchedule,
   getRecurringJob,
   listDueJobs,
   listForTask,
   listForWorkspace,
+  listResearchSchedulesForTopic,
+  listUpcomingResearch,
   markRunFailure,
   markRunSuccess,
   RecurringJobValidationError,
   renderScopeKey,
   setJobStatus,
 } from './recurring-jobs';
+
+function freshTopic(workspaceId: string, name = 'WAL on macOS'): string {
+  const id = `tp-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO topics (id, workspace_id, name, description, tags_json, created_at, updated_at)
+     VALUES (?, ?, ?, '', '[]', datetime('now'), datetime('now'))`,
+    [id, workspaceId, name],
+  );
+  return id;
+}
 
 function freshWorkspace(): string {
   const id = `ws-rj-${uuidv4().slice(0, 8)}`;
@@ -179,4 +192,77 @@ test('listForTask: returns jobs scoped to a task', () => {
   const taskJobs = listForTask(taskId);
   assert.equal(taskJobs.length, 1);
   assert.equal(taskJobs[0].id, a.id);
+});
+
+// --- Phase 2: research-bound schedules ----------------------------
+
+test('createRecurringJob: rejects half-set research binding', () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  assert.throws(
+    () => createRecurringJob(baseInput(ws, { topic_id: tp })),
+    RecurringJobValidationError,
+  );
+  assert.throws(
+    () => createRecurringJob(baseInput(ws, { brief_template: 'general_brief' })),
+    RecurringJobValidationError,
+  );
+});
+
+test('createResearchSchedule: round-trip + first_run defaults to one-cadence-out', () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  const before = Date.now();
+  const s = createResearchSchedule({
+    workspace_id: ws,
+    topic_id: tp,
+    brief_template: 'general_brief',
+    cadence_seconds: 604800, // weekly
+  });
+  const after = Date.now();
+  assert.equal(s.topic_id, tp);
+  assert.equal(s.brief_template, 'general_brief');
+  assert.equal(s.role, 'researcher');
+  assert.equal(s.cadence_seconds, 604800);
+  // next_run_at should be one cadence ahead, not 'now'.
+  const nextMs = Date.parse(s.next_run_at);
+  assert.ok(nextMs >= before + 604800 * 1000 - 50);
+  assert.ok(nextMs <= after + 604800 * 1000 + 50);
+});
+
+test('listResearchSchedulesForTopic: scopes to topic', () => {
+  const ws = freshWorkspace();
+  const a = freshTopic(ws, 'topic A');
+  const b = freshTopic(ws, 'topic B');
+  const sa = createResearchSchedule({ workspace_id: ws, topic_id: a, brief_template: 'general_brief', cadence_seconds: 60 });
+  createResearchSchedule({ workspace_id: ws, topic_id: b, brief_template: 'general_brief', cadence_seconds: 60 });
+
+  const onA = listResearchSchedulesForTopic(a);
+  assert.equal(onA.length, 1);
+  assert.equal(onA[0].id, sa.id);
+});
+
+test('listUpcomingResearch: orders by next_run_at and excludes paused / non-research', () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  // Three research schedules, different next_run_at offsets.
+  const earliest = createResearchSchedule({
+    workspace_id: ws, topic_id: tp, brief_template: 'general_brief',
+    cadence_seconds: 60, first_run_at: new Date(Date.now() + 1000).toISOString(),
+  });
+  createResearchSchedule({
+    workspace_id: ws, topic_id: tp, brief_template: 'general_brief',
+    cadence_seconds: 60, first_run_at: new Date(Date.now() + 60_000).toISOString(),
+  });
+  const paused = createResearchSchedule({
+    workspace_id: ws, topic_id: tp, brief_template: 'general_brief',
+    cadence_seconds: 60, first_run_at: new Date(Date.now() + 500).toISOString(),
+  });
+  setJobStatus(paused.id, 'paused');
+  // A non-research recurring_jobs row in the same workspace must not leak.
+  createRecurringJob(baseInput(ws, { name: 'scope-keyed-only' }));
+
+  const upcoming = listUpcomingResearch(ws, 10);
+  assert.equal(upcoming.length, 2);
+  assert.equal(upcoming[0].id, earliest.id);
 });

--- a/src/lib/db/recurring-jobs.ts
+++ b/src/lib/db/recurring-jobs.ts
@@ -32,6 +32,13 @@ export interface RecurringJob {
   run_count: number;
   created_at: string;
   created_by_agent_id: string | null;
+  /**
+   * Phase-2 research binding (migration 077). When set, this row is a
+   * research schedule and the scheduler dispatches via run-brief
+   * instead of dispatchScope.
+   */
+  topic_id: string | null;
+  brief_template: string | null;
 }
 
 export class RecurringJobValidationError extends Error {
@@ -54,6 +61,15 @@ export interface CreateRecurringJobInput {
   /** ISO datetime; defaults to now (fires immediately on first sweep). */
   first_run_at?: string;
   created_by_agent_id?: string | null;
+  /**
+   * Phase-2 research binding. Set both `topic_id` and `brief_template`
+   * to make this a research schedule. The scheduler will dispatch via
+   * run-brief; `scope_key_template` is unused in that path but the
+   * column remains NOT NULL, so callers can pass any placeholder
+   * (`createResearchSchedule` below fills one in for them).
+   */
+  topic_id?: string | null;
+  brief_template?: string | null;
 }
 
 export function createRecurringJob(input: CreateRecurringJobInput): RecurringJob {
@@ -74,6 +90,12 @@ export function createRecurringJob(input: CreateRecurringJobInput): RecurringJob
   if (!input.briefing_template.trim()) {
     throw new RecurringJobValidationError('briefing_template is required');
   }
+  // Research binding: both fields go together or neither.
+  if ((input.topic_id == null) !== (input.brief_template == null)) {
+    throw new RecurringJobValidationError(
+      'topic_id and brief_template must be set together or both omitted',
+    );
+  }
 
   const id = uuidv4();
   const nextRun = input.first_run_at ?? new Date().toISOString();
@@ -83,8 +105,9 @@ export function createRecurringJob(input: CreateRecurringJobInput): RecurringJob
        id, workspace_id, name, role, scope_key_template, briefing_template,
        initiative_id, task_id, cadence_seconds, attempt_strategy,
        status, last_run_at, last_run_scope_key, next_run_at,
-       consecutive_failures, run_count, created_at, created_by_agent_id
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', NULL, NULL, ?, 0, 0, datetime('now'), ?)`,
+       consecutive_failures, run_count, created_at, created_by_agent_id,
+       topic_id, brief_template
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', NULL, NULL, ?, 0, 0, datetime('now'), ?, ?, ?)`,
     [
       id,
       input.workspace_id,
@@ -98,6 +121,8 @@ export function createRecurringJob(input: CreateRecurringJobInput): RecurringJob
       input.attempt_strategy ?? 'reuse',
       nextRun,
       input.created_by_agent_id ?? null,
+      input.topic_id ?? null,
+      input.brief_template ?? null,
     ],
   );
 
@@ -128,6 +153,76 @@ export function listForTask(taskId: string): RecurringJob[] {
     `SELECT * FROM recurring_jobs WHERE task_id = ? ORDER BY created_at DESC`,
     [taskId],
   );
+}
+
+/**
+ * Research phase 2: list every recurring research schedule (topic_id
+ * IS NOT NULL) for a topic, newest first.
+ */
+export function listResearchSchedulesForTopic(topicId: string): RecurringJob[] {
+  return queryAll<RecurringJob>(
+    `SELECT * FROM recurring_jobs WHERE topic_id = ? ORDER BY created_at DESC`,
+    [topicId],
+  );
+}
+
+/**
+ * Research phase 2: the next ~N due research schedules in a workspace
+ * (active + topic-bound), ordered by next_run_at ASC. Drives the
+ * "Upcoming" lane on /research.
+ */
+export function listUpcomingResearch(workspaceId: string, limit = 10): RecurringJob[] {
+  const cap = Math.min(Math.max(limit, 1), 100);
+  return queryAll<RecurringJob>(
+    `SELECT * FROM recurring_jobs
+       WHERE workspace_id = ?
+         AND topic_id IS NOT NULL
+         AND status = 'active'
+       ORDER BY next_run_at ASC
+       LIMIT ${cap}`,
+    [workspaceId],
+  );
+}
+
+export interface CreateResearchScheduleInput {
+  workspace_id: string;
+  topic_id: string;
+  brief_template: string;
+  cadence_seconds: number;
+  /** Defaults to a topic+template-derived label if omitted. */
+  name?: string;
+  /**
+   * Defaults to `now() + cadence_seconds` (wait one full cadence on
+   * first run). Pass an earlier ISO timestamp to fire sooner; the
+   * `run-now` endpoint sets this to `now()` to dispatch on the next
+   * sweep. See build-plan §3.3.
+   */
+  first_run_at?: string;
+  created_by_agent_id?: string | null;
+}
+
+/**
+ * Convenience constructor for research schedules. Fills in the
+ * NOT-NULL columns (`scope_key_template`, `briefing_template`) that
+ * the run-brief dispatch path doesn't actually use, then delegates to
+ * `createRecurringJob`.
+ */
+export function createResearchSchedule(input: CreateResearchScheduleInput): RecurringJob {
+  const firstRun = input.first_run_at ?? new Date(Date.now() + input.cadence_seconds * 1000).toISOString();
+  return createRecurringJob({
+    workspace_id: input.workspace_id,
+    name: input.name ?? `research:${input.topic_id}:${input.brief_template}`,
+    role: 'researcher',
+    // Placeholder — the research dispatch path ignores it but the
+    // column is NOT NULL with the {job_id}/{wsid} validator.
+    scope_key_template: 'research-brief-{job_id}',
+    briefing_template: 'researcher',
+    cadence_seconds: input.cadence_seconds,
+    first_run_at: firstRun,
+    created_by_agent_id: input.created_by_agent_id ?? null,
+    topic_id: input.topic_id,
+    brief_template: input.brief_template,
+  });
 }
 
 /**


### PR DESCRIPTION
Slice 2/5 of [research-phase-2-schedules-build-plan.md](specs/research-phase-2-schedules-build-plan.md). Stacked on #180.

## Summary
- Scheduler now branches on \`topic_id\`: research-bound rows dispatch through \`createBriefWithRun\` + \`runBrief\` instead of \`dispatchScope\`.
- Fail-fast preflight: topic archived/missing, researcher roster missing, runner missing — each marks the run failed cleanly without orphaning a brief row.
- Pause-after-3 behavior + system pause-note unchanged from the existing scope-keyed path.

## Changes
- \`src/lib/agents/recurring-scheduler.ts\` — new \`dispatchResearchScheduleOnce\` + branching at the top of \`dispatchRecurringJobOnce\`.
- \`src/lib/agents/recurring-scheduler.test.ts\` (new) — 3 tests covering topic-archived, missing-researcher, pause-after-3 paths.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] \`tsx --test src/lib/agents/recurring-scheduler.test.ts\` — 3/3 pass.
- [x] \`tsx --test src/lib/db/recurring-jobs.test.ts\` — 13/13 pass (no slice-1 regression).
- [ ] Validation scenarios newly exercisable: RP2.S2.2 (force runner offline), partial RP2.S2.1 (success path needs live agent — slice 5 eval).

## Stacked-merge note
When ready to merge, retarget this PR's base from \`feat/research-phase-2/schema\` to \`main\` BEFORE merging #180 with \`--delete-branch\` (per \`feedback_stacked_pr_merges.md\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)