### PR TITLE
fix(pm-chat): suppress synth placeholder, surface agent's actual reply

### DIFF
--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -217,15 +217,24 @@ export function dispatchPm(input: DispatchPmInput): DispatchPmResult {
     parent_proposal_id: input.parent_proposal_id ?? null,
     dispatch_state: gatewayUp ? 'pending_agent' : 'synth_only',
   });
-  try {
-    postPmChatMessage({
-      workspace_id: input.workspace_id,
-      content: synth.impact_md,
-      proposal_id: placeholder.id,
-      role: 'assistant',
-    });
-  } catch (err) {
-    console.warn('[pm-dispatch] chat insert failed:', (err as Error).message);
+  // Echo the synth proposal into chat ONLY when we know the agent
+  // can't respond (gateway down). When the gateway is up the synth
+  // is a placeholder — posting it as chat now produced a misleading
+  // "Proposal — 0 changes" card BEFORE the PM agent had a chance to
+  // reply. The agent's actual reply (and any structured proposal) is
+  // posted later by the background dispatch via supersede or via the
+  // synth-only fallback below.
+  if (!gatewayUp) {
+    try {
+      postPmChatMessage({
+        workspace_id: input.workspace_id,
+        content: synth.impact_md,
+        proposal_id: placeholder.id,
+        role: 'assistant',
+      });
+    } catch (err) {
+      console.warn('[pm-dispatch] chat insert failed:', (err as Error).message);
+    }
   }
 
   if (!gatewayUp) {
@@ -361,6 +370,25 @@ async function runDisruptionDispatchInBackground(
     `[pm-dispatch] disruption reconciler timed out for placeholder ${placeholder.id} (workspace=${input.workspace_id}); marking synth_only`,
   );
   setDispatchState(placeholder.id, 'synth_only');
+
+  // Surface what the agent ACTUALLY said. The structured-proposal
+  // path didn't fire (no propose_changes call landed), but the agent
+  // typically still replied with text — that's the most useful thing
+  // to show in chat. If we have nothing usable, fall back to the
+  // synth content so the operator at least sees that.
+  const replyText = extractAgentReplyText(result);
+  const chatBody = replyText.trim() || placeholder.impact_md;
+  try {
+    postPmChatMessage({
+      workspace_id: input.workspace_id,
+      content: chatBody,
+      proposal_id: replyText ? undefined : placeholder.id,
+      role: 'assistant',
+    });
+  } catch (err) {
+    console.warn('[pm-dispatch] synth-only chat insert failed:', (err as Error).message);
+  }
+
   broadcast({
     type: 'pm_proposal_dispatch_state_changed',
     payload: {
@@ -374,6 +402,42 @@ async function runDisruptionDispatchInBackground(
     used_named_agent: false,
     used_synthesize_fallback: true,
   };
+}
+
+/**
+ * Pull readable assistant text out of a sendChatAndAwaitReply result.
+ * Prefers `doneEvent` (the model's final message) and falls back to
+ * the streamed `reply` events. Empty string when the dispatch
+ * produced no usable text (transport failure / nothing emitted).
+ */
+function extractAgentReplyText(
+  result: Awaited<ReturnType<typeof sendChatAndAwaitReply>> | null,
+): string {
+  if (!result || !result.sent) return '';
+  const readMessage = (m: unknown): string => {
+    if (!m) return '';
+    if (typeof m === 'string') return m;
+    if (typeof m === 'object' && 'content' in m) {
+      const c = (m as { content: unknown }).content;
+      if (typeof c === 'string') return c;
+      if (Array.isArray(c)) {
+        return c
+          .map(part =>
+            typeof part === 'string'
+              ? part
+              : typeof part === 'object' && part && 'text' in part && typeof (part as { text: unknown }).text === 'string'
+                ? (part as { text: string }).text
+                : '',
+          )
+          .filter(Boolean)
+          .join('');
+      }
+    }
+    return '';
+  };
+  const fromDone = readMessage(result.doneEvent?.message).trim();
+  if (fromDone) return fromDone;
+  return (result.reply ?? []).map(e => readMessage(e.message)).join('').trim();
 }
 
 // ─── Named-agent dispatch ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
PM chat always rendered a misleading \"Proposal — 0 changes / disruption acknowledged\" card the moment the operator hit Send, before the PM agent had a chance to respond. The synth placeholder was being posted as a chat message immediately on dispatch; the agent's actual reply was discarded by the time the chat surface looked.

Two changes in \`dispatchPm\` + \`runDisruptionDispatchInBackground\`:

1. **Don't echo the synth content into chat when the gateway is up.** The synth proposal is still persisted (so \`/pm/activity\` has something to show) but no chat message is posted for it.
2. **In the synth_only fallback** (agent didn't call \`propose_changes\`), extract the assistant text from \`dispatch.reply.doneEvent.message\` and post **that** as the chat message. Falls back to the synth content only if the agent produced no readable text at all.

Mirrors the AgentChatTab UX where the thread shows what the agent actually said. The structured-proposal path is unchanged — \`propose_changes\` calls still supersede the placeholder and re-echo the agent's \`impact_md\`.

## Changes
- \`src/lib/agents/pm-dispatch.ts\` — gate the synth chat echo on \`!gatewayUp\`; new \`extractAgentReplyText\` helper used in the synth_only fallback.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] \`tsx --test pm-e2e.test.ts pm.test.ts\` — 29/29 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)