### PR TITLE
fix(recurring): in-flight lock to stop sweep re-fire

### DIFF
--- a/src/lib/agents/recurring-scheduler.ts
+++ b/src/lib/agents/recurring-scheduler.ts
@@ -15,6 +15,7 @@ import {
 import {
   listDueJobs,
   markRunFailure,
+  markRunInFlight,
   markRunSuccess,
   renderScopeKey,
   type RecurringJob,
@@ -112,6 +113,12 @@ async function dispatchResearchScheduleOnce(job: RecurringJob): Promise<void> {
     `body in your final assistant message — do not save it to a file ` +
     `and do not call register_deliverable.`;
 
+  // Reserve the row before we start the brief: advance next_run_at by
+  // one cadence so a slow brief (or a mid-brief server restart) can't
+  // be re-picked by the next sweep. markRunSuccess re-advances on
+  // completion; markRunFailure overrides with its own backoff.
+  markRunInFlight(job.id);
+
   let result: { brief_id: string; agent_run_id: string; state: 'started' | 'rejected'; reason?: string };
   try {
     const created = createBriefWithRun({
@@ -191,6 +198,10 @@ export async function dispatchRecurringJobOnce(job: RecurringJob): Promise<void>
   // rendered key as the suffix; dispatchScope then prepends the prefix
   // automatically. We strip-once-if-present to avoid double-prefixing
   // when templates are written like `agent:mc-runner-dev:main:recurring-{job_id}`.
+
+  // Reserve the row before dispatch — see dispatchResearchScheduleOnce
+  // for rationale. Prevents overlapping sweeps and post-restart re-fires.
+  markRunInFlight(job.id);
 
   try {
     const result = await dispatchScope({

--- a/src/lib/db/recurring-jobs.test.ts
+++ b/src/lib/db/recurring-jobs.test.ts
@@ -20,6 +20,7 @@ import {
   listResearchSchedulesForTopic,
   listUpcomingResearch,
   markRunFailure,
+  markRunInFlight,
   markRunSuccess,
   recordBriefOutcome,
   RecurringJobValidationError,
@@ -133,6 +134,27 @@ test('markRunSuccess: bumps run_count, advances next_run_at, clears failures', (
   const nowMs = Date.now();
   assert.ok(nextMs >= nowMs + 50_000 && nextMs <= nowMs + 70_000,
     `next_run_at not advanced by cadence: delta=${nextMs - nowMs}`);
+});
+
+test('markRunInFlight: advances next_run_at without bumping run_count or last_run_at', () => {
+  const ws = freshWorkspace();
+  const job = createRecurringJob(baseInput(ws, { cadence_seconds: 60 }));
+  const beforeMs = new Date(job.next_run_at).getTime();
+  // The lock should push next_run_at to ~now + cadence so an
+  // overlapping sweep tick (or a post-restart sweep) won't re-pick it.
+  const after = markRunInFlight(job.id);
+  assert.ok(after);
+  const nextMs = new Date(after!.next_run_at).getTime();
+  const nowMs = Date.now();
+  assert.ok(nextMs >= nowMs + 50_000 && nextMs <= nowMs + 70_000,
+    `next_run_at not advanced by cadence: delta=${nextMs - nowMs}`);
+  assert.ok(nextMs > beforeMs, 'next_run_at must move forward');
+  // run_count + last_run_at stay untouched — those move on terminal outcome.
+  assert.equal(after!.run_count, 0);
+  assert.equal(after!.last_run_at, null);
+  // Job is no longer due, so listDueJobs would skip it on the next tick.
+  const dueIds = new Set(listDueJobs().map((j) => j.id));
+  assert.equal(dueIds.has(job.id), false);
 });
 
 test('markRunFailure: pauses after threshold', () => {

--- a/src/lib/db/recurring-jobs.ts
+++ b/src/lib/db/recurring-jobs.ts
@@ -242,6 +242,26 @@ export function listDueJobs(opts: { now?: string; limit?: number } = {}): Recurr
 }
 
 /**
+ * Reserve a job for an in-flight dispatch. Advances `next_run_at` by
+ * one full cadence immediately so that:
+ *   - a slow brief (longer than the sweep interval) can't be re-picked
+ *     by an overlapping sweep tick, and
+ *   - a server restart mid-brief doesn't see the row as "due" again
+ *     (the orphaned brief surfaces via its own brief_failed signal,
+ *     not via the scheduler re-firing).
+ *
+ * Returns the updated row. Does NOT bump run_count or touch
+ * last_run_at — that happens on terminal success/failure.
+ */
+export function markRunInFlight(id: string): RecurringJob | null {
+  const job = getRecurringJob(id);
+  if (!job) return null;
+  const next = new Date(Date.now() + job.cadence_seconds * 1000).toISOString();
+  run(`UPDATE recurring_jobs SET next_run_at = ? WHERE id = ?`, [next, id]);
+  return getRecurringJob(id);
+}
+
+/**
  * Mark a successful run. Bumps run_count, clears consecutive_failures,
  * advances next_run_at by cadence_seconds, records the scope_key
  * actually used.


### PR DESCRIPTION
## Summary
- The recurring scheduler advanced \`next_run_at\` only after \`runBrief\` / \`dispatchScope\` resolved. A brief running longer than the 60s sweep interval — or a server restart while one was in flight — left the row marked due, so the next sweep re-dispatched it. In dev this surfaced as duplicate \`brief-*\` gateway sessions.
- The comment on \`recordBriefOutcome\` already claimed the dispatch path advances \`next_run_at\` to prevent concurrent runs while in flight; this PR makes that comment true.

## Changes
- \`markRunInFlight(id)\` in the recurring-jobs DAO bumps \`next_run_at\` by one cadence without touching \`run_count\` or \`last_run_at\`.
- Both dispatch paths in the scheduler call it before the await: research (\`dispatchResearchScheduleOnce\`) and worker (\`dispatchScope\` branch).
- \`markRunSuccess\` re-advances on terminal success; \`markRunFailure\` keeps its existing backoff.

## Test plan
- [x] \`yarn tsc --noEmit\` (only pre-existing pm-decompose failures)
- [x] \`recurring-jobs.test.ts\` — added a case asserting markRunInFlight pushes the row out of \`listDueJobs\` without bumping run_count
- [x] \`recurring-scheduler.test.ts\` — existing 3 cases still pass
- [ ] Operator: confirm no duplicate \`brief-*\` sessions on the openclaw sessions page during a slow brief