### PR TITLE
feat(scripts): deny memory_search/memory_get/x_search on runner agents

### DIFF
--- a/scripts/apply-mc-servers.mjs
+++ b/scripts/apply-mc-servers.mjs
@@ -187,10 +187,27 @@ function rewritePmDeny(deny, agentId) {
 }
 
 /**
+ * Tools we never want a runner-hosted persona to call. Surface area
+ * pruning — every additional tool burns ~450 tokens of schema and adds
+ * noise to the agent's decision tree. These three were called out by
+ * the operator as actively unhelpful for the worker roles the runner
+ * hosts:
+ *   - memory_search / memory_get — openclaw's built-in personal memory
+ *     surface. Runner-hosted personas get their context from MC's
+ *     scope-keyed sessions + the briefing pipeline, not openclaw's
+ *     per-agent memory; the memory tools encourage personas to write
+ *     state that won't survive into the next dispatch.
+ *   - x_search — Twitter / X search. Not a useful research surface for
+ *     this org's workloads.
+ */
+const RUNNER_ALWAYS_DENY = ['memory_search', 'memory_get', 'x_search'];
+
+/**
  * Runner agents keep the full-surface allowlist. They still need their
  * deny[] extended so they can't see the new PM/CRUD-scoped catalogs
  * from the OTHER environment (and to keep CRUD off their plate even in
- * their own env, since they don't use it).
+ * their own env, since they don't use it). Plus the static
+ * RUNNER_ALWAYS_DENY list of tools we never want runner personas to use.
  */
 function rewriteRunnerDeny(deny, agentId) {
   const existing = Array.isArray(deny) ? deny : [];
@@ -206,6 +223,11 @@ function rewriteRunnerDeny(deny, agentId) {
   } else {
     wanted.add('sc-mission-control-pm__*');
     wanted.add('sc-mission-control-crud__*');
+  }
+  // Static deny list — bare tool names (no MCP-server prefix; these
+  // come from openclaw's tool catalog directly).
+  for (const tool of RUNNER_ALWAYS_DENY) {
+    wanted.add(tool);
   }
   return [...wanted];
 }

--- a/src/lib/scripts/apply-mc-servers.test.ts
+++ b/src/lib/scripts/apply-mc-servers.test.ts
@@ -143,6 +143,10 @@ test('apply-mc-servers: write mode rewrites PM and adds scoped servers', () => {
     assert.ok(runnerStable.tools.deny.includes('sc-mission-control-pm__*'));
     assert.ok(runnerStable.tools.deny.includes('sc-mission-control-crud__*'));
     assert.ok(runnerStable.tools.deny.includes('sc-mission-control-dev__*'));
+    // Static deny list — bare tool names from openclaw's catalog.
+    assert.ok(runnerStable.tools.deny.includes('memory_search'), 'runner must deny memory_search');
+    assert.ok(runnerStable.tools.deny.includes('memory_get'), 'runner must deny memory_get');
+    assert.ok(runnerStable.tools.deny.includes('x_search'), 'runner must deny x_search');
 
     // Unrelated agent untouched.
     const random = after.agents.list.find((a: { id: string }) => a.id === 'random-agent');


### PR DESCRIPTION
## Summary

Quick follow-up to the MCP surface v2 stack. Adds three tool names to the static deny list `apply-mc-servers.mjs` writes onto runner agents.

## Changes

- `scripts/apply-mc-servers.mjs` — new `RUNNER_ALWAYS_DENY = ['memory_search', 'memory_get', 'x_search']` constant, extended onto every runner agent's `tools.deny[]` in `rewriteRunnerDeny()`. Idempotent.
- `src/lib/scripts/apply-mc-servers.test.ts` — three assertions added to the runner-deny test.

## Test plan

- [x] `yarn` script tests 9/9 pass.
- [x] Live `yarn openclaw:apply-mc-servers:check`: identifies `mc-runner` (stable) as needing the update; `mc-runner-dev` already has those entries (operator added manually) so it's a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)