### PR TITLE
feat(scripts): pin runner skills to canonical list

### DIFF
--- a/scripts/apply-mc-servers.mjs
+++ b/scripts/apply-mc-servers.mjs
@@ -203,6 +203,33 @@ function rewritePmDeny(deny, agentId) {
 const RUNNER_ALWAYS_DENY = ['memory_search', 'memory_get', 'x_search'];
 
 /**
+ * Canonical openclaw skills list for runner-hosted personas. Same
+ * surface-pruning rationale as RUNNER_ALWAYS_DENY: skills that aren't
+ * useful for any of the worker personas the runner hosts (coordinator,
+ * builder, tester, reviewer, researcher, writer, learner) just burn
+ * context and confuse the agent's decision tree. Kept in lock-step
+ * with whatever the operator validates as the working set.
+ */
+const RUNNER_SKILLS = [
+  'acp-router',
+  'github',
+  'healthcheck',
+  'node-connect',
+  'peekaboo',
+  'tmux',
+  'video-frames',
+  'native-data-fetching',
+  'taskflow',
+];
+
+function arraysEqual(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/**
  * Runner agents keep the full-surface allowlist. They still need their
  * deny[] extended so they can't see the new PM/CRUD-scoped catalogs
  * from the OTHER environment (and to keep CRUD off their plate even in
@@ -289,7 +316,12 @@ function applyAgentChanges(config, { dryRun }) {
         agent.memorySearch && typeof agent.memorySearch === 'object' ? agent.memorySearch : {};
       const nextMemorySearch = { ...existingMemorySearch, enabled: false };
 
-      const candidate = { ...agent, tools: nextTools, memorySearch: nextMemorySearch };
+      // (c) Pin skills to the canonical RUNNER_SKILLS list. Hard
+      // overwrite — operator-validated working set; anything else just
+      // burns context for personas that won't use it.
+      const nextSkills = arraysEqual(agent.skills, RUNNER_SKILLS) ? agent.skills : [...RUNNER_SKILLS];
+
+      const candidate = { ...agent, tools: nextTools, memorySearch: nextMemorySearch, skills: nextSkills };
       if (JSON.stringify(candidate) !== JSON.stringify(agent)) {
         updated = candidate;
         changes.push({

--- a/src/lib/scripts/apply-mc-servers.test.ts
+++ b/src/lib/scripts/apply-mc-servers.test.ts
@@ -41,11 +41,13 @@ const baseConfig = () => ({
       {
         id: 'mc-runner',
         name: 'MC Runner',
+        skills: ['acp-router', 'old-skill-to-be-pruned'],
         tools: { alsoAllow: ['sc-mission-control__*', 'browser'], deny: ['image_generate'] },
       },
       {
         id: 'mc-runner-dev',
         name: 'MC Runner Dev',
+        skills: ['acp-router', 'old-skill-to-be-pruned'],
         tools: { alsoAllow: ['sc-mission-control-dev__*', 'browser'], deny: ['image_generate'] },
       },
       {
@@ -153,6 +155,10 @@ test('apply-mc-servers: write mode rewrites PM and adds scoped servers', () => {
     assert.deepEqual(runnerStable.memorySearch, { enabled: false }, 'runner must have memorySearch.enabled=false');
     const runnerDev = after.agents.list.find((a: { id: string }) => a.id === 'mc-runner-dev');
     assert.deepEqual(runnerDev.memorySearch, { enabled: false }, 'dev runner must have memorySearch.enabled=false too');
+    // Skills pinned to the canonical RUNNER_SKILLS list — old-skill-to-be-pruned dropped.
+    const expectedSkills = ['acp-router', 'github', 'healthcheck', 'node-connect', 'peekaboo', 'tmux', 'video-frames', 'native-data-fetching', 'taskflow'];
+    assert.deepEqual(runnerStable.skills, expectedSkills, 'runner skills must match canonical list');
+    assert.deepEqual(runnerDev.skills, expectedSkills, 'dev runner skills must match canonical list');
 
     // Unrelated agent untouched.
     const random = after.agents.list.find((a: { id: string }) => a.id === 'random-agent');


### PR DESCRIPTION
## Summary

Bakes the operator-validated runner skills working set into `apply-mc-servers.mjs` as the canonical list, applied to every `^mc-runner[-dev]?$` agent block.

```js
const RUNNER_SKILLS = [
  'acp-router', 'github', 'healthcheck', 'node-connect',
  'peekaboo', 'tmux', 'video-frames', 'native-data-fetching', 'taskflow'
];
```

Hard overwrite. Live config already matches (operator hand-tagged), so dry-run is in-sync; the pin keeps it that way.

## Test plan

- [x] 9/9 script tests pass (fixture extended with a stale skill that gets pruned).
- [x] Live `:check` reports in-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)