### PR TITLE
fix(db): hard-fail when test runner opens production DB

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -32,6 +32,21 @@ function resolveDbPath(): string {
     const unique = `${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
     return path.join(dir, `mc-test-${unique}.db`);
   }
+  // Defense: if a Node test runner is loading this module without
+  // NODE_ENV=test, we'd otherwise silently open the production DB and
+  // every `freshWorkspace()` test fixture would leak rows into it.
+  // The recurring_jobs test fixtures are particularly bad — leaked
+  // rows get picked up by the production scheduler and fire on
+  // cadence forever. Hard-fail here so the operator notices and runs
+  // the suite via `yarn test` (or prefixes ad-hoc invocations with
+  // `NODE_ENV=test`).
+  if (process.env.NODE_TEST_CONTEXT) {
+    throw new Error(
+      'Refusing to open production DB from a Node test runner. Set ' +
+      'NODE_ENV=test (e.g. `NODE_ENV=test npx tsx --test ...`) or use ' +
+      '`yarn test`.',
+    );
+  }
   return process.env.DATABASE_PATH || path.join(process.cwd(), 'mission-control.db');
 }
 


### PR DESCRIPTION
## Summary
- Found 24 leaked rows in dev's \`mission-control.db\` (10 still firing every 60s) — workspaces named \`ws-rj-*\` from \`recurring-jobs.test.ts\`'s \`freshWorkspace()\`. They got there by running \`npx tsx --test ...\` ad-hoc without \`NODE_ENV=test\`, which routes the test fixtures into the production DB. The production scheduler then dispatched them on cadence forever (this is also why the user saw mystery brief activity after the restart).
- Cleaned the leaked rows manually; this PR adds the prevention.

## Changes
- \`resolveDbPath\` now throws when \`NODE_TEST_CONTEXT\` is set (Node's test runner sets this in workers) but \`NODE_ENV !== 'test'\`. The operator gets a pointed error telling them to use \`yarn test\` or prefix \`NODE_ENV=test\`.

## Test plan
- [x] Ad-hoc \`npx tsx --test\` against a file that touches the DB now fails with the new message.
- [x] \`NODE_ENV=test npx tsx --test src/lib/db/recurring-jobs.test.ts\` still passes (18/18).
- [ ] \`yarn test\` end-to-end (script already sets \`NODE_ENV=test\`).