### PR TITLE
feat(scripts): deny cron + disable startupContext on runners

### DIFF
--- a/scripts/apply-mc-servers.mjs
+++ b/scripts/apply-mc-servers.mjs
@@ -200,7 +200,21 @@ function rewritePmDeny(deny, agentId) {
  *   - x_search — Twitter / X search. Not a useful research surface for
  *     this org's workloads.
  */
-const RUNNER_ALWAYS_DENY = ['memory_search', 'memory_get', 'x_search'];
+const RUNNER_ALWAYS_DENY = [
+  // Memory layer — runner hosts every persona; openclaw memory is
+  // persona-agnostic and would bleed context across persona switches.
+  // Belt-and-suspenders to memorySearch.enabled = false stamped below.
+  'memory_search',
+  'memory_get',
+  // Twitter / X search — not useful for any of the worker personas
+  // the runner hosts.
+  'x_search',
+  // Cron — scheduling is a PM / operator concern, not a runner-hosted
+  // persona concern. A coordinator subagent shouldn't be able to
+  // schedule wake events on the runner gateway. MC's own
+  // recurring-scheduler covers the runner-side scheduling needs.
+  'cron',
+];
 
 /**
  * Canonical openclaw skills list for runner-hosted personas. Same
@@ -316,12 +330,33 @@ function applyAgentChanges(config, { dryRun }) {
         agent.memorySearch && typeof agent.memorySearch === 'object' ? agent.memorySearch : {};
       const nextMemorySearch = { ...existingMemorySearch, enabled: false };
 
+      // (b2) Force `startupContext.enabled = false` so openclaw doesn't
+      // inject the "Recent daily memory" prelude (memory/<date>-*.md
+      // files) into the runner's session-init context. This is a SEPARATE
+      // config from memorySearch — memorySearch controls the runtime
+      // memory_search/memory_get tools (already denied above), while
+      // startupContext controls the one-shot bootstrap that auto-loads
+      // daily memory files at /new and /reset boundaries. Without this,
+      // the runner cold-starts with yesterday's persona context bleeding
+      // into today's session — the exact failure mode the rest of this
+      // block is designed to prevent.
+      // Per agents.defaults.startupContext.{enabled,applyOn,dailyMemoryDays,...}.
+      const existingStartupContext =
+        agent.startupContext && typeof agent.startupContext === 'object' ? agent.startupContext : {};
+      const nextStartupContext = { ...existingStartupContext, enabled: false };
+
       // (c) Pin skills to the canonical RUNNER_SKILLS list. Hard
       // overwrite — operator-validated working set; anything else just
       // burns context for personas that won't use it.
       const nextSkills = arraysEqual(agent.skills, RUNNER_SKILLS) ? agent.skills : [...RUNNER_SKILLS];
 
-      const candidate = { ...agent, tools: nextTools, memorySearch: nextMemorySearch, skills: nextSkills };
+      const candidate = {
+        ...agent,
+        tools: nextTools,
+        memorySearch: nextMemorySearch,
+        startupContext: nextStartupContext,
+        skills: nextSkills,
+      };
       if (JSON.stringify(candidate) !== JSON.stringify(agent)) {
         updated = candidate;
         changes.push({

--- a/src/lib/scripts/apply-mc-servers.test.ts
+++ b/src/lib/scripts/apply-mc-servers.test.ts
@@ -149,12 +149,15 @@ test('apply-mc-servers: write mode rewrites PM and adds scoped servers', () => {
     assert.ok(runnerStable.tools.deny.includes('memory_search'), 'runner must deny memory_search');
     assert.ok(runnerStable.tools.deny.includes('memory_get'), 'runner must deny memory_get');
     assert.ok(runnerStable.tools.deny.includes('x_search'), 'runner must deny x_search');
+    assert.ok(runnerStable.tools.deny.includes('cron'), 'runner must deny cron');
     // Per-agent memorySearch override — disables openclaw memory layer
     // for the runner so persona switches don't bleed context. Belt-and-
     // suspenders to the memory_search/memory_get deny above.
     assert.deepEqual(runnerStable.memorySearch, { enabled: false }, 'runner must have memorySearch.enabled=false');
+    assert.deepEqual(runnerStable.startupContext, { enabled: false }, 'runner must have startupContext.enabled=false');
     const runnerDev = after.agents.list.find((a: { id: string }) => a.id === 'mc-runner-dev');
     assert.deepEqual(runnerDev.memorySearch, { enabled: false }, 'dev runner must have memorySearch.enabled=false too');
+    assert.deepEqual(runnerDev.startupContext, { enabled: false }, 'dev runner must have startupContext.enabled=false too');
     // Skills pinned to the canonical RUNNER_SKILLS list — old-skill-to-be-pruned dropped.
     const expectedSkills = ['acp-router', 'github', 'healthcheck', 'node-connect', 'peekaboo', 'tmux', 'video-frames', 'native-data-fetching', 'taskflow'];
     assert.deepEqual(runnerStable.skills, expectedSkills, 'runner skills must match canonical list');


### PR DESCRIPTION
## Summary

Two follow-ups to PR #222, driven by analyzing a live runner session-init payload.

1. **cron** added to `RUNNER_ALWAYS_DENY`. Scheduling is a PM/operator concern; runner-hosted personas shouldn't schedule wake events on the gateway.

2. **`startupContext.enabled = false`** stamped onto runner blocks. This is the **missing piece** for memory isolation — `memorySearch` only controls the runtime `memory_search`/`memory_get` tools (already denied). `startupContext` is the SEPARATE config that governs the "Recent daily memory" prelude openclaw injects on `/new` and `/reset`. The live session-init payload showed two `memory/<date>-*.md` files loaded as untrusted context despite `memorySearch=false` + tool deny. Per [docs.openclaw.ai/gateway/config-agents](https://docs.openclaw.ai/gateway/config-agents).

## Changes

- `scripts/apply-mc-servers.mjs` — `RUNNER_ALWAYS_DENY` += `cron`; new per-agent stamp `startupContext: { enabled: false }` on runner blocks.
- `src/lib/scripts/apply-mc-servers.test.ts` — assertions for both.

## Test plan

- [x] 9/9 script tests pass.
- [x] Live `:check` identifies both `mc-runner` and `mc-runner-dev` as needing the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)