### PR TITLE
refactor(mcp): consolidate subtask actions into update_subtask (PR 4)

### DIFF
--- a/agent-templates/_shared/messaging-protocol.md
+++ b/agent-templates/_shared/messaging-protocol.md
@@ -60,9 +60,7 @@ If your *role* is `coordinator` (set in the dispatch briefing — most subagents
 | Action | Tool |
 |---|---|
 | Delegate a slice to a peer (creates a child task in the convoy) | `spawn_subtask({ agent_id, task_id, peer_gateway_id, slice, message, expected_deliverables, acceptance_criteria, expected_duration_minutes, … })` |
-| Accept a delivered child slice | `accept_subtask({ agent_id, subtask_id })` |
-| Reject a delivered child slice (loops back to peer) | `reject_subtask({ agent_id, subtask_id, reason, new_acceptance_criteria? })` |
-| Cancel a stuck or out-of-scope slice | `cancel_subtask({ agent_id, subtask_id, reason })` |
+| Accept / reject / cancel a delivered child slice | `update_subtask({ agent_id, subtask_id, action: 'accept' \| 'reject' \| 'cancel', reason?, new_acceptance_criteria? })` — `accept` needs no extras; `reject` needs `reason` (≥10 chars) and optional `new_acceptance_criteria`; `cancel` needs `reason` (≥5 chars). |
 | List my active subtasks ("who am I waiting on?") | `list_my_subtasks({ agent_id, task_id, states? })` |
 
 Peer sub-delegation is rejected by authz — only the task's coordinator can `spawn_subtask`.

--- a/agent-templates/coordinator/AGENTS.md
+++ b/agent-templates/coordinator/AGENTS.md
@@ -11,7 +11,7 @@ The dispatch briefing is authoritative. It carries your `agent_id`, the parent `
 3. **Discover peers.** `list_peers({ agent_id })` returns the workspace roster: `{ gateway_id, mc_agent_id, name, role }`. Never hardcode gateway ids; rosters are workspace-specific.
 4. **Delegate.** One `spawn_subtask` per slice (see contract below).
 5. **Track.** `list_my_subtasks({ task_id })` returns derived per-row state. Re-poll after major events; don't loop tightly.
-6. **Accept / reject / cancel.** Each delivered slice gets one of `accept_subtask` (success), `reject_subtask` (loop back with revision), or `cancel_subtask` (dead branch).
+6. **Accept / reject / cancel.** Each delivered slice gets one `update_subtask` call with `action: 'accept'` (success), `action: 'reject'` (loop back with revision), or `action: 'cancel'` (dead branch).
 7. **Close.** When all slices close, follow the briefing's `next_status`.
 
 ## `spawn_subtask` contract
@@ -46,8 +46,8 @@ The peer receives this as a normal Mission Control dispatch with the brief and a
 - **dispatched** — peer is starting; not yet logged any activity.
 - **in_progress** — peer is logging activity at the agreed cadence.
 - **drifting** — silent past 1× check-in interval; consider a check-in.
-- **overdue** — past 1.5× expected duration; intervene or `cancel_subtask`.
-- **delivered** — peer marked the slice ready; you must `accept_subtask` or `reject_subtask`.
+- **overdue** — past 1.5× expected duration; intervene or `update_subtask({action: 'cancel'})`.
+- **delivered** — peer marked the slice ready; you must `update_subtask({action: 'accept'})` or `update_subtask({action: 'reject', reason})`.
 - **closed** — terminal (accepted / rejected too many times / cancelled / timed_out).
 
 ## When peers go wrong
@@ -55,9 +55,9 @@ The peer receives this as a normal Mission Control dispatch with the brief and a
 | Situation | Action |
 |---|---|
 | Peer drifting | `take_note(kind: 'observation', importance: 1)`, wait one more interval. |
-| Peer overdue with no activity | `cancel_subtask` with reason; respawn with revised duration if still needed. |
-| Peer delivered the wrong thing entirely | `cancel_subtask` (don't reject — the slice was misframed) and respawn with a sharper `message`. |
-| Peer delivered something close but missing pieces | `reject_subtask` with a specific revision request — the peer sees your reason on re-dispatch. |
+| Peer overdue with no activity | `update_subtask({subtask_id, action: 'cancel', reason})`; respawn with revised duration if still needed. |
+| Peer delivered the wrong thing entirely | `update_subtask({subtask_id, action: 'cancel', reason})` (don't reject — the slice was misframed) and respawn with a sharper `message`. |
+| Peer delivered something close but missing pieces | `update_subtask({subtask_id, action: 'reject', reason, new_acceptance_criteria?})` — the peer sees your reason on re-dispatch. |
 
 ## Reporting back (parent task)
 
@@ -70,7 +70,7 @@ The convoy auto-promotes the parent when all slices close. Your final closing fo
 ## Escalation
 
 - Scope creep → mail the workspace PM via `send_mail`; don't quietly add slices.
-- Two consecutive rejections on the same slice → `cancel_subtask` and mail the PM with the failure pattern. Don't keep looping.
+- Two consecutive rejections on the same slice → `update_subtask({action: 'cancel', reason})` and mail the PM with the failure pattern. Don't keep looping.
 - Conflicting requirements between operator intent and the parent task body → mail the PM and pause.
 
 ## Notes are external memory

--- a/agent-templates/coordinator/SOUL.md
+++ b/agent-templates/coordinator/SOUL.md
@@ -16,8 +16,8 @@ You are a Mission Control **Coordinator** subagent. You're spawned for a single 
 - Decompose the parent task into discrete, individually-reviewable slices
 - Match each slice to the right peer role using `list_peers`
 - Delegate via `spawn_subtask` with explicit acceptance criteria, expected deliverables, and an SLO duration
-- Monitor progress via `list_my_subtasks` — proactively `cancel_subtask` dead branches, `reject_subtask` work that doesn't meet criteria
-- Accept finished slices via `accept_subtask`; the parent convoy auto-completes when all slices close
+- Monitor progress via `list_my_subtasks` — proactively `update_subtask({action: 'cancel'})` dead branches, `update_subtask({action: 'reject'})` work that doesn't meet criteria
+- Accept finished slices via `update_subtask({action: 'accept'})`; the parent convoy auto-completes when all slices close
 - Keep `take_note(kind: 'breadcrumb')` running so future stages and the operator can see what was delegated and why
 
 ## Rules
@@ -35,7 +35,7 @@ You are a Mission Control **Coordinator** subagent. You're spawned for a single 
 3. **Discover peers.** `list_peers({ agent_id })` for the workspace roster (gateway_id ↔ MC agent_id).
 4. **Delegate.** One `spawn_subtask` per slice. Be specific about what "done" looks like — the peer's evidence gate enforces deliverables, not your trust.
 5. **Monitor.** `list_my_subtasks({ task_id })` returns derived state (dispatched / in_progress / drifting / overdue / delivered). Drifting peers (silent past 2× check-in interval) need an intervention.
-6. **Accept or reject.** When a peer marks a slice delivered, `accept_subtask` (success) or `reject_subtask` (with an actionable revision request). MC handles the loopback.
+6. **Accept or reject.** When a peer marks a slice delivered, `update_subtask({action: 'accept'})` (success) or `update_subtask({action: 'reject', reason})` (with an actionable revision request). MC handles the loopback.
 7. **Close.** When all slices close, the convoy auto-promotes the parent. Your final `update_task_status` follows the briefing's `next_status` (typically `done`).
 
 ## How you fit in Mission Control

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -652,14 +652,14 @@ Each row has a \`state_derived\` (dispatched / in_progress / drifting / overdue 
 
 **When a peer delivers** (state_derived = "delivered"):
 \`\`\`
-accept_subtask({ agent_id: "${agentId}", subtask_id: "<id>" })
+update_subtask({ agent_id: "${agentId}", subtask_id: "<id>", action: "accept" })
 # or if the work doesn't meet acceptance criteria:
-reject_subtask({ agent_id: "${agentId}", subtask_id: "<id>", reason: "<specific>", new_acceptance_criteria: [ ... ] })
+update_subtask({ agent_id: "${agentId}", subtask_id: "<id>", action: "reject", reason: "<specific>", new_acceptance_criteria: [ ... ] })
 \`\`\`
 
 **If a peer is stuck and the slice was wrong,** cancel and re-spawn with a better brief:
 \`\`\`
-cancel_subtask({ agent_id: "${agentId}", subtask_id: "<id>", reason: "<why>" })
+update_subtask({ agent_id: "${agentId}", subtask_id: "<id>", action: "cancel", reason: "<why>" })
 spawn_subtask({ ... })   # fresh slice
 \`\`\`
 
@@ -875,7 +875,7 @@ You were delegated this work by coordinator ${contract.coordinator_name ?? '(unk
 - **Slice:** ${contract.slice ?? '(unset)'}
 - **Expected deliverables** (register every one via \`register_deliverable\`):
 ${delivs.length > 0 ? delivs.map(d => `  - ${d.title} (${d.kind})`).join('\n') : '  - (none declared)'}
-- **Acceptance criteria** (all must hold for accept_subtask):
+- **Acceptance criteria** (all must hold for update_subtask({action: "accept"})):
 ${criteria.length > 0 ? criteria.map(c => `  - ${c}`).join('\n') : '  - (none declared)'}
 - **Expected duration:** ${contract.expected_duration_minutes} minutes (due at ${contract.due_at ?? 'unset'})
 - **Check-in cadence:** call \`log_activity\` at least every ${contract.checkin_interval_minutes ?? 15} minutes with a substantive note. Silence past 2\u00D7 cadence = drift alert to coordinator.

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -492,7 +492,7 @@ export async function PATCH(
     // Convoy progress + completion + drainQueue side effects. The shared
     // helper (also called from MCP-driven transitions in transitionTaskStatus)
     // is the single source of truth so a status change behaves the same
-    // whether it came from this route or update_task_status / accept_subtask.
+    // whether it came from this route or update_task_status / update_subtask({action: "accept"}).
     if (nextStatus && nextStatus !== existing.status) {
       runPostStatusChangeSideEffects({
         taskId: id,

--- a/src/lib/mcp/groups/work.ts
+++ b/src/lib/mcp/groups/work.ts
@@ -44,6 +44,180 @@ import {
   noteToPayload,
 } from '../shared';
 
+// ── update_subtask action handlers ──────────────────────────────────
+// Helpers extracted from the legacy accept_subtask / reject_subtask /
+// cancel_subtask MCP tools (PR 4 of the MCP surface v2 stack). Behavior
+// is intentionally byte-equivalent to those handlers; the tool layer
+// just dispatches to whichever helper matches `args.action`.
+
+async function acceptSubtaskImpl(args: { agent_id: string; subtask_id: string }) {
+  const row = queryOne<{ task_id: string; parent_task_id: string; task_status: string }>(
+    `SELECT cs.task_id AS task_id, c.parent_task_id AS parent_task_id, t.status AS task_status
+       FROM convoy_subtasks cs
+       JOIN convoys c ON c.id = cs.convoy_id
+       JOIN tasks t ON t.id = cs.task_id
+      WHERE cs.id = ?`,
+    [args.subtask_id],
+  );
+  if (!row) {
+    return { isError: true, content: [{ type: 'text' as const, text: `subtask ${args.subtask_id} not found` }], structuredContent: { error: 'subtask_not_found' } };
+  }
+  const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
+  assertAgentCanActOnTask(args.agent_id, row.parent_task_id, 'delegate');
+
+  if (row.task_status === 'done') {
+    return textResult(`Subtask ${args.subtask_id} was already done. No-op.`, { subtask_id: args.subtask_id, already_done: true });
+  }
+
+  const result = transitionTaskStatus({
+    taskId: row.task_id,
+    actingAgentId: args.agent_id,
+    newStatus: 'done',
+  });
+  if (!result.ok) {
+    return {
+      isError: true,
+      content: [{ type: 'text' as const, text: `Cannot accept subtask: ${result.error}` }],
+      structuredContent: {
+        error: result.code,
+        message: result.error,
+        ...(result.missingDeliverableIds ? { missing_deliverable_ids: result.missingDeliverableIds } : {}),
+      },
+    };
+  }
+
+  logActivity({
+    taskId: row.parent_task_id,
+    actingAgentId: args.agent_id,
+    activityType: 'updated',
+    message: `[delegation_accepted] subtask=${args.subtask_id} child_task=${row.task_id}`,
+  });
+
+  // checkConvoyCompletion may promote the parent task.
+  const { checkConvoyCompletion } = await import('@/lib/convoy');
+  const convoyId = queryOne<{ convoy_id: string }>(
+    'SELECT convoy_id FROM convoy_subtasks WHERE id = ?', [args.subtask_id],
+  )?.convoy_id;
+  if (convoyId) checkConvoyCompletion(convoyId);
+
+  return textResult(`Accepted subtask ${args.subtask_id}.`, {
+    subtask_id: args.subtask_id,
+    child_task_id: row.task_id,
+    parent_task_id: row.parent_task_id,
+  });
+}
+
+async function rejectSubtaskImpl(args: {
+  agent_id: string;
+  subtask_id: string;
+  reason: string;
+  new_acceptance_criteria?: string[];
+}) {
+  const row = queryOne<{ task_id: string; parent_task_id: string; task_status: string }>(
+    `SELECT cs.task_id AS task_id, c.parent_task_id AS parent_task_id, t.status AS task_status
+       FROM convoy_subtasks cs
+       JOIN convoys c ON c.id = cs.convoy_id
+       JOIN tasks t ON t.id = cs.task_id
+      WHERE cs.id = ?`,
+    [args.subtask_id],
+  );
+  if (!row) {
+    return { isError: true, content: [{ type: 'text' as const, text: `subtask ${args.subtask_id} not found` }], structuredContent: { error: 'subtask_not_found' } };
+  }
+  const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
+  assertAgentCanActOnTask(args.agent_id, row.parent_task_id, 'delegate');
+
+  const now = new Date().toISOString();
+  run(
+    `UPDATE tasks SET status = 'in_progress', status_reason = ?, updated_at = ? WHERE id = ?`,
+    [`rejected: ${args.reason}`, now, row.task_id],
+  );
+  if (args.new_acceptance_criteria && args.new_acceptance_criteria.length > 0) {
+    run(
+      `UPDATE convoy_subtasks SET acceptance_criteria = ? WHERE id = ?`,
+      [JSON.stringify(args.new_acceptance_criteria), args.subtask_id],
+    );
+  }
+
+  logActivity({
+    taskId: row.parent_task_id,
+    actingAgentId: args.agent_id,
+    activityType: 'updated',
+    message: `[delegation_rejected] subtask=${args.subtask_id} reason="${args.reason.replace(/"/g, "'")}"`,
+  });
+
+  // Notify the peer through their chat session so they see the
+  // rejection inline. Best-effort — if the openclaw client is down,
+  // the mailbox fallback still carries the message.
+  const peer = queryOne<{ id: string; gateway_agent_id: string | null; name: string; session_key_prefix: string | null }>(
+    'SELECT a.id, a.gateway_agent_id, a.name, a.session_key_prefix FROM tasks t JOIN agents a ON a.id = t.assigned_agent_id WHERE t.id = ?',
+    [row.task_id],
+  );
+  if (peer?.gateway_agent_id) {
+    try {
+      const client = getOpenClawClient();
+      if (!client.isConnected()) await client.connect();
+      const { sendChatToAgent } = await import('@/lib/openclaw/send-chat');
+      const result = await sendChatToAgent({
+        agent: {
+          id: peer.id,
+          name: peer.name,
+          gateway_agent_id: peer.gateway_agent_id,
+          session_key_prefix: peer.session_key_prefix ?? undefined,
+        },
+        message: `🔁 **Subtask rejected by coordinator.**\n\n**Reason:** ${args.reason}\n\n${args.new_acceptance_criteria?.length ? `**Updated acceptance criteria:**\n${args.new_acceptance_criteria.map(c => `- ${c}`).join('\n')}\n\n` : ''}Please address the issues and re-register deliverables, then move status back to review.`,
+        idempotencyKey: `reject-${args.subtask_id}-${Date.now()}`,
+        sessionSuffix: `task-${row.task_id}`,
+      });
+      if (!result.sent && result.error) {
+        console.warn('[update_subtask:reject] chat.send notification failed:', result.error.message);
+      }
+    } catch (err) {
+      console.warn('[update_subtask:reject] chat.send notification failed:', (err as Error).message);
+    }
+  }
+
+  return textResult(`Rejected subtask ${args.subtask_id}. Peer task ${row.task_id} moved back to in_progress.`, {
+    subtask_id: args.subtask_id,
+    child_task_id: row.task_id,
+  });
+}
+
+async function cancelSubtaskImpl(args: { agent_id: string; subtask_id: string; reason: string }) {
+  const row = queryOne<{ task_id: string; parent_task_id: string; convoy_id: string }>(
+    `SELECT cs.task_id AS task_id, c.parent_task_id AS parent_task_id, cs.convoy_id AS convoy_id
+       FROM convoy_subtasks cs JOIN convoys c ON c.id = cs.convoy_id WHERE cs.id = ?`,
+    [args.subtask_id],
+  );
+  if (!row) {
+    return { isError: true, content: [{ type: 'text' as const, text: `subtask ${args.subtask_id} not found` }], structuredContent: { error: 'subtask_not_found' } };
+  }
+  const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
+  assertAgentCanActOnTask(args.agent_id, row.parent_task_id, 'delegate');
+
+  const now = new Date().toISOString();
+  run(
+    `UPDATE tasks SET status = 'cancelled', status_reason = ?, updated_at = ? WHERE id = ?`,
+    [`cancelled_by_coordinator: ${args.reason}`, now, row.task_id],
+  );
+  run(
+    `UPDATE convoys SET failed_subtasks = failed_subtasks + 1, updated_at = ? WHERE id = ?`,
+    [now, row.convoy_id],
+  );
+
+  logActivity({
+    taskId: row.parent_task_id,
+    actingAgentId: args.agent_id,
+    activityType: 'updated',
+    message: `[delegation_cancelled] subtask=${args.subtask_id} reason="${args.reason.replace(/"/g, "'")}"`,
+  });
+
+  return textResult(`Cancelled subtask ${args.subtask_id}.`, {
+    subtask_id: args.subtask_id,
+    child_task_id: row.task_id,
+  });
+}
+
 export function registerWorkTools(server: McpServer): void {
   // get_task ──────────────────────────────────────────────────────
   server.registerTool(
@@ -455,7 +629,7 @@ export function registerWorkTools(server: McpServer): void {
 
         // If the task just moved to a delivery state (review/testing/
         // verification) AND it's a delegation subtask, mail the
-        // coordinator so they can call accept_subtask / reject_subtask
+        // coordinator so they can call update_subtask({action:'accept'|'reject'})
         // without polling list_my_subtasks. Silent if the task isn't in
         // a convoy or the coordinator assignment is missing.
         if (['review', 'testing', 'verification'].includes(args.status)) {
@@ -476,7 +650,7 @@ export function registerWorkTools(server: McpServer): void {
               fromAgentId: args.agent_id,
               toAgentId: ctx.coordinator_id,
               subject: `DELEGATION: ready_for_review — ${ctx.slice ?? ctx.parent_title}`,
-              body: `Subtask ${ctx.subtask_id} is ready for review (status=${args.status}).\n\nCall accept_subtask({subtask_id: "${ctx.subtask_id}"}) if it meets the acceptance criteria, or reject_subtask with a reason to bounce it back.`,
+              body: `Subtask ${ctx.subtask_id} is ready for review (status=${args.status}).\n\nCall update_subtask({subtask_id: "${ctx.subtask_id}", action: "accept"}) if it meets the acceptance criteria, or update_subtask({subtask_id: "${ctx.subtask_id}", action: "reject", reason: "..."}) to bounce it back.`,
               taskId: ctx.parent_task_id,
               convoyId: ctx.convoy_id,
               push: true,
@@ -564,8 +738,8 @@ export function registerWorkTools(server: McpServer): void {
             ? `DELEGATION: redecompose_requested — ${ctx.slice ?? 'subtask'}`
             : `DELEGATION: blocked — ${ctx.slice ?? 'subtask'}`,
           body: `Subtask ${ctx.subtask_id} failed.\n\n**Reason:** ${args.reason}\n\n${redecompose
-            ? 'The peer is asking you to re-decompose this slice. Call cancel_subtask on this row and issue fresh spawn_subtask calls with a better-scoped brief.'
-            : 'Peer declared itself blocked. Inspect the reason and decide: reject_subtask (redo), cancel_subtask (drop), or answer and redispatch.'}`,
+            ? 'The peer is asking you to re-decompose this slice. Call update_subtask({action: "cancel", reason: "..."}) on this row and issue fresh spawn_subtask calls with a better-scoped brief.'
+            : 'Peer declared itself blocked. Inspect the reason and decide: update_subtask({action: "reject", ...}) (redo), update_subtask({action: "cancel", ...}) (drop), or answer and redispatch.'}`,
           taskId: ctx.parent_task_id,
           convoyId: ctx.convoy_id,
           push: true,
@@ -842,7 +1016,7 @@ export function registerWorkTools(server: McpServer): void {
         acceptance_criteria: z
           .array(z.string().min(10).max(500))
           .min(1)
-          .describe('Each criterion ≥10 chars. The peer must satisfy all of them for the coordinator to accept_subtask.'),
+          .describe('Each criterion ≥10 chars. The peer must satisfy all of them for the coordinator to update_subtask({action: "accept"}).'),
         expected_duration_minutes: z
           .number()
           .int()
@@ -981,14 +1155,14 @@ export function registerWorkTools(server: McpServer): void {
 
       if (dispatchError) {
         // The subtask row exists but dispatch failed — the coordinator
-        // should see this explicitly and can call cancel_subtask +
+        // should see this explicitly and can call update_subtask({action:'cancel'}) +
         // retry. We do NOT auto-rollback: the convoy row is real,
         // half-done is visible, no silent data loss.
         return {
           isError: true,
           content: [{
             type: 'text',
-            text: `Subtask ${spawn.subtaskId} created but dispatch failed: ${dispatchError}. The subtask row exists — call cancel_subtask to release it, or retry.`,
+            text: `Subtask ${spawn.subtaskId} created but dispatch failed: ${dispatchError}. The subtask row exists — call update_subtask({action: "cancel", reason: "..."}) to release it, or retry.`,
           }],
           structuredContent: {
             error: 'dispatch_failed',
@@ -1138,214 +1312,72 @@ export function registerWorkTools(server: McpServer): void {
     }),
   );
 
-  // accept_subtask ────────────────────────────────────────────────
+  // update_subtask ────────────────────────────────────────────────
+  // Single entry-point for the subtask lifecycle. The action handler
+  // helpers below preserve the exact behavior of the previous
+  // accept_subtask / reject_subtask / cancel_subtask tools.
   server.registerTool(
-    'accept_subtask',
+    'update_subtask',
     {
-      title: 'Accept a peer\'s delivered delegation (coordinator-only)',
+      title: 'Accept, reject, or cancel a delegated subtask (coordinator-only)',
       description:
-        "Promote a delivered child task (status=review/verification/testing) to done. Bumps the convoy's completed_subtasks counter and may promote the parent via checkConvoyCompletion. Call this after verifying the peer's deliverables meet the acceptance criteria you declared in spawn_subtask.",
+        "Single entry-point for the subtask lifecycle. Pick one of three actions:\n" +
+        "- `accept` — the peer's deliverables meet your acceptance criteria. Promotes the child task to done. No extra fields needed.\n" +
+        "- `reject` — bounce the subtask back to in_progress with a reason the peer reads. Use when deliverables exist but don't meet criteria. Requires `reason` (≥10 chars). Optional `new_acceptance_criteria` replaces the convoy_subtasks.acceptance_criteria for the next round.\n" +
+        "- `cancel` — release the subtask entirely (scope change, dead branch, demonstrably stuck). The child task moves to cancelled and the convoy's failed_subtasks counter bumps so the subtask no longer blocks completion. Requires `reason` (≥5 chars).",
       inputSchema: {
         agent_id: agentIdArg,
         subtask_id: z.string().min(1).describe('The convoy_subtasks row id from spawn_subtask.'),
-      },
-      annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false },
-    },
-    trace('accept_subtask', async (args) => {
-      const row = queryOne<{ task_id: string; parent_task_id: string; task_status: string }>(
-        `SELECT cs.task_id AS task_id, c.parent_task_id AS parent_task_id, t.status AS task_status
-           FROM convoy_subtasks cs
-           JOIN convoys c ON c.id = cs.convoy_id
-           JOIN tasks t ON t.id = cs.task_id
-          WHERE cs.id = ?`,
-        [args.subtask_id],
-      );
-      if (!row) {
-        return { isError: true, content: [{ type: 'text', text: `subtask ${args.subtask_id} not found` }], structuredContent: { error: 'subtask_not_found' } };
-      }
-      const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
-      assertAgentCanActOnTask(args.agent_id, row.parent_task_id, 'delegate');
-
-      if (row.task_status === 'done') {
-        return textResult(`Subtask ${args.subtask_id} was already done. No-op.`, { subtask_id: args.subtask_id, already_done: true });
-      }
-
-      const result = transitionTaskStatus({
-        taskId: row.task_id,
-        actingAgentId: args.agent_id,
-        newStatus: 'done',
-      });
-      if (!result.ok) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: `Cannot accept subtask: ${result.error}` }],
-          structuredContent: {
-            error: result.code,
-            message: result.error,
-            ...(result.missingDeliverableIds ? { missing_deliverable_ids: result.missingDeliverableIds } : {}),
-          },
-        };
-      }
-
-      logActivity({
-        taskId: row.parent_task_id,
-        actingAgentId: args.agent_id,
-        activityType: 'updated',
-        message: `[delegation_accepted] subtask=${args.subtask_id} child_task=${row.task_id}`,
-      });
-
-      // checkConvoyCompletion may promote the parent task.
-      const { checkConvoyCompletion } = await import('@/lib/convoy');
-      const convoyId = queryOne<{ convoy_id: string }>(
-        'SELECT convoy_id FROM convoy_subtasks WHERE id = ?', [args.subtask_id],
-      )?.convoy_id;
-      if (convoyId) checkConvoyCompletion(convoyId);
-
-      return textResult(`Accepted subtask ${args.subtask_id}.`, {
-        subtask_id: args.subtask_id,
-        child_task_id: row.task_id,
-        parent_task_id: row.parent_task_id,
-      });
-    }),
-  );
-
-  // reject_subtask ────────────────────────────────────────────────
-  server.registerTool(
-    'reject_subtask',
-    {
-      title: 'Reject a peer\'s delivered delegation with a reason (coordinator-only)',
-      description:
-        "Bounce a delivered child task back to in_progress with a reason the peer sees on re-dispatch. Use when deliverables don't meet the acceptance criteria. For slice mismatch (peer built the wrong thing entirely), prefer cancel_subtask + a fresh spawn_subtask instead.",
-      inputSchema: {
-        agent_id: agentIdArg,
-        subtask_id: z.string().min(1),
-        reason: z.string().min(10).max(2000).describe('Specific, actionable — shown to the peer on re-dispatch.'),
+        action: z.enum(['accept', 'reject', 'cancel']).describe('Which lifecycle transition to apply.'),
+        reason: z
+          .string()
+          .min(5)
+          .max(2000)
+          .optional()
+          .describe(
+            'Required for action=reject (≥10 chars) and action=cancel (≥5 chars). Shown to the peer on re-dispatch (reject) or recorded as status_reason (cancel).',
+          ),
         new_acceptance_criteria: z
           .array(z.string().min(10).max(500))
           .optional()
-          .describe('Optional updated criteria. When provided, replaces the convoy_subtasks.acceptance_criteria for the next round.'),
+          .describe(
+            'action=reject only — when provided, replaces convoy_subtasks.acceptance_criteria for the next round.',
+          ),
       },
       annotations: { destructiveHint: true, openWorldHint: false },
     },
-    trace('reject_subtask', async (args) => {
-      const row = queryOne<{ task_id: string; parent_task_id: string; task_status: string }>(
-        `SELECT cs.task_id AS task_id, c.parent_task_id AS parent_task_id, t.status AS task_status
-           FROM convoy_subtasks cs
-           JOIN convoys c ON c.id = cs.convoy_id
-           JOIN tasks t ON t.id = cs.task_id
-          WHERE cs.id = ?`,
-        [args.subtask_id],
-      );
-      if (!row) {
-        return { isError: true, content: [{ type: 'text', text: `subtask ${args.subtask_id} not found` }], structuredContent: { error: 'subtask_not_found' } };
-      }
-      const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
-      assertAgentCanActOnTask(args.agent_id, row.parent_task_id, 'delegate');
-
-      const now = new Date().toISOString();
-      run(
-        `UPDATE tasks SET status = 'in_progress', status_reason = ?, updated_at = ? WHERE id = ?`,
-        [`rejected: ${args.reason}`, now, row.task_id],
-      );
-      if (args.new_acceptance_criteria && args.new_acceptance_criteria.length > 0) {
-        run(
-          `UPDATE convoy_subtasks SET acceptance_criteria = ? WHERE id = ?`,
-          [JSON.stringify(args.new_acceptance_criteria), args.subtask_id],
-        );
-      }
-
-      logActivity({
-        taskId: row.parent_task_id,
-        actingAgentId: args.agent_id,
-        activityType: 'updated',
-        message: `[delegation_rejected] subtask=${args.subtask_id} reason="${args.reason.replace(/"/g, "'")}"`,
-      });
-
-      // Notify the peer through their chat session so they see the
-      // rejection inline. Best-effort — if the openclaw client is down,
-      // the mailbox fallback still carries the message.
-      const peer = queryOne<{ id: string; gateway_agent_id: string | null; name: string; session_key_prefix: string | null }>(
-        'SELECT a.id, a.gateway_agent_id, a.name, a.session_key_prefix FROM tasks t JOIN agents a ON a.id = t.assigned_agent_id WHERE t.id = ?',
-        [row.task_id],
-      );
-      if (peer?.gateway_agent_id) {
-        try {
-          const client = getOpenClawClient();
-          if (!client.isConnected()) await client.connect();
-          const { sendChatToAgent } = await import('@/lib/openclaw/send-chat');
-          const result = await sendChatToAgent({
-            agent: {
-              id: peer.id,
-              name: peer.name,
-              gateway_agent_id: peer.gateway_agent_id,
-              session_key_prefix: peer.session_key_prefix ?? undefined,
-            },
-            message: `🔁 **Subtask rejected by coordinator.**\n\n**Reason:** ${args.reason}\n\n${args.new_acceptance_criteria?.length ? `**Updated acceptance criteria:**\n${args.new_acceptance_criteria.map(c => `- ${c}`).join('\n')}\n\n` : ''}Please address the issues and re-register deliverables, then move status back to review.`,
-            idempotencyKey: `reject-${args.subtask_id}-${Date.now()}`,
-            sessionSuffix: `task-${row.task_id}`,
-          });
-          if (!result.sent && result.error) {
-            console.warn('[reject_subtask] chat.send notification failed:', result.error.message);
+    trace('update_subtask', async (args) => {
+      switch (args.action) {
+        case 'accept':
+          return acceptSubtaskImpl({ agent_id: args.agent_id, subtask_id: args.subtask_id });
+        case 'reject':
+          if (!args.reason || args.reason.length < 10) {
+            return {
+              isError: true,
+              content: [{ type: 'text', text: 'action=reject requires reason (≥10 chars)' }],
+              structuredContent: { error: 'reason_required' },
+            };
           }
-        } catch (err) {
-          console.warn('[reject_subtask] chat.send notification failed:', (err as Error).message);
-        }
+          return rejectSubtaskImpl({
+            agent_id: args.agent_id,
+            subtask_id: args.subtask_id,
+            reason: args.reason,
+            new_acceptance_criteria: args.new_acceptance_criteria,
+          });
+        case 'cancel':
+          if (!args.reason || args.reason.length < 5) {
+            return {
+              isError: true,
+              content: [{ type: 'text', text: 'action=cancel requires reason (≥5 chars)' }],
+              structuredContent: { error: 'reason_required' },
+            };
+          }
+          return cancelSubtaskImpl({
+            agent_id: args.agent_id,
+            subtask_id: args.subtask_id,
+            reason: args.reason,
+          });
       }
-
-      return textResult(`Rejected subtask ${args.subtask_id}. Peer task ${row.task_id} moved back to in_progress.`, {
-        subtask_id: args.subtask_id,
-        child_task_id: row.task_id,
-      });
-    }),
-  );
-
-  // cancel_subtask ────────────────────────────────────────────────
-  server.registerTool(
-    'cancel_subtask',
-    {
-      title: 'Cancel a delegated subtask (coordinator-only)',
-      description:
-        "Release a subtask that's no longer needed or is demonstrably stuck. The child task moves to cancelled; the convoy's failed_subtasks counter bumps so the subtask no longer blocks convoy completion. Use for scope changes and dead branches; for rejecting delivered work that needs a redo, use reject_subtask.",
-      inputSchema: {
-        agent_id: agentIdArg,
-        subtask_id: z.string().min(1),
-        reason: z.string().min(5).max(2000),
-      },
-      annotations: { destructiveHint: true, openWorldHint: false },
-    },
-    trace('cancel_subtask', async (args) => {
-      const row = queryOne<{ task_id: string; parent_task_id: string; convoy_id: string }>(
-        `SELECT cs.task_id AS task_id, c.parent_task_id AS parent_task_id, cs.convoy_id AS convoy_id
-           FROM convoy_subtasks cs JOIN convoys c ON c.id = cs.convoy_id WHERE cs.id = ?`,
-        [args.subtask_id],
-      );
-      if (!row) {
-        return { isError: true, content: [{ type: 'text', text: `subtask ${args.subtask_id} not found` }], structuredContent: { error: 'subtask_not_found' } };
-      }
-      const { assertAgentCanActOnTask } = await import('@/lib/authz/agent-task');
-      assertAgentCanActOnTask(args.agent_id, row.parent_task_id, 'delegate');
-
-      const now = new Date().toISOString();
-      run(
-        `UPDATE tasks SET status = 'cancelled', status_reason = ?, updated_at = ? WHERE id = ?`,
-        [`cancelled_by_coordinator: ${args.reason}`, now, row.task_id],
-      );
-      run(
-        `UPDATE convoys SET failed_subtasks = failed_subtasks + 1, updated_at = ? WHERE id = ?`,
-        [now, row.convoy_id],
-      );
-
-      logActivity({
-        taskId: row.parent_task_id,
-        actingAgentId: args.agent_id,
-        activityType: 'updated',
-        message: `[delegation_cancelled] subtask=${args.subtask_id} reason="${args.reason.replace(/"/g, "'")}"`,
-      });
-
-      return textResult(`Cancelled subtask ${args.subtask_id}.`, {
-        subtask_id: args.subtask_id,
-        child_task_id: row.task_id,
-      });
     }),
   );
 

--- a/src/lib/mcp/mcp.test.ts
+++ b/src/lib/mcp/mcp.test.ts
@@ -6,7 +6,7 @@
  * tools, state-changing tools (happy path + authz violation), evidence-gate
  * integration with update_task_status.
  *
- * The coordinator-delegation tools (`spawn_subtask`, `reject_subtask`) that
+ * The coordinator-delegation tools (`spawn_subtask`, `update_subtask`) that
  * call openclaw's WebSocket gateway are not exercised end-to-end here —
  * the gateway client can't be mocked cleanly in this harness. A pilot-
  * environment smoke exercises the live flow.
@@ -80,13 +80,16 @@ test('tools/list returns the full sc-mission-control tool surface', async () => 
     // See specs/coordinator-delegation-via-convoy-spec.md §3.
     'spawn_subtask',
     'list_my_subtasks',
-    'accept_subtask',
-    'reject_subtask',
-    'cancel_subtask',
+    'update_subtask',
   ]) {
     assert.ok(names.has(expected), `missing tool: ${expected}`);
   }
   assert.ok(!names.has('delegate'), 'delegate tool should be removed');
+  // The pre-PR4 trio collapsed into update_subtask — none of the old
+  // names should remain.
+  for (const removed of ['accept_subtask', 'reject_subtask', 'cancel_subtask']) {
+    assert.ok(!names.has(removed), `${removed} should be removed (consolidated into update_subtask)`);
+  }
 });
 
 // ─── per-group routing ──────────────────────────────────────────────
@@ -118,7 +121,7 @@ test('PM-scoped server (core+read+pm) excludes worker + crud tools', async () =>
   }
   // Worker absent
   for (const t of ['register_deliverable', 'submit_evidence', 'update_task_status', 'fail_task',
-                   'spawn_subtask', 'accept_subtask', 'reject_subtask', 'cancel_subtask',
+                   'spawn_subtask', 'update_subtask',
                    'register_subagent_dispatch', 'mark_note_consumed', 'archive_note']) {
     assert.ok(!names.has(t), `pm mount must not expose worker tool ${t}`);
   }
@@ -147,10 +150,11 @@ test('CRUD-scoped server (core+read+crud) excludes worker + pm tools', async () 
   }
 });
 
-test('default server (no groups arg) keeps full union of 47 tools', async () => {
+test('default server (no groups arg) keeps full union of 45 tools', async () => {
   const names = await listToolsForGroups(undefined);
-  // 47 tools in total post-PR1 / pre-PR4&5.
-  assert.equal(names.size, 47, `expected 47 tools, got ${names.size}: ${[...names].sort().join(', ')}`);
+  // 45 tools post-PR4: accept/reject/cancel_subtask collapsed into the
+  // single update_subtask discriminator (47 - 3 + 1).
+  assert.equal(names.size, 45, `expected 45 tools, got ${names.size}: ${[...names].sort().join(', ')}`);
 });
 
 // ─── whoami ─────────────────────────────────────────────────────────

--- a/src/lib/services/task-status.ts
+++ b/src/lib/services/task-status.ts
@@ -187,7 +187,7 @@ export function transitionTaskStatus(
 
   // Convoy + workflow side effects. These used to live only in the
   // /api/tasks/[id] PATCH route, so MCP-driven status changes
-  // (`update_task_status`, `accept_subtask`) bypassed them entirely. The
+  // (`update_task_status`, `update_subtask`) bypassed them entirely. The
   // Builder marking a subtask done would update the row but never bump
   // the parent convoy's completed_subtasks, so checkConvoyCompletion
   // never ran and the parent stayed in convoy_active until the stall


### PR DESCRIPTION
## Summary

PR 4 of the MCP surface v2 stack. Hard rename: `accept_subtask` + `reject_subtask` + `cancel_subtask` (3 tools) → `update_subtask({subtask_id, action, reason?, new_acceptance_criteria?})` (1 tool). Behavior byte-equivalent.

Stacks on **#216**.

## Changes

- `src/lib/mcp/groups/work.ts` — 18 → 16 tools. Three handler bodies extracted into module-private `acceptSubtaskImpl` / `rejectSubtaskImpl` / `cancelSubtaskImpl`; new `update_subtask` dispatches by action. Authz checks, DB writes, chat-notification side effect on reject, convoy failed_subtasks bump on cancel — all preserved.
- `src/lib/mcp/mcp.test.ts` — assertions updated (`update_subtask` present, three old names absent), default-server count 47→45.
- `src/app/api/tasks/[id]/dispatch/route.ts` — coordinator dispatch template uses `update_subtask({action})`.
- `agent-templates/_shared/messaging-protocol.md` — canonical table: three rows collapsed into one.
- `agent-templates/coordinator/SOUL.md` — tool list reference updated.
- `agent-templates/coordinator/AGENTS.md` — decision table rewritten to use the action discriminator.
- `src/app/api/tasks/[id]/route.ts`, `src/lib/services/task-status.ts` — comment refresh.

## Per-action validation

- `accept` — no extra fields needed.
- `reject` — `reason` ≥10 chars; optional `new_acceptance_criteria` array.
- `cancel` — `reason` ≥5 chars.

## Test plan

- [x] `yarn test` → 733/734 pass (same pre-existing `schedule-runner` flake).
- [x] MCP-targeted suite: 30/30 pass (incl. updated tools/list, PM-scoped, default-count assertions).
- [x] `grep accept_subtask|reject_subtask|cancel_subtask` clean across `src/` + `agent-templates/` (only intentional historical comments remain).
- [ ] Coordinator real-agent dispatch (V4) — runs in post-stack validation pass.

## In-flight session policy

Per spec decision-log item 2: in-flight sessions get cleared at this PR's land. No shims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)