### PR TITLE
feat(agents): hard-stop matching gateway sessions

### DIFF
--- a/src/app/(app)/agents/page.tsx
+++ b/src/app/(app)/agents/page.tsx
@@ -21,6 +21,7 @@ import {
   Loader2,
   Megaphone,
   RotateCcw,
+  Octagon,
   Plus,
   Search,
   Power,
@@ -93,6 +94,9 @@ export default function AgentsPage() {
   const [rollCallBusy, setRollCallBusy] = useState(false);
   const [rollCallResult, setRollCallResult] = useState<RollCallResultView | null>(null);
   const [resetSessionsBusy, setResetSessionsBusy] = useState(false);
+  const [hardStopBusy, setHardStopBusy] = useState(false);
+  const [showHardStopDialog, setShowHardStopDialog] = useState(false);
+  const [hardStopPattern, setHardStopPattern] = useState('');
   const [syncBusy, setSyncBusy] = useState(false);
   // Replaces native window.confirm() — see §1.7 finding in PREVIEW_TEST_FINDINGS.
   // The native dialog blocks automation tooling and breaks the test-flow walk.
@@ -339,6 +343,48 @@ export default function AgentsPage() {
     }
   };
 
+  const doHardStopMatching = async (pattern: string) => {
+    setHardStopBusy(true);
+    try {
+      const res = await fetch('/api/openclaw/sessions/abort-matching', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pattern }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        showAlertDialog('Hard stop failed', data.error || 'Failed to abort sessions');
+        return;
+      }
+      const lines: string[] = [
+        `Pattern: ${data.pattern}`,
+        `Matched ${data.matched} session(s) on the gateway.`,
+        `Aborted: ${data.aborted.length}`,
+      ];
+      if (data.failed?.length) {
+        lines.push(`Abort failed: ${data.failed.length}`);
+      }
+      const lm = data.local_marked ?? {};
+      lines.push(
+        `Local rows scrubbed — openclaw_sessions: ${lm.openclaw_sessions ?? 0}, ` +
+          `research_cycles: ${lm.research_cycles ?? 0}, ideation_cycles: ${lm.ideation_cycles ?? 0}.`,
+      );
+      if (data.aborted.length) {
+        lines.push('', 'Aborted keys:', ...data.aborted.slice(0, 20).map((k: string) => `  ${k}`));
+        if (data.aborted.length > 20) lines.push(`  …and ${data.aborted.length - 20} more`);
+      }
+      showAlertDialog('Hard stop result', lines.join('\n'));
+      setShowHardStopDialog(false);
+      setHardStopPattern('');
+      // Refresh session display so the matrix reflects ended rows.
+      void loadOpenClawSessions();
+    } catch (err) {
+      showAlertDialog('Hard stop failed', `Request failed: ${(err as Error).message}`);
+    } finally {
+      setHardStopBusy(false);
+    }
+  };
+
   // ─── per-agent actions ──────────────────────────────────────────────
 
   // Generic optimistic-update PATCH used by the inline avatar / role /
@@ -526,6 +572,14 @@ export default function AgentsPage() {
               {resetSessionsBusy ? 'Resetting…' : 'Reset all sessions'}
             </HeaderButton>
             <HeaderButton
+              icon={hardStopBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Octagon className="w-4 h-4" />}
+              onClick={() => setShowHardStopDialog(true)}
+              disabled={hardStopBusy}
+              tone="amber"
+            >
+              {hardStopBusy ? 'Stopping…' : 'Hard stop matching…'}
+            </HeaderButton>
+            <HeaderButton
               icon={<Search className="w-4 h-4" />}
               onClick={() => setShowDiscoverModal(true)}
               tone="blue"
@@ -661,6 +715,104 @@ export default function AgentsPage() {
         }}
         onCancel={() => setPendingConfirm(null)}
       />
+      {showHardStopDialog && (
+        <HardStopDialog
+          pattern={hardStopPattern}
+          onChange={setHardStopPattern}
+          busy={hardStopBusy}
+          onCancel={() => {
+            if (hardStopBusy) return;
+            setShowHardStopDialog(false);
+            setHardStopPattern('');
+          }}
+          onConfirm={() => {
+            const p = hardStopPattern.trim();
+            if (!p) return;
+            void doHardStopMatching(p);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+interface HardStopDialogProps {
+  pattern: string;
+  onChange: (next: string) => void;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Modal for the "Hard stop matching" action. Lives inline so it can
+ * read/write the page's pattern state without a context bridge. The
+ * destructive flag styles the confirm button red — aborting gateway
+ * sessions is irreversible (the agent loop is killed mid-tool-call,
+ * losing whatever the agent was about to emit).
+ */
+function HardStopDialog({ pattern, onChange, busy, onCancel, onConfirm }: HardStopDialogProps) {
+  const trimmed = pattern.trim();
+  const tooBroad = trimmed === '*' || trimmed === '**';
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="w-full max-w-lg rounded-lg bg-mc-bg-primary border border-mc-border-primary shadow-xl p-5">
+        <h2 className="text-base font-semibold text-mc-text-primary">Hard stop matching sessions</h2>
+        <p className="mt-2 text-sm text-mc-text-secondary">
+          Aborts every gateway session whose key matches the pattern, then marks the
+          corresponding rows in <code className="text-xs px-1 rounded bg-mc-bg-secondary">openclaw_sessions</code>,{' '}
+          <code className="text-xs px-1 rounded bg-mc-bg-secondary">research_cycles</code>, and{' '}
+          <code className="text-xs px-1 rounded bg-mc-bg-secondary">ideation_cycles</code> ended/interrupted
+          so a server restart won't resurrect them.
+        </p>
+        <p className="mt-2 text-xs text-mc-text-secondary">
+          Wildcard: <code className="px-1 rounded bg-mc-bg-secondary">*</code>. Examples:{' '}
+          <code className="px-1 rounded bg-mc-bg-secondary">*ws-rj-*</code>,{' '}
+          <code className="px-1 rounded bg-mc-bg-secondary">*recurring-*</code>,{' '}
+          <code className="px-1 rounded bg-mc-bg-secondary">*brief-*</code>.
+        </p>
+        <input
+          autoFocus
+          type="text"
+          value={pattern}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && trimmed && !tooBroad && !busy) onConfirm();
+            if (e.key === 'Escape' && !busy) onCancel();
+          }}
+          placeholder="*ws-rj-*"
+          className="mt-4 w-full rounded border border-mc-border-primary bg-mc-bg-secondary px-3 py-2 text-sm text-mc-text-primary font-mono"
+          disabled={busy}
+        />
+        {tooBroad && (
+          <p className="mt-2 text-xs text-mc-status-failed-text">
+            Pattern too broad — use <span className="font-semibold">Reset all sessions</span> instead.
+          </p>
+        )}
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            className="px-3 py-1.5 text-sm rounded border border-mc-border-primary text-mc-text-secondary hover:bg-mc-bg-secondary disabled:opacity-50"
+            onClick={onCancel}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="px-3 py-1.5 text-sm rounded bg-red-600 hover:bg-red-700 text-white disabled:opacity-50"
+            onClick={onConfirm}
+            disabled={busy || !trimmed || tooBroad}
+          >
+            {busy ? 'Stopping…' : 'Hard stop'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/agents/page.tsx
+++ b/src/app/(app)/agents/page.tsx
@@ -761,8 +761,8 @@ function HardStopDialog({ pattern, onChange, busy, onCancel, onConfirm }: HardSt
         if (e.target === e.currentTarget) onCancel();
       }}
     >
-      <div className="w-full max-w-lg rounded-lg bg-mc-bg-primary border border-mc-border-primary shadow-xl p-5">
-        <h2 className="text-base font-semibold text-mc-text-primary">Hard stop matching sessions</h2>
+      <div className="w-full max-w-lg rounded-lg bg-mc-bg border border-mc-border shadow-xl p-5">
+        <h2 className="text-base font-semibold text-mc-text">Hard stop matching sessions</h2>
         <p className="mt-2 text-sm text-mc-text-secondary">
           Aborts every gateway session whose key matches the pattern, then marks the
           corresponding rows in <code className="text-xs px-1 rounded bg-mc-bg-secondary">openclaw_sessions</code>,{' '}
@@ -786,18 +786,18 @@ function HardStopDialog({ pattern, onChange, busy, onCancel, onConfirm }: HardSt
             if (e.key === 'Escape' && !busy) onCancel();
           }}
           placeholder="*ws-rj-*"
-          className="mt-4 w-full rounded border border-mc-border-primary bg-mc-bg-secondary px-3 py-2 text-sm text-mc-text-primary font-mono"
+          className="mt-4 w-full rounded border border-mc-border bg-mc-bg-secondary px-3 py-2 text-sm text-mc-text font-mono"
           disabled={busy}
         />
         {tooBroad && (
-          <p className="mt-2 text-xs text-mc-status-failed-text">
+          <p className="mt-2 text-xs text-amber-400">
             Pattern too broad — use <span className="font-semibold">Reset all sessions</span> instead.
           </p>
         )}
         <div className="mt-5 flex justify-end gap-2">
           <button
             type="button"
-            className="px-3 py-1.5 text-sm rounded border border-mc-border-primary text-mc-text-secondary hover:bg-mc-bg-secondary disabled:opacity-50"
+            className="px-3 py-1.5 text-sm rounded border border-mc-border text-mc-text-secondary hover:bg-mc-bg-secondary disabled:opacity-50"
             onClick={onCancel}
             disabled={busy}
           >

--- a/src/app/api/openclaw/sessions/abort-matching/route.ts
+++ b/src/app/api/openclaw/sessions/abort-matching/route.ts
@@ -1,0 +1,159 @@
+/**
+ * POST /api/openclaw/sessions/abort-matching
+ *
+ * "Hard stop" affordance for the agents page. The operator gives a
+ * glob (e.g. `*ws-rj-*`, `*recurring-*`); we list every gateway
+ * session, abort the ones that match, then scrub the matching rows
+ * from MC's local state so a server restart won't resurrect them:
+ *
+ *   - openclaw_sessions: status='ended', ended_at=now()
+ *   - research_cycles / ideation_cycles: status='interrupted'
+ *     (autopilot/recovery.ts re-dispatches anything still 'running'
+ *      at startup — that's how stale sessions kept coming back)
+ *
+ * Body: { pattern: string }
+ *   `*` is the only wildcard. `*` or `**` alone is rejected (use
+ *   the existing /api/openclaw/sessions DELETE for a full nuke).
+ *
+ * Response:
+ *   { pattern, matched, aborted: string[], failed: {id,error}[],
+ *     local_marked: { openclaw_sessions, research_cycles,
+ *                     ideation_cycles } }
+ */
+
+import { NextResponse } from 'next/server';
+import { getOpenClawClient } from '@/lib/openclaw/client';
+import { getDb } from '@/lib/db';
+import { logDebugEvent } from '@/lib/debug-log';
+
+export const dynamic = 'force-dynamic';
+
+function compileGlob(pattern: string): RegExp {
+  // Escape regex metachars except `*`, then convert `*` → `.*`.
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+export async function POST(request: Request) {
+  let pattern: unknown;
+  try {
+    const body = await request.json();
+    pattern = body?.pattern;
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  if (typeof pattern !== 'string' || !pattern.trim()) {
+    return NextResponse.json({ error: 'pattern is required' }, { status: 400 });
+  }
+  const trimmed = pattern.trim();
+  if (trimmed === '*' || trimmed === '**') {
+    return NextResponse.json(
+      {
+        error:
+          'pattern too broad — use the "Reset all sessions" button for a full nuke',
+      },
+      { status: 400 },
+    );
+  }
+
+  const re = compileGlob(trimmed);
+
+  const client = getOpenClawClient();
+  if (!client.isConnected()) {
+    try {
+      await client.connect();
+    } catch (err) {
+      return NextResponse.json(
+        { error: `gateway unreachable: ${(err as Error).message}` },
+        { status: 503 },
+      );
+    }
+  }
+
+  let sessions;
+  try {
+    sessions = await client.listSessions();
+  } catch (err) {
+    return NextResponse.json(
+      { error: `sessions.list failed: ${(err as Error).message}` },
+      { status: 502 },
+    );
+  }
+
+  const matched = sessions.filter((s) => re.test(s.id));
+  const aborted: string[] = [];
+  const failed: { id: string; error: string }[] = [];
+
+  for (const s of matched) {
+    try {
+      await client.abortSession(s.id);
+      aborted.push(s.id);
+      logDebugEvent({
+        type: 'session.end',
+        direction: 'outbound',
+        sessionKey: s.id,
+        metadata: { reason: 'hard_stop_matching', pattern: trimmed, op: 'sessions.abort' },
+      });
+    } catch (err) {
+      failed.push({ id: s.id, error: (err as Error).message });
+    }
+  }
+
+  // Local-state scrub. We update by exact session_key match against
+  // the keys we successfully aborted (or matched, even if abort
+  // failed — the operator's intent is clear, and leaving the row in
+  // a 'running' state will trip autopilot recovery on next boot).
+  const db = getDb();
+  const keysToScrub = matched.map((s) => s.id);
+  let openclawSessionRows = 0;
+  let researchCycleRows = 0;
+  let ideationCycleRows = 0;
+  if (keysToScrub.length > 0) {
+    const placeholders = keysToScrub.map(() => '?').join(',');
+    openclawSessionRows = db
+      .prepare(
+        `UPDATE openclaw_sessions
+            SET status = 'ended', ended_at = ?, updated_at = ?
+          WHERE openclaw_session_id IN (${placeholders})
+            AND status != 'ended'`,
+      )
+      .run(new Date().toISOString(), new Date().toISOString(), ...keysToScrub).changes;
+
+    // research_cycles / ideation_cycles use `session_key` (not
+    // openclaw_session_id) — see autopilot/recovery.ts.
+    researchCycleRows = db
+      .prepare(
+        `UPDATE research_cycles
+            SET status = 'interrupted',
+                error_message = COALESCE(error_message, 'hard-stopped via abort-matching'),
+                completed_at = ?
+          WHERE session_key IN (${placeholders})
+            AND status = 'running'`,
+      )
+      .run(new Date().toISOString(), ...keysToScrub).changes;
+
+    ideationCycleRows = db
+      .prepare(
+        `UPDATE ideation_cycles
+            SET status = 'interrupted',
+                error_message = COALESCE(error_message, 'hard-stopped via abort-matching'),
+                completed_at = ?
+          WHERE session_key IN (${placeholders})
+            AND status = 'running'`,
+      )
+      .run(new Date().toISOString(), ...keysToScrub).changes;
+  }
+
+  return NextResponse.json({
+    pattern: trimmed,
+    matched: matched.length,
+    aborted,
+    failed,
+    local_marked: {
+      openclaw_sessions: openclawSessionRows,
+      research_cycles: researchCycleRows,
+      ideation_cycles: ideationCycleRows,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a **Hard stop matching…** button on the agents page that takes a glob (e.g. \`*ws-rj-*\`, \`*recurring-*\`) and aborts every matching gateway session, then scrubs the corresponding rows in MC's local state so they don't resurrect after a restart.
- The "they keep coming back" behavior was driven by \`autopilot/recovery.ts\` re-dispatching \`research_cycles\` / \`ideation_cycles\` rows still in \`status='running'\` on every DB init. This endpoint marks them \`interrupted\` so recovery skips them.

## Changes
- **API**: \`POST /api/openclaw/sessions/abort-matching\` — body \`{ pattern: string }\`. Compiles a simple glob (\`*\` → \`.*\`, regex metachars escaped). Bare \`*\` / \`**\` rejected — operator should use *Reset all sessions* for that. Lists sessions on the gateway, aborts each match via \`sessions.abort\`, then UPDATEs:
  - \`openclaw_sessions.status = 'ended'\` for matched keys
  - \`research_cycles.status = 'interrupted'\` for matched \`session_key\`
  - \`ideation_cycles.status = 'interrupted'\` for matched \`session_key\`
- **UI**: header button next to *Reset all sessions* opens a small dialog with a pattern input + Abort button. Shows aborted/failed/local-scrubbed counts on completion.

## Test plan
- [x] \`yarn tsc --noEmit\` (only pre-existing pm-decompose failures)
- [x] Endpoint resolves: \`curl POST /api/openclaw/sessions/abort-matching\` returns 401 (auth middleware) instead of 404
- [ ] End-to-end: create a leaked session on the gateway, run pattern \`*<unique>*\`, confirm the gateway session list shrinks and the local rows flip to \`ended\` / \`interrupted\`

## Why now
We had ~30 leaked recurring/eval sessions that kept regenerating on every preview restart. Manual deletion in the openclaw UI didn't stick because MC's \`recoverOrphanedCycles()\` re-dispatched them. This gives the operator a single button to clear them by pattern.