### PR TITLE
fix(research): extractReplyText prefers heading-bearing message

### DIFF
--- a/src/lib/research/run-brief.test.ts
+++ b/src/lib/research/run-brief.test.ts
@@ -233,6 +233,52 @@ test('extractReplyText: handles object-shape messages with content arrays', () =
   assert.equal(text, 'hello world');
 });
 
+test('extractReplyText: prefers heading-bearing message over later narration', () => {
+  // Mimics the failure mode observed during phase-2 validation: the
+  // researcher emits the brief as one long heading-bearing message,
+  // then narrates about saving the file in a final short message,
+  // which the gateway captures as the `done` event.
+  const briefBody = '# Research Brief: Topic X\n\n## Executive Summary\n\nFindings...';
+  const text = extractReplyText(
+    [
+      { message: 'Now let me compile the findings.' },
+      { message: briefBody },
+      { message: 'A copy has been saved to research-brief-abc.md.' },
+    ],
+    { state: 'final', message: 'A copy has been saved to research-brief-abc.md.' },
+  );
+  assert.equal(text, briefBody);
+});
+
+test('extractReplyText: matches heading after a leading separator', () => {
+  // Real briefs sometimes lead with `***\n\n# Heading` because the
+  // researcher uses a horizontal rule before the brief body.
+  const briefBody = '***\n\n# Brief\n\n## Body\n\nText';
+  const text = extractReplyText(
+    [{ message: briefBody }, { message: 'short narration' }],
+    { state: 'final', message: 'short narration' },
+  );
+  assert.equal(text, briefBody);
+});
+
+test('extractReplyText: ignores empty-string messages without breaking the heuristic', () => {
+  const text = extractReplyText(
+    [{ message: '' }, { message: '   ' }, { message: '## Heading\n\nbody' }],
+    { state: 'final' },
+  );
+  assert.equal(text, '## Heading\n\nbody');
+});
+
+test('extractReplyText: picks the longest heading message when multiple have headings', () => {
+  const short = '# A\n\nshort';
+  const long = '# B\n\nA much longer body with more content for readers.';
+  const text = extractReplyText(
+    [{ message: short }, { message: long }],
+    { state: 'final' },
+  );
+  assert.equal(text, long);
+});
+
 test('buildBriefPrompt: includes topic context when supplied', () => {
   const prompt = buildBriefPrompt({
     template: 'general_brief',

--- a/src/lib/research/run-brief.ts
+++ b/src/lib/research/run-brief.ts
@@ -258,17 +258,45 @@ function extractSourcesSection(markdown: string): string | null {
 }
 
 /**
- * Extract a single concatenated text body from the gateway's
- * collected ChatEvents. The done event typically carries the full
- * reply but we fall back to the concatenated stream if missing.
+ * Extract the brief body from the gateway's ChatEvents.
+ *
+ * The naive read — concatenate everything or use the `done` event's
+ * message — fails when the researcher makes tool calls. A typical
+ * problem run interleaves narration messages with `register_deliverable`
+ * / file-write tool calls; the `done` event then carries only the
+ * final narration ("A copy has been saved to research-brief-*.md")
+ * and we lose the actual brief body that landed in an earlier
+ * assistant message.
+ *
+ * Heuristic, in priority order:
+ *
+ *   1. If any assistant message contains a markdown heading
+ *      (`# `, `## `, `### `, with optional leading `***`/`---`
+ *      separator), pick the LONGEST such message. Briefs always
+ *      open with a heading; narrations almost never do.
+ *   2. Otherwise fall back to the `done` event's text.
+ *   3. Otherwise concatenate the stream.
  */
 export function extractReplyText(reply: ChatEvent[], doneEvent?: ChatEvent): string {
-  const fromDone = readMessageText(doneEvent?.message);
-  if (fromDone) return fromDone;
-  const parts = reply
+  const candidates = reply
     .map(e => readMessageText(e.message))
-    .filter((s): s is string => !!s);
-  return parts.join('').trim();
+    .filter((s): s is string => !!s)
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  // Headings the brief writer reliably emits. Allow optional leading
+  // `***`/`---`/whitespace so a leading separator before the heading
+  // isn't a miss.
+  const HEADING_RE = /(^|\n)\s*(?:[*-]{3,}\s*\n+)?\s*#{1,3}\s+\S/;
+  const headingMatches = candidates.filter(s => HEADING_RE.test(s));
+  if (headingMatches.length > 0) {
+    headingMatches.sort((a, b) => b.length - a.length);
+    return headingMatches[0];
+  }
+
+  const fromDone = readMessageText(doneEvent?.message)?.trim();
+  if (fromDone) return fromDone;
+  return candidates.join('').trim();
 }
 
 function readMessageText(message: unknown): string | null {


### PR DESCRIPTION
Follow-up #2 from the [phase-2 validation](specs/research-phase-2-validation/04-e2e-run-results.md).

## Summary
Hardens \`extractReplyText\` against the failure mode that surfaced during the validation run: a researcher emits the brief in one assistant message and a "saved to file" narration in a follow-up; the gateway's \`done\` event carries the trailing narration so the naive read drops the brief.

New heuristic:
1. Prefer the longest assistant message containing a markdown heading (\`# \` / \`## \` / \`### \`, with optional leading \`***\`/\`---\` separator).
2. Fall back to the \`done\` event's text.
3. Fall back to the concatenated stream.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] \`tsx --test run-brief.test.ts\` — 29/29 pass (4 new tests: heading-preference, leading-separator, empty-message tolerance, longest-tie-break; 3 existing kept their original semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)