### PR TITLE
feat(scripts): disable memorySearch on runner agents

### DIFF
--- a/scripts/apply-mc-servers.mjs
+++ b/scripts/apply-mc-servers.mjs
@@ -263,17 +263,39 @@ function applyAgentChanges(config, { dryRun }) {
         });
       }
     } else if (RUNNER_AGENT_RE.test(agent.id)) {
-      // Runner deny rewrite only.
+      // Runner agents host every persona (coordinator, builder, tester,
+      // reviewer, researcher, writer, learner) via scope-keyed sessions.
+      // Two mutations:
+      //
+      //   (a) Extend tools.deny[] with the cross-env / same-env scoped
+      //       MCP servers + the static RUNNER_ALWAYS_DENY list.
+      //
+      //   (b) Force `memorySearch.enabled = false` so openclaw's memory
+      //       layer doesn't bleed context between personas hosted on
+      //       the same runner gateway agent. Per-agent override of
+      //       agents.defaults.memorySearch.enabled. Note: a known QMD
+      //       backend regression (openclaw/openclaw#20581) may ignore
+      //       this flag — combined with the memory_search/memory_get
+      //       deny in RUNNER_ALWAYS_DENY, the agent-loop side is still
+      //       insulated from cross-persona leakage. Stamping the flag
+      //       lands the documented intent in config so the disable
+      //       takes effect when the regression is fixed (or when the
+      //       operator switches memory.backend to "builtin").
       const tools = agent.tools && typeof agent.tools === 'object' ? agent.tools : {};
       const newDeny = rewriteRunnerDeny(tools.deny, agent.id);
       const nextTools = { ...tools, deny: newDeny };
-      const candidate = { ...agent, tools: nextTools };
+
+      const existingMemorySearch =
+        agent.memorySearch && typeof agent.memorySearch === 'object' ? agent.memorySearch : {};
+      const nextMemorySearch = { ...existingMemorySearch, enabled: false };
+
+      const candidate = { ...agent, tools: nextTools, memorySearch: nextMemorySearch };
       if (JSON.stringify(candidate) !== JSON.stringify(agent)) {
         updated = candidate;
         changes.push({
           id: agent.id,
           index: i,
-          kind: 'runner-deny',
+          kind: 'runner-rewrite',
           block: candidate,
         });
       }

--- a/src/lib/scripts/apply-mc-servers.test.ts
+++ b/src/lib/scripts/apply-mc-servers.test.ts
@@ -94,8 +94,8 @@ test('apply-mc-servers: dry-run on fresh config reports drift and exits 2', () =
     assert.match(r.stdout, /add mcp.servers.sc-mission-control-crud-dev /);
     assert.match(r.stdout, /pm-rewrite mc-pm-default(?!-dev)/);
     assert.match(r.stdout, /pm-rewrite mc-pm-default-dev/);
-    assert.match(r.stdout, /runner-deny mc-runner(?!-dev)/);
-    assert.match(r.stdout, /runner-deny mc-runner-dev/);
+    assert.match(r.stdout, /runner-rewrite mc-runner(?!-dev)/);
+    assert.match(r.stdout, /runner-rewrite mc-runner-dev/);
 
     // Confirm fixture wasn't mutated.
     const after = JSON.parse(readFileSync(path, 'utf8'));
@@ -147,6 +147,12 @@ test('apply-mc-servers: write mode rewrites PM and adds scoped servers', () => {
     assert.ok(runnerStable.tools.deny.includes('memory_search'), 'runner must deny memory_search');
     assert.ok(runnerStable.tools.deny.includes('memory_get'), 'runner must deny memory_get');
     assert.ok(runnerStable.tools.deny.includes('x_search'), 'runner must deny x_search');
+    // Per-agent memorySearch override — disables openclaw memory layer
+    // for the runner so persona switches don't bleed context. Belt-and-
+    // suspenders to the memory_search/memory_get deny above.
+    assert.deepEqual(runnerStable.memorySearch, { enabled: false }, 'runner must have memorySearch.enabled=false');
+    const runnerDev = after.agents.list.find((a: { id: string }) => a.id === 'mc-runner-dev');
+    assert.deepEqual(runnerDev.memorySearch, { enabled: false }, 'dev runner must have memorySearch.enabled=false too');
 
     // Unrelated agent untouched.
     const random = after.agents.list.find((a: { id: string }) => a.id === 'random-agent');


### PR DESCRIPTION
## Summary

Stamps `memorySearch: { enabled: false }` onto every `^mc-runner[-dev]?$` agent block in `~/.openclaw/openclaw.json`. Belt-and-suspenders to PR #221's `memory_search` / `memory_get` deny.

## Why

The runner hosts every persona via scope-keyed sessions. Openclaw's memory layer is persona-agnostic — without this disable, daily snapshots in `~/.openclaw/workspaces/mc-runner-dev/memory/` would bleed coordinator context into a builder dispatch and vice versa. The tool deny prevents the agent from *reading* memory; this flag prevents openclaw from *building the index* in the first place.

## Caveat

[openclaw/openclaw#20581](https://github.com/openclaw/openclaw/issues/20581) — QMD backend currently ignores per-agent `memorySearch.enabled: false`. Your config has `memory.backend: "qmd"`, so the flag is presently a documented-intent statement; it activates when the regression is fixed (or when you switch backends). The tool deny is the load-bearing guard until then.

## Changes

- `scripts/apply-mc-servers.mjs` — runner block update now also stamps `memorySearch.enabled = false` (preserving any other `memorySearch.*` keys). Change kind renamed `runner-deny` → `runner-rewrite` since it touches more than `tools.deny[]`.
- `src/lib/scripts/apply-mc-servers.test.ts` — assertions added for both stable and dev runner.

## Test plan

- [x] `yarn` script tests 9/9 pass.
- [x] Live `yarn openclaw:apply-mc-servers:check`: identifies both `mc-runner` and `mc-runner-dev` as needing the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)