### PR TITLE
feat(pm-chat): in-flight visibility — live PM-is-composing preview (PR C)

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -331,6 +331,43 @@ function PmChatPageInner() {
   const [steerBusy, setSteerBusy] = useState(false);
   const [abortBusy, setAbortBusy] = useState(false);
 
+  // Live in-flight preview (PR C). The pm-dispatch onEvent tap
+  // broadcasts `pm_dispatch_in_flight` events with kind 'delta'
+  // (assistant text streaming) and 'control' (final marker). We
+  // mirror just the latest delta preview here; a 'control' marker
+  // clears it.
+  const [livePreview, setLivePreview] = useState<{ text: string; length: number } | null>(null);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+    const es = new EventSource('/api/events/stream');
+    es.onmessage = (raw) => {
+      try {
+        if (raw.data.startsWith(':')) return;
+        const evt = JSON.parse(raw.data) as { type?: string; payload?: Record<string, unknown> };
+        if (evt.type !== 'pm_dispatch_in_flight') return;
+        if (evt.payload?.workspace_id !== workspaceId) return;
+        if (evt.payload?.kind === 'delta') {
+          const preview = typeof evt.payload.preview === 'string' ? evt.payload.preview : '';
+          const length = typeof evt.payload.length === 'number' ? evt.payload.length : preview.length;
+          setLivePreview({ text: preview, length });
+        } else if (evt.payload?.kind === 'control') {
+          // Any control event (final / aborted) clears the preview;
+          // the assistant message will land in the chat thread via
+          // the normal post-dispatch path.
+          setLivePreview(null);
+        }
+      } catch { /* ignore parse errors */ }
+    };
+    return () => es.close();
+  }, [workspaceId]);
+
+  // Clear the preview when we stop awaiting (timeout / response /
+  // abort) so a stale tail doesn't linger after the gate releases.
+  useEffect(() => {
+    if (!awaitingAgent) setLivePreview(null);
+  }, [awaitingAgent]);
+
   const submitSteer = useCallback(async () => {
     if (!workspaceId || !steerText.trim() || steerBusy) return;
     setSteerBusy(true);
@@ -775,29 +812,40 @@ function PmChatPageInner() {
                 Stop calls sessions.abort and re-enables send
                 immediately. */}
             {awaitingAgent && (
-              <div className="rounded-sm border border-mc-accent/30 bg-mc-accent/5 px-3 py-2 text-xs flex items-center gap-2">
-                <Loader className="w-3.5 h-3.5 animate-spin text-mc-accent shrink-0" />
-                <span className="flex-1 text-mc-text-secondary">PM is replying…</span>
-                {!steerOpen && (
+              <div className="rounded-sm border border-mc-accent/30 bg-mc-accent/5 px-3 py-2 text-xs space-y-1.5">
+                <div className="flex items-center gap-2">
+                  <Loader className="w-3.5 h-3.5 animate-spin text-mc-accent shrink-0" />
+                  <span className="flex-1 text-mc-text-secondary">
+                    {livePreview
+                      ? `PM is composing — ${livePreview.length} chars so far…`
+                      : 'PM is replying…'}
+                  </span>
+                  {!steerOpen && (
+                    <button
+                      type="button"
+                      onClick={() => setSteerOpen(true)}
+                      disabled={steerBusy || abortBusy}
+                      className="px-2 py-1 rounded-sm text-mc-accent hover:bg-mc-accent/10 disabled:opacity-50"
+                      title="Inject an additional message at the next model boundary"
+                    >
+                      Steer
+                    </button>
+                  )}
                   <button
                     type="button"
-                    onClick={() => setSteerOpen(true)}
-                    disabled={steerBusy || abortBusy}
-                    className="px-2 py-1 rounded-sm text-mc-accent hover:bg-mc-accent/10 disabled:opacity-50"
-                    title="Inject an additional message at the next model boundary"
+                    onClick={submitAbort}
+                    disabled={abortBusy || steerBusy}
+                    className="px-2 py-1 rounded-sm text-red-400 hover:bg-red-400/10 disabled:opacity-50"
+                    title="Abort the in-flight dispatch"
                   >
-                    Steer
+                    {abortBusy ? '…' : 'Stop'}
                   </button>
+                </div>
+                {livePreview && livePreview.text && (
+                  <div className="font-mono text-[11px] text-mc-text-secondary/80 italic line-clamp-3 whitespace-pre-wrap">
+                    …{livePreview.text}
+                  </div>
                 )}
-                <button
-                  type="button"
-                  onClick={submitAbort}
-                  disabled={abortBusy || steerBusy}
-                  className="px-2 py-1 rounded-sm text-red-400 hover:bg-red-400/10 disabled:opacity-50"
-                  title="Abort the in-flight dispatch"
-                >
-                  {abortBusy ? '…' : 'Stop'}
-                </button>
               </div>
             )}
 

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -48,6 +48,7 @@ import { getOpenClawClient } from '@/lib/openclaw/client';
 import {
   sendChatAndAwaitReply,
   __setSendChatClientForTests,
+  type ChatEvent,
   type SendChatClient,
 } from '@/lib/openclaw/send-chat';
 import { buildNotesIntakeMessage } from './pm-prompts/notes-intake';
@@ -364,6 +365,60 @@ async function runDisruptionDispatchInBackground(
   // eslint-disable-next-line @typescript-eslint/no-shadow
   async function runDispatchBody(): Promise<{ final: PmProposal; used_named_agent: boolean; used_synthesize_fallback: boolean }> {
   try {
+    // In-flight visibility (PR C): tap chat_event deltas + final
+    // markers and broadcast as `pm_dispatch_in_flight` so /pm can
+    // render a live work-products strip while the dispatch runs. We
+    // debounce streaming text deltas to ~250ms cadence so the SSE
+    // channel doesn't get hammered token-by-token. tool_call events
+    // ride through chat_event payloads when state is non-final and
+    // the message contains structured tool data (depends on gateway
+    // shape — broadcast everything non-final for now and let the UI
+    // filter).
+    let lastDeltaBroadcastAt = 0;
+    let accumulatedText = '';
+    const DELTA_BROADCAST_INTERVAL_MS = 250;
+    const onEvent = (event: ChatEvent): void => {
+      try {
+        const msgText = readChatEventMessage(event);
+        if (event.state === 'final') {
+          // Final marker — let the UI clear its in-flight strip.
+          broadcast({
+            type: 'pm_dispatch_in_flight',
+            payload: {
+              workspace_id: input.workspace_id,
+              correlation_id: correlationId,
+              placeholder_id: placeholder.id,
+              kind: 'control',
+              control: 'final',
+            },
+          });
+          return;
+        }
+        if (msgText && msgText.length > accumulatedText.length) {
+          accumulatedText = msgText;
+          const now = Date.now();
+          if (now - lastDeltaBroadcastAt >= DELTA_BROADCAST_INTERVAL_MS) {
+            lastDeltaBroadcastAt = now;
+            broadcast({
+              type: 'pm_dispatch_in_flight',
+              payload: {
+                workspace_id: input.workspace_id,
+                correlation_id: correlationId,
+                placeholder_id: placeholder.id,
+                kind: 'delta',
+                // Ship the tail so /pm can show a live preview without
+                // streaming the whole accumulated body every tick.
+                preview: accumulatedText.slice(-400),
+                length: accumulatedText.length,
+              },
+            });
+          }
+        }
+      } catch {
+        // Diagnostics-only path; never let it break dispatch.
+      }
+    };
+
     const dispatch = await dispatchScope({
       workspace_id: input.workspace_id,
       role: 'pm',
@@ -373,6 +428,7 @@ async function runDisruptionDispatchInBackground(
       trigger_kind: input.trigger_kind ?? 'manual',
       idempotencyKey: `pm-dispatch-${correlationId}`,
       timeoutMs: namedAgentTimeoutMs(),
+      onEvent,
     });
     result = dispatch.reply;
   } catch (err) {
@@ -521,6 +577,34 @@ function extractAgentReplyText(
   const fromDone = readMessage(result.doneEvent?.message).trim();
   if (fromDone) return fromDone;
   return (result.reply ?? []).map(e => readMessage(e.message)).join('').trim();
+}
+
+/**
+ * Pull a flat string out of a single ChatEvent's message payload.
+ * Used by the in-flight visibility tap in PR C; same heuristic as
+ * extractAgentReplyText but per-event.
+ */
+function readChatEventMessage(e: ChatEvent): string {
+  const m = e?.message;
+  if (!m) return '';
+  if (typeof m === 'string') return m;
+  if (typeof m === 'object' && 'content' in m) {
+    const c = (m as { content: unknown }).content;
+    if (typeof c === 'string') return c;
+    if (Array.isArray(c)) {
+      return c
+        .map(part =>
+          typeof part === 'string'
+            ? part
+            : typeof part === 'object' && part && 'text' in part && typeof (part as { text: unknown }).text === 'string'
+              ? (part as { text: string }).text
+              : '',
+        )
+        .filter(Boolean)
+        .join('');
+    }
+  }
+  return '';
 }
 
 // ─── Named-agent dispatch ───────────────────────────────────────────

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1035,7 +1035,14 @@ export type SSEEventType =
   | 'brief_started'
   | 'brief_progress'
   | 'brief_completed'
-  | 'brief_failed';
+  | 'brief_failed'
+  // PM dispatch in-flight visibility (PR C of pm-chat-prompt). The
+  // /pm chat surface taps these to show what the PM agent is doing
+  // mid-run (streaming text deltas, tool calls). Payload carries a
+  // `correlation_id` (matches pm-dispatch's correlationId) plus a
+  // discriminator `kind: 'delta' | 'tool_call' | 'control'` and
+  // event-specific extras. See spec/pm-chat-prompt.md PR B.
+  | 'pm_dispatch_in_flight';
 
 export interface SSEEvent {
   type: SSEEventType;


### PR DESCRIPTION
PR C of [specs/pm-chat-prompt.md](specs/pm-chat-prompt.md). Replaces the static \"PM is replying…\" indicator from PR A/B with a live preview strip that shows the assistant text the agent is streaming in real time.

## Summary
- New \`pm_dispatch_in_flight\` SSEEventType with discriminated payload (\`kind: 'delta' | 'control'\`).
- New \`onEvent\` tap in \`runDisruptionDispatchInBackground\` debounces streaming chat_event deltas to ~250ms cadence and broadcasts the latest 400-char tail. Control events mark final boundaries.
- /pm subscribes to \`pm_dispatch_in_flight\` events and renders \"PM is composing — N chars so far…\" with the live tail below the in-flight strip from PR B. Cleared on control events AND on \`awaitingAgent\` resolve so stale tails don't linger.
- The tap is diagnostics-only; any throw is swallowed so it never breaks dispatch.

## Changes
- \`src/lib/types.ts\` — new SSEEventType.
- \`src/lib/agents/pm-dispatch.ts\` — \`onEvent\` tap + \`readChatEventMessage\` helper + delta debouncing.
- \`src/app/(app)/pm/page.tsx\` — EventSource subscription + \`livePreview\` state + UI rendering.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] \`tsx --test pm-e2e.test.ts pm.test.ts\` — 29/29 pass.
- [⚠️] **Streaming preview only fires when the gateway emits text deltas.** Currently-stuck silent-PM scenarios (empty \`final\` chat_event with no message body — same model-behavior issue documented in PR A/B) only trigger the \`control: final\` clear path, which is correct. When the gateway is healthy and the PM streams text mid-composition, the preview populates. Plumbing is correct; visualization is downstream of the model actually streaming.

## Out of scope
- Tool-call surfacing (\"PM is reading workspace state…\" / \"PM noted: …\"). Tool calls fire as \`agent_event\`, not \`chat_event\`; sendChatAndAwaitReply only subscribes to chat_event today. Adding agent_event capture is a clean extension on this same SSE channel — separate PR when we want to invest in it.
- Generalising the same panel pattern to workers / researchers / coordinators (the SSEEventType is generic enough; UI lives in /pm only for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)