### PR TITLE
feat: agent detail responsive + drop redundant workspace settings header

### DIFF
--- a/src/app/(app)/agents/[id]/page.tsx
+++ b/src/app/(app)/agents/[id]/page.tsx
@@ -374,6 +374,12 @@ export default function AgentDetailsPage({
     <PageWithRails
       header={header}
       leftRail={<SectionNav sections={sections} />}
+      collapsibleLeftRail
+      leftRailStorageKey="mc:agents:detail:rail"
+      // Wide right rail (routing preview + activity timeline) needs xl
+      // breathing room. Below xl it stacks under main as a labeled
+      // section so the form column stays readable. See PageWithRails docs.
+      rightRailMinViewport="xl"
       rightRail={
         <div className="space-y-4">
           <RoutingPreview info={sessionInfo} loading={sessionInfoLoading} error={sessionInfoError} />

--- a/src/app/(app)/workspace/[slug]/settings/page.tsx
+++ b/src/app/(app)/workspace/[slug]/settings/page.tsx
@@ -17,12 +17,10 @@
 
 import { useEffect, useState, use, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
   AlertTriangle,
-  ArrowLeft,
   Download,
   Folder,
   Loader,
@@ -181,29 +179,13 @@ export default function WorkspaceSettingsPage({
     { id: 'danger-zone', label: 'Danger zone' },
   ];
 
-  const header = (
-    <div className="flex items-center justify-between gap-4">
-      <div className="flex items-center gap-3 min-w-0">
-        <Link
-          href={`/workspace/${workspace.slug}`}
-          className="inline-flex items-center gap-1 px-2 py-1 rounded text-mc-text-secondary hover:text-mc-text text-sm shrink-0"
-        >
-          <ArrowLeft className="w-4 h-4" /> Back
-        </Link>
-        <span className="text-2xl shrink-0">{workspace.icon}</span>
-        <div className="min-w-0">
-          <h1 className="text-base font-semibold truncate">{workspace.name}</h1>
-          <div className="text-[11px] text-mc-text-secondary font-mono truncate">
-            /workspace/{workspace.slug} — settings
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  // No top header here: the Identity section below already shows the
+  // workspace's name + icon + description, and the global left nav
+  // already provides navigation back out — a sticky breadcrumb on top
+  // was just cropping the form column on narrow viewports.
 
   return (
     <PageWithRails
-      header={header}
       leftRail={<SectionNav sections={sections} />}
       collapsibleLeftRail
       leftRailStorageKey="mc:workspace:settings:rail"


### PR DESCRIPTION
## Summary
Two paper cuts from the operator:

1. **Agent detail had the same right-rail crowding** as workspace settings did before #192. Routing preview + activity timeline + the main form all tried to share a 1024–1279px viewport, squashing the form. Opted into the new \`collapsibleLeftRail\` + \`rightRailMinViewport='xl'\` props so the right rail stacks under main as \"Routing & activity\" when there isn't room for the 3-col layout.

2. **Workspace settings top bar dropped.** The Back link was redundant (global left nav handles it) and the workspace name + slug were already shown by the Identity section directly below. Removed the \`header\` plus the now-unused \`Link\` / \`ArrowLeft\` imports.

The agent-detail header is **kept** — it shows the specific agent the page covers (which the global nav doesn't) and Back ↦ agent list is meaningful context.

## Changes
- \`src/app/(app)/agents/[id]/page.tsx\` — opt into the responsive props.
- \`src/app/(app)/workspace/[slug]/settings/page.tsx\` — drop the \`header\`.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] Preview at 1200px (between lg and xl):
  - Workspace settings: top bar gone, content starts at \"Identity\" header.
  - Agent detail: left rail (256px) + main (960px), Routing & activity preview stacks below as labeled section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)