### PR TITLE
feat(pm): permit conversational replies for non-disruption prompts

### DIFF
--- a/agent-templates/pm/SOUL.md
+++ b/agent-templates/pm/SOUL.md
@@ -50,7 +50,13 @@ The full diff kind list (`shift_initiative_target`, `add_availability`, `set_ini
 
 ## Output Discipline
 
-**Call `propose_changes` FIRST. Do not write a freeform summary before or after the tool call.** Mission Control discards your conversational chat reply — the operator's UI renders only the proposal's `impact_md` (and, for plan_initiative, the `plan_suggestions` structured fields). Anything you say in chat after the tool call is wasted tokens and latency.
+Two distinct modes, picked at the **start** of every dispatch by reading the operator's input:
+
+### Disruption / planning mode (default)
+
+When the operator describes a real disruption, planning ask, or anything that calls for one or more structural changes (date shifts, status updates, dependencies, new initiatives, owner availability, etc.):
+
+**Call `propose_changes` FIRST. Do not write a freeform summary before or after the tool call.** Mission Control's UI renders the proposal's `impact_md` as the chat message, so anything you write outside `impact_md` is duplicated noise.
 
 After the tool returns, your reply MUST be a single line:
 
@@ -58,9 +64,24 @@ After the tool returns, your reply MUST be a single line:
 Proposal {proposal_id}.
 ```
 
-That's it. Put all the substance — headline, bullets, recommendations, owner-area TODOs — into `impact_md`. Keep `impact_md` ≤ 8 bullets, each bullet quantifying one effect. No throat-clearing.
+Put all the substance — headline, bullets, recommendations, owner-area TODOs — into `impact_md`. Keep `impact_md` ≤ 8 bullets, each bullet quantifying one effect. No throat-clearing.
 
 Do **not** ask permission to call the tool — the operator approves at the proposal level (Accept / Refine / Reject).
+
+### Conversational mode (when nothing is worth proposing)
+
+When the operator's input is a question, status check, greeting, ambiguous prompt, or anything that doesn't warrant a structural change ("how are things?", "what should we work on this week?", "Test", "ping"), **do not call `propose_changes` with `[]`** — that produces a misleading "0 changes" card.
+
+Instead, reply with a **brief conversational message (1–4 sentences)** answering the operator directly. Mission Control will surface this text in the chat thread.
+
+Use this mode for:
+
+- Greetings / small talk → respond briefly, redirect to something actionable if helpful.
+- Status questions ("what's open?", "anything blocked?") → answer from the snapshot, no tool call.
+- Ambiguous prompts ("Test", "ok?", "?") → ask a clarifying question.
+- Questions about Mission Control itself or your own role → answer plainly.
+
+Pick the mode early. If you start in conversational mode and realize you need to propose changes, just call `propose_changes` and switch — your conversational text BEFORE the tool call is discarded but the tool result wins. If you start in disruption mode and decide there's no change to make, switch by emitting a single conversational paragraph instead of `Proposal {id}.`.
 
 ## Roadmap vs. task-execution split
 

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -295,13 +295,13 @@ async function runDisruptionDispatchInBackground(
     input.trigger_kind === 'notes_intake'
       ? buildNotesIntakeMessage({ correlationId, notes: input.trigger_text, summary })
       : `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
-        `Operator-reported event:\n> ${input.trigger_text}\n\n` +
+        `Operator input:\n> ${input.trigger_text}\n\n` +
         `Workspace snapshot summary (call \`get_roadmap_snapshot\` via MCP for full detail):\n\n` +
         `${summary}\n\n` +
-        `Per your SOUL.md: analyse the disruption and call \`propose_changes\` ` +
-        `with a structured PmDiff[] and impact_md. Reference only ids that ` +
-        `appear in the snapshot. Output discipline: tool call FIRST, then a single-line ` +
-        `\`Proposal {id}.\` reply — no freeform summary (it's discarded).`;
+        `Pick output mode per your SOUL.md:\n` +
+        `- If this is a disruption or planning ask warranting one or more structural changes, call ` +
+        `\`propose_changes\` with PmDiff[] + impact_md (reference only ids from the snapshot), then reply with the single line \`Proposal {id}.\`.\n` +
+        `- If this is conversational / ambiguous / status-check / has nothing structural to propose, reply with a brief conversational message (1–4 sentences). Do NOT call \`propose_changes\` with \`[]\` — that produces a misleading "0 changes" card. The conversational reply is surfaced to the operator as chat.`;
   const sessionSuffix = input.trigger_kind === 'notes_intake' ? `notes-${correlationId}` : 'dispatch-main';
 
   let result: Awaited<ReturnType<typeof sendChatAndAwaitReply>> | null = null;


### PR DESCRIPTION
## Summary
Two-mode PM SOUL.md so the agent can reply conversationally when no structural change is warranted. Trigger_body updated to surface the mode-picking decision explicitly.

## Investigation

Walked the /pm chat flow with verbose logging in pm-dispatch + send-chat:

1. **Substantive prompts work.** \"Hi PM, what should we work on this week?\" → 2-change structured proposal with full impact_md. The structured-proposal pipeline is intact.
2. **Vague prompts produce empty replies.** \"Test\", \"Status check\", \"Hi PM, just saying hello\" → the gateway emits a single \`chat_event\` with \`state: 'final'\` and **no \`message\` field at all**. The agent finishes the turn without producing any text content, so Mission Control's chat thread sits empty.
3. **Root cause: SOUL discipline.** The previous SOUL hardcoded \"tool call FIRST … no freeform summary … the operator's UI discards your conversational chat reply.\" Combined with no \`propose_changes\` to make for vague prompts, the agent had no permitted output mode and just emitted an empty turn.
4. **Empty replies persist after \`/reset\`.** The agent's gateway session has accumulated turns under the old discipline; even with the new SOUL prepended via dispatchScope's briefing, the conversation history anchors the model's output behavior. A full agent reset (Agents → … → Reset) is the operator escape hatch until session memory rolls over.

## Changes

- \`agent-templates/pm/SOUL.md\` — split Output Discipline into two modes:
  - **Disruption / planning** (unchanged): tool call → single-line \`Proposal {id}.\` reply.
  - **Conversational** (new): brief 1–4 sentence reply, no \`propose_changes\` call. Used for greetings, status checks, ambiguous prompts.
- \`src/lib/agents/pm-dispatch.ts\` — trigger_body now asks the PM to pick a mode based on the input rather than \"analyse the disruption\".

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] Existing PM tests pass.
- [ ] Manual: send a vague prompt to a PM whose gateway session has been freshly \`/reset\`. Expect a 1–4 sentence reply.

## Known limit (downstream of MC)
The empty-final-chat_event behavior on stale sessions is a model-output issue on the gateway side. MC can't force the agent to emit text; we can only update the briefing (done) and supply the escape hatch (\`/reset\`). The earlier-shipped #197 suppresses the misleading \"0 changes\" card so the silent case is honestly silent rather than misrepresented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)