### PR TITLE
feat(research): async outcome tracking for scheduled briefs

### DIFF
--- a/src/lib/db/recurring-jobs.test.ts
+++ b/src/lib/db/recurring-jobs.test.ts
@@ -21,6 +21,7 @@ import {
   listUpcomingResearch,
   markRunFailure,
   markRunSuccess,
+  recordBriefOutcome,
   RecurringJobValidationError,
   renderScopeKey,
   setJobStatus,
@@ -265,4 +266,80 @@ test('listUpcomingResearch: orders by next_run_at and excludes paused / non-rese
   const upcoming = listUpcomingResearch(ws, 10);
   assert.equal(upcoming.length, 2);
   assert.equal(upcoming[0].id, earliest.id);
+});
+
+// --- recordBriefOutcome (async outcome tracking) ------------------
+
+function makeScheduledAgentRun(workspaceId: string, scheduleId: string): string {
+  const id = `ar-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT INTO agent_runs (id, workspace_id, kind, status, source_kind, source_ref, created_at, updated_at)
+     VALUES (?, ?, 'brief', 'queued', 'schedule', ?, datetime('now'), datetime('now'))`,
+    [id, workspaceId, scheduleId],
+  );
+  return id;
+}
+
+test('recordBriefOutcome: returns null for non-schedule runs', () => {
+  const ws = freshWorkspace();
+  const id = `ar-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT INTO agent_runs (id, workspace_id, kind, status, source_kind, created_at, updated_at)
+     VALUES (?, ?, 'brief', 'queued', 'manual', datetime('now'), datetime('now'))`,
+    [id, ws],
+  );
+  assert.equal(recordBriefOutcome(id, 'failed'), null);
+  assert.equal(recordBriefOutcome(id, 'completed'), null);
+});
+
+test('recordBriefOutcome: failure bumps consecutive_failures, no next_run_at change', () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  const sched = createResearchSchedule({
+    workspace_id: ws, topic_id: tp, brief_template: 'general_brief', cadence_seconds: 60,
+  });
+  const ar = makeScheduledAgentRun(ws, sched.id);
+  const beforeNext = getRecurringJob(sched.id)!.next_run_at;
+
+  const out = recordBriefOutcome(ar, 'failed');
+  assert.equal(out?.consecutive_failures, 1);
+  assert.equal(out?.status, 'active');
+  // next_run_at MUST NOT be touched — dispatch already advanced it.
+  assert.equal(getRecurringJob(sched.id)!.next_run_at, beforeNext);
+});
+
+test('recordBriefOutcome: pauses after 3 async failures', () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  const sched = createResearchSchedule({
+    workspace_id: ws, topic_id: tp, brief_template: 'general_brief', cadence_seconds: 60,
+  });
+  // Three independent agent_runs all marked failed.
+  const ar1 = makeScheduledAgentRun(ws, sched.id);
+  const ar2 = makeScheduledAgentRun(ws, sched.id);
+  const ar3 = makeScheduledAgentRun(ws, sched.id);
+  recordBriefOutcome(ar1, 'failed');
+  recordBriefOutcome(ar2, 'failed');
+  const out = recordBriefOutcome(ar3, 'failed');
+  assert.equal(out?.consecutive_failures, 3);
+  assert.equal(out?.status, 'paused');
+});
+
+test('recordBriefOutcome: completion clears consecutive_failures', () => {
+  const ws = freshWorkspace();
+  const tp = freshTopic(ws);
+  const sched = createResearchSchedule({
+    workspace_id: ws, topic_id: tp, brief_template: 'general_brief', cadence_seconds: 60,
+  });
+  // Simulate two prior failures, then a successful run.
+  const ar1 = makeScheduledAgentRun(ws, sched.id);
+  const ar2 = makeScheduledAgentRun(ws, sched.id);
+  const ar3 = makeScheduledAgentRun(ws, sched.id);
+  recordBriefOutcome(ar1, 'failed');
+  recordBriefOutcome(ar2, 'failed');
+  assert.equal(getRecurringJob(sched.id)!.consecutive_failures, 2);
+
+  const out = recordBriefOutcome(ar3, 'completed');
+  assert.equal(out?.consecutive_failures, 0);
+  assert.equal(getRecurringJob(sched.id)!.consecutive_failures, 0);
 });

--- a/src/lib/db/recurring-jobs.ts
+++ b/src/lib/db/recurring-jobs.ts
@@ -371,6 +371,76 @@ export function pauseSchedulesForTopic(topicId: string): number {
   return result.changes ?? 0;
 }
 
+export interface BriefOutcomeUpdate {
+  job_id: string;
+  status: JobStatus;
+  consecutive_failures: number;
+}
+
+/**
+ * Record the async outcome of a brief produced by a research
+ * schedule. Resolves the schedule via `agent_runs.source_kind` +
+ * `agent_runs.source_ref`, then:
+ *   - on 'completed' clears consecutive_failures (a successful run
+ *     after a failure streak resets the counter so a transient
+ *     blip doesn't pause an otherwise-healthy schedule).
+ *   - on 'failed' bumps consecutive_failures, pauses the row when
+ *     it reaches `pauseThreshold` (default 3, matching the synchronous
+ *     dispatch-time path).
+ *
+ * Does NOT touch `next_run_at`: the dispatch path already advanced
+ * it by `cadence_seconds` to prevent concurrent runs while the brief
+ * was in flight. Returns null if the agent_run isn't schedule-bound
+ * or the schedule no longer exists (deleted while in flight).
+ */
+export function recordBriefOutcome(
+  agentRunId: string,
+  outcome: 'completed' | 'failed',
+  opts: { pauseThreshold?: number } = {},
+): BriefOutcomeUpdate | null {
+  const sched = queryOne<{ id: string; status: JobStatus; consecutive_failures: number }>(
+    `SELECT rj.id, rj.status, rj.consecutive_failures
+       FROM recurring_jobs rj
+       JOIN agent_runs ar ON ar.source_ref = rj.id
+      WHERE ar.id = ? AND ar.source_kind = 'schedule'
+      LIMIT 1`,
+    [agentRunId],
+  );
+  if (!sched) return null;
+
+  if (outcome === 'completed') {
+    if (sched.consecutive_failures > 0) {
+      run(
+        `UPDATE recurring_jobs SET consecutive_failures = 0 WHERE id = ?`,
+        [sched.id],
+      );
+    }
+    return {
+      job_id: sched.id,
+      status: sched.status,
+      consecutive_failures: 0,
+    };
+  }
+
+  // outcome === 'failed'
+  const newFailures = sched.consecutive_failures + 1;
+  const threshold = opts.pauseThreshold ?? 3;
+  const nextStatus: JobStatus =
+    newFailures >= threshold && sched.status === 'active' ? 'paused' : sched.status;
+  run(
+    `UPDATE recurring_jobs
+        SET consecutive_failures = ?,
+            status = ?
+      WHERE id = ?`,
+    [newFailures, nextStatus, sched.id],
+  );
+  return {
+    job_id: sched.id,
+    status: nextStatus,
+    consecutive_failures: newFailures,
+  };
+}
+
 /**
  * Render a scope_key_template by substituting `{wsid}`, `{job_id}`,
  * and `{run_n}` placeholders. Defaults to the job's actual values.

--- a/src/lib/research/run-brief.ts
+++ b/src/lib/research/run-brief.ts
@@ -49,6 +49,7 @@ import {
   type BriefTemplate,
 } from '@/lib/db/briefs';
 import { getTopic } from '@/lib/db/topics';
+import { recordBriefOutcome } from '@/lib/db/recurring-jobs';
 import { broadcast } from '@/lib/events';
 import { dispatchScope } from '@/lib/agents/dispatch-scope';
 import { getRunnerAgent } from '@/lib/agents/runner';
@@ -295,6 +296,23 @@ function emit(
     broadcast({ type, payload });
   } catch (err) {
     console.error(`[run-brief] failed to broadcast ${type}:`, err);
+  }
+  // Async outcome tracking for research schedules: when a brief that
+  // came from a recurring schedule terminates, update the schedule's
+  // failure counter so async failures bump consecutive_failures and
+  // pause-after-3 fires correctly. The dispatch path's
+  // markRunSuccess already advanced next_run_at — we only adjust the
+  // failure book-keeping here. Non-schedule briefs return null and
+  // this is a no-op.
+  if (type === 'brief_completed' || type === 'brief_failed') {
+    const agentRunId = payload.agent_run_id;
+    if (typeof agentRunId === 'string' && agentRunId) {
+      try {
+        recordBriefOutcome(agentRunId, type === 'brief_completed' ? 'completed' : 'failed');
+      } catch (err) {
+        console.error(`[run-brief] recordBriefOutcome failed:`, err);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Follow-up #4 from the [phase-2 validation](specs/research-phase-2-validation/04-e2e-run-results.md).

## Summary
Phase 2 called \`markRunSuccess\` synchronously when \`runBrief\` returned \`'started'\`, but the brief itself ran async; later \`brief_failed\` events left the schedule's \`consecutive_failures\` untouched, so a schedule could fail every run forever and never trip the pause-after-3 threshold.

New \`recordBriefOutcome\` DAO joins \`agent_runs.source_kind='schedule'\` + \`source_ref\` to find the originating schedule, then:
- on \`brief_completed\`: clears \`consecutive_failures\` (a successful run resets the streak)
- on \`brief_failed\`: bumps \`consecutive_failures\`; pauses at threshold

Does NOT touch \`next_run_at\` (dispatch already advanced it to prevent concurrent runs).

Wired by piggy-backing the \`emit()\` helper in \`run-brief.ts\` — every terminal broadcast now calls \`recordBriefOutcome\` with the \`agent_run_id\` from the payload. Manual briefs no-op via the SQL filter.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] \`tsx --test recurring-jobs.test.ts\` — 17/17 pass (4 new tests: non-schedule no-op, single failure, pause-at-3, success-clears).
- [x] \`tsx --test run-brief.test.ts\` + \`recurring-scheduler.test.ts\` regress clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)