### PR TITLE
feat(research): phase-2 eval — scheduled-run scenario

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mcp:e2e:next": "node scripts/mcp-next-e2e.mjs",
     "db:seed": "tsx src/lib/db/seed.ts",
     "research:eval": "tsx scripts/run-research-eval.ts",
+    "research:eval:schedule": "tsx scripts/run-research-schedule-eval.ts",
     "db:backup": "tsx scripts/db-backup.ts",
     "db:backup:list": "tsx scripts/db-backup.ts --list",
     "db:restore": "cp mission-control.db.backup mission-control.db && echo 'Restored from backup'",

--- a/scripts/run-research-schedule-eval.ts
+++ b/scripts/run-research-schedule-eval.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env tsx
+/**
+ * yarn research:eval:schedule entry point.
+ *
+ * Exercises the recurring-scheduler research dispatch path end-to-end
+ * with a canned-reply gateway stub. Validates RP2.S6.1 in the
+ * phase-2 validation plan.
+ */
+
+import { runScheduleEval } from '@/lib/research/eval/schedule-runner';
+
+async function main() {
+  console.log('[schedule-eval] starting…');
+  const report = await runScheduleEval();
+  console.log('[schedule-eval] done.');
+  console.log(`  run_id:       ${report.run_id}`);
+  console.log(`  workspace:    ${report.workspace_id}`);
+  console.log(`  schedule:     ${report.schedule_id}`);
+  console.log(`  brief_id:     ${report.brief_id ?? '(none)'}`);
+  console.log(`  brief_status: ${report.brief_status}`);
+  console.log(`  run_count:    ${report.schedule_run_count_after}`);
+  console.log(`  failures:     ${report.schedule_consecutive_failures_after}`);
+  console.log(`  passed:       ${report.passed}`);
+  if (!report.passed) process.exit(1);
+}
+
+main().catch(err => {
+  console.error('[schedule-eval] failed:', err);
+  process.exit(1);
+});

--- a/src/lib/research/eval/schedule-runner.test.ts
+++ b/src/lib/research/eval/schedule-runner.test.ts
@@ -1,0 +1,26 @@
+/**
+ * schedule-runner self-test.
+ *
+ * Self-contained: spins up its own workspace, researcher, runner,
+ * topic, schedule, and stubbed gateway client; confirms a brief was
+ * produced and the schedule's run_count advanced.
+ *
+ * Mirrors RP2.S6.1 in
+ * specs/research-phase-2-validation/02-test-plan.md.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { runScheduleEval } from './schedule-runner';
+
+test('schedule-runner: produces a brief and advances run_count', async () => {
+  const tmpDir = path.join(os.tmpdir(), `mc-sched-eval-${Date.now()}`);
+  const report = await runScheduleEval({ outputDir: tmpDir });
+  assert.equal(report.brief_status, 'complete');
+  assert.notEqual(report.brief_id, null);
+  assert.equal(report.schedule_run_count_after, 1);
+  assert.equal(report.schedule_consecutive_failures_after, 0);
+  assert.ok(report.passed);
+});

--- a/src/lib/research/eval/schedule-runner.ts
+++ b/src/lib/research/eval/schedule-runner.ts
@@ -1,0 +1,176 @@
+/**
+ * Scheduled-run eval scenario for research phase 2.
+ *
+ * Drives the recurring_jobs scheduler's research dispatch path
+ * end-to-end: create workspace + researcher + runner, create a
+ * topic, attach a 1-second-cadence schedule, force-fire it via
+ * `dispatchRecurringJobOnce`, and assert that a brief row landed
+ * and the recurring_jobs counters advanced.
+ *
+ * Uses the same canned-reply stubbing as `runner.ts` so the harness
+ * works without a live gateway. RP2.S6.1 in
+ * specs/research-phase-2-validation/02-test-plan.md.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import { v4 as uuidv4 } from 'uuid';
+import { run, queryOne } from '@/lib/db';
+import { createTopic } from '@/lib/db/topics';
+import {
+  createResearchSchedule,
+  getRecurringJob,
+} from '@/lib/db/recurring-jobs';
+import {
+  __setSendChatClientForTests,
+  type ChatEvent,
+  type SendChatClient,
+} from '@/lib/openclaw/send-chat';
+import { dispatchRecurringJobOnce } from '@/lib/agents/recurring-scheduler';
+
+export interface ScheduleEvalReport {
+  run_id: string;
+  started_at: string;
+  completed_at: string;
+  workspace_id: string;
+  topic_id: string;
+  schedule_id: string;
+  brief_id: string | null;
+  brief_status: 'complete' | 'failed' | 'missing';
+  schedule_run_count_after: number;
+  schedule_consecutive_failures_after: number;
+  passed: boolean;
+}
+
+export interface ScheduleEvalOptions {
+  outputDir?: string;
+  /** Canned reply the stubbed gateway emits. Defaults to a minimal
+   *  brief-shaped markdown so the rubric / parsing doesn't barf. */
+  cannedReply?: string;
+}
+
+const DEFAULT_REPLY =
+  '## Research Brief — schedule eval\n\n' +
+  '### Executive summary\n\nScheduled brief produced by the eval harness.\n\n' +
+  '### Citations\n\n- [example](https://example.com)\n';
+
+function ensureWorkspace(): string {
+  const id = `ws-sched-eval-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function ensureResearcherAndRunner(workspaceId: string): void {
+  run(
+    `INSERT OR IGNORE INTO agents (id, name, role, avatar_emoji, status, is_master, workspace_id, source, is_active, created_at, updated_at)
+     VALUES (?, 'mc-researcher-sched-eval', 'researcher', '🔍', 'standby', 0, ?, 'local', 1, datetime('now'), datetime('now'))`,
+    [`agent-sched-${workspaceId.slice(-8)}`, workspaceId],
+  );
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES ('default', 'default', 'default', datetime('now'))`,
+  );
+  run(
+    `INSERT OR IGNORE INTO agents
+       (id, name, role, avatar_emoji, status, is_master, workspace_id, source, gateway_agent_id, session_key_prefix, model, is_active, created_at, updated_at)
+       VALUES ('runner-sched-eval', 'MC Runner Dev', 'runner', '⚙️', 'standby', 0, 'default', 'gateway', 'mc-runner-dev', 'agent:mc-runner-dev:main', 'spark-lb/agent', 1, datetime('now'), datetime('now'))`,
+  );
+}
+
+function buildCannedClient(reply: string): SendChatClient {
+  const listeners = new Set<(p: ChatEvent) => void>();
+  return {
+    isConnected: () => true,
+    on: (event, listener) => {
+      if (event === 'chat_event') listeners.add(listener);
+      return undefined;
+    },
+    off: (event, listener) => {
+      if (event === 'chat_event') listeners.delete(listener);
+      return undefined;
+    },
+    call: async (method, params) => {
+      if (method !== 'chat.send') return undefined;
+      const sessionKey = (params as { sessionKey?: string } | undefined)?.sessionKey;
+      setImmediate(() => {
+        for (const listener of listeners) {
+          listener({ sessionKey, state: 'final', message: reply });
+        }
+      });
+      return {};
+    },
+  };
+}
+
+export async function runScheduleEval(opts: ScheduleEvalOptions = {}): Promise<ScheduleEvalReport> {
+  const startedAt = new Date().toISOString();
+  const runId = `${startedAt.replace(/[:.]/g, '-')}_${uuidv4().slice(0, 6)}`;
+  const outputDir = opts.outputDir ?? path.join(process.cwd(), 'tmp', 'research-eval-schedule');
+
+  const workspaceId = ensureWorkspace();
+  ensureResearcherAndRunner(workspaceId);
+  const topic = createTopic({
+    workspace_id: workspaceId,
+    name: 'Scheduled-run eval topic',
+    description: 'Survey: any small, deterministic prompt for the scheduled-run harness.',
+  });
+  const schedule = createResearchSchedule({
+    workspace_id: workspaceId,
+    topic_id: topic.id,
+    brief_template: 'general_brief',
+    cadence_seconds: 1,
+    first_run_at: new Date().toISOString(),
+  });
+
+  const reply = opts.cannedReply ?? DEFAULT_REPLY;
+  __setSendChatClientForTests(buildCannedClient(reply));
+
+  let briefId: string | null = null;
+  let briefStatus: ScheduleEvalReport['brief_status'] = 'missing';
+  try {
+    // Force the sweep tick for this single job.
+    await dispatchRecurringJobOnce(schedule);
+
+    // Find the brief produced by this schedule.
+    const briefRow = queryOne<{ id: string; result_md: string | null; error_md: string | null }>(
+      `SELECT id, result_md, error_md FROM briefs WHERE workspace_id = ? AND topic_id = ? ORDER BY created_at DESC LIMIT 1`,
+      [workspaceId, topic.id],
+    );
+    if (briefRow) {
+      briefId = briefRow.id;
+      briefStatus = briefRow.error_md ? 'failed' : 'complete';
+    }
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+
+  const after = getRecurringJob(schedule.id);
+  const passed =
+    briefStatus === 'complete' &&
+    (after?.run_count ?? 0) === 1 &&
+    (after?.consecutive_failures ?? 0) === 0;
+
+  const report: ScheduleEvalReport = {
+    run_id: runId,
+    started_at: startedAt,
+    completed_at: new Date().toISOString(),
+    workspace_id: workspaceId,
+    topic_id: topic.id,
+    schedule_id: schedule.id,
+    brief_id: briefId,
+    brief_status: briefStatus,
+    schedule_run_count_after: after?.run_count ?? 0,
+    schedule_consecutive_failures_after: after?.consecutive_failures ?? 0,
+    passed,
+  };
+
+  const runDir = path.join(outputDir, runId);
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(runDir, 'report.json'),
+    JSON.stringify(report, null, 2),
+  );
+  return report;
+}


### PR DESCRIPTION
Slice 5/5 of [research-phase-2-schedules-build-plan.md](specs/research-phase-2-schedules-build-plan.md). Stacked on #183 → #182 → #181 → #180.

## Summary
- New \`runScheduleEval()\` drives the scheduler's research dispatch path end-to-end with a canned-reply gateway stub.
- New \`yarn research:eval:schedule\` script (exit 1 on failure).
- Self-test runs in the standard \`yarn test\` sweep.

## Changes
- \`src/lib/research/eval/schedule-runner.ts\` (new) — harness.
- \`src/lib/research/eval/schedule-runner.test.ts\` (new) — self-test.
- \`scripts/run-research-schedule-eval.ts\` (new) — CLI entrypoint.
- \`package.json\` — \`research:eval:schedule\` script.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] \`tsx --test schedule-runner.test.ts\` — 1/1 pass; brief produced, run_count=1, failures=0.
- [ ] Validation scenario newly exercisable: RP2.S6.1 (canned-reply self-test). Real-agent variant against \`spark-lb/agent\` is the operator-driven part of the validation run.

## Stacked-merge note
Per \`feedback_stacked_pr_merges.md\`: when ready to merge, retarget this PR's base to \`main\` BEFORE merging the parent (#183) with \`--delete-branch\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)