### PR TITLE
fix(pm-chat): suppress misleading synth post when nothing real to say

### DIFF
--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -372,21 +372,45 @@ async function runDisruptionDispatchInBackground(
   setDispatchState(placeholder.id, 'synth_only');
 
   // Surface what the agent ACTUALLY said. The structured-proposal
-  // path didn't fire (no propose_changes call landed), but the agent
-  // typically still replied with text — that's the most useful thing
-  // to show in chat. If we have nothing usable, fall back to the
-  // synth content so the operator at least sees that.
-  const replyText = extractAgentReplyText(result);
-  const chatBody = replyText.trim() || placeholder.impact_md;
-  try {
-    postPmChatMessage({
-      workspace_id: input.workspace_id,
-      content: chatBody,
-      proposal_id: replyText ? undefined : placeholder.id,
-      role: 'assistant',
-    });
-  } catch (err) {
-    console.warn('[pm-dispatch] synth-only chat insert failed:', (err as Error).message);
+  // path didn't fire (no propose_changes call landed). Three sub-cases:
+  //
+  //   - Agent replied with usable text → post that. Most useful path
+  //     for chatty prompts ("Test", "What about X?") that don't merit
+  //     a structured proposal.
+  //   - Agent replied empty AND the synth produced ≥1 structured
+  //     change → post the synth content (it's at least factual about
+  //     workspace state).
+  //   - Agent replied empty AND synth has 0 changes → post NOTHING.
+  //     The misleading "Proposal — 0 changes / disruption acknowledged"
+  //     card was the worst of all worlds: implied a proposal where
+  //     none exists. Better to leave the chat clean; the placeholder
+  //     row still exists in pm_proposals for /pm/activity.
+  const replyText = extractAgentReplyText(result).trim();
+  if (replyText) {
+    try {
+      postPmChatMessage({
+        workspace_id: input.workspace_id,
+        content: replyText,
+        role: 'assistant',
+      });
+    } catch (err) {
+      console.warn('[pm-dispatch] synth-only chat insert failed:', (err as Error).message);
+    }
+  } else if (placeholder.proposed_changes.length > 0) {
+    try {
+      postPmChatMessage({
+        workspace_id: input.workspace_id,
+        content: placeholder.impact_md,
+        proposal_id: placeholder.id,
+        role: 'assistant',
+      });
+    } catch (err) {
+      console.warn('[pm-dispatch] synth-only chat insert failed:', (err as Error).message);
+    }
+  } else {
+    console.log(
+      `[pm-dispatch] synth-only with empty reply + 0 changes for ${placeholder.id}; suppressing misleading chat post`,
+    );
   }
 
   broadcast({


### PR DESCRIPTION
## Summary
Follow-up to #196. The synth-only fallback still posted \"Proposal — 0 changes / disruption acknowledged\" whenever the PM agent's reply came back empty (the most common case for short prompts like \"Test\"), because the post unconditionally fell back to \`placeholder.impact_md\`.

Refined into three sub-cases:
1. Agent replied with usable text → post that.
2. Agent replied empty AND synth has ≥1 structured change → post the synth content (factual about workspace state).
3. **Agent replied empty AND synth has 0 changes → post nothing.** The \"0 changes\" card was actively misleading; cleaner thread is more honest.

The placeholder row still exists in \`pm_proposals\` for \`/pm/activity\` forensic review.

## Changes
- \`src/lib/agents/pm-dispatch.ts\` — three-way branch in the synth-only fallback chat post.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] \`tsx --test pm-e2e.test.ts pm.test.ts\` — 29/29 pass.
- [x] Preview verification: a fresh \"Quick smoke test\" dispatch with synth changes=0 + no agent reply produces no follow-up card. Operator sees only their own message — accurate signal that the PM had no structured response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)