### PR TITLE
feat(pm-chat): two-mode prompt + on-demand snapshot + one-at-a-time send (PR A)

### DIFF
--- a/agent-templates/pm/SOUL.md
+++ b/agent-templates/pm/SOUL.md
@@ -50,38 +50,51 @@ The full diff kind list (`shift_initiative_target`, `add_availability`, `set_ini
 
 ## Output Discipline
 
-Two distinct modes, picked at the **start** of every dispatch by reading the operator's input:
+Two distinct modes. **Pick one at the start of every dispatch by reading the operator's input. Do NOT switch mid-stream.**
 
-### Disruption / planning mode (default)
+### Mode A — Disruption / planning
 
-When the operator describes a real disruption, planning ask, or anything that calls for one or more structural changes (date shifts, status updates, dependencies, new initiatives, owner availability, etc.):
+Trigger: the input describes a real change to roadmap state — dates shifting, owners blocked, status updates, scoping, decomposition asks, schedule pressure, etc.
 
-**Call `propose_changes` FIRST. Do not write a freeform summary before or after the tool call.** Mission Control's UI renders the proposal's `impact_md` as the chat message, so anything you write outside `impact_md` is duplicated noise.
+Examples that fit Mode A:
+- "Sarah is out next week — what slips?"
+- "Refactor-X is blocked by upstream API changes; push it 2 weeks"
+- "Decompose this epic into stories for May"
+- "What's the impact of cancelling Initiative Foo?" (an analysis ask that warrants a structured proposal)
 
-After the tool returns, your reply MUST be a single line:
+Output contract:
+1. Call `propose_changes` with a non-empty `PmDiff[]` and rich `impact_md`.
+2. After the tool returns, reply with a single line: `Proposal {proposal_id}.`
+3. All substance — headline, bullets, recommendations, owner-area TODOs — goes in `impact_md`. ≤ 8 bullets, each quantifying one effect. No throat-clearing.
 
-```
-Proposal {proposal_id}.
-```
+Do NOT ask permission to call the tool — the operator approves at the proposal level (Accept / Refine / Reject).
 
-Put all the substance — headline, bullets, recommendations, owner-area TODOs — into `impact_md`. Keep `impact_md` ≤ 8 bullets, each bullet quantifying one effect. No throat-clearing.
+### Mode B — Conversational
 
-Do **not** ask permission to call the tool — the operator approves at the proposal level (Accept / Refine / Reject).
+Trigger: the input is a question, status check, greeting, ambiguous prompt, or anything that doesn't warrant a structural change.
 
-### Conversational mode (when nothing is worth proposing)
+Examples that fit Mode B:
+- "Hi PM" → greet back; offer next-step suggestions.
+- "Status check please" → 2–3 sentence summary lifted from the snapshot.
+- "What's blocked?" → enumerate from the snapshot, no proposal.
+- "Test", "ping", "?" → ask what the operator needs.
+- "What is initiative X about?" → answer plainly from the snapshot.
 
-When the operator's input is a question, status check, greeting, ambiguous prompt, or anything that doesn't warrant a structural change ("how are things?", "what should we work on this week?", "Test", "ping"), **do not call `propose_changes` with `[]`** — that produces a misleading "0 changes" card.
+Output contract:
+1. **Do NOT call `propose_changes`.** Especially not with `[]` — that produces a misleading "0 changes" card.
+2. Reply with **1–4 sentences of plain text**. No `## Heading` formatting; this is chat, not a brief.
+3. If the input is unclear, ask one clarifying question.
+4. If you reference workspace state, lift it from the workspace snapshot — don't fabricate. Call `get_roadmap_snapshot` via MCP if you don't already have what you need; skip it for greetings or generic clarifying questions.
+5. If a Mode B answer would be longer than 4 sentences, suggest a more specific follow-up question instead of dumping a wall of text.
+6. **Mode B never produces a structured proposal.** If the operator asks "what's blocked?", answer the question. They will follow up with "propose an update" if they want action — that's a separate Mode A turn.
 
-Instead, reply with a **brief conversational message (1–4 sentences)** answering the operator directly. Mission Control will surface this text in the chat thread.
+### Hard rule (applies to both modes)
 
-Use this mode for:
+Every response MUST contain at least one of:
+- a `propose_changes` tool call with a non-empty `proposed_changes` array, OR
+- a chat reply of at least one full sentence (≥ 8 words).
 
-- Greetings / small talk → respond briefly, redirect to something actionable if helpful.
-- Status questions ("what's open?", "anything blocked?") → answer from the snapshot, no tool call.
-- Ambiguous prompts ("Test", "ok?", "?") → ask a clarifying question.
-- Questions about Mission Control itself or your own role → answer plainly.
-
-Pick the mode early. If you start in conversational mode and realize you need to propose changes, just call `propose_changes` and switch — your conversational text BEFORE the tool call is discarded but the tool result wins. If you start in disruption mode and decide there's no change to make, switch by emitting a single conversational paragraph instead of `Proposal {id}.`.
+A fully empty `final` chat_event is a bug. If you find yourself about to emit `Proposal {id}.` after a `propose_changes` call with `[]`, switch into Mode B instead and explain in 1–4 sentences what you considered. If you're uncertain which mode applies, default to Mode B with a clarifying question.
 
 ## Roadmap vs. task-execution split
 

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -107,6 +107,12 @@ function PmChatPageInner() {
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // One-at-a-time send. After POST /api/pm/proposals returns 201 with
+  // awaiting_agent: true, we keep the input disabled until the agent's
+  // reply lands (a new assistant message appears in the thread) OR a
+  // bounded fallback fires so the silent-PM scenario doesn't lock the
+  // operator out forever. See specs/pm-chat-prompt.md PR A §4.
+  const [awaitingAgent, setAwaitingAgent] = useState<{ since: number; userMessageCount: number } | null>(null);
   const [refining, setRefining] = useState<string | null>(null);
   const [refineText, setRefineText] = useState('');
   const [runningStandup, setRunningStandup] = useState(false);
@@ -247,8 +253,14 @@ function PmChatPageInner() {
     setStuckToBottom(true);
   }, []);
 
+  // Agent timeout in pm-dispatch is 60s with another 60s reconciler tail
+  // (NAMED_AGENT_TIMEOUT_MS + RECONCILER_TAIL_MS). Bound the UI lockout
+  // at 3× the inner timeout so a silent-PM scenario surfaces an error
+  // and re-enables send rather than wedging the input forever.
+  const AWAITING_AGENT_TIMEOUT_MS = 180_000;
+
   const handleSend = async () => {
-    if (!input.trim() || sending) return;
+    if (!input.trim() || sending || awaitingAgent) return;
     setSending(true);
     setError(null);
     try {
@@ -264,18 +276,51 @@ function PmChatPageInner() {
         const data = await res.json().catch(() => ({}));
         throw new Error(data.error || `Failed to dispatch (${res.status})`);
       }
+      const body = await res.json().catch(() => ({} as { awaiting_agent?: boolean }));
       setInput('');
       // The operator just dispatched — they want to see the result. Re-stick
       // to the bottom even if they had been scrolled up reading old cards.
       setStuckToBottom(true);
+      // Refetch so the user message appears immediately, then arm the
+      // "awaiting agent" gate so the next send is blocked until the
+      // assistant message lands (or we time out).
       await loadMessages();
       await loadRecent();
+      if (body.awaiting_agent !== false) {
+        // Snapshot the user-message count we have right now; agent's
+        // reply is detected as "thread grew an assistant message after
+        // the count of user messages stayed the same."
+        setAwaitingAgent({
+          since: Date.now(),
+          userMessageCount: messages.filter((m) => m.role === 'user').length + 1,
+        });
+      }
     } catch (err) {
       setError((err as Error).message);
     } finally {
       setSending(false);
     }
   };
+
+  // Watch for the agent's reply / timeout while awaiting. The 3s poll
+  // already runs; we just react to its results here.
+  useEffect(() => {
+    if (!awaitingAgent) return;
+    const lastAssistantAt = messages
+      .filter((m) => m.role === 'assistant')
+      .reduce((max, m) => Math.max(max, new Date(m.created_at).getTime()), 0);
+    if (lastAssistantAt > awaitingAgent.since) {
+      setAwaitingAgent(null);
+      return;
+    }
+    if (Date.now() - awaitingAgent.since > AWAITING_AGENT_TIMEOUT_MS) {
+      setAwaitingAgent(null);
+      setError(
+        'The PM didn\'t reply within ' + Math.round(AWAITING_AGENT_TIMEOUT_MS / 1000) +
+          's. Try /reset on the PM\'s dispatch session if this persists.',
+      );
+    }
+  }, [messages, awaitingAgent, AWAITING_AGENT_TIMEOUT_MS]);
 
   // plan_initiative proposals are advisory at the database level — they
   // carry the suggestions JSON inside impact_md but no link to a target
@@ -668,21 +713,24 @@ function PmChatPageInner() {
                 onKeyDown={onKeyDown}
                 rows={2}
                 placeholder={
-                  pmAgent
-                    ? 'Drop anything that reshapes the plan — blocker, opportunity, new idea — the PM will respond with a proposal.'
-                    : 'No PM agent in this workspace.'
+                  awaitingAgent
+                    ? 'PM is replying — send re-enables when the response lands.'
+                    : pmAgent
+                      ? 'Ask a question or describe a disruption — the PM picks chat or a structured proposal.'
+                      : 'No PM agent in this workspace.'
                 }
-                disabled={!pmAgent || sending}
+                disabled={!pmAgent || sending || !!awaitingAgent}
                 className="flex-1 bg-mc-bg border border-mc-border rounded-sm px-3 py-2 text-sm focus:outline-hidden focus:border-mc-accent resize-none disabled:opacity-50"
               />
               <button
                 type="button"
                 onClick={handleSend}
-                disabled={!pmAgent || !input.trim() || sending}
-                className="self-end flex items-center gap-2 px-3 py-2 bg-mc-accent text-mc-bg rounded-sm text-sm font-medium hover:bg-mc-accent/90 disabled:opacity-50"
+                disabled={!pmAgent || !input.trim() || sending || !!awaitingAgent}
+                title={awaitingAgent ? 'Wait for the PM\'s reply before sending another message.' : undefined}
+                className="self-end flex items-center gap-2 px-3 py-2 bg-mc-accent text-mc-bg rounded-sm text-sm font-medium hover:bg-mc-accent/90 disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {sending ? <Loader className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
-                Dispatch
+                {sending || awaitingAgent ? <Loader className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
+                {awaitingAgent ? 'Waiting' : 'Dispatch'}
               </button>
             </div>
           </div>

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -290,18 +290,22 @@ async function runDisruptionDispatchInBackground(
   // the `trigger_body` parameter.
   const correlationId = uuidv4();
   const sinceIso = new Date().toISOString();
-  const summary = buildSnapshotSummary(snapshot);
+  // notes_intake still ships the precomputed summary inline because that
+  // path is a one-shot bulk-process flow, not interactive chat — context
+  // cost matters less and the caller benefits from having every initiative
+  // in front of it. Interactive PM chat (the disruption path below) drops
+  // the inline summary and tells the agent to fetch on demand. See
+  // specs/pm-chat-prompt.md §"Trigger_body changes".
   const trigger_body =
     input.trigger_kind === 'notes_intake'
-      ? buildNotesIntakeMessage({ correlationId, notes: input.trigger_text, summary })
+      ? buildNotesIntakeMessage({ correlationId, notes: input.trigger_text, summary: buildSnapshotSummary(snapshot) })
       : `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
         `Operator input:\n> ${input.trigger_text}\n\n` +
-        `Workspace snapshot summary (call \`get_roadmap_snapshot\` via MCP for full detail):\n\n` +
-        `${summary}\n\n` +
-        `Pick output mode per your SOUL.md:\n` +
-        `- If this is a disruption or planning ask warranting one or more structural changes, call ` +
-        `\`propose_changes\` with PmDiff[] + impact_md (reference only ids from the snapshot), then reply with the single line \`Proposal {id}.\`.\n` +
-        `- If this is conversational / ambiguous / status-check / has nothing structural to propose, reply with a brief conversational message (1–4 sentences). Do NOT call \`propose_changes\` with \`[]\` — that produces a misleading "0 changes" card. The conversational reply is surfaced to the operator as chat.`;
+        `Pick mode per your SOUL.md:\n` +
+        `- **Mode A (disruption / planning)** — call \`propose_changes\` with PmDiff[] + impact_md, then reply with the single line \`Proposal {id}.\`.\n` +
+        `- **Mode B (conversational)** — reply with 1–4 plain-text sentences. No \`propose_changes\` (especially not with \`[]\`).\n\n` +
+        `If you need workspace state to answer (status questions, "what's blocked", impact analysis, planning), call \`get_roadmap_snapshot\` via MCP. Skip it for greetings, ambiguous prompts, or "Test"-style inputs.\n\n` +
+        `Hard rule: every response MUST contain a \`propose_changes\` call with a non-empty array OR at least one full sentence of chat text. A fully empty reply is a bug.`;
   const sessionSuffix = input.trigger_kind === 'notes_intake' ? `notes-${correlationId}` : 'dispatch-main';
 
   let result: Awaited<ReturnType<typeof sendChatAndAwaitReply>> | null = null;


### PR DESCRIPTION
PR A of [specs/pm-chat-prompt.md](specs/pm-chat-prompt.md). PR B (steer/abort + in-flight visibility) stacks on top.

## Summary
Three entangled changes shipping together — the SOUL rewrite enables Mode B, the trigger_body drops the always-on snapshot, and the UI gate prevents pile-up sends while the PM is replying.

### \`agent-templates/pm/SOUL.md\` — Output Discipline rewrite
- **Mode A (disruption / planning)** — unchanged: tool call FIRST, single-line \`Proposal {id}.\`, ≤8 bullets in \`impact_md\`.
- **Mode B (conversational, new)** — 1–4 plain-text sentences, no \`propose_changes\` (especially not with \`[]\`), \`get_roadmap_snapshot\` only when the answer needs state, never cascade into Mode A on the same turn.
- **Hard rule** — every response MUST contain a non-empty \`propose_changes\` call OR ≥ 8 words of chat. A fully-empty \`final\` chat_event is a bug, not a passive outcome.

### \`src/lib/agents/pm-dispatch.ts\` trigger_body
- Drop the inline workspace snapshot for interactive dispatches (PM calls \`get_roadmap_snapshot\` via MCP on demand). Saves ~1–3KB per send for the common short-prompt case.
- Replace "analyse the disruption" framing with an explicit Mode A / Mode B picker.
- Append the verbatim Hard-rule line so the model pattern-matches it next to the input.
- \`notes_intake\` keeps the inline summary (one-shot bulk process, different cost profile).

### \`src/app/(app)/pm/page.tsx\` one-at-a-time send
- New \`awaitingAgent\` state armed after a successful POST. Textarea + Dispatch button disable until an assistant message lands OR a bounded fallback fires at 3× \`NAMED_AGENT_TIMEOUT_MS\` (180s).
- Placeholder + button copy reflect the waiting state.
- Fallback points the operator at the per-session reset escape hatch from #199.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] \`tsx --test pm-e2e.test.ts pm.test.ts\` — 29/29 pass.
- [ ] Manual: substantive prompt → Mode A proposal; vague prompt → Mode B chat. (Requires a healthy gateway / fresh PM session per spec note.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)