### PR TITLE
feat(pm-chat): sessions.steer + sessions.abort wiring (PR B)

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -322,6 +322,69 @@ function PmChatPageInner() {
     }
   }, [messages, awaitingAgent, AWAITING_AGENT_TIMEOUT_MS]);
 
+  // Steer / Abort wiring. Both target the active dispatch via
+  // /api/pm/active-dispatch — that endpoint resolves the gateway
+  // sessionKey from MC's in-memory registry so we don't need to
+  // re-derive the session here.
+  const [steerOpen, setSteerOpen] = useState(false);
+  const [steerText, setSteerText] = useState('');
+  const [steerBusy, setSteerBusy] = useState(false);
+  const [abortBusy, setAbortBusy] = useState(false);
+
+  const submitSteer = useCallback(async () => {
+    if (!workspaceId || !steerText.trim() || steerBusy) return;
+    setSteerBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/pm/active-dispatch?workspace_id=${encodeURIComponent(workspaceId)}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'steer', message: steerText.trim() }),
+        },
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Steer failed (${res.status})`);
+      }
+      setSteerText('');
+      setSteerOpen(false);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSteerBusy(false);
+    }
+  }, [workspaceId, steerText, steerBusy]);
+
+  const submitAbort = useCallback(async () => {
+    if (!workspaceId || abortBusy) return;
+    setAbortBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/pm/active-dispatch?workspace_id=${encodeURIComponent(workspaceId)}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'abort' }),
+        },
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Abort failed (${res.status})`);
+      }
+      // Clear the awaiting gate optimistically; the operator wants to
+      // send something else.
+      setAwaitingAgent(null);
+      setSteerOpen(false);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setAbortBusy(false);
+    }
+  }, [workspaceId, abortBusy]);
+
   // plan_initiative proposals are advisory at the database level — they
   // carry the suggestions JSON inside impact_md but no link to a target
   // initiative. Clicking Accept on one used to flip the proposal to
@@ -706,6 +769,76 @@ function PmChatPageInner() {
           </div>
 
           <div className="border-t border-mc-border p-3 space-y-2 shrink-0">
+            {/* In-flight strip — visible while a PM dispatch is in
+                flight. Steer queues an additional operator message at
+                the next model boundary (cheap, doesn't kill work).
+                Stop calls sessions.abort and re-enables send
+                immediately. */}
+            {awaitingAgent && (
+              <div className="rounded-sm border border-mc-accent/30 bg-mc-accent/5 px-3 py-2 text-xs flex items-center gap-2">
+                <Loader className="w-3.5 h-3.5 animate-spin text-mc-accent shrink-0" />
+                <span className="flex-1 text-mc-text-secondary">PM is replying…</span>
+                {!steerOpen && (
+                  <button
+                    type="button"
+                    onClick={() => setSteerOpen(true)}
+                    disabled={steerBusy || abortBusy}
+                    className="px-2 py-1 rounded-sm text-mc-accent hover:bg-mc-accent/10 disabled:opacity-50"
+                    title="Inject an additional message at the next model boundary"
+                  >
+                    Steer
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={submitAbort}
+                  disabled={abortBusy || steerBusy}
+                  className="px-2 py-1 rounded-sm text-red-400 hover:bg-red-400/10 disabled:opacity-50"
+                  title="Abort the in-flight dispatch"
+                >
+                  {abortBusy ? '…' : 'Stop'}
+                </button>
+              </div>
+            )}
+
+            {awaitingAgent && steerOpen && (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={steerText}
+                  onChange={(e) => setSteerText(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      submitSteer();
+                    } else if (e.key === 'Escape') {
+                      setSteerOpen(false);
+                      setSteerText('');
+                    }
+                  }}
+                  placeholder="Steer with additional context (e.g. &ldquo;only consider initiatives owned by Sarah&rdquo;)"
+                  disabled={steerBusy}
+                  autoFocus
+                  className="flex-1 bg-mc-bg border border-mc-accent/40 rounded-sm px-3 py-1.5 text-xs focus:outline-hidden focus:border-mc-accent disabled:opacity-50"
+                />
+                <button
+                  type="button"
+                  onClick={submitSteer}
+                  disabled={!steerText.trim() || steerBusy}
+                  className="px-2 py-1 text-xs rounded-sm bg-mc-accent text-mc-bg hover:opacity-90 disabled:opacity-50"
+                >
+                  {steerBusy ? '…' : 'Send'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setSteerOpen(false); setSteerText(''); }}
+                  className="px-2 py-1 text-xs rounded-sm text-mc-text-secondary hover:bg-mc-bg-tertiary"
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
+
             <div className="flex gap-2">
               <textarea
                 value={input}
@@ -726,7 +859,7 @@ function PmChatPageInner() {
                 type="button"
                 onClick={handleSend}
                 disabled={!pmAgent || !input.trim() || sending || !!awaitingAgent}
-                title={awaitingAgent ? 'Wait for the PM\'s reply before sending another message.' : undefined}
+                title={awaitingAgent ? 'Wait for the PM\'s reply before sending another message — use Steer above to add context, or Stop to abort.' : undefined}
                 className="self-end flex items-center gap-2 px-3 py-2 bg-mc-accent text-mc-bg rounded-sm text-sm font-medium hover:bg-mc-accent/90 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {sending || awaitingAgent ? <Loader className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}

--- a/src/app/api/pm/active-dispatch/route.ts
+++ b/src/app/api/pm/active-dispatch/route.ts
@@ -1,0 +1,87 @@
+/**
+ * /api/pm/active-dispatch — read the in-flight PM dispatch for a
+ * workspace, plus steer / abort affordances.
+ *
+ *   GET    /api/pm/active-dispatch?workspace_id=… → null | dispatch
+ *   POST   /api/pm/active-dispatch?workspace_id=… { action: 'steer', message }
+ *   POST   /api/pm/active-dispatch?workspace_id=… { action: 'abort' }
+ *
+ * The dispatch entry is the in-memory registry maintained by
+ * runDisruptionDispatchInBackground; cleared the moment the dispatch
+ * resolves. /pm uses GET for the live "PM is replying" panel and
+ * POST for the Steer / Stop buttons.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getOpenClawClient } from '@/lib/openclaw/client';
+import { getActivePmDispatch } from '@/lib/agents/pm-dispatch';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const workspaceId = new URL(request.url).searchParams.get('workspace_id');
+  if (!workspaceId) {
+    return NextResponse.json({ error: 'workspace_id is required' }, { status: 400 });
+  }
+  const active = getActivePmDispatch(workspaceId);
+  return NextResponse.json(active);
+}
+
+const PostSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('steer'),
+    message: z.string().min(1).max(20_000),
+  }),
+  z.object({
+    action: z.literal('abort'),
+  }),
+]);
+
+export async function POST(request: NextRequest) {
+  const workspaceId = new URL(request.url).searchParams.get('workspace_id');
+  if (!workspaceId) {
+    return NextResponse.json({ error: 'workspace_id is required' }, { status: 400 });
+  }
+  const active = getActivePmDispatch(workspaceId);
+  if (!active) {
+    return NextResponse.json(
+      { error: 'No active PM dispatch for this workspace' },
+      { status: 409 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const parsed = PostSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const client = getOpenClawClient();
+  if (!client.isConnected()) {
+    return NextResponse.json(
+      { error: 'Gateway is not connected; cannot steer or abort right now.' },
+      { status: 503 },
+    );
+  }
+
+  try {
+    if (parsed.data.action === 'steer') {
+      const result = await client.steerSession(active.session_key, parsed.data.message);
+      return NextResponse.json({ ok: true, action: 'steer', result, dispatch: active });
+    }
+    const result = await client.abortSession(active.session_key);
+    return NextResponse.json({ ok: true, action: 'abort', result, dispatch: active });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Gateway call failed';
+    return NextResponse.json({ error: msg, dispatch: active }, { status: 502 });
+  }
+}

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -109,6 +109,28 @@ export class PmDispatchGatewayUnavailableError extends Error {
 const NAMED_AGENT_TIMEOUT_MS = 60_000;
 
 /**
+ * In-memory registry of active PM dispatches keyed by workspace_id.
+ * Lets steer/abort REST endpoints look up the gateway sessionKey and
+ * placeholder proposal id without re-deriving them. Cleared the moment
+ * the dispatch resolves (success, failure, or synth_only fallback).
+ *
+ * Workspace-keyed (one PM per workspace; one in-flight dispatch at a
+ * time per the one-at-a-time UI gate from PR A).
+ */
+interface ActivePmDispatch {
+  workspace_id: string;
+  correlation_id: string;
+  placeholder_id: string;
+  session_key: string;
+  started_at: number;
+}
+const activePmDispatches = new Map<string, ActivePmDispatch>();
+
+export function getActivePmDispatch(workspaceId: string): ActivePmDispatch | null {
+  return activePmDispatches.get(workspaceId) ?? null;
+}
+
+/**
  * Dependency seam for tests. Routes BOTH the local connection probe
  * (`isConnected()`) and the underlying chat send through a shared mock,
  * so tests can simulate "agent finishes its turn → final frame arrives"
@@ -308,7 +330,39 @@ async function runDisruptionDispatchInBackground(
         `Hard rule: every response MUST contain a \`propose_changes\` call with a non-empty array OR at least one full sentence of chat text. A fully empty reply is a bug.`;
   const sessionSuffix = input.trigger_kind === 'notes_intake' ? `notes-${correlationId}` : 'dispatch-main';
 
+  // Compute the FULL gateway sessionKey here so the activePmDispatches
+  // registry holds the same key the gateway uses (mirrors how
+  // sendChatAndAwaitReply derives it via buildAgentSessionKey).
+  const fullSessionKey = (() => {
+    const prefix = (pm as Agent & { session_key_prefix?: string | null }).session_key_prefix?.trim();
+    if (prefix) return prefix.endsWith(':') ? `${prefix}${sessionSuffix}` : `${prefix}:${sessionSuffix}`;
+    if (pm.gateway_agent_id) return `agent:${pm.gateway_agent_id}:${sessionSuffix}`;
+    return sessionSuffix;
+  })();
+
+  // Register this dispatch so the steer/abort REST endpoints can look
+  // up the sessionKey by workspace. Cleared in `finally` regardless of
+  // outcome so we never leak a stale entry.
+  activePmDispatches.set(input.workspace_id, {
+    workspace_id: input.workspace_id,
+    correlation_id: correlationId,
+    placeholder_id: placeholder.id,
+    session_key: fullSessionKey,
+    started_at: Date.now(),
+  });
+
   let result: Awaited<ReturnType<typeof sendChatAndAwaitReply>> | null = null;
+  try {
+    return await runDispatchBody();
+  } finally {
+    // Clear the in-flight registry entry on any exit path so steer/abort
+    // never targets a stale dispatch. The body function below populates
+    // `result` via closure capture before its returns hit.
+    activePmDispatches.delete(input.workspace_id);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  async function runDispatchBody(): Promise<{ final: PmProposal; used_named_agent: boolean; used_synthesize_fallback: boolean }> {
   try {
     const dispatch = await dispatchScope({
       workspace_id: input.workspace_id,
@@ -430,6 +484,7 @@ async function runDisruptionDispatchInBackground(
     used_named_agent: false,
     used_synthesize_fallback: true,
   };
+  }
 }
 
 /**

--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -615,6 +615,37 @@ export class OpenClawClient extends EventEmitter {
     return this.call<OpenClawSessionInfo>('sessions.create', { channel, peer });
   }
 
+  /**
+   * Steer an active session — inject an additional operator message
+   * into a run that's already in flight. The gateway queues the
+   * steering at the next model boundary; pending tool calls are
+   * preserved (it's not an abort). Used by /pm's "Steer" button so
+   * the operator can correct course without aborting + restarting.
+   *
+   * sessionKey is the FULL gateway session identifier (e.g.
+   * `agent:mc-pm-default-dev:dispatch-main`), not just the suffix.
+   *
+   * Param shape confirmed via the gateway's validation error
+   * response: `key` (not `sessionKey`); `message`. The `mode`
+   * variants documented in the broader protocol (interrupt /
+   * collect / followup / steer-backlog) are NOT accepted by
+   * `sessions.steer` — that's covered by `/queue` slash modes
+   * embedded in the message text instead, which is a more
+   * operator-driven affordance than something MC controls today.
+   */
+  async steerSession(sessionKey: string, message: string): Promise<unknown> {
+    return this.call('sessions.steer', { key: sessionKey, message });
+  }
+
+  /**
+   * Abort the active run on a session. Used by /pm's "Stop" button
+   * when the operator wants to kill the in-flight PM dispatch
+   * outright (typing-indicator stuck, agent went off-track, etc.).
+   */
+  async abortSession(sessionKey: string): Promise<unknown> {
+    return this.call('sessions.abort', { key: sessionKey });
+  }
+
   // Agent methods
   async listAgents(): Promise<unknown[]> {
     const result = await this.call<{ agents?: unknown[] }>('agents.list');


### PR DESCRIPTION
Stacks on #201. Adds gateway-side mid-flight control over the PM dispatch so the operator can nudge the in-flight run with extra context (Steer) or kill it outright (Stop) without waiting for the 3-minute timeout fallback from PR A.

## Summary
- New \`steerSession\` / \`abortSession\` wrappers in \`src/lib/openclaw/client.ts\` around the gateway's \`sessions.steer\` and \`sessions.abort\` RPCs. Param shape confirmed via the gateway's validation responses (\`key\`, not \`sessionKey\`; steer takes no \`mode\` — that's a slash-command affordance, not a client param).
- New in-memory \`activePmDispatches\` registry in \`pm-dispatch.ts\` keyed by workspace_id. Populated when \`runDisruptionDispatchInBackground\` enters the body; cleared in \`finally\` on every exit path.
- New \`POST /api/pm/active-dispatch\` accepting \`{action: 'steer' | 'abort', message?}\` and a \`GET\` for the live registry entry.
- /pm UI: in-flight strip with Steer + Stop buttons; Steer opens an inline input; Stop calls abort and re-enables send optimistically.

## Verification (against dev gateway)
- [x] \`yarn tsc --noEmit\` clean.
- [x] \`tsx --test pm-e2e.test.ts pm.test.ts\` — 29/29 pass.
- [x] **Registry populates** on \`POST /api/pm/proposals\` and clears on resolve.
- [x] **Abort works end-to-end** — gateway returned \`{ok: true, abortedRunId: 'pm-dispatch-…', status: 'aborted'}\`. Operator's chat thread re-enables immediately.
- [⚠️] **Steer is gateway-conditional** — sometimes returns \"Session ... is still active; try again in a moment.\" The gateway rejects when the session is mid-tool-call. Wiring is correct (param shape confirmed); the rejection is a gateway pre-condition we don't fully control. Surfaces honestly to the operator in the existing error banner. Stop is the reliable escape hatch in those windows.

## Out of scope (deferred from spec)
- Live work-products strip showing tool calls and streaming deltas (\`take_note\`, \`log_activity\`, assistant text deltas). Requires \`onEvent\` tap on dispatchScope + a new SSE event type. Bigger lift; lands separately when we're ready to invest in the visualisation.

## Stacked-merge note
Per \`feedback_stacked_pr_merges.md\`: when ready to merge, retarget this PR's base from \`feat/pm-chat-prompt-prA\` to \`main\` BEFORE merging #201 with \`--delete-branch\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)