### PR TITLE
fix(scripts): drop runner startupContext stamp (openclaw rejects per-agent)

### DIFF
--- a/scripts/apply-mc-servers.mjs
+++ b/scripts/apply-mc-servers.mjs
@@ -330,20 +330,22 @@ function applyAgentChanges(config, { dryRun }) {
         agent.memorySearch && typeof agent.memorySearch === 'object' ? agent.memorySearch : {};
       const nextMemorySearch = { ...existingMemorySearch, enabled: false };
 
-      // (b2) Force `startupContext.enabled = false` so openclaw doesn't
-      // inject the "Recent daily memory" prelude (memory/<date>-*.md
-      // files) into the runner's session-init context. This is a SEPARATE
-      // config from memorySearch — memorySearch controls the runtime
-      // memory_search/memory_get tools (already denied above), while
-      // startupContext controls the one-shot bootstrap that auto-loads
-      // daily memory files at /new and /reset boundaries. Without this,
-      // the runner cold-starts with yesterday's persona context bleeding
-      // into today's session — the exact failure mode the rest of this
-      // block is designed to prevent.
-      // Per agents.defaults.startupContext.{enabled,applyOn,dailyMemoryDays,...}.
-      const existingStartupContext =
-        agent.startupContext && typeof agent.startupContext === 'object' ? agent.startupContext : {};
-      const nextStartupContext = { ...existingStartupContext, enabled: false };
+      // (b2) NOTE: we previously stamped `startupContext.enabled = false`
+      // here to disable the daily-memory bootstrap on /new and /reset.
+      // Confirmed via live trial that openclaw's reload validator
+      // rejects `agents.list[].startupContext` as an Unrecognized key —
+      // per-agent override isn't supported in the current schema (only
+      // agents.defaults.startupContext.* is recognized). Openclaw
+      // atomically reverts to last-good on any schema failure, taking
+      // out the rest of our changes (cron deny etc.) as collateral.
+      // Until openclaw lands per-agent override support, the daily-
+      // memory bootstrap must be disabled globally via
+      // agents.defaults.startupContext.enabled = false (affects every
+      // agent including the PM), or via openclaw's own admin tooling.
+      // Tracking gap: the agent-loop side is still insulated from
+      // cross-persona memory leakage by the memory_search/memory_get
+      // tool deny in RUNNER_ALWAYS_DENY — the bootstrap context just
+      // arrives in the prompt as untrusted text the agent cannot query.
 
       // (c) Pin skills to the canonical RUNNER_SKILLS list. Hard
       // overwrite — operator-validated working set; anything else just
@@ -354,7 +356,6 @@ function applyAgentChanges(config, { dryRun }) {
         ...agent,
         tools: nextTools,
         memorySearch: nextMemorySearch,
-        startupContext: nextStartupContext,
         skills: nextSkills,
       };
       if (JSON.stringify(candidate) !== JSON.stringify(agent)) {

--- a/src/lib/scripts/apply-mc-servers.test.ts
+++ b/src/lib/scripts/apply-mc-servers.test.ts
@@ -154,10 +154,12 @@ test('apply-mc-servers: write mode rewrites PM and adds scoped servers', () => {
     // for the runner so persona switches don't bleed context. Belt-and-
     // suspenders to the memory_search/memory_get deny above.
     assert.deepEqual(runnerStable.memorySearch, { enabled: false }, 'runner must have memorySearch.enabled=false');
-    assert.deepEqual(runnerStable.startupContext, { enabled: false }, 'runner must have startupContext.enabled=false');
     const runnerDev = after.agents.list.find((a: { id: string }) => a.id === 'mc-runner-dev');
     assert.deepEqual(runnerDev.memorySearch, { enabled: false }, 'dev runner must have memorySearch.enabled=false too');
-    assert.deepEqual(runnerDev.startupContext, { enabled: false }, 'dev runner must have startupContext.enabled=false too');
+    // startupContext per-agent is rejected by openclaw schema validator in
+    // current version — must be disabled globally at agents.defaults if needed.
+    assert.equal(runnerStable.startupContext, undefined, 'runner must NOT have agent-level startupContext (openclaw rejects it)');
+    assert.equal(runnerDev.startupContext, undefined, 'dev runner must NOT have agent-level startupContext (openclaw rejects it)');
     // Skills pinned to the canonical RUNNER_SKILLS list — old-skill-to-be-pruned dropped.
     const expectedSkills = ['acp-router', 'github', 'healthcheck', 'node-connect', 'peekaboo', 'tmux', 'video-frames', 'native-data-fetching', 'taskflow'];
     assert.deepEqual(runnerStable.skills, expectedSkills, 'runner skills must match canonical list');


### PR DESCRIPTION
## Summary

Per-agent \`startupContext\` is rejected by openclaw's reload validator. Live trial: \`yarn openclaw:apply-mc-servers\` writes successfully; openclaw on restart auto-restores last-good and saves our payload as \`.clobbered.<ts>\`. The cron deny was reverted too as collateral damage (whole-config atomic rollback).

## Fix

Drop the per-agent \`startupContext\` stamp; keep the cron deny (independently valid).

## Mitigation for daily-memory bootstrap

Until openclaw lands per-agent override support, two paths:
1. **Global disable**: set \`agents.defaults.startupContext.enabled = false\` in \`~/.openclaw/openclaw.json\` (affects every agent, including PM).
2. **Live with it**: the runner's tool deny on \`memory_search\`/\`memory_get\` already prevents the agent loop from *querying* prior memory — the bootstrap text just arrives as untrusted prompt context.

## Test plan

- [x] 9/9 script tests pass.
- [x] Live trace from openclaw logs confirmed schema rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)