### PR TITLE
refactor(mcp): consolidate note lifecycle into update_note (PR 5)

### DIFF
--- a/agent-templates/_shared/messaging-protocol.md
+++ b/agent-templates/_shared/messaging-protocol.md
@@ -40,7 +40,7 @@ OpenClaw namespaces MCP tools as `<server-name>__<tool-name>`, so the exact name
 | Action | Tool |
 |---|---|
 | Query notes by task / scope / audience | `read_notes({ agent_id, task_id?, audience?, … })` |
-| Acknowledge a note from a prior stage | `mark_note_consumed({ agent_id, note_id, stage_slug })` |
+| Acknowledge a note from a prior stage / archive a stale note | `update_note({ agent_id, note_id, action: 'consume' \| 'archive', stage_slug?, reason? })` (`stage_slug` required for `consume`; `reason` optional for `archive`) |
 | Recall lessons from the workspace knowledge base | `request_knowledge({ agent_id, query, task_id?, workspace_id? })` |
 | Save a lesson (Learner role) | `save_knowledge({ agent_id, workspace_id, category, title, content, … })` |
 

--- a/agent-templates/_shared/notetaker.md
+++ b/agent-templates/_shared/notetaker.md
@@ -28,11 +28,25 @@ Before you commit to an approach, check:
 
 After you make progress, scan for any `kind: question` you can now answer.
 
-## Closing a note
+## Acting on notes you read
 
-When a `blocker` is resolved or an `uncertainty` clarified, call
-`archive_note(note_id, reason: '<one line>')`. Don't leave stale
-worries in the feed.
+The note lifecycle has two terminal calls, both via `update_note`:
+
+- **You acted on a note from a prior stage.** Call
+  `update_note({ note_id, action: 'consume', stage_slug: '<your role>' })`.
+  This records that *your* stage processed it, so the next dispatch for
+  your stage doesn't re-show the same breadcrumb. Idempotent.
+  Critical: do this whenever you act on a note — without it, your
+  briefings keep growing as old notes pile up.
+
+- **A note has gone stale for everyone.** Call
+  `update_note({ note_id, action: 'archive', reason: '<one line>' })`.
+  Use when a `blocker` is resolved, an `uncertainty` clarified, or an
+  observation no longer reflects reality. The row stays for audit but
+  drops out of every future briefing and the live feed.
+
+Don't leave stale worries in the feed; don't let prior-stage notes
+keep appearing on your briefings after you've acted on them.
 
 ## Why this matters
 

--- a/agent-templates/runner-host/AGENTS.md
+++ b/agent-templates/runner-host/AGENTS.md
@@ -40,8 +40,9 @@ Your gateway_agent_id is: mc-runner-dev
 
 Treat the role section as your active SOUL. Treat the task context as
 your starting facts. Treat prior notes as the previous stages'
-breadcrumbs — read them, ack them via `mark_note_consumed` when
-processed.
+breadcrumbs — read them, ack them via
+`update_note({note_id, action: 'consume', stage_slug: '<your role>'})`
+when processed.
 
 ### 2. Without a role briefing (anomaly)
 
@@ -68,7 +69,8 @@ to refresh what's been observed since you last saw this scope.
 - `whoami` is for verifying identity once at session start. Don't
   re-call it mid-session unless something is wrong.
 - `read_notes` before committing to an approach.
-- `mark_note_consumed` when you actually act on a note from a prior stage.
+- `update_note({action: 'consume', stage_slug})` when you act on a prior-stage note;
+  `update_note({action: 'archive'})` when a note has gone stale for everyone.
 
 ## When you finish
 

--- a/src/lib/mcp/groups/work.ts
+++ b/src/lib/mcp/groups/work.ts
@@ -1,7 +1,7 @@
 /**
  * Work MCP tools — task execution, mail, deliverables, evidence,
  * subtask delegation, knowledge, subagent dispatch registration, and the
- * note-lifecycle tools (mark_note_consumed / archive_note).
+ * note-lifecycle tool (update_note — consume + archive actions).
  *
  * Behavior is unchanged from the legacy `tools.ts` consolidation; this is
  * a pure relocation as part of the MCP surface refactor (PR 1).
@@ -447,61 +447,68 @@ export function registerWorkTools(server: McpServer): void {
     }),
   );
 
-  // mark_note_consumed ─────────────────────────────────────────────
+  // update_note ────────────────────────────────────────────────────
+  // Consolidated lifecycle tool. Replaces mark_note_consumed and
+  // archive_note (PR 5 of the MCP surface v2 stack). Action enum keeps
+  // the agent's mental model concrete (consume vs archive are
+  // semantically distinct: consume = "I read it"; archive = "kill it
+  // for everyone").
   server.registerTool(
-    'mark_note_consumed',
+    'update_note',
     {
-      title: 'Record that this stage has read a note',
+      title: 'Update a note (mark consumed by your stage, or archive it)',
       description:
-        "Idempotent. Call this when you've actually processed a note from a prior stage so the next briefing for this stage doesn't re-show it. Pass your stage slug (your current role) — e.g., 'tester' if you're the tester reading a builder breadcrumb.",
+        "Two actions:\n" +
+        "- `consume` — record that your stage has read this note so the next briefing for your stage doesn't re-show it. Idempotent. Requires `stage_slug` (typically your current role, e.g. 'tester' if you're the tester reading a builder breadcrumb).\n" +
+        "- `archive` — soft-hide the note from future briefings and the live feed. The row stays for audit. Use when a blocker is resolved, an uncertainty clarified, or an observation has gone stale. Idempotent. Optional `reason` (max 500 chars).",
       inputSchema: {
         agent_id: agentIdArg,
         note_id: z.string().min(1),
+        action: z.enum(['consume', 'archive']).describe('Which lifecycle transition to apply.'),
         stage_slug: z
           .string()
           .min(1)
-          .describe("Your stage slug (typically your current role). Idempotent — duplicate calls are no-ops."),
+          .optional()
+          .describe("Required for action=consume. Your stage slug (typically your current role). Idempotent — duplicate calls are no-ops."),
+        reason: z
+          .string()
+          .max(500)
+          .optional()
+          .describe('action=archive only. Optional reason recorded with the archive event.'),
       },
       annotations: { destructiveHint: false, openWorldHint: false },
     },
-    trace('mark_note_consumed', async (args) => {
-      const note = markNoteConsumedDb(args.note_id, args.stage_slug);
-      if (!note) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: `note ${args.note_id} not found` }],
-          structuredContent: { error: 'not_found', note_id: args.note_id },
-        };
+    trace('update_note', async (args) => {
+      if (args.action === 'consume') {
+        if (!args.stage_slug) {
+          return {
+            isError: true,
+            content: [{ type: 'text', text: 'action=consume requires stage_slug' }],
+            structuredContent: { error: 'stage_slug_required' },
+          };
+        }
+        const note = markNoteConsumedDb(args.note_id, args.stage_slug);
+        if (!note) {
+          return {
+            isError: true,
+            content: [{ type: 'text', text: `note ${args.note_id} not found` }],
+            structuredContent: { error: 'not_found', note_id: args.note_id },
+          };
+        }
+        const payload = noteToPayload(note);
+        broadcast({
+          type: 'agent_note_consumed',
+          payload: {
+            note_id: note.id,
+            workspace_id: note.workspace_id,
+            stage_slug: args.stage_slug,
+            consumed_by_stages: parseConsumedStages(note),
+          },
+        });
+        return textResult(JSON.stringify(payload, null, 2), payload);
       }
-      const payload = noteToPayload(note);
-      broadcast({
-        type: 'agent_note_consumed',
-        payload: {
-          note_id: note.id,
-          workspace_id: note.workspace_id,
-          stage_slug: args.stage_slug,
-          consumed_by_stages: parseConsumedStages(note),
-        },
-      });
-      return textResult(JSON.stringify(payload, null, 2), payload);
-    }),
-  );
 
-  // archive_note ───────────────────────────────────────────────────
-  server.registerTool(
-    'archive_note',
-    {
-      title: 'Soft-archive a note',
-      description:
-        "Hide a note from future briefings and the live feed. The row stays for audit. Use when a blocker is resolved, an uncertainty clarified, or an observation has gone stale. Idempotent — already-archived notes are no-ops.",
-      inputSchema: {
-        agent_id: agentIdArg,
-        note_id: z.string().min(1),
-        reason: z.string().max(500).optional(),
-      },
-      annotations: { destructiveHint: false, openWorldHint: false },
-    },
-    trace('archive_note', async (args) => {
+      // action === 'archive'
       const existing = getNote(args.note_id);
       if (!existing) {
         return {

--- a/src/lib/mcp/mcp.test.ts
+++ b/src/lib/mcp/mcp.test.ts
@@ -122,8 +122,13 @@ test('PM-scoped server (core+read+pm) excludes worker + crud tools', async () =>
   // Worker absent
   for (const t of ['register_deliverable', 'submit_evidence', 'update_task_status', 'fail_task',
                    'spawn_subtask', 'update_subtask',
-                   'register_subagent_dispatch', 'mark_note_consumed', 'archive_note']) {
+                   'register_subagent_dispatch', 'update_note']) {
     assert.ok(!names.has(t), `pm mount must not expose worker tool ${t}`);
+  }
+  // The pre-PR5 note lifecycle pair collapsed into update_note —
+  // neither old name should appear anywhere.
+  for (const removed of ['mark_note_consumed', 'archive_note']) {
+    assert.ok(!names.has(removed), `${removed} should be removed (consolidated into update_note)`);
   }
   // CRUD absent
   for (const t of ['create_initiative', 'update_initiative', 'move_initiative', 'convert_initiative']) {
@@ -150,11 +155,18 @@ test('CRUD-scoped server (core+read+crud) excludes worker + pm tools', async () 
   }
 });
 
-test('default server (no groups arg) keeps full union of 45 tools', async () => {
+test('default server (no groups arg) keeps full union of 44 tools', async () => {
   const names = await listToolsForGroups(undefined);
-  // 45 tools post-PR4: accept/reject/cancel_subtask collapsed into the
-  // single update_subtask discriminator (47 - 3 + 1).
-  assert.equal(names.size, 45, `expected 45 tools, got ${names.size}: ${[...names].sort().join(', ')}`);
+  // 44 tools post-PR4+PR5: accept/reject/cancel_subtask → update_subtask
+  // and mark_note_consumed/archive_note → update_note (47 - 3 + 1 - 2 + 1).
+  assert.equal(names.size, 44, `expected 44 tools, got ${names.size}: ${[...names].sort().join(', ')}`);
+  // Make absences explicit so a regression has a clear failure.
+  for (const removed of ['accept_subtask', 'reject_subtask', 'cancel_subtask', 'mark_note_consumed', 'archive_note']) {
+    assert.ok(!names.has(removed), `${removed} should not be present`);
+  }
+  for (const present of ['update_subtask', 'update_note']) {
+    assert.ok(names.has(present), `${present} should be present`);
+  }
 });
 
 // ─── whoami ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

PR 5 of the MCP surface v2 stack. Hard rename: `mark_note_consumed` + `archive_note` (2 tools) → `update_note({note_id, action: 'consume'|'archive', stage_slug?, reason?})` (1 tool). Behavior byte-equivalent.

Stacks on **#217**.

## Changes

- `src/lib/mcp/groups/work.ts` — 16 → 15 tools. Single `update_note` handler dispatches by action; same DB helpers + broadcast events as before.
- `src/lib/mcp/mcp.test.ts` — assertions updated (`update_note` present, two old names absent), default-server count 45 → 44.
- `agent-templates/_shared/messaging-protocol.md` — canonical table row collapsed.
- `agent-templates/_shared/notetaker.md` — **rewritten** to provide prescriptive guidance for BOTH the consume and archive actions. (Pre-PR coverage gap: agents were only told about `archive_note`; `mark_note_consumed` was invisible.)
- `agent-templates/runner-host/AGENTS.md` — tool discipline list updated.

## Per-action validation

- `consume` — `stage_slug` required (returns `stage_slug_required` error otherwise).
- `archive` — optional `reason` (max 500 chars).

## Coverage fix (called out in spec)

Pre-PR templates only documented the archive path. The `mark_note_consumed` MCP tool existed but agents had no prescriptive guidance to call it — so the noteboard kept growing as old notes piled up in briefings. This PR closes that gap as part of the rename: `notetaker.md` now teaches both actions explicitly.

## Test plan

- [x] `yarn test` → 733/734 pass (same pre-existing `schedule-runner` flake).
- [x] MCP-targeted suite: 21/21 pass with updated assertions.
- [x] `grep mark_note_consumed|archive_note` clean in live code (only intentional historical comments + explicit-absent test assertions remain).
- [ ] Worker real-agent dispatch (V5) — runs in post-stack validation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)