### PR TITLE
feat(research): phase-2 UI — Schedules section + Upcoming lane

### DIFF
--- a/src/app/(app)/research/page.tsx
+++ b/src/app/(app)/research/page.tsx
@@ -19,6 +19,7 @@ import { RefreshCw, FileText, AlertTriangle } from 'lucide-react';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 import { formatDistanceToNow } from 'date-fns';
 import { useResearchPreflight } from '@/components/research/useResearchPreflight';
+import { ScheduleRow, type ScheduleSummary } from '@/components/research/ScheduleRow';
 
 interface TopicSummary {
   id: string;
@@ -47,6 +48,10 @@ const RELEVANT_EVENTS = new Set([
   'brief_started', 'brief_progress', 'brief_completed', 'brief_failed',
 ]);
 
+interface ScheduleSummaryWithTopic extends ScheduleSummary {
+  topic_id: string;
+}
+
 const STATUS_COLOR: Record<AgentRunSummary['status'], string> = {
   queued:    'bg-mc-bg-tertiary text-mc-text-secondary border-mc-border',
   running:   'bg-mc-accent/15 text-mc-accent border-mc-accent/30',
@@ -62,6 +67,7 @@ export default function ResearchHubPage() {
   const [topics, setTopics] = useState<TopicSummary[]>([]);
   const [briefs, setBriefs] = useState<BriefSummary[]>([]);
   const [runs, setRuns] = useState<AgentRunSummary[]>([]);
+  const [upcoming, setUpcoming] = useState<ScheduleSummaryWithTopic[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -71,14 +77,16 @@ export default function ResearchHubPage() {
     setError(null);
     try {
       const qs = `?workspace_id=${encodeURIComponent(workspaceId)}`;
-      const [t, b, r] = await Promise.all([
+      const [t, b, r, sched] = await Promise.all([
         fetch(`/api/topics${qs}`).then(res => res.ok ? res.json() : Promise.reject(new Error(`topics: ${res.status}`))),
         fetch(`/api/briefs${qs}&limit=20`).then(res => res.ok ? res.json() : Promise.reject(new Error(`briefs: ${res.status}`))),
         fetch(`/api/agent-runs${qs}&kind=brief&limit=50`).then(res => res.ok ? res.json() : Promise.reject(new Error(`agent-runs: ${res.status}`))),
+        fetch(`/api/schedules${qs}&limit=10`).then(res => res.ok ? res.json() : []),
       ]);
       setTopics(t);
       setBriefs(b);
       setRuns(r);
+      setUpcoming(sched);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load research data');
     } finally {
@@ -163,7 +171,22 @@ export default function ResearchHubPage() {
         ))}
       </Lane>
 
-      <Lane title="Upcoming" emptyText="Schedules land in phase 2 — this lane will populate then." />
+      <Lane
+        title="Upcoming"
+        emptyText="No schedules yet. Open a topic and hit Schedule to start one."
+      >
+        {upcoming.map(s => {
+          const topic = topics.find(t => t.id === s.topic_id);
+          return (
+            <ScheduleRow
+              key={s.id}
+              schedule={s}
+              topicName={topic?.name}
+              onChanged={load}
+            />
+          );
+        })}
+      </Lane>
 
       <Lane title="Recent results" emptyText="Completed briefs appear here.">
         {recent.map(b => (

--- a/src/app/(app)/research/topics/[id]/page.tsx
+++ b/src/app/(app)/research/topics/[id]/page.tsx
@@ -3,10 +3,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { Archive, ArchiveRestore, FileText, RefreshCw, Zap } from 'lucide-react';
+import { Archive, ArchiveRestore, Calendar, FileText, RefreshCw, Zap } from 'lucide-react';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 import { formatDistanceToNow } from 'date-fns';
 import { RunBriefDrawer } from '@/components/research/RunBriefDrawer';
+import { ScheduleDrawer } from '@/components/research/ScheduleDrawer';
+import { ScheduleRow, type ScheduleSummary } from '@/components/research/ScheduleRow';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 
 interface Topic {
@@ -35,9 +37,11 @@ export default function TopicDetailPage() {
   const workspaceId = useCurrentWorkspaceId();
   const [topic, setTopic] = useState<Topic | null>(null);
   const [briefs, setBriefs] = useState<BriefSummary[]>([]);
+  const [schedules, setSchedules] = useState<ScheduleSummary[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [runBriefOpen, setRunBriefOpen] = useState(false);
+  const [scheduleOpen, setScheduleOpen] = useState(false);
   const [confirmArchive, setConfirmArchive] = useState(false);
 
   const load = useCallback(async () => {
@@ -46,8 +50,12 @@ export default function TopicDetailPage() {
     try {
       const t = await fetch(`/api/topics/${params.id}`).then(r => r.ok ? r.json() : Promise.reject(new Error(`topic: ${r.status}`)));
       setTopic(t);
-      const b = await fetch(`/api/briefs?workspace_id=${encodeURIComponent(t.workspace_id)}&topic_id=${encodeURIComponent(t.id)}`).then(r => r.ok ? r.json() : []);
+      const [b, s] = await Promise.all([
+        fetch(`/api/briefs?workspace_id=${encodeURIComponent(t.workspace_id)}&topic_id=${encodeURIComponent(t.id)}`).then(r => r.ok ? r.json() : []),
+        fetch(`/api/topics/${encodeURIComponent(t.id)}/schedules`).then(r => r.ok ? r.json() : []),
+      ]);
       setBriefs(b);
+      setSchedules(s);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load topic');
     } finally {
@@ -138,16 +146,41 @@ export default function TopicDetailPage() {
             </button>
           )}
           {!topic.archived_at && (
-            <button
-              type="button"
-              onClick={() => setRunBriefOpen(true)}
-              className="px-3 py-1.5 bg-mc-accent text-mc-bg rounded-sm text-sm font-medium hover:opacity-90 flex items-center gap-1.5"
-            >
-              <Zap className="w-3.5 h-3.5" /> Run a brief
-            </button>
+            <>
+              <button
+                type="button"
+                onClick={() => setScheduleOpen(true)}
+                className="px-3 py-1.5 text-sm rounded-sm text-mc-text-secondary hover:bg-mc-bg-tertiary border border-mc-border flex items-center gap-1.5"
+              >
+                <Calendar className="w-3.5 h-3.5" /> Schedule
+              </button>
+              <button
+                type="button"
+                onClick={() => setRunBriefOpen(true)}
+                className="px-3 py-1.5 bg-mc-accent text-mc-bg rounded-sm text-sm font-medium hover:opacity-90 flex items-center gap-1.5"
+              >
+                <Zap className="w-3.5 h-3.5" /> Run a brief
+              </button>
+            </>
           )}
         </div>
       </header>
+
+      {/* Schedules section. Renders only when at least one schedule
+          exists; the Schedule button at the top is the create entry
+          point so an empty state would just duplicate that affordance. */}
+      {schedules.length > 0 && (
+        <section className="mb-6">
+          <h2 className="text-[11px] uppercase tracking-wider text-mc-text-secondary mb-2">Schedules</h2>
+          <ul className="space-y-2">
+            {schedules.map(s => (
+              <li key={s.id}>
+                <ScheduleRow schedule={s} onChanged={load} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       <section>
         <h2 className="text-[11px] uppercase tracking-wider text-mc-text-secondary mb-2">Brief history</h2>
@@ -179,6 +212,14 @@ export default function TopicDetailPage() {
         topics={[{ id: topic.id, name: topic.name }]}
         defaultTopicId={topic.id}
         onLaunched={() => setRunBriefOpen(false)}
+      />
+
+      <ScheduleDrawer
+        open={scheduleOpen}
+        onClose={() => setScheduleOpen(false)}
+        topicId={topic.id}
+        topicName={topic.name}
+        onCreated={() => { setScheduleOpen(false); load(); }}
       />
 
       <ConfirmDialog

--- a/src/app/(app)/research/topics/[id]/page.tsx
+++ b/src/app/(app)/research/topics/[id]/page.tsx
@@ -100,8 +100,8 @@ export default function TopicDetailPage() {
 
   return (
     <div className="px-6 py-5 max-w-4xl">
-      <header className="flex items-start justify-between mb-4">
-        <div className="flex-1 min-w-0">
+      <header className="flex items-start justify-between gap-3 flex-wrap mb-4">
+        <div className="min-w-0 basis-full sm:basis-auto sm:flex-1">
           <div className="flex items-center gap-2 mb-1">
             <h1 className="text-xl font-semibold text-mc-text">{topic.name}</h1>
             {topic.archived_at && (
@@ -119,7 +119,7 @@ export default function TopicDetailPage() {
             </div>
           )}
         </div>
-        <div className="flex items-center gap-2 shrink-0">
+        <div className="flex items-center gap-2 shrink-0 flex-wrap">
           <button
             type="button"
             onClick={load}

--- a/src/components/research/ResearchSideRail.tsx
+++ b/src/components/research/ResearchSideRail.tsx
@@ -49,6 +49,7 @@ import {
   Loader2,
   Pin,
   PinOff,
+  Clock,
 } from 'lucide-react';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 import { useResearchPreflight } from '@/components/research/useResearchPreflight';
@@ -76,6 +77,12 @@ interface BriefSummary {
 interface AgentRunSummary {
   id: string;
   status: 'queued' | 'running' | 'complete' | 'failed' | 'cancelled';
+}
+
+interface ScheduleSummary {
+  id: string;
+  topic_id: string | null;
+  status: 'active' | 'paused' | 'done';
 }
 
 const RAIL_COLLAPSED_KEY = 'mc.research.rail.collapsed';
@@ -136,6 +143,7 @@ export function ResearchSideRail() {
   const [topics, setTopics] = useState<TopicSummary[]>([]);
   const [briefs, setBriefs] = useState<BriefSummary[]>([]);
   const [runs, setRuns] = useState<AgentRunSummary[]>([]);
+  const [schedules, setSchedules] = useState<ScheduleSummary[]>([]);
   const [createTopicOpen, setCreateTopicOpen] = useState(false);
   const [runBriefOpen, setRunBriefOpen] = useState(false);
   const [suggestKind, setSuggestKind] = useState<'topic' | 'brief' | null>(null);
@@ -254,19 +262,23 @@ export function ResearchSideRail() {
 
   const load = useCallback(async () => {
     if (!workspaceId) {
-      setTopics([]); setBriefs([]); setRuns([]);
+      setTopics([]); setBriefs([]); setRuns([]); setSchedules([]);
       return;
     }
     const qs = `?workspace_id=${encodeURIComponent(workspaceId)}`;
     try {
-      const [t, b, r] = await Promise.all([
+      const [t, b, r, s] = await Promise.all([
         fetch(`/api/topics${qs}`).then(res => res.ok ? res.json() : []),
         fetch(`/api/briefs${qs}&limit=20`).then(res => res.ok ? res.json() : []),
         fetch(`/api/agent-runs${qs}&kind=brief&limit=50`).then(res => res.ok ? res.json() : []),
+        // limit=100 covers any realistic per-workspace schedule count;
+        // we just need topic_ids for the indicator dot.
+        fetch(`/api/schedules${qs}&limit=100`).then(res => res.ok ? res.json() : []),
       ]);
       setTopics(t);
       setBriefs(b);
       setRuns(r);
+      setSchedules(s);
     } catch {
       // Quiet failure — main panel surfaces its own load error.
     }
@@ -305,6 +317,16 @@ export function ResearchSideRail() {
     const rest = topics.filter(t => !pinSet.has(t.id));
     return [...pinned, ...rest];
   }, [topics, pinnedTopics]);
+
+  // topic_ids that have at least one active schedule attached.
+  // Drives the small clock indicator next to the topic name.
+  const scheduledTopicIds = useMemo(() => {
+    const s = new Set<string>();
+    for (const sc of schedules) {
+      if (sc.topic_id && sc.status === 'active') s.add(sc.topic_id);
+    }
+    return s;
+  }, [schedules]);
 
   const sortedBriefs = useMemo(() => {
     const pinSet = new Set(pinnedBriefs);
@@ -467,6 +489,7 @@ export function ResearchSideRail() {
               {sortedTopics.map(t => {
                 const active = activeTopicId === t.id;
                 const pinned = pinnedTopics.includes(t.id);
+                const hasSchedule = scheduledTopicIds.has(t.id);
                 return (
                   <li key={t.id} className="group">
                     <div className={`mx-2 rounded-sm flex items-center ${
@@ -482,6 +505,12 @@ export function ResearchSideRail() {
                         {pinned && <Pin className="w-3 h-3 shrink-0 text-mc-accent fill-mc-accent" />}
                         {t.archived_at && <Archive className="w-3 h-3 shrink-0 opacity-60" />}
                         <span className="truncate">{t.name}</span>
+                        {hasSchedule && (
+                          <Clock
+                            className="w-3 h-3 shrink-0 text-mc-accent ml-auto"
+                            aria-label="Has active schedule"
+                          />
+                        )}
                       </Link>
                       <PinToggle
                         pinned={pinned}

--- a/src/components/research/ScheduleDrawer.tsx
+++ b/src/components/research/ScheduleDrawer.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+/**
+ * ScheduleDrawer — create a recurring research schedule for a topic.
+ *
+ * Phase-2 spec: cadence is a fixed dropdown (no cron parser, no event
+ * triggers). See specs/research-phase-2-schedules-build-plan.md §3.2.
+ *
+ * The actual scheduling is workspace-scoped via the topic's workspace,
+ * so this drawer just needs the topic's id; it doesn't need a
+ * workspaceId prop.
+ */
+
+import { useEffect, useState } from 'react';
+import { Calendar as CalendarIcon, Sparkles, X } from 'lucide-react';
+
+export interface CadenceOption {
+  label: string;
+  seconds: number;
+}
+
+export const CADENCE_OPTIONS: CadenceOption[] = [
+  { label: 'Hourly', seconds: 3600 },
+  { label: 'Every 4 hours', seconds: 4 * 3600 },
+  { label: 'Daily', seconds: 24 * 3600 },
+  { label: 'Every 2 days', seconds: 2 * 24 * 3600 },
+  { label: 'Weekly', seconds: 7 * 24 * 3600 },
+  { label: 'Bi-weekly', seconds: 14 * 24 * 3600 },
+  { label: 'Monthly (28d)', seconds: 28 * 24 * 3600 },
+];
+
+const DEFAULT_CADENCE_SECONDS = 7 * 24 * 3600; // Weekly per build-plan §7.
+
+interface ScheduleDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  topicId: string;
+  topicName: string;
+  onCreated: () => void;
+}
+
+export function ScheduleDrawer({ open, onClose, topicId, topicName, onCreated }: ScheduleDrawerProps) {
+  const [cadenceSeconds, setCadenceSeconds] = useState(DEFAULT_CADENCE_SECONDS);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setCadenceSeconds(DEFAULT_CADENCE_SECONDS);
+      setError(null);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const submit = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/topics/${topicId}/schedules`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          brief_template: 'general_brief',
+          cadence_seconds: cadenceSeconds,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `Create failed (${res.status})`);
+      }
+      onCreated();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create schedule');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-40 bg-black/60 flex justify-end"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Create schedule"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md bg-mc-bg-secondary border-l border-mc-border h-full flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between px-4 py-3 border-b border-mc-border">
+          <h2 className="text-sm font-semibold text-mc-text flex items-center gap-2">
+            <CalendarIcon className="w-4 h-4 text-mc-accent" />
+            Schedule recurring brief
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded-sm hover:bg-mc-bg-tertiary text-mc-text-secondary"
+            aria-label="Close"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+          <div>
+            <span className="text-[11px] uppercase tracking-wider text-mc-text-secondary">Topic</span>
+            <p className="text-sm text-mc-text mt-0.5">{topicName}</p>
+          </div>
+
+          <label className="block">
+            <span className="text-[11px] uppercase tracking-wider text-mc-text-secondary">Cadence</span>
+            <select
+              className="mt-1 w-full bg-mc-bg border border-mc-border rounded-sm px-2 py-1.5 text-sm text-mc-text"
+              value={cadenceSeconds}
+              onChange={(e) => setCadenceSeconds(parseInt(e.target.value, 10))}
+              disabled={submitting}
+            >
+              {CADENCE_OPTIONS.map((o) => (
+                <option key={o.seconds} value={o.seconds}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+
+          <div className="text-[11px] text-mc-text-secondary/80 leading-snug">
+            <Sparkles className="inline w-3 h-3 mr-1" />
+            First run will fire one cadence from now. You can hit <strong className="text-mc-text">Run now</strong> on the
+            schedule row to dispatch off-cadence at any time.
+          </div>
+
+          {error && (
+            <div className="px-3 py-2 rounded-sm bg-red-900/20 border border-red-500/30 text-red-300 text-xs">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <footer className="px-4 py-3 border-t border-mc-border flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-sm rounded-sm text-mc-text-secondary hover:bg-mc-bg-tertiary"
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="px-3 py-1.5 bg-mc-accent text-mc-bg rounded-sm text-sm font-medium hover:opacity-90 disabled:opacity-40"
+          >
+            {submitting ? 'Creating…' : 'Create schedule'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Format a cadence_seconds value into the operator-facing label,
+ * matching CADENCE_OPTIONS where possible. Custom values (set via
+ * the API) fall back to a "every Ns" string.
+ */
+export function formatCadence(seconds: number): string {
+  const opt = CADENCE_OPTIONS.find((o) => o.seconds === seconds);
+  if (opt) return opt.label;
+  if (seconds < 60) return `Every ${seconds}s`;
+  if (seconds < 3600) return `Every ${Math.round(seconds / 60)} min`;
+  if (seconds < 86400) return `Every ${Math.round(seconds / 3600)} hours`;
+  return `Every ${Math.round(seconds / 86400)} days`;
+}

--- a/src/components/research/ScheduleRow.tsx
+++ b/src/components/research/ScheduleRow.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+/**
+ * ScheduleRow + Schedules section for /research/topics/[id]. Also
+ * exports the lighter-weight UpcomingScheduleRow used by the hub's
+ * "Upcoming" lane.
+ *
+ * State actions hit /api/schedules/[id] PATCH/DELETE/run-now. The
+ * caller is expected to refetch on success — both surfaces already
+ * have an SSE subscription, but optimistic refetch keeps the lag off
+ * the user-perceived path.
+ */
+
+import { useState } from 'react';
+import { Calendar as CalendarIcon, Pause, Play, Trash2, Zap } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { formatCadence } from './ScheduleDrawer';
+
+export interface ScheduleSummary {
+  id: string;
+  topic_id: string | null;
+  brief_template: string | null;
+  cadence_seconds: number;
+  status: 'active' | 'paused' | 'done';
+  next_run_at: string;
+  last_run_at: string | null;
+  consecutive_failures: number;
+  run_count: number;
+}
+
+interface ScheduleRowProps {
+  schedule: ScheduleSummary;
+  topicName?: string;
+  onChanged: () => void;
+}
+
+export function ScheduleRow({ schedule, topicName, onChanged }: ScheduleRowProps) {
+  const [busy, setBusy] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const patch = async (body: unknown) => {
+    setBusy(true); setError(null);
+    try {
+      const res = await fetch(`/api/schedules/${schedule.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const b = await res.json().catch(() => ({}));
+        throw new Error(b.error ?? `Update failed (${res.status})`);
+      }
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Update failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runNow = async () => {
+    setBusy(true); setError(null);
+    try {
+      const res = await fetch(`/api/schedules/${schedule.id}/run-now`, { method: 'POST' });
+      if (!res.ok) {
+        const b = await res.json().catch(() => ({}));
+        throw new Error(b.error ?? `Run-now failed (${res.status})`);
+      }
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Run-now failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doDelete = async () => {
+    setBusy(true); setError(null);
+    try {
+      const res = await fetch(`/api/schedules/${schedule.id}`, { method: 'DELETE' });
+      if (!res.ok && res.status !== 204) {
+        const b = await res.json().catch(() => ({}));
+        throw new Error(b.error ?? `Delete failed (${res.status})`);
+      }
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Delete failed');
+    } finally {
+      setBusy(false);
+      setConfirmDelete(false);
+    }
+  };
+
+  const paused = schedule.status === 'paused';
+
+  return (
+    <div className="border border-mc-border rounded-sm bg-mc-bg-secondary px-3 py-2">
+      <div className="flex items-center gap-3">
+        <CalendarIcon className={`w-4 h-4 shrink-0 ${paused ? 'text-yellow-400' : 'text-mc-accent'}`} />
+        <div className="flex-1 min-w-0">
+          <div className="text-sm text-mc-text truncate">
+            {topicName && <span className="text-mc-text-secondary">{topicName} · </span>}
+            {formatCadence(schedule.cadence_seconds)} · {schedule.brief_template ?? 'general_brief'}
+          </div>
+          <div className="text-[11px] text-mc-text-secondary mt-0.5 flex flex-wrap gap-2">
+            <span>
+              Next: {formatDistanceToNow(new Date(schedule.next_run_at), { addSuffix: true })}
+            </span>
+            {schedule.last_run_at && (
+              <span>· Last: {formatDistanceToNow(new Date(schedule.last_run_at), { addSuffix: true })}</span>
+            )}
+            <span>· Run count: {schedule.run_count}</span>
+            {paused && (
+              <span className="text-yellow-400">
+                · Paused{schedule.consecutive_failures > 0 ? ` (${schedule.consecutive_failures} failures)` : ''}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          {!paused && (
+            <button
+              type="button"
+              onClick={runNow}
+              disabled={busy}
+              className="p-1.5 rounded-sm text-mc-text-secondary hover:text-mc-accent hover:bg-mc-bg-tertiary disabled:opacity-40"
+              title="Run now"
+              aria-label="Run now"
+            >
+              <Zap className="w-3.5 h-3.5" />
+            </button>
+          )}
+          {paused ? (
+            <button
+              type="button"
+              onClick={() => patch({ status: 'active' })}
+              disabled={busy}
+              className="p-1.5 rounded-sm text-mc-text-secondary hover:text-mc-accent hover:bg-mc-bg-tertiary disabled:opacity-40"
+              title="Resume"
+              aria-label="Resume"
+            >
+              <Play className="w-3.5 h-3.5" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => patch({ status: 'paused' })}
+              disabled={busy}
+              className="p-1.5 rounded-sm text-mc-text-secondary hover:text-yellow-400 hover:bg-mc-bg-tertiary disabled:opacity-40"
+              title="Pause"
+              aria-label="Pause"
+            >
+              <Pause className="w-3.5 h-3.5" />
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(true)}
+            disabled={busy}
+            className="p-1.5 rounded-sm text-mc-text-secondary hover:text-red-400 hover:bg-mc-bg-tertiary disabled:opacity-40"
+            title="Delete schedule"
+            aria-label="Delete schedule"
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+      {error && (
+        <div className="mt-2 px-2 py-1 rounded-sm bg-red-900/20 border border-red-500/30 text-red-300 text-[11px]">
+          {error}
+        </div>
+      )}
+      <ConfirmDialog
+        open={confirmDelete}
+        title="Delete schedule?"
+        body="The schedule stops firing. Past briefs it produced are preserved."
+        confirmLabel="Delete"
+        destructive
+        onConfirm={doDelete}
+        onCancel={() => setConfirmDelete(false)}
+      />
+    </div>
+  );
+}

--- a/src/components/research/ScheduleRow.tsx
+++ b/src/components/research/ScheduleRow.tsx
@@ -11,11 +11,12 @@
  * the user-perceived path.
  */
 
-import { useState } from 'react';
-import { Calendar as CalendarIcon, Pause, Play, Trash2, Zap } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Calendar as CalendarIcon, Loader2, Pause, Play, Trash2, Zap } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { formatCadence } from './ScheduleDrawer';
+
 
 export interface ScheduleSummary {
   id: string;
@@ -39,6 +40,27 @@ export function ScheduleRow({ schedule, topicName, onChanged }: ScheduleRowProps
   const [busy, setBusy] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // A schedule whose next_run_at has already elapsed is queued for the
+  // next sweep tick (~60s loop). We track the current time to drive
+  // the "queued" indicator + the run-now cooldown without polling.
+  // useEffect re-renders every second so the timestamp transitions
+  // from "next_run_at in 5s" to "queued" to "fired" naturally as the
+  // sweep advances next_run_at past now() again.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  // A schedule whose next_run_at is already in the past is "queued":
+  // the next sweep tick (~60s) will fire it. This is the steady state
+  // right after Run-now (which sets next_run_at = now()), so we use
+  // it both for the visual indicator and the cooldown that prevents
+  // queuing the same job multiple times.
+  const nextMs = Date.parse(schedule.next_run_at);
+  const queuedForNextSweep =
+    schedule.status === 'active' && nextMs <= now;
 
   const patch = async (body: unknown) => {
     setBusy(true); setError(null);
@@ -95,19 +117,33 @@ export function ScheduleRow({ schedule, topicName, onChanged }: ScheduleRowProps
 
   const paused = schedule.status === 'paused';
 
+  // Pick the lead icon to make the row's state legible at a glance:
+  // queued = pulsing spinner, paused = yellow calendar, idle = accent
+  // calendar.
+  const LeadIcon = queuedForNextSweep ? Loader2 : CalendarIcon;
+  const leadIconClass = queuedForNextSweep
+    ? 'text-mc-accent animate-spin'
+    : paused
+      ? 'text-yellow-400'
+      : 'text-mc-accent';
+
   return (
     <div className="border border-mc-border rounded-sm bg-mc-bg-secondary px-3 py-2">
       <div className="flex items-center gap-3">
-        <CalendarIcon className={`w-4 h-4 shrink-0 ${paused ? 'text-yellow-400' : 'text-mc-accent'}`} />
+        <LeadIcon className={`w-4 h-4 shrink-0 ${leadIconClass}`} />
         <div className="flex-1 min-w-0">
           <div className="text-sm text-mc-text truncate">
             {topicName && <span className="text-mc-text-secondary">{topicName} · </span>}
             {formatCadence(schedule.cadence_seconds)} · {schedule.brief_template ?? 'general_brief'}
           </div>
           <div className="text-[11px] text-mc-text-secondary mt-0.5 flex flex-wrap gap-2">
-            <span>
-              Next: {formatDistanceToNow(new Date(schedule.next_run_at), { addSuffix: true })}
-            </span>
+            {queuedForNextSweep ? (
+              <span className="text-mc-accent">Queued — running on next sweep</span>
+            ) : (
+              <span>
+                Next: {formatDistanceToNow(new Date(schedule.next_run_at), { addSuffix: true })}
+              </span>
+            )}
             {schedule.last_run_at && (
               <span>· Last: {formatDistanceToNow(new Date(schedule.last_run_at), { addSuffix: true })}</span>
             )}
@@ -124,9 +160,9 @@ export function ScheduleRow({ schedule, topicName, onChanged }: ScheduleRowProps
             <button
               type="button"
               onClick={runNow}
-              disabled={busy}
-              className="p-1.5 rounded-sm text-mc-text-secondary hover:text-mc-accent hover:bg-mc-bg-tertiary disabled:opacity-40"
-              title="Run now"
+              disabled={busy || queuedForNextSweep}
+              className="p-1.5 rounded-sm text-mc-text-secondary hover:text-mc-accent hover:bg-mc-bg-tertiary disabled:opacity-40 disabled:cursor-not-allowed"
+              title={queuedForNextSweep ? 'Already queued for the next sweep' : 'Run now'}
               aria-label="Run now"
             >
               <Zap className="w-3.5 h-3.5" />

--- a/src/lib/agents/recurring-scheduler.ts
+++ b/src/lib/agents/recurring-scheduler.ts
@@ -96,12 +96,23 @@ async function dispatchResearchScheduleOnce(job: RecurringJob): Promise<void> {
 
   const today = new Date().toISOString().slice(0, 10);
   const title = `${topic.name} · ${today}`;
-  // The brief's prompt is the topic description by default. If the
-  // operator left description empty, a minimal directive keeps the
-  // researcher productive.
-  const prompt = topic.description.trim()
-    ? topic.description
-    : `Survey "${topic.name}" and produce a research brief.`;
+  // The auto-prompt frames this as a recurring survey ASK rather than
+  // a topic DESCRIPTION. The researcher persona's AGENTS.md leans
+  // hard on "save file + register_deliverable" when given a vague
+  // descriptive prompt; framing it as "produce a current brief and
+  // reply with it" puts the orchestrator's reply-capture path back
+  // on the rails. See run-brief.ts buildBriefPrompt for the
+  // anti-deliverable override the orchestrator stacks on top.
+  const desc = topic.description.trim();
+  const prompt =
+    `Recurring research brief — ${today}.\n\n` +
+    `Topic: ${topic.name}\n` +
+    (desc ? `Context: ${desc}\n\n` : '\n') +
+    `Produce a fresh research brief on this topic right now. Cover ` +
+    `current state, what changed since any prior coverage, key findings ` +
+    `with citations, gaps, and concrete next steps. Reply with the brief ` +
+    `body in your final assistant message — do not save it to a file ` +
+    `and do not call register_deliverable.`;
 
   let result: { brief_id: string; agent_run_id: string; state: 'started' | 'rejected'; reason?: string };
   try {

--- a/src/lib/db/recurring-jobs.ts
+++ b/src/lib/db/recurring-jobs.ts
@@ -252,15 +252,19 @@ export function markRunSuccess(id: string, scopeKey: string): RecurringJob | nul
   const cadenceMs = job.cadence_seconds * 1000;
   const now = Date.now();
   const next = new Date(now + cadenceMs).toISOString();
+  // ISO with `Z` so client-side Date.parse() reads as UTC. Bare
+  // SQLite `datetime('now')` would produce a tz-naïve string that
+  // browsers parse as local time, drifting last_run_at by the user's
+  // TZ offset on the rail / topic page.
   run(
     `UPDATE recurring_jobs
-        SET last_run_at = datetime('now'),
+        SET last_run_at = ?,
             last_run_scope_key = ?,
             next_run_at = ?,
             consecutive_failures = 0,
             run_count = run_count + 1
       WHERE id = ?`,
-    [scopeKey, next, id],
+    [new Date(now).toISOString(), scopeKey, next, id],
   );
   return getRecurringJob(id);
 }
@@ -278,14 +282,15 @@ export function markRunFailure(id: string, opts: { pauseThreshold?: number; back
   const backoff = opts.backoffSeconds ?? Math.min(job.cadence_seconds, 600);
   const nextStatus: JobStatus = newFailures >= threshold ? 'paused' : job.status;
   const nextRun = new Date(Date.now() + backoff * 1000).toISOString();
+  // ISO with `Z` for last_run_at — see markRunSuccess.
   run(
     `UPDATE recurring_jobs
         SET consecutive_failures = ?,
             status = ?,
             next_run_at = ?,
-            last_run_at = datetime('now')
+            last_run_at = ?
       WHERE id = ?`,
-    [newFailures, nextStatus, nextRun, id],
+    [newFailures, nextStatus, nextRun, new Date().toISOString(), id],
   );
   return getRecurringJob(id);
 }

--- a/src/lib/db/recurring-jobs.ts
+++ b/src/lib/db/recurring-jobs.ts
@@ -296,11 +296,15 @@ export function setJobStatus(id: string, status: JobStatus): RecurringJob | null
   const current = getRecurringJob(id);
   if (!current) return null;
   if (current.status === 'paused' && status === 'active') {
+    // Use ISO 8601 with `Z` so JS Date.parse() reads it as UTC. The
+    // bare `datetime('now')` SQLite literal omits the timezone marker
+    // and gets parsed as local time, drifting next_run_at by the
+    // browser's TZ offset on the rail / topic page.
     run(
       `UPDATE recurring_jobs
-          SET status = 'active', consecutive_failures = 0, next_run_at = datetime('now')
+          SET status = 'active', consecutive_failures = 0, next_run_at = ?
         WHERE id = ?`,
-      [id],
+      [new Date().toISOString(), id],
     );
   } else {
     run(`UPDATE recurring_jobs SET status = ? WHERE id = ?`, [status, id]);
@@ -334,7 +338,9 @@ export function setJobCadence(id: string, cadenceSeconds: number): RecurringJob 
  * post-success cadence advancement works as usual.
  */
 export function setJobRunNow(id: string): RecurringJob | null {
-  run(`UPDATE recurring_jobs SET next_run_at = datetime('now') WHERE id = ?`, [id]);
+  // ISO with `Z` so client-side Date.parse() reads it as UTC; bare
+  // SQLite `datetime('now')` is naive and ends up local-time-shifted.
+  run(`UPDATE recurring_jobs SET next_run_at = ? WHERE id = ?`, [new Date().toISOString(), id]);
   return getRecurringJob(id);
 }
 


### PR DESCRIPTION
Slice 4/5 of [research-phase-2-schedules-build-plan.md](specs/research-phase-2-schedules-build-plan.md). Stacked on #182 → #181 → #180.

## Summary
- New \`ScheduleDrawer\` (fixed cadence dropdown, 7 options, default Weekly).
- New \`ScheduleRow\` shared by topic detail + hub Upcoming lane (Run-now / Pause / Resume / Delete with \`ConfirmDialog\`).
- Topic detail gains a Schedules section + Schedule button.
- Hub Upcoming lane wires to \`/api/schedules?limit=10\`.

## Changes
- \`src/components/research/ScheduleDrawer.tsx\` (new) — drawer + cadence helpers.
- \`src/components/research/ScheduleRow.tsx\` (new) — shared row component.
- \`src/app/(app)/research/topics/[id]/page.tsx\` — Schedules section + drawer wiring.
- \`src/app/(app)/research/page.tsx\` — Upcoming lane populated from \`/api/schedules\`.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] Preview verification:
  - Created topic + schedule via API; refetched hub; "Daily / Phase-2 Smoke" appeared in Upcoming with Run-now + Pause buttons.
  - Topic detail shows Schedules section + Schedule button; drawer opens with all 7 cadence options.
  - Cleaned up smoke artifacts.
- [ ] Validation scenarios newly exercisable: RP2.S4.1, RP2.S4.2, RP2.S4.3, RP2.S4.4 (manual click flows).

## Stacked-merge note
Per \`feedback_stacked_pr_merges.md\`: when ready to merge, retarget this PR's base to \`main\` BEFORE merging the parent (#182) with \`--delete-branch\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)