### PR TITLE
feat(pm-chat): tool-call surfacing via agent_event tap (PR D)

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -333,10 +333,12 @@ function PmChatPageInner() {
 
   // Live in-flight preview (PR C). The pm-dispatch onEvent tap
   // broadcasts `pm_dispatch_in_flight` events with kind 'delta'
-  // (assistant text streaming) and 'control' (final marker). We
-  // mirror just the latest delta preview here; a 'control' marker
-  // clears it.
+  // (assistant text streaming), 'control' (final marker), and
+  // 'tool_call' (PR D — agent_event taps). We mirror the latest
+  // delta preview + a small tail of recent tool calls so the
+  // operator can see what the PM is actually doing.
   const [livePreview, setLivePreview] = useState<{ text: string; length: number } | null>(null);
+  const [liveToolCalls, setLiveToolCalls] = useState<Array<{ tool: string; phase?: string; note?: string; at: number }>>([]);
 
   useEffect(() => {
     if (!workspaceId) return;
@@ -351,21 +353,35 @@ function PmChatPageInner() {
           const preview = typeof evt.payload.preview === 'string' ? evt.payload.preview : '';
           const length = typeof evt.payload.length === 'number' ? evt.payload.length : preview.length;
           setLivePreview({ text: preview, length });
+        } else if (evt.payload?.kind === 'tool_call') {
+          const tool = typeof evt.payload.tool === 'string' ? evt.payload.tool : '';
+          if (!tool) return;
+          const phase = typeof evt.payload.phase === 'string' ? evt.payload.phase : undefined;
+          const note = typeof evt.payload.note === 'string' ? evt.payload.note : undefined;
+          // Cap the trail at the last 6 entries — anything older
+          // becomes noise and crowds the in-flight strip.
+          setLiveToolCalls(prev => [...prev, { tool, phase, note, at: Date.now() }].slice(-6));
         } else if (evt.payload?.kind === 'control') {
-          // Any control event (final / aborted) clears the preview;
-          // the assistant message will land in the chat thread via
-          // the normal post-dispatch path.
+          // Any control event (final / aborted) clears the preview
+          // AND the tool-call trail; the assistant message will
+          // land in the chat thread via the normal post-dispatch
+          // path.
           setLivePreview(null);
+          setLiveToolCalls([]);
         }
       } catch { /* ignore parse errors */ }
     };
     return () => es.close();
   }, [workspaceId]);
 
-  // Clear the preview when we stop awaiting (timeout / response /
-  // abort) so a stale tail doesn't linger after the gate releases.
+  // Clear the preview + tool-call trail when we stop awaiting
+  // (timeout / response / abort) so stale state doesn't linger
+  // after the gate releases.
   useEffect(() => {
-    if (!awaitingAgent) setLivePreview(null);
+    if (!awaitingAgent) {
+      setLivePreview(null);
+      setLiveToolCalls([]);
+    }
   }, [awaitingAgent]);
 
   const submitSteer = useCallback(async () => {
@@ -841,6 +857,20 @@ function PmChatPageInner() {
                     {abortBusy ? '…' : 'Stop'}
                   </button>
                 </div>
+                {liveToolCalls.length > 0 && (
+                  <ul className="space-y-0.5 text-[11px] text-mc-text-secondary/80">
+                    {liveToolCalls.map((tc, i) => (
+                      <li key={`${tc.at}-${i}`} className="flex items-start gap-1.5">
+                        <span className="text-mc-accent shrink-0">↳</span>
+                        <span className="flex-1 min-w-0">
+                          <span className="font-mono text-mc-text">{tc.tool}</span>
+                          {tc.phase && <span className="text-mc-text-secondary/60"> · {tc.phase}</span>}
+                          {tc.note && <span className="text-mc-text-secondary/60"> — {tc.note}</span>}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
                 {livePreview && livePreview.text && (
                   <div className="font-mono text-[11px] text-mc-text-secondary/80 italic line-clamp-3 whitespace-pre-wrap">
                     …{livePreview.text}

--- a/src/lib/agents/dispatch-scope.ts
+++ b/src/lib/agents/dispatch-scope.ts
@@ -16,6 +16,7 @@ import type { Agent } from '@/lib/types';
 import type { PmProposalTriggerKind } from '@/lib/db/pm-proposals';
 import {
   sendChatAndAwaitReply,
+  type AgentEvent,
   type ChatEvent,
 } from '@/lib/openclaw/send-chat';
 import { buildBriefing, type BriefingRole } from './briefing';
@@ -87,6 +88,13 @@ export interface DispatchScopeInput {
   attempt_strategy?: 'fresh' | 'reuse';
   /** Optional event listener forwarded to sendChatAndAwaitReply. */
   onEvent?: (event: ChatEvent) => void;
+  /**
+   * Optional agent_event listener forwarded to sendChatAndAwaitReply.
+   * Tool calls, tool results, and status transitions ride this
+   * channel; pm-dispatch's PR D taps it to surface tool calls in
+   * the operator's in-flight panel.
+   */
+  onAgentEvent?: (event: AgentEvent) => void;
   /**
    * Test seam: when set, returns the briefing without dispatching.
    * Used by unit tests that don't want to mock the gateway.
@@ -179,6 +187,7 @@ export async function dispatchScope(input: DispatchScopeInput): Promise<Dispatch
     timeoutMs: input.timeoutMs,
     sessionSuffix: input.session_suffix,
     onEvent: input.onEvent,
+    onAgentEvent: input.onAgentEvent,
   });
 
   return {

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -48,6 +48,7 @@ import { getOpenClawClient } from '@/lib/openclaw/client';
 import {
   sendChatAndAwaitReply,
   __setSendChatClientForTests,
+  type AgentEvent,
   type ChatEvent,
   type SendChatClient,
 } from '@/lib/openclaw/send-chat';
@@ -377,6 +378,34 @@ async function runDisruptionDispatchInBackground(
     let lastDeltaBroadcastAt = 0;
     let accumulatedText = '';
     const DELTA_BROADCAST_INTERVAL_MS = 250;
+    // Tool-call surfacing (PR D). agent_event payloads carry tool
+    // calls / tool results / status transitions. Broadcast each
+    // matching event as a `pm_dispatch_in_flight` event with
+    // `kind: 'tool_call'` plus a best-effort summary so /pm can
+    // render "PM is calling X…" / "PM noted: Y…" lines next to the
+    // streaming preview. Payload shape varies; we extract what we
+    // can and ship the raw object for the UI to render flexibly.
+    const onAgentEvent = (event: AgentEvent): void => {
+      try {
+        const summary = summariseAgentEvent(event);
+        if (!summary) return;
+        broadcast({
+          type: 'pm_dispatch_in_flight',
+          payload: {
+            workspace_id: input.workspace_id,
+            correlation_id: correlationId,
+            placeholder_id: placeholder.id,
+            kind: 'tool_call',
+            tool: summary.tool,
+            phase: summary.phase,
+            note: summary.note,
+          },
+        });
+      } catch {
+        // Diagnostics-only; never let it break dispatch.
+      }
+    };
+
     const onEvent = (event: ChatEvent): void => {
       try {
         const msgText = readChatEventMessage(event);
@@ -429,6 +458,7 @@ async function runDisruptionDispatchInBackground(
       idempotencyKey: `pm-dispatch-${correlationId}`,
       timeoutMs: namedAgentTimeoutMs(),
       onEvent,
+      onAgentEvent,
     });
     result = dispatch.reply;
   } catch (err) {
@@ -577,6 +607,46 @@ function extractAgentReplyText(
   const fromDone = readMessage(result.doneEvent?.message).trim();
   if (fromDone) return fromDone;
   return (result.reply ?? []).map(e => readMessage(e.message)).join('').trim();
+}
+
+/**
+ * Defensive heuristic for extracting "what is the PM doing right
+ * now?" out of an agent_event payload. The OpenClaw protocol
+ * doesn't pin the payload shape to a single schema — different
+ * event kinds carry different fields. We try the names we've
+ * observed in practice (`tool`, `name`, `function`, `event`,
+ * `kind`, `phase`, `step`) and fall back to null when nothing
+ * useful surfaces — caller suppresses null-summary events.
+ *
+ * Returns:
+ *   - tool: the tool / event name to render ("propose_changes",
+ *     "take_note", "get_roadmap_snapshot", etc.)
+ *   - phase: optional — 'started' | 'completed' | 'failed' (or
+ *     whatever the gateway tags) if we can find it.
+ *   - note: optional one-line excerpt of any human-readable text
+ *     in the payload (note bodies, error messages).
+ */
+function summariseAgentEvent(
+  event: AgentEvent,
+): { tool: string; phase?: string; note?: string } | null {
+  const pickStr = (...keys: string[]): string | undefined => {
+    for (const k of keys) {
+      const v = event[k];
+      if (typeof v === 'string' && v.trim()) return v.trim();
+    }
+    return undefined;
+  };
+  const tool = pickStr('tool', 'name', 'function', 'event', 'kind');
+  if (!tool) return null;
+
+  const phase = pickStr('phase', 'step', 'state', 'status');
+
+  // Pull a short note from anything resembling a body / message /
+  // text field. Capped so we never broadcast a huge payload.
+  const noteRaw = pickStr('note', 'message', 'text', 'body', 'summary', 'description');
+  const note = noteRaw ? noteRaw.slice(0, 200) : undefined;
+
+  return { tool, phase, note };
 }
 
 /**

--- a/src/lib/openclaw/send-chat.ts
+++ b/src/lib/openclaw/send-chat.ts
@@ -131,8 +131,15 @@ export interface SendChatAndAwaitInput extends SendChatInput {
    * uses to write replies into agent_chat_messages / task_notes.
    */
   isDone?: (event: ChatEvent) => boolean;
-  /** Tap for every matching event between send and done. */
+  /** Tap for every matching chat_event between send and done. */
   onEvent?: (event: ChatEvent) => void;
+  /**
+   * Tap for every matching agent_event between send and done. Tool
+   * calls, tool results, and status transitions ride this channel.
+   * Filtered by sessionKey the same way chat_events are. Caller-side
+   * exceptions are swallowed so a noisy tap can't break the wait.
+   */
+  onAgentEvent?: (event: AgentEvent) => void;
 }
 
 export interface SendChatAndAwaitResult extends SendChatResult {
@@ -149,11 +156,29 @@ export interface SendChatAndAwaitResult extends SendChatResult {
  * Minimum surface we need from the openclaw client. The real
  * `OpenClawClient` satisfies this implicitly; tests inject a stub.
  */
+/**
+ * Loose shape for openclaw `agent_event` payloads. The gateway emits
+ * these for every agent activity that ISN'T a chat token (tool calls,
+ * tool results, status transitions). Field set varies by event kind;
+ * the only thing we rely on is the optional `sessionKey` for routing.
+ *
+ * Used by `sendChatAndAwaitReply`'s `onAgentEvent` tap (PR D of
+ * specs/pm-chat-prompt.md) so callers can surface tool calls to
+ * operators as they happen.
+ */
+export type AgentEvent = Record<string, unknown> & { sessionKey?: string };
+
 export interface SendChatClient {
   isConnected: () => boolean;
   call: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
-  on: (event: 'chat_event', listener: (payload: ChatEvent) => void) => unknown;
-  off: (event: 'chat_event', listener: (payload: ChatEvent) => void) => unknown;
+  on: {
+    (event: 'chat_event', listener: (payload: ChatEvent) => void): unknown;
+    (event: 'agent_event', listener: (payload: AgentEvent) => void): unknown;
+  };
+  off: {
+    (event: 'chat_event', listener: (payload: ChatEvent) => void): unknown;
+    (event: 'agent_event', listener: (payload: AgentEvent) => void): unknown;
+  };
 }
 
 let clientOverride: SendChatClient | null = null;
@@ -353,7 +378,23 @@ export async function sendChatAndAwaitReply(
     }
   };
 
+  // Sibling listener for agent_event (tool calls, tool results,
+  // status transitions). Only attached when the caller supplies
+  // `onAgentEvent` — most callers don't care about non-chat
+  // activity. sessionKey filter mirrors the chat_event path.
+  const agentEventListener = input.onAgentEvent
+    ? (payload: AgentEvent) => {
+        if (!payload || payload.sessionKey !== sessionKey) return;
+        try {
+          input.onAgentEvent?.(payload);
+        } catch {
+          // Caller's tap shouldn't break the wait.
+        }
+      }
+    : null;
+
   client.on('chat_event', listener);
+  if (agentEventListener) client.on('agent_event', agentEventListener);
 
   try {
     // Send the frame. If this fails, short-circuit with the SendChatResult
@@ -405,5 +446,6 @@ export async function sendChatAndAwaitReply(
     };
   } finally {
     client.off('chat_event', listener);
+    if (agentEventListener) client.off('agent_event', agentEventListener);
   }
 }


### PR DESCRIPTION
Closes the visualization gap from #203. The streaming chat_event preview only catches assistant text; tool calls (\`propose_changes\`, \`take_note\`, \`get_roadmap_snapshot\`, \`log_activity\`) ride a sibling channel — \`agent_event\` — that nothing on MC was listening for. PR D adds that listener and surfaces tool calls in the in-flight panel as they fire.

## Summary
- New \`AgentEvent\` type + SendChatClient \`on\`/\`off\` overloads for the new event kind.
- New \`onAgentEvent\` callback on \`sendChatAndAwaitReply\` (sessionKey-filtered, forwarded to caller, detached in finally).
- Plumbed through \`dispatchScope\`.
- pm-dispatch's tap broadcasts \`pm_dispatch_in_flight\` with \`kind: 'tool_call'\` plus a summary (tool name + optional phase + optional capped note). The summariser is defensive — picks fields from a permissive name list since the gateway varies per-event-kind.
- /pm renders each tool call as a \`↳ tool · phase — note\` line in the in-flight strip; capped at the last 6 entries.

## Changes
- \`src/lib/openclaw/send-chat.ts\` — \`AgentEvent\` type + overloaded client surface + \`onAgentEvent\` parameter.
- \`src/lib/agents/dispatch-scope.ts\` — pass \`onAgentEvent\` through.
- \`src/lib/agents/pm-dispatch.ts\` — new tap + \`summariseAgentEvent\` helper.
- \`src/app/(app)/pm/page.tsx\` — \`liveToolCalls\` state + rendered list.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] \`tsx --test pm-e2e.test.ts pm.test.ts\` — 29/29 pass.
- [⚠️] **Tool-call lines only fire when the gateway emits agent_events.** Same caveat as PR C's streaming preview — currently-silent PM scenarios produce no agent_events; the trail stays empty. When the PM actually works, the trail populates in real time.

## Out of scope
- Generalising the in-flight panel to workers / researchers / coordinators (the SSEEventType is generic enough; only /pm consumes it today).
- Recording the tool-call trail durably (today it's UI-only and clears on control events). Ties into a broader observability investment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)