### PR TITLE
docs(mcp-surface-v2): build plan + validation pack (foundation)

### DIFF
--- a/specs/mcp-surface-v2-build-plan.md
+++ b/specs/mcp-surface-v2-build-plan.md
@@ -1,0 +1,77 @@
+# MCP surface v2 — build plan
+
+Companion to [`mcp-surface-review.md`](./mcp-surface-review.md). The spec carries the **why**; this doc carries the **how/order/test-strategy**. Validation pack lives at [`mcp-surface-v2-validation/`](./mcp-surface-v2-validation/).
+
+## Audit (state at branch-cut)
+
+- 47 MCP tools registered globally via `src/lib/mcp/server.ts → buildServer()` calling `registerAllTools` (24 in `tools.ts`) + `registerRoadmapTools` (23 in `roadmap-tools.ts`).
+- One route: `/api/mcp` (`src/app/api/mcp/route.ts`). Both PM and runner mount it. PM-only tools (`propose_changes`, etc.) are visible to every persona today.
+- Existing operator-facing scripts in this neighborhood: `yarn openclaw:sync` (`scripts/sync-openclaw-agents.mjs`), `yarn workspace:provision` (`scripts/provision-workspace-runner.ts`), `yarn runner-host:reseed` (`scripts/neutralize-runner-host.ts`). The two new tools (PR 3, PR 3.5) live alongside.
+- `instrumentation.ts` already starts the recurring scheduler + DB backup loop. No additional wiring required for this work.
+- `agent-templates/_shared/messaging-protocol.md` is referenced by every role-specific AGENTS.md as the canonical tool list. PR 4 / PR 5 must edit it in lockstep with the code change.
+- Named gateway agents (PM, runner-host) read AGENTS.md / SOUL.md / IDENTITY.md from `~/.openclaw/workspaces/mc-{role}-{dev,stable}/` at session start — physical files, not MC's briefing pipeline. PR 3.5 closes that staleness gap.
+
+## Design decisions
+
+**1. Group split: by *audience*, not by surface area.** Files: `core` (universally needed), `read` (read-only roadmap), `work` (worker write tools), `pm` (proposal toolkit), `crud` (operator-direct mutations). Reversibility: trivial — refactor only, no schema or DB change.
+
+**2. Default `/api/mcp` keeps the union.** The default route imports every group. No agent loses tools at PR 1 / PR 2 land. The token savings are realized at PR 3 (operator points PM at `/api/mcp/pm`). Reversibility: roll back the openclaw.json edit, PM is back to full surface.
+
+**3. CRUD tools parked, not deleted.** Future direct-edit agents may want them. Cost is 8 tool registrations on a route nobody mounts by default. Reversibility: trivial.
+
+**4. Action-discriminator over discriminated-union for the consolidations.** `update_subtask({action})` and `update_note({action})` use a string `action` enum (not Zod's `discriminatedUnion`) because the per-action argument shape barely diverges. Keeps the JSON schema legible and the agent decision tree simple. `propose_changes`'s `PmDiff` stays a true discriminated union because per-kind shapes are genuinely different.
+
+**5. Hard rename on consolidations.** Per spec decision-log item 2: in-flight sessions get cleared, no shims. Old tool names disappear at PR 4 / PR 5 land.
+
+**6. Named-agent sync uses MC's briefing-builder composition order.** The PR 3.5 script imports the same composition function MC's dispatch pipeline uses for runner-hosted personas. Single source of truth.
+
+## Slice plan
+
+| PR | Branch | Base | Scope | Files (rough) | Becomes testable |
+|---|---|---|---|---|---|
+| 1 | `feat/mcp-groups-refactor` | main | Move tools into `src/lib/mcp/groups/{core,read,work,pm,crud}.ts` + `buildServer(groups[])` factory | `src/lib/mcp/{groups/*.ts,server.ts,tools.ts→removed,roadmap-tools.ts→removed}` | Existing MCP test suite still green; tool list unchanged on `/api/mcp` |
+| 2 | `feat/mcp-routes-pm-crud` | PR 1 | New `/api/mcp/pm`, `/api/mcp/crud`; rewrite pm/SOUL.md line 32 | `src/app/api/mcp/{pm,crud}/route.ts`, `agent-templates/pm/SOUL.md` | Curl shows 16-tool PM endpoint, 16-tool CRUD endpoint; default route still 47 |
+| 3 | `feat/openclaw-apply-mc-servers` | PR 2 | `scripts/apply-mc-servers.ts` + `package.json` script | scripts + small declarative config | `yarn openclaw:apply-mc-servers --dry-run` reports the diff to be applied; live run rewrites openclaw.json idempotently |
+| 3.5 | `feat/openclaw-sync-named-agents` | PR 3 | `scripts/sync-named-agent-workspaces.ts` + script entry | scripts + briefing-builder import | `yarn openclaw:sync-named-agents --dry-run` shows expected diffs; live run brings PM/runner workspace files in line with `_shared` |
+| 4 | `feat/update-subtask` | PR 3.5 | New `update_subtask`; remove `accept/reject/cancel_subtask`; update coordinator templates + messaging-protocol | `src/lib/mcp/groups/work.ts`, `agent-templates/coordinator/{SOUL,AGENTS}.md`, `agent-templates/_shared/messaging-protocol.md`, `src/app/api/tasks/[id]/dispatch/route.ts`, mcp.test.ts | New tool exposed at `/api/mcp` + `/api/mcp/pm` if applicable; coordinator dispatches use new tool |
+| 5 | `feat/update-note` | PR 4 | New `update_note`; remove `mark_note_consumed` + `archive_note`; add `consume` guidance to `_shared/notetaker.md` + `messaging-protocol.md` | `src/lib/mcp/groups/core.ts`, `agent-templates/_shared/{messaging-protocol,notetaker}.md`, `agent-templates/runner-host/AGENTS.md`, mcp.test.ts | Notes can be consumed/archived via the unified tool |
+| 6 | `docs/mcp-discriminated-union` | PR 5 | Doc-only: PM SOUL + spec stating "extend `propose_changes`, don't add new tools" | `agent-templates/pm/SOUL.md`, `specs/mcp-surface-review.md` | n/a |
+
+## Test strategy per slice
+
+- **PR 1**: `yarn test` (full suite); `mcp.test.ts` validates tool count and per-tool registration. Same 47 tools after refactor.
+- **PR 2**: extend `mcp.test.ts` with route-scoped tests asserting `/api/mcp/pm` returns the PM subset, `/api/mcp/crud` returns the CRUD subset, default route unchanged. Curl smoke documented in PR body.
+- **PR 3**: unit test for `applyMcServers()` covering dry-run vs apply; idempotence (run twice, second is a no-op); dev/stable variant pass.
+- **PR 3.5**: unit test that recompose produces byte-identical output to MC's briefing builder for runner-hosted personas, then asserts the file write is gated on diff. Mock `~/.openclaw/workspaces/` via a fixture dir.
+- **PR 4**: replace existing `accept/reject/cancel_subtask` test cases with `update_subtask({action})` cases. Coordinator dispatch e2e (validation V4).
+- **PR 5**: replace existing note-lifecycle test cases with `update_note({action})` cases. Note consume/archive e2e (validation V5).
+- **PR 6**: doc-only, no tests.
+
+## Validation gates (real-agent dispatches)
+
+Detailed in `mcp-surface-v2-validation/02-test-plan.md`. Summary:
+- **V1** PM dispatch lists tools after PR 2/3 → expect ~16 tools, no `register_deliverable` etc.
+- **V2** Runner-hosted persona dispatch still has full surface (`/api/mcp` default).
+- **V3** PR 3.5 sync brings PM workspace AGENTS.md in line with `_shared/messaging-protocol.md` after a deliberate edit; idempotent on second run.
+- **V4** Coordinator dispatch uses `update_subtask` (real OpenClaw against `spark-lb/agent`).
+- **V5** Worker dispatch consumes/archives a note via `update_note`.
+- **V6** PM `propose_changes` flow unaffected by the route split — dispatch a small proposal end-to-end.
+
+Per `project_openclaw_model.md` all real-agent dispatches use `spark-lb/agent`.
+
+## Open questions
+
+1. **Where are MC's briefing-builder composition rules?** Need to grep `src/lib/agents/briefing.ts` or similar at PR 3.5 start to confirm the import target. Listed as PR 3.5 first task.
+2. **`agent_role_overrides` for PM/runner-host?** Need to check at PR 3.5 whether per-workspace overrides exist for the named agents and how they should interact with the sync (override wins / sync warns / sync skips).
+
+## Out of scope
+
+- Initiative dependency tool merge (`add_/remove_initiative_dependency`) — deferred per spec.
+- Anthropic MCP Tool Search / lazy loading.
+- Code-execution wrapping pattern.
+- Per-session tool injection.
+- Any change to the `propose_changes` discriminated union — extension policy is "do nothing until threshold."
+
+## Cost ceiling
+
+Real-agent model `spark-lb/agent` (self-hosted, no budget concern per `project_openclaw_model.md`). Expected total real-agent dispatches across V1–V6: ~12–15 (each scenario plus 1–2 retries on flake).

--- a/specs/mcp-surface-v2-validation/00-baseline-observations.md
+++ b/specs/mcp-surface-v2-validation/00-baseline-observations.md
@@ -1,0 +1,43 @@
+# 00 — Baseline observations
+
+Snapshot taken before PR 1 lands. Re-snapshot after the stack lands and diff for unexpected drift.
+
+## MCP surface (current)
+
+- **Total tools:** 47
+- **Endpoints:** one — `/api/mcp` (`src/app/api/mcp/route.ts`). Both PM and runner-host mount it.
+- **`tools.ts` count:** 24 — `whoami`, `get_workspace_context`, `list_peers`, `get_task`, `fetch_mail`, `register_deliverable`, `submit_evidence`, `log_activity`, `take_note`, `read_notes`, `mark_note_consumed`, `archive_note`, `update_task_status`, `fail_task`, `save_checkpoint`, `send_mail`, `save_knowledge`, `request_knowledge`, `spawn_subtask`, `list_my_subtasks`, `accept_subtask`, `reject_subtask`, `cancel_subtask`, `register_subagent_dispatch`.
+- **`roadmap-tools.ts` count:** 23 — `list_initiatives`, `get_initiative`, `get_initiative_tree`, `get_roadmap_snapshot`, `get_initiative_history`, `get_task_initiative_history`, `list_owner_availability`, `get_velocity_data`, `list_proposals`, `create_initiative`, `update_initiative`, `move_initiative`, `convert_initiative`, `add_initiative_dependency`, `remove_initiative_dependency`, `move_task_to_initiative`, `promote_initiative_to_task`, `promote_task_to_inbox`, `add_owner_availability`, `propose_changes`, `propose_from_notes`, `refine_proposal`, `preview_derivation`.
+
+## Agent template state
+
+- `agent-templates/_shared/messaging-protocol.md` — canonical tool table, references all 47 by name including: `accept_subtask`, `reject_subtask`, `cancel_subtask` (PR 4 targets), `archive_note` (PR 5 target). `mark_note_consumed` is **not** referenced.
+- `agent-templates/_shared/notetaker.md` — references `archive_note` (line ~34) only.
+- `agent-templates/coordinator/{SOUL,AGENTS}.md` — densest subtask-tool decision table.
+- `agent-templates/pm/SOUL.md` — line ~32 explicitly forbids `create_initiative`/`update_initiative` (becomes redundant after PR 2).
+
+## Named gateway agents
+
+Two physical workspace dirs each per environment:
+- Dev: `~/.openclaw/workspaces/mc-pm-default-dev/`, `~/.openclaw/workspaces/mc-runner-dev/`
+- Stable: `~/.openclaw/workspaces/mc-pm-default-stable/`, `~/.openclaw/workspaces/mc-runner-stable/`
+
+Each contains `AGENTS.md` / `SOUL.md` / `IDENTITY.md` read at gateway session start. Currently hand-synced.
+
+## openclaw.json relevant sections
+
+- `mcp.servers.<name>` — per-MC-route MCP server registration.
+- `agents[].tools.alsoAllow` / `deny` — per-named-agent allowlist patterns. Today: typically `"sc-mission-control-dev__*"` for dev runner.
+
+## Test suite state
+
+- `yarn test` — full Node/TS suite. Run before branch-cut to record any pre-existing failures.
+- `yarn mcp:smoke` — MCP smoke against the launcher.
+- `yarn mcp:integration` — MCP integration script.
+
+Pre-existing failures (to fill at branch-cut):
+- _TBD — capture during pre-check on each milestone run._
+
+## Capture location
+
+`/tmp/mc-validation/mcp-surface-v2/baseline/` — for the `tools/list` snapshot taken at pre-check time.

--- a/specs/mcp-surface-v2-validation/01-pre-check-initialization.md
+++ b/specs/mcp-surface-v2-validation/01-pre-check-initialization.md
@@ -1,0 +1,83 @@
+# 01 — Pre-check initialization
+
+Destructive runbook to reach a known-good baseline before each E2E run. Halt on first failure.
+
+## 0. Branch + working tree
+
+```sh
+cd /Users/snappytwo/snappytwo-sandbox/mission-control
+git status                           # expect: clean
+git rev-parse --abbrev-ref HEAD      # expect: feat/mcp-surface-v2 (or active slice branch)
+```
+
+If dirty, stash; if on wrong branch, halt.
+
+## 1. Test-suite baseline pass
+
+```sh
+yarn test 2>&1 | tee /tmp/mc-validation/mcp-surface-v2/precheck-test.log
+yarn mcp:smoke 2>&1 | tee /tmp/mc-validation/mcp-surface-v2/precheck-mcp-smoke.log
+```
+
+List any pre-existing failures (file + reason) in the run results doc — never silently ignore.
+
+## 2. Dev DB reset
+
+```sh
+yarn db:backup
+yarn db:reset
+```
+
+Dev DB is independent of prod (`project_dev_prod_db_split.md`); `db:reset` is routine.
+
+## 3. Dev server restart (so new MCP routes register)
+
+```sh
+# In a separate terminal or background:
+yarn dev   # listens on :4010 per project_lan_dev_origins.md
+```
+
+Wait until `Compiled successfully`.
+
+## 4. MCP endpoint sanity
+
+```sh
+TOKEN=$(grep MC_API_TOKEN .env.local | cut -d= -f2)
+curl -sS -H "Authorization: Bearer $TOKEN" -H "Accept: application/json, text/event-stream" \
+  -X POST http://localhost:4010/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | tee /tmp/mc-validation/mcp-surface-v2/baseline/tools-list-default.json
+
+# After PR 2:
+curl ... http://localhost:4010/api/mcp/pm    > /tmp/.../tools-list-pm.json
+curl ... http://localhost:4010/api/mcp/crud  > /tmp/.../tools-list-crud.json
+```
+
+Tool counts: pre-PR1 = 47 on default. Post-PR1 = 47 on default. Post-PR4 = 45. Post-PR5 = 44. Post-PR2 = ~16 on `/api/mcp/pm`, ~16 on `/api/mcp/crud`.
+
+## 5. Openclaw config sanity (PR 3 / PR 3.5 onward)
+
+```sh
+yarn openclaw:apply-mc-servers --dry-run    > /tmp/.../openclaw-apply-dryrun.txt
+yarn openclaw:sync-named-agents --dry-run   > /tmp/.../sync-named-dryrun.txt
+```
+
+Empty diff after live runs = idempotent ✅.
+
+## 6. PM gateway alive
+
+Browse to `http://localhost:4010/pm` (or LAN equivalent). Confirm the chat panel renders, no console errors.
+
+## 7. Capture roots
+
+```sh
+mkdir -p /tmp/mc-validation/mcp-surface-v2/{baseline,V1,V2,V3,V4,V5,V6}
+```
+
+## Halt conditions
+
+- `yarn test` regresses vs baseline → halt, surface failures.
+- MCP `tools/list` count off-by-one from expected → halt, diff against baseline.
+- Dev server fails to start → halt.
+- openclaw.json edit not idempotent on second `--dry-run` → halt, debug script.

--- a/specs/mcp-surface-v2-validation/02-test-plan.md
+++ b/specs/mcp-surface-v2-validation/02-test-plan.md
@@ -1,0 +1,118 @@
+# 02 — Test plan
+
+Six scenarios. Each ~5 min real-agent time. Capture per-scenario at `/tmp/mc-validation/mcp-surface-v2/<id>/`.
+
+All real-agent dispatches use `spark-lb/agent` per `project_openclaw_model.md`.
+
+## V1 — PM endpoint surfaces only PM-relevant tools
+
+**Tests:** PR 1 (refactor), PR 2 (route).
+
+**Setup:** Dev server up. PM gateway points at `/api/mcp/pm` (PR 3 applied).
+
+**Action:**
+```sh
+curl ... -X POST http://localhost:4010/api/mcp/pm \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  > /tmp/mc-validation/mcp-surface-v2/V1/tools-list.json
+```
+
+**Observation:**
+- Tool count ~16 (core 5 + read 9 + pm 4 = 18, ±1 depending on final group split).
+- `register_deliverable`, `submit_evidence`, `update_task_status`, `fail_task`, `spawn_subtask`, `update_subtask`, `register_subagent_dispatch` **absent**.
+- `propose_changes`, `propose_from_notes`, `refine_proposal`, `preview_derivation`, `add_owner_availability` **present**.
+- `whoami`, `list_peers`, `get_workspace_context`, `list_initiatives`, `get_initiative_tree`, `get_roadmap_snapshot` **present**.
+
+## V2 — Default endpoint preserves runner surface
+
+**Tests:** PR 1 (refactor) regression check.
+
+**Setup:** Same.
+
+**Action:**
+```sh
+curl ... -X POST http://localhost:4010/api/mcp \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  > /tmp/mc-validation/mcp-surface-v2/V2/tools-list.json
+```
+
+**Observation:**
+- Tool count = 44 post-PR5 (47 baseline − 3 subtask ± 1 update_subtask − 2 note ± 1 update_note = 47 − 3 + 1 − 2 + 1 = 44).
+- `update_subtask`, `update_note` present.
+- `accept_subtask`, `reject_subtask`, `cancel_subtask`, `mark_note_consumed`, `archive_note` absent.
+
+## V3 — `_shared` edit propagates to named agents via sync script
+
+**Tests:** PR 3.5.
+
+**Setup:** Stack landed through PR 3.5. Dev workspace dirs at `~/.openclaw/workspaces/mc-{pm-default,runner}-dev/` exist.
+
+**Action:**
+1. Snapshot `~/.openclaw/workspaces/mc-pm-default-dev/AGENTS.md` → `before.md`.
+2. Append a one-line marker to `agent-templates/_shared/messaging-protocol.md`: `<!-- v3-validation-marker -->`.
+3. `yarn openclaw:sync-named-agents --dry-run` → expect a non-empty diff for both `mc-pm-default-dev` and `mc-runner-dev`.
+4. `yarn openclaw:sync-named-agents` → file rewritten.
+5. Snapshot `AGENTS.md` again → `after.md`. Diff must include the marker.
+6. `yarn openclaw:sync-named-agents --dry-run` again → empty diff (idempotent).
+7. Revert the `_shared` edit; re-run sync; verify roundtrip.
+
+**Observation:** capture all four files (`before.md`, `after.md`, two dry-run logs, post-revert) under `V3/`.
+
+## V4 — Coordinator dispatch uses `update_subtask`
+
+**Tests:** PR 4.
+
+**Setup:** Seed a parent task with a coordinator role + at least one spawned subtask. Use existing seed flow or `yarn db:seed` plus a hand-issued `spawn_subtask` via curl.
+
+**Action:** Dispatch the coordinator against the parent task. Capture transcript.
+
+**Observation:**
+- Coordinator briefing references `update_subtask`, not the old verbs.
+- At least one tool call to `update_subtask({action: "accept" | "reject" | "cancel"})` lands.
+- Subtask status transitions correctly in `tasks` table.
+
+**Capture:** transcript (`transcript.txt`), SSE events (`sse.log`), final DB row state (`subtask-row.json`).
+
+## V5 — Worker dispatch consumes/archives a note
+
+**Tests:** PR 5.
+
+**Setup:** Seed a worker task with at least one inbound note (`audience='builder'` or similar). PM-style note recipient flow.
+
+**Action:** Dispatch the worker. Capture transcript.
+
+**Observation:**
+- Worker briefing references `update_note` for both consume and archive paths.
+- At least one tool call to `update_note({action: "consume", stage_slug: ...})` lands.
+- Note `consumed_at` (or equivalent) is set in DB.
+
+**Capture:** as V4.
+
+## V6 — PM `propose_changes` flow unaffected by route split
+
+**Tests:** PR 2 regression check.
+
+**Setup:** PM points at `/api/mcp/pm`. Operator dispatches a small prompt that should produce a proposal (e.g. "Set initiative X to in_progress").
+
+**Action:** Send PM chat via UI. Capture chat events.
+
+**Observation:**
+- `propose_changes` tool call lands successfully.
+- Proposal card appears in PM chat.
+- `proposals` table has a new row.
+- No 404 / 500 from `/api/mcp/pm`.
+
+**Capture:** chat-events log (`chat-events.log`), proposal row (`proposal.json`), screenshot.
+
+## Time budget
+
+| Scenario | Expected real-agent minutes | Retries permitted |
+|---|---|---|
+| V1 | 0 (curl only) | n/a |
+| V2 | 0 (curl only) | n/a |
+| V3 | 0 (script only) | n/a |
+| V4 | ~5 | 2 (FLAKE policy: pass if 2/3) |
+| V5 | ~5 | 2 |
+| V6 | ~5 | 2 |
+
+Total worst-case real-agent dispatches: 9.

--- a/specs/mcp-surface-v2-validation/03-validation-criteria.md
+++ b/specs/mcp-surface-v2-validation/03-validation-criteria.md
@@ -1,0 +1,62 @@
+# 03 — Validation criteria
+
+Pass requires every gate in a scenario AND-ed; final verdict requires all scenarios + global gates.
+
+## Per-scenario gates
+
+### V1 — PM endpoint surface
+- G1.1 `tools/list` returns ≤ 20 tools.
+- G1.2 None of: `register_deliverable`, `submit_evidence`, `update_task_status`, `fail_task`, `spawn_subtask`, `update_subtask`, `register_subagent_dispatch`.
+- G1.3 All of: `propose_changes`, `propose_from_notes`, `refine_proposal`, `preview_derivation`, `add_owner_availability`.
+- G1.4 All of: `whoami`, `list_peers`, `get_workspace_context`.
+
+### V2 — Default endpoint regression
+- G2.1 `tools/list` count = 44 (after full stack lands).
+- G2.2 `update_subtask` and `update_note` present.
+- G2.3 `accept_subtask`, `reject_subtask`, `cancel_subtask`, `mark_note_consumed`, `archive_note` absent.
+
+### V3 — `_shared` propagation
+- G3.1 Marker appears in `mc-pm-default-dev/AGENTS.md` after sync.
+- G3.2 Marker appears in `mc-runner-dev/AGENTS.md` after sync.
+- G3.3 Second `--dry-run` is empty (idempotent).
+- G3.4 Reverting the `_shared` edit + re-syncing removes the marker (round-trip).
+- G3.5 No file outside the named-agent workspace dirs is touched.
+
+### V4 — Coordinator uses `update_subtask`
+- G4.1 Coordinator briefing references `update_subtask` (grep transcript).
+- G4.2 ≥ 1 `update_subtask` tool call in transcript.
+- G4.3 Subtask status moved correctly per the action requested (accept/reject/cancel).
+- G4.4 No reference to old verbs in briefing.
+
+### V5 — Worker uses `update_note`
+- G5.1 Worker briefing references `update_note`.
+- G5.2 ≥ 1 `update_note` tool call in transcript.
+- G5.3 Note row has `consumed_at` set or `archived_at` set as expected.
+- G5.4 No reference to `mark_note_consumed` or `archive_note` in briefing.
+
+### V6 — PM `propose_changes` flow
+- G6.1 Tool call to `propose_changes` lands without 404/500.
+- G6.2 New `proposals` row created with the expected `kind`.
+- G6.3 Proposal card renders in PM chat UI.
+- G6.4 No console errors / SSE errors during dispatch.
+
+## Global gates
+
+- GG1 `yarn test` passes (or only pre-existing failures listed in 04).
+- GG2 `yarn mcp:smoke` passes.
+- GG3 No unhandled errors in dev server log across the run.
+- GG4 `yarn openclaw:apply-mc-servers --dry-run` is empty after the live apply step (idempotence).
+- GG5 `yarn openclaw:sync-named-agents --dry-run` is empty after the live apply step (idempotence).
+
+## FLAKE policy
+
+V4 / V5 / V6 (real-agent) may flake on model output. Re-run up to 3×; pass if ≥ 2/3 pass with all gates.
+
+## Verdict matrix
+
+| Verdict | Condition |
+|---|---|
+| **GREEN** | All scenarios + all global gates pass. |
+| **YELLOW** | All scenarios pass; 1 global gate is a pre-existing failure (must be enumerated). |
+| **BLOCKED** | Pre-check fails or environment can't reach baseline. |
+| **RED** | Any scenario gate fails after FLAKE retries, or any global gate fails for a non-pre-existing reason. |

--- a/specs/mcp-surface-v2-validation/04-e2e-run-results.md
+++ b/specs/mcp-surface-v2-validation/04-e2e-run-results.md
@@ -1,0 +1,59 @@
+# 04 — E2E run results
+
+_Filled in during/after the validation run. Operator reads this to decide "ship the stack."_
+
+## Verdict
+
+**TBD** — populated after PR 6 lands and validation runs.
+
+## Summary paragraph
+
+_(one paragraph: what passed, what didn't, any surprises)_
+
+## Per-scenario results
+
+| Scenario | Verdict | Notes / evidence pointer |
+|---|---|---|
+| V1 — PM endpoint surface | TBD | `/tmp/mc-validation/mcp-surface-v2/V1/` |
+| V2 — Default endpoint regression | TBD | `/tmp/mc-validation/mcp-surface-v2/V2/` |
+| V3 — `_shared` propagation | TBD | `/tmp/mc-validation/mcp-surface-v2/V3/` |
+| V4 — Coordinator `update_subtask` | TBD | `/tmp/mc-validation/mcp-surface-v2/V4/` |
+| V5 — Worker `update_note` | TBD | `/tmp/mc-validation/mcp-surface-v2/V5/` |
+| V6 — PM `propose_changes` | TBD | `/tmp/mc-validation/mcp-surface-v2/V6/` |
+
+## Global gates
+
+| Gate | Verdict | Notes |
+|---|---|---|
+| GG1 `yarn test` | TBD | |
+| GG2 `yarn mcp:smoke` | TBD | |
+| GG3 dev server clean | TBD | |
+| GG4 apply-mc-servers idempotent | TBD | |
+| GG5 sync-named-agents idempotent | TBD | |
+
+## Pre-existing test failures (carried in)
+
+Captured at branch-cut (commit base = `b3ee394`):
+
+| Test | File | Reason |
+|---|---|---|
+| `schedule-runner: produces a brief and advances run_count` | `src/lib/research/eval/schedule-runner.test.ts:23` | Flake in `runBriefInternal` orchestrator — `markComplete: agent_run … not found`. Unrelated to MCP surface work. Track as separate follow-up. |
+
+722 tests total, 721 pass, 1 fail. Treat as carried-forward; don't gate this stack on it.
+
+## Issues found
+
+_(per-PR issues that surfaced during validation; whether fixed in-stack or filed for follow-up)_
+
+## Token-savings measurement
+
+| Endpoint | Tool count | Approx token cost |
+|---|---|---|
+| `/api/mcp` (default, post-stack) | TBD | TBD |
+| `/api/mcp/pm` | TBD | TBD |
+| `/api/mcp/crud` | TBD | TBD |
+| Savings vs baseline (PM dispatch) | — | TBD |
+
+## Sign-off
+
+_Operator review here._

--- a/specs/mcp-surface-v2-validation/README.md
+++ b/specs/mcp-surface-v2-validation/README.md
@@ -1,0 +1,17 @@
+# MCP surface v2 — validation pack
+
+Validation pack for [`../mcp-surface-v2-build-plan.md`](../mcp-surface-v2-build-plan.md) against [`../mcp-surface-review.md`](../mcp-surface-review.md).
+
+## Order to read
+
+1. [`00-baseline-observations.md`](./00-baseline-observations.md) — state before any slice lands
+2. [`01-pre-check-initialization.md`](./01-pre-check-initialization.md) — destructive runbook to reach a clean baseline
+3. [`02-test-plan.md`](./02-test-plan.md) — V1–V6 scenarios with setup/action/observation
+4. [`03-validation-criteria.md`](./03-validation-criteria.md) — gates per scenario + globals
+5. [`04-e2e-run-results.md`](./04-e2e-run-results.md) — verdict + evidence (written after run)
+
+## How this pack is used
+
+Per [`../long-unattended-feature-dev.md`](../long-unattended-feature-dev.md): every slice has its own per-PR test plan in the PR body for spot-checking; this pack is what the operator reads to decide "ship the stack." All real-agent dispatches use `spark-lb/agent`.
+
+Capture root: `/tmp/mc-validation/mcp-surface-v2/<scenario>/`.


### PR DESCRIPTION
## Summary

Foundation for the long-unattended MCP surface refactor stack. Build plan + validation pack only — no code changes, no behavior changes. Stacks PR 1–PR 6 follow.

Implements the [`long-unattended-feature-dev.md`](specs/long-unattended-feature-dev.md) contract against the [merged spec](specs/mcp-surface-review.md).

## Changes

- `specs/mcp-surface-v2-build-plan.md` — design decisions + slice plan + test strategy per PR
- `specs/mcp-surface-v2-validation/` (6 docs) — README, baseline, pre-check, test plan (V1–V6), criteria, run results
- Pre-existing test failure recorded: `schedule-runner.test.ts:23` (1/722 fail at branch-cut, unrelated to MCP work)

## Test plan

- [ ] Operator reviews build plan + validation pack before any code lands
- [ ] No code changes — `yarn test` baseline already captured (721/722)

## Stack order

1. **This PR (foundation)**
2. PR 1 — refactor into scope groups
3. PR 2 — `/api/mcp/pm` + `/api/mcp/crud` routes
4. PR 3 — `yarn openclaw:apply-mc-servers`
5. PR 3.5 — `yarn openclaw:sync-named-agents`
6. PR 4 — consolidate subtask actions
7. PR 5 — consolidate note lifecycle
8. PR 6 — doc-only (extension principle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)