### PR TITLE
feat(research): View-latest link on schedule rows

### DIFF
--- a/src/components/research/ScheduleRow.tsx
+++ b/src/components/research/ScheduleRow.tsx
@@ -12,7 +12,8 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Calendar as CalendarIcon, Loader2, Pause, Play, Trash2, Zap } from 'lucide-react';
+import Link from 'next/link';
+import { ArrowUpRight, Calendar as CalendarIcon, Loader2, Pause, Play, Trash2, Zap } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { formatCadence } from './ScheduleDrawer';
@@ -26,8 +27,26 @@ export interface ScheduleSummary {
   status: 'active' | 'paused' | 'done';
   next_run_at: string;
   last_run_at: string | null;
+  /**
+   * The scope_key the schedule's last successful sweep recorded. For
+   * research schedules this is `research-brief-<briefId>` per
+   * dispatchResearchScheduleOnce; the row parses out the brief id to
+   * render the "View latest" link.
+   */
+  last_run_scope_key?: string | null;
   consecutive_failures: number;
   run_count: number;
+}
+
+/**
+ * Pull the brief id out of a `research-brief-<id>` scope key. Returns
+ * null for any other shape (defends against scope keys from the
+ * scope-keyed-sessions path or future schedule kinds).
+ */
+function lastBriefIdFrom(scopeKey: string | null | undefined): string | null {
+  if (!scopeKey) return null;
+  const m = /^research-brief-([0-9a-f-]+)$/i.exec(scopeKey);
+  return m ? m[1] : null;
 }
 
 interface ScheduleRowProps {
@@ -116,6 +135,7 @@ export function ScheduleRow({ schedule, topicName, onChanged }: ScheduleRowProps
   };
 
   const paused = schedule.status === 'paused';
+  const lastBriefId = lastBriefIdFrom(schedule.last_run_scope_key);
 
   // Pick the lead icon to make the row's state legible at a glance:
   // queued = pulsing spinner, paused = yellow calendar, idle = accent
@@ -148,6 +168,17 @@ export function ScheduleRow({ schedule, topicName, onChanged }: ScheduleRowProps
               <span>· Last: {formatDistanceToNow(new Date(schedule.last_run_at), { addSuffix: true })}</span>
             )}
             <span>· Run count: {schedule.run_count}</span>
+            {lastBriefId && (
+              <Link
+                href={`/research/briefs/${lastBriefId}`}
+                className="text-mc-accent hover:underline inline-flex items-center gap-0.5"
+                onClick={(e) => e.stopPropagation()}
+                title="View the most recent brief this schedule produced"
+              >
+                · View latest
+                <ArrowUpRight className="w-3 h-3" />
+              </Link>
+            )}
             {paused && (
               <span className="text-yellow-400">
                 · Paused{schedule.consecutive_failures > 0 ? ` (${schedule.consecutive_failures} failures)` : ''}


### PR DESCRIPTION
Follow-up #3 from the [phase-2 validation](specs/research-phase-2-validation/04-e2e-run-results.md).

## Summary
Closes the visible feedback loop after Run-now: schedule rows now show a \`· View latest ↗\` link that jumps directly to the most recent brief the schedule produced. Parses the brief id out of \`last_run_scope_key\` (already stored as \`research-brief-<id>\` by \`dispatchResearchScheduleOnce\` in slice 2).

Hides cleanly when there's no last run yet, or when the scope_key isn't research-shaped (defensive).

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] Preview verification: link rendered for the existing weekly schedule, pointed at the correct brief id (\`fd8fd46e\` — the 10,739-char brief produced during validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)