### PR TITLE
feat(scripts): yarn openclaw:sync-named-agents (PR 3.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "openclaw:sync:check": "node scripts/sync-openclaw-agents.mjs --dry-run",
     "openclaw:apply-mc-servers": "node scripts/apply-mc-servers.mjs",
     "openclaw:apply-mc-servers:check": "node scripts/apply-mc-servers.mjs --dry-run",
+    "openclaw:sync-named-agents": "node scripts/sync-named-agent-workspaces.mjs",
+    "openclaw:sync-named-agents:check": "node scripts/sync-named-agent-workspaces.mjs --dry-run",
     "workspace:export": "tsx scripts/export-workspace.ts",
     "workspace:import": "tsx scripts/import-workspace.ts",
     "workspace:provision": "tsx scripts/provision-workspace-runner.ts",

--- a/scripts/sync-named-agent-workspaces.mjs
+++ b/scripts/sync-named-agent-workspaces.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * sync-named-agent-workspaces.mjs
+ *
+ * Keeps the named gateway agents' on-disk workspace files
+ * (~/.openclaw/workspaces/mc-{pm-*,runner}-{dev,stable}/) in sync with
+ * the canonical templates in agent-templates/.
+ *
+ * Why: runner-hosted personas resolve _shared addenda dynamically at
+ * MC's briefing-build time, so an edit to agent-templates/_shared/*.md
+ * propagates next dispatch. Named gateway agents (PM, runner-host)
+ * read AGENTS.md / SOUL.md / IDENTITY.md / MESSAGING-PROTOCOL.md /
+ * SHARED-RULES.md as physical files at session start, OUTSIDE MC's
+ * briefing pipeline. Without this script, edits to _shared or to
+ * agent-templates/{pm,runner-host}/ silently diverge from what those
+ * named agents actually read.
+ *
+ * What it does, idempotently:
+ *
+ *   For each workspace dir matching ~/.openclaw/workspaces/mc-{pm-*,runner}-{,-dev}/:
+ *     - Detect role: mc-pm-* → 'pm', mc-runner / mc-runner-dev → 'runner-host'.
+ *     - For each (workspace-file → template-source) pair:
+ *         SOUL.md            ← agent-templates/<role>/SOUL.md
+ *         AGENTS.md          ← agent-templates/<role>/AGENTS.md
+ *         IDENTITY.md        ← agent-templates/<role>/IDENTITY.md
+ *       PLUS (runner-host only — the PM workspace doesn't mirror these):
+ *         MESSAGING-PROTOCOL.md ← agent-templates/_shared/messaging-protocol.md
+ *         SHARED-RULES.md    ← agent-templates/_shared/shared-rules.md
+ *       Write the template content into the workspace file if it differs.
+ *       Take a .bak.<ts> snapshot before the first overwrite of each file.
+ *
+ *   Operator-managed files (TOOLS.md, HEARTBEAT.md, USER.md, MC-CONTEXT.json,
+ *   MEMORY-ORG.md, the memory/, projects/, skills/ dirs, etc.) are not
+ *   touched — they're outside the allowlist.
+ *
+ *   Dirs that don't match the mc-{pm,runner} regex are skipped silently
+ *   (covers non-MC openclaw workspaces).
+ *
+ * Usage:
+ *   node scripts/sync-named-agent-workspaces.mjs              # apply, write back
+ *   node scripts/sync-named-agent-workspaces.mjs --dry-run    # report only (exits 2 on drift)
+ *   node scripts/sync-named-agent-workspaces.mjs --root=PATH  # alt workspaces root
+ *   node scripts/sync-named-agent-workspaces.mjs --templates=PATH  # alt agent-templates root
+ *
+ * Exits non-zero on parse errors or when --dry-run finds drift.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+// ─── role detection ─────────────────────────────────────────────────
+
+const PM_DIR_RE = /^mc-pm-[a-z0-9-]+?(?:-dev)?$/;
+const RUNNER_DIR_RE = /^mc-runner(?:-dev)?$/;
+
+function roleForWorkspaceDir(dirName) {
+  if (PM_DIR_RE.test(dirName)) return 'pm';
+  if (RUNNER_DIR_RE.test(dirName)) return 'runner-host';
+  return null;
+}
+
+// ─── file pair plan ─────────────────────────────────────────────────
+
+/**
+ * Per-role list of `{ wsFile, templatePath }` pairs to keep in sync.
+ * `templatePath` is relative to `agent-templates/`.
+ */
+function syncPlanForRole(role) {
+  const common = [
+    { wsFile: 'SOUL.md',     templatePath: `${role}/SOUL.md` },
+    { wsFile: 'AGENTS.md',   templatePath: `${role}/AGENTS.md` },
+    { wsFile: 'IDENTITY.md', templatePath: `${role}/IDENTITY.md` },
+  ];
+  if (role === 'runner-host') {
+    return [
+      ...common,
+      { wsFile: 'MESSAGING-PROTOCOL.md', templatePath: '_shared/messaging-protocol.md' },
+      { wsFile: 'SHARED-RULES.md',       templatePath: '_shared/shared-rules.md' },
+    ];
+  }
+  return common;
+}
+
+// ─── sync loop ──────────────────────────────────────────────────────
+
+async function readIfExists(p) {
+  try {
+    return await fs.readFile(p, 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+async function syncWorkspace({ wsDir, role, templatesRoot, dryRun, results }) {
+  const plan = syncPlanForRole(role);
+  for (const { wsFile, templatePath } of plan) {
+    const fullWsFile = path.join(wsDir, wsFile);
+    const fullTemplate = path.join(templatesRoot, templatePath);
+
+    const [wsContent, templateContent] = await Promise.all([
+      readIfExists(fullWsFile),
+      readIfExists(fullTemplate),
+    ]);
+
+    if (templateContent === null) {
+      results.push({
+        wsDir,
+        wsFile,
+        kind: 'skip',
+        reason: `template missing: ${templatePath}`,
+      });
+      continue;
+    }
+
+    if (wsContent === null) {
+      // Workspace file doesn't exist. We don't create files implicitly —
+      // that surfaces as a misconfiguration the operator should review.
+      results.push({
+        wsDir,
+        wsFile,
+        kind: 'missing',
+        reason: 'workspace file does not exist (skipping; create manually if intended)',
+      });
+      continue;
+    }
+
+    if (wsContent === templateContent) {
+      results.push({ wsDir, wsFile, kind: 'in-sync' });
+      continue;
+    }
+
+    if (!dryRun) {
+      const backupPath = `${fullWsFile}.bak.${Date.now()}`;
+      await fs.copyFile(fullWsFile, backupPath);
+      await fs.writeFile(fullWsFile, templateContent, 'utf8');
+      results.push({
+        wsDir,
+        wsFile,
+        kind: 'updated',
+        backup: path.basename(backupPath),
+      });
+    } else {
+      results.push({ wsDir, wsFile, kind: 'drift' });
+    }
+  }
+}
+
+// ─── main ───────────────────────────────────────────────────────────
+
+function repoRoot() {
+  // This file lives at <repo>/scripts/sync-named-agent-workspaces.mjs.
+  const here = fileURLToPath(import.meta.url);
+  return path.resolve(path.dirname(here), '..');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+
+  const rootFlag = args.find((a) => a.startsWith('--root='));
+  const wsRoot = rootFlag
+    ? rootFlag.slice('--root='.length).replace(/^~/, os.homedir())
+    : path.join(os.homedir(), '.openclaw', 'workspaces');
+
+  const tplFlag = args.find((a) => a.startsWith('--templates='));
+  const templatesRoot = tplFlag
+    ? tplFlag.slice('--templates='.length).replace(/^~/, os.homedir())
+    : path.join(repoRoot(), 'agent-templates');
+
+  console.log(`[sync-named-agents] workspaces root: ${wsRoot}`);
+  console.log(`[sync-named-agents] templates root: ${templatesRoot}`);
+  console.log(`[sync-named-agents] mode: ${dryRun ? 'dry-run' : 'write'}`);
+
+  const entries = await fs.readdir(wsRoot, { withFileTypes: true });
+
+  const results = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const role = roleForWorkspaceDir(entry.name);
+    if (!role) continue;
+    const wsDir = path.join(wsRoot, entry.name);
+    await syncWorkspace({ wsDir, role, templatesRoot, dryRun, results });
+  }
+
+  let drift = 0;
+  let updated = 0;
+  let inSync = 0;
+  let missing = 0;
+  let skipped = 0;
+  for (const r of results) {
+    const tag = `[sync-named-agents] ${path.basename(r.wsDir)}/${r.wsFile}`;
+    switch (r.kind) {
+      case 'in-sync': inSync++; break;
+      case 'updated':
+        updated++;
+        console.log(`${tag}: updated (backup: ${r.backup})`);
+        break;
+      case 'drift':
+        drift++;
+        console.log(`${tag}: drift — would update`);
+        break;
+      case 'missing':
+        missing++;
+        console.log(`${tag}: ${r.reason}`);
+        break;
+      case 'skip':
+        skipped++;
+        console.log(`${tag}: skip — ${r.reason}`);
+        break;
+    }
+  }
+
+  console.log(
+    `[sync-named-agents] summary: ` +
+      `${inSync} in-sync, ${updated} updated, ${drift} drift, ${missing} missing, ${skipped} skipped`,
+  );
+
+  if (dryRun && drift > 0) {
+    process.exitCode = 2;
+  }
+}
+
+main().catch((err) => {
+  console.error(`[sync-named-agents] ERROR: ${err.message}`);
+  process.exit(1);
+});

--- a/src/lib/scripts/sync-named-agent-workspaces.test.ts
+++ b/src/lib/scripts/sync-named-agent-workspaces.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for scripts/sync-named-agent-workspaces.mjs.
+ *
+ * Builds a fixture workspaces tree + templates tree under tmpdir, runs
+ * the script via execFileSync, and asserts on file contents + exit
+ * codes. Validates idempotence (second dry-run must exit 0) and the
+ * round-trip (revert template, re-sync, original content restored).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SCRIPT = join(process.cwd(), 'scripts', 'sync-named-agent-workspaces.mjs');
+
+interface FixtureLayout {
+  templates: { path: string };
+  workspaces: { path: string };
+  pmDir: string;
+  runnerDir: string;
+}
+
+function makeFixture(): FixtureLayout {
+  const root = mkdtempSync(join(tmpdir(), 'sync-named-agents-'));
+  const templates = join(root, 'templates');
+  const workspaces = join(root, 'workspaces');
+
+  // Templates
+  mkdirSync(join(templates, 'pm'), { recursive: true });
+  mkdirSync(join(templates, 'runner-host'), { recursive: true });
+  mkdirSync(join(templates, '_shared'), { recursive: true });
+  writeFileSync(join(templates, 'pm', 'SOUL.md'), 'PM SOUL v2\n');
+  writeFileSync(join(templates, 'pm', 'AGENTS.md'), 'PM AGENTS v2\n');
+  writeFileSync(join(templates, 'pm', 'IDENTITY.md'), 'PM IDENTITY v2\n');
+  writeFileSync(join(templates, 'runner-host', 'SOUL.md'), 'RUNNER SOUL v2\n');
+  writeFileSync(join(templates, 'runner-host', 'AGENTS.md'), 'RUNNER AGENTS v2\n');
+  writeFileSync(join(templates, 'runner-host', 'IDENTITY.md'), 'RUNNER IDENTITY v2\n');
+  writeFileSync(join(templates, '_shared', 'messaging-protocol.md'), 'MSG PROTOCOL v2\n');
+  writeFileSync(join(templates, '_shared', 'shared-rules.md'), 'SHARED RULES v2\n');
+
+  // Workspaces — start with stale content
+  const pmDir = join(workspaces, 'mc-pm-default-dev');
+  mkdirSync(pmDir, { recursive: true });
+  writeFileSync(join(pmDir, 'SOUL.md'), 'PM SOUL v1 (stale)\n');
+  writeFileSync(join(pmDir, 'AGENTS.md'), 'PM AGENTS v1 (stale)\n');
+  writeFileSync(join(pmDir, 'IDENTITY.md'), 'PM IDENTITY v2\n'); // already in sync
+  writeFileSync(join(pmDir, 'TOOLS.md'), 'OPERATOR-MANAGED\n');  // must NOT be touched
+
+  const runnerDir = join(workspaces, 'mc-runner-dev');
+  mkdirSync(runnerDir, { recursive: true });
+  writeFileSync(join(runnerDir, 'SOUL.md'), 'RUNNER SOUL v1 (stale)\n');
+  writeFileSync(join(runnerDir, 'AGENTS.md'), 'RUNNER AGENTS v2\n');
+  writeFileSync(join(runnerDir, 'IDENTITY.md'), 'RUNNER IDENTITY v1 (stale)\n');
+  writeFileSync(join(runnerDir, 'MESSAGING-PROTOCOL.md'), 'MSG PROTOCOL v1 (stale)\n');
+  writeFileSync(join(runnerDir, 'SHARED-RULES.md'), 'SHARED RULES v2\n');
+
+  // Untouchable: non-mc workspace dir, must be skipped silently
+  const otherDir = join(workspaces, 'random-other-workspace');
+  mkdirSync(otherDir, { recursive: true });
+  writeFileSync(join(otherDir, 'SOUL.md'), 'NOT OURS\n');
+
+  return {
+    templates: { path: templates },
+    workspaces: { path: workspaces },
+    pmDir,
+    runnerDir,
+  };
+}
+
+function run(fix: FixtureLayout, opts: { dryRun?: boolean } = {}): { stdout: string; status: number } {
+  try {
+    const stdout = execFileSync(
+      'node',
+      [
+        SCRIPT,
+        `--root=${fix.workspaces.path}`,
+        `--templates=${fix.templates.path}`,
+        ...(opts.dryRun ? ['--dry-run'] : []),
+      ],
+      { encoding: 'utf8' },
+    );
+    return { stdout, status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; status?: number };
+    return { stdout: e.stdout ?? '', status: e.status ?? 1 };
+  }
+}
+
+test('sync-named-agents: dry-run reports drift and exits 2', () => {
+  const fix = makeFixture();
+  try {
+    const r = run(fix, { dryRun: true });
+    assert.equal(r.status, 2, 'dry-run with drift exits 2');
+    assert.match(r.stdout, /mc-pm-default-dev\/SOUL\.md: drift/);
+    assert.match(r.stdout, /mc-pm-default-dev\/AGENTS\.md: drift/);
+    assert.match(r.stdout, /mc-runner-dev\/SOUL\.md: drift/);
+    assert.match(r.stdout, /mc-runner-dev\/MESSAGING-PROTOCOL\.md: drift/);
+    // Untouched files
+    assert.equal(readFileSync(join(fix.pmDir, 'SOUL.md'), 'utf8'), 'PM SOUL v1 (stale)\n');
+  } finally {
+    rmSync(fix.workspaces.path, { recursive: true, force: true });
+    rmSync(fix.templates.path, { recursive: true, force: true });
+  }
+});
+
+test('sync-named-agents: write mode replaces stale + leaves operator files alone', () => {
+  const fix = makeFixture();
+  try {
+    const r = run(fix);
+    assert.equal(r.status, 0);
+
+    // Stale files updated to template content
+    assert.equal(readFileSync(join(fix.pmDir, 'SOUL.md'), 'utf8'), 'PM SOUL v2\n');
+    assert.equal(readFileSync(join(fix.pmDir, 'AGENTS.md'), 'utf8'), 'PM AGENTS v2\n');
+    assert.equal(readFileSync(join(fix.runnerDir, 'SOUL.md'), 'utf8'), 'RUNNER SOUL v2\n');
+    assert.equal(readFileSync(join(fix.runnerDir, 'IDENTITY.md'), 'utf8'), 'RUNNER IDENTITY v2\n');
+    assert.equal(readFileSync(join(fix.runnerDir, 'MESSAGING-PROTOCOL.md'), 'utf8'), 'MSG PROTOCOL v2\n');
+
+    // Operator-managed file untouched
+    assert.equal(readFileSync(join(fix.pmDir, 'TOOLS.md'), 'utf8'), 'OPERATOR-MANAGED\n');
+
+    // .bak files exist for what we changed
+    const pmFiles = readdirSync(fix.pmDir);
+    assert.ok(pmFiles.some((f) => f.startsWith('SOUL.md.bak.')), 'PM SOUL backup created');
+    assert.ok(pmFiles.some((f) => f.startsWith('AGENTS.md.bak.')), 'PM AGENTS backup created');
+    assert.ok(!pmFiles.some((f) => f.startsWith('IDENTITY.md.bak.')), 'in-sync file should not have backup');
+    assert.ok(!pmFiles.some((f) => f.startsWith('TOOLS.md.bak.')), 'operator file should not have backup');
+  } finally {
+    rmSync(fix.workspaces.path, { recursive: true, force: true });
+    rmSync(fix.templates.path, { recursive: true, force: true });
+  }
+});
+
+test('sync-named-agents: idempotent — second dry-run exits 0', () => {
+  const fix = makeFixture();
+  try {
+    run(fix); // apply
+    const second = run(fix, { dryRun: true });
+    assert.equal(second.status, 0, 'second --dry-run on synced tree must exit 0');
+    assert.match(second.stdout, /summary:.*0 drift/);
+  } finally {
+    rmSync(fix.workspaces.path, { recursive: true, force: true });
+    rmSync(fix.templates.path, { recursive: true, force: true });
+  }
+});
+
+test('sync-named-agents: roundtrip — revert template, re-sync, marker absent', () => {
+  const fix = makeFixture();
+  try {
+    // Apply once
+    run(fix);
+
+    // Inject a marker into the template
+    const soulPath = join(fix.templates.path, 'pm', 'SOUL.md');
+    writeFileSync(soulPath, 'PM SOUL v3 + marker\n');
+    run(fix);
+    assert.equal(readFileSync(join(fix.pmDir, 'SOUL.md'), 'utf8'), 'PM SOUL v3 + marker\n');
+
+    // Revert template, re-sync
+    writeFileSync(soulPath, 'PM SOUL v2\n');
+    run(fix);
+    assert.equal(readFileSync(join(fix.pmDir, 'SOUL.md'), 'utf8'), 'PM SOUL v2\n');
+  } finally {
+    rmSync(fix.workspaces.path, { recursive: true, force: true });
+    rmSync(fix.templates.path, { recursive: true, force: true });
+  }
+});
+
+test('sync-named-agents: skips non-mc workspace dirs', () => {
+  const fix = makeFixture();
+  try {
+    const before = readFileSync(join(fix.workspaces.path, 'random-other-workspace', 'SOUL.md'), 'utf8');
+    run(fix);
+    const after = readFileSync(join(fix.workspaces.path, 'random-other-workspace', 'SOUL.md'), 'utf8');
+    assert.equal(after, before, 'non-mc workspaces must not be touched');
+  } finally {
+    rmSync(fix.workspaces.path, { recursive: true, force: true });
+    rmSync(fix.templates.path, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

PR 3.5 of the MCP surface v2 stack. New script propagating in-repo agent template edits into the on-disk gateway-agent workspaces. Closes the gap where `_shared/*.md` edits propagate to runner-hosted personas automatically but leave named gateway agents stale.

Stacks on **#215**.

**Sequenced before PR 4 and PR 5** because those are the first concrete `_shared/messaging-protocol.md` edits since this gap was identified.

## Changes

- `scripts/sync-named-agent-workspaces.mjs` — for each `~/.openclaw/workspaces/mc-{pm-*,runner}-{,-dev}/`, recomposes SOUL.md / AGENTS.md / IDENTITY.md from `agent-templates/<role>/`, and additionally MESSAGING-PROTOCOL.md / SHARED-RULES.md from `agent-templates/_shared/` for runner-host. Operator-managed files (TOOLS.md, HEARTBEAT.md, USER.md, MC-CONTEXT.json, MEMORY-ORG.md, memory/, projects/, skills/) are untouched. Timestamped per-file `.bak.<ts>` backups taken before each overwrite. Idempotent.
- `package.json` — adds `yarn openclaw:sync-named-agents` and `yarn openclaw:sync-named-agents:check` scripts.
- `src/lib/scripts/sync-named-agent-workspaces.test.ts` — 5 tests: dry-run drift detection, write-mode rewrites + operator-file preservation, idempotence, roundtrip (revert template → re-sync → original restored), non-mc-workspace skip.

## Test plan

- [x] Unit tests: 9/9 pass against tmpfile fixtures (5 new + 4 from prior PR).
- [x] Live smoke `yarn openclaw:sync-named-agents:check` against real `~/.openclaw/workspaces`: detects 6 drifts. Exits 2. ✅

## Detected drifts (real config)

```
[sync-named-agents] mc-pm-default-dev/SOUL.md: drift — would update
[sync-named-agents] mc-pm-default-dev/AGENTS.md: drift — would update
[sync-named-agents] mc-pm-foia-dev/SOUL.md: drift — would update
[sync-named-agents] mc-pm-foia-dev/AGENTS.md: drift — would update
[sync-named-agents] mc-runner/MESSAGING-PROTOCOL.md: drift — would update
[sync-named-agents] mc-runner-dev/MESSAGING-PROTOCOL.md: drift — would update
summary: 10 in-sync, 0 updated, 6 drift, 0 missing, 0 skipped
```

The PM SOUL drifts include the rewrite from PR 2 (the "use propose_changes" framing) waiting to land; once the stack merges, a single `yarn openclaw:sync-named-agents` run brings everyone current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)