### PR TITLE
feat(scripts): restore runner startupContext stamp (OpenClaw 2026.427)

### DIFF
--- a/scripts/apply-mc-servers.mjs
+++ b/scripts/apply-mc-servers.mjs
@@ -330,22 +330,25 @@ function applyAgentChanges(config, { dryRun }) {
         agent.memorySearch && typeof agent.memorySearch === 'object' ? agent.memorySearch : {};
       const nextMemorySearch = { ...existingMemorySearch, enabled: false };
 
-      // (b2) NOTE: we previously stamped `startupContext.enabled = false`
-      // here to disable the daily-memory bootstrap on /new and /reset.
-      // Confirmed via live trial that openclaw's reload validator
-      // rejects `agents.list[].startupContext` as an Unrecognized key —
-      // per-agent override isn't supported in the current schema (only
-      // agents.defaults.startupContext.* is recognized). Openclaw
-      // atomically reverts to last-good on any schema failure, taking
-      // out the rest of our changes (cron deny etc.) as collateral.
-      // Until openclaw lands per-agent override support, the daily-
-      // memory bootstrap must be disabled globally via
-      // agents.defaults.startupContext.enabled = false (affects every
-      // agent including the PM), or via openclaw's own admin tooling.
-      // Tracking gap: the agent-loop side is still insulated from
-      // cross-persona memory leakage by the memory_search/memory_get
-      // tool deny in RUNNER_ALWAYS_DENY — the bootstrap context just
-      // arrives in the prompt as untrusted text the agent cannot query.
+      // (b2) Force `startupContext.enabled = false` so openclaw doesn't
+      // inject the "Recent daily memory" prelude (memory/<date>-*.md
+      // files) into the runner's session-init context. SEPARATE config
+      // from memorySearch — memorySearch governs the runtime
+      // memory_search/memory_get tools (already denied above);
+      // startupContext governs the one-shot bootstrap that auto-loads
+      // daily memory files at /new and /reset boundaries. Without this
+      // the runner cold-starts with yesterday's persona context bleeding
+      // into today's session.
+      //
+      // Per-agent override added in OpenClaw 2026.427. A previous
+      // attempt was rejected by the reload validator on ≤ 2026.426
+      // (openclaw atomically reverted the whole config to last-known-
+      // good when an Unrecognized key was present); restored here now
+      // that the schema accepts agents.list[].startupContext.
+      // Per agents.defaults.startupContext.{enabled,applyOn,dailyMemoryDays,...}.
+      const existingStartupContext =
+        agent.startupContext && typeof agent.startupContext === 'object' ? agent.startupContext : {};
+      const nextStartupContext = { ...existingStartupContext, enabled: false };
 
       // (c) Pin skills to the canonical RUNNER_SKILLS list. Hard
       // overwrite — operator-validated working set; anything else just
@@ -356,6 +359,7 @@ function applyAgentChanges(config, { dryRun }) {
         ...agent,
         tools: nextTools,
         memorySearch: nextMemorySearch,
+        startupContext: nextStartupContext,
         skills: nextSkills,
       };
       if (JSON.stringify(candidate) !== JSON.stringify(agent)) {

--- a/src/lib/scripts/apply-mc-servers.test.ts
+++ b/src/lib/scripts/apply-mc-servers.test.ts
@@ -156,10 +156,10 @@ test('apply-mc-servers: write mode rewrites PM and adds scoped servers', () => {
     assert.deepEqual(runnerStable.memorySearch, { enabled: false }, 'runner must have memorySearch.enabled=false');
     const runnerDev = after.agents.list.find((a: { id: string }) => a.id === 'mc-runner-dev');
     assert.deepEqual(runnerDev.memorySearch, { enabled: false }, 'dev runner must have memorySearch.enabled=false too');
-    // startupContext per-agent is rejected by openclaw schema validator in
-    // current version — must be disabled globally at agents.defaults if needed.
-    assert.equal(runnerStable.startupContext, undefined, 'runner must NOT have agent-level startupContext (openclaw rejects it)');
-    assert.equal(runnerDev.startupContext, undefined, 'dev runner must NOT have agent-level startupContext (openclaw rejects it)');
+    // Per-agent startupContext.enabled=false — supported in OpenClaw
+    // 2026.427+; previously rejected by the reload validator.
+    assert.deepEqual(runnerStable.startupContext, { enabled: false }, 'runner must have startupContext.enabled=false');
+    assert.deepEqual(runnerDev.startupContext, { enabled: false }, 'dev runner must have startupContext.enabled=false too');
     // Skills pinned to the canonical RUNNER_SKILLS list — old-skill-to-be-pruned dropped.
     const expectedSkills = ['acp-router', 'github', 'healthcheck', 'node-connect', 'peekaboo', 'tmux', 'video-frames', 'native-data-fetching', 'taskflow'];
     assert.deepEqual(runnerStable.skills, expectedSkills, 'runner skills must match canonical list');


### PR DESCRIPTION
## Summary

OpenClaw 2026.427 added per-agent \`startupContext\` support. Reverts PR #225's workaround and restores the \`agents.list[].startupContext: { enabled: false }\` stamp on runner blocks.

Disables the "Recent daily memory" bootstrap prelude for runner sessions — the cross-persona isolation gap we couldn't close on ≤2026.426.

## Changes

- \`scripts/apply-mc-servers.mjs\` — re-add the \`nextStartupContext\` stamp; comment records the version history.
- \`src/lib/scripts/apply-mc-servers.test.ts\` — assertions flipped back from \`undefined\` to \`{ enabled: false }\`.

## Test plan

- [x] 9/9 script tests pass.
- [x] Live \`:check\` identifies both runners as needing the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)