### PR TITLE
fix(agents): add 'runner' to the standard role dropdown

### DIFF
--- a/src/app/(app)/agents/[id]/page.tsx
+++ b/src/app/(app)/agents/[id]/page.tsx
@@ -46,6 +46,13 @@ const EMOJI_OPTIONS = ['🤖', '🦞', '💻', '🔍', '✍️', '🎨', '📊',
 // (e.g. planners, glue agents) that don't fit the standard taxonomy.
 const STANDARD_ROLES = [
   'pm',
+  // `runner` is the gateway-bound scope-keyed-session host
+  // (mc-runner / mc-runner-dev). Not a BriefingRole — it doesn't
+  // carry a persona briefing — but it IS a first-class role for
+  // operator-facing agents. Was missing, so newly-imported runner
+  // rows landed in "Custom…" instead of matching their canonical
+  // label.
+  'runner',
   'coordinator',
   'builder',
   'researcher',


### PR DESCRIPTION
## Summary
Imported \`mc-runner\` / \`mc-runner-dev\` agents had their role rendered as \"Custom…\" with the value typed into the free-text input, because the dropdown only listed \`BriefingRole\` values. The runner isn't a BriefingRole — it doesn't carry a persona briefing — but it IS a first-class role for operator-facing agents (the gateway-bound host for scope-keyed sessions; see \`specs/scope-keyed-sessions.md\` §1).

## Changes
- \`src/app/(app)/agents/[id]/page.tsx\` — adds \`runner\` to \`STANDARD_ROLES\` with a comment explaining why it's there even though \`briefing.ts\` excludes it.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] Preview verification: opened the runner agent's detail page, dropdown now selects \"runner\" directly and the custom-text input is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)