### PR TITLE
fix(scripts): drop runner startupContext (verified not in openclaw schema)

### DIFF
--- a/scripts/apply-mc-servers.mjs
+++ b/scripts/apply-mc-servers.mjs
@@ -330,25 +330,29 @@ function applyAgentChanges(config, { dryRun }) {
         agent.memorySearch && typeof agent.memorySearch === 'object' ? agent.memorySearch : {};
       const nextMemorySearch = { ...existingMemorySearch, enabled: false };
 
-      // (b2) Force `startupContext.enabled = false` so openclaw doesn't
-      // inject the "Recent daily memory" prelude (memory/<date>-*.md
-      // files) into the runner's session-init context. SEPARATE config
-      // from memorySearch — memorySearch governs the runtime
-      // memory_search/memory_get tools (already denied above);
-      // startupContext governs the one-shot bootstrap that auto-loads
-      // daily memory files at /new and /reset boundaries. Without this
-      // the runner cold-starts with yesterday's persona context bleeding
-      // into today's session.
+      // (b2) NOTE — DO NOT stamp `startupContext.enabled = false` here.
+      // Verified against the openclaw source tree: per-agent
+      // `startupContext` is NOT in the schema. The loader at
+      // src/auto-reply/reply/startup-context.ts only reads from
+      // `agents.defaults.startupContext`, and `AgentConfig` in
+      // src/config/types.agents.ts has no `startupContext` field. The
+      // schema (zod-schema.agent-defaults.ts) declares it `.strict()`,
+      // so any per-agent stamp gets rejected as Unrecognized and
+      // openclaw atomically reverts to last-known-good — taking out
+      // the rest of our changes (cron deny, etc.) as collateral.
       //
-      // Per-agent override added in OpenClaw 2026.427. A previous
-      // attempt was rejected by the reload validator on ≤ 2026.426
-      // (openclaw atomically reverted the whole config to last-known-
-      // good when an Unrecognized key was present); restored here now
-      // that the schema accepts agents.list[].startupContext.
-      // Per agents.defaults.startupContext.{enabled,applyOn,dailyMemoryDays,...}.
-      const existingStartupContext =
-        agent.startupContext && typeof agent.startupContext === 'object' ? agent.startupContext : {};
-      const nextStartupContext = { ...existingStartupContext, enabled: false };
+      // 2026.427's release notes implied per-agent support was added;
+      // they were misleading. Tracking upstream feature request.
+      //
+      // To disable daily-memory bootstrap, the operator must set it
+      // GLOBALLY at agents.defaults.startupContext.enabled = false
+      // (affects every agent, PM included).
+      //
+      // Mitigation in place: memory_search / memory_get tool deny in
+      // RUNNER_ALWAYS_DENY prevents the runner-hosted personas from
+      // querying memory mid-session. The bootstrap text still arrives
+      // in the prompt as an [Untrusted daily memory] block the agent
+      // is instructed to treat as untrusted background only.
 
       // (c) Pin skills to the canonical RUNNER_SKILLS list. Hard
       // overwrite — operator-validated working set; anything else just
@@ -359,7 +363,6 @@ function applyAgentChanges(config, { dryRun }) {
         ...agent,
         tools: nextTools,
         memorySearch: nextMemorySearch,
-        startupContext: nextStartupContext,
         skills: nextSkills,
       };
       if (JSON.stringify(candidate) !== JSON.stringify(agent)) {

--- a/src/lib/scripts/apply-mc-servers.test.ts
+++ b/src/lib/scripts/apply-mc-servers.test.ts
@@ -156,10 +156,14 @@ test('apply-mc-servers: write mode rewrites PM and adds scoped servers', () => {
     assert.deepEqual(runnerStable.memorySearch, { enabled: false }, 'runner must have memorySearch.enabled=false');
     const runnerDev = after.agents.list.find((a: { id: string }) => a.id === 'mc-runner-dev');
     assert.deepEqual(runnerDev.memorySearch, { enabled: false }, 'dev runner must have memorySearch.enabled=false too');
-    // Per-agent startupContext.enabled=false — supported in OpenClaw
-    // 2026.427+; previously rejected by the reload validator.
-    assert.deepEqual(runnerStable.startupContext, { enabled: false }, 'runner must have startupContext.enabled=false');
-    assert.deepEqual(runnerDev.startupContext, { enabled: false }, 'dev runner must have startupContext.enabled=false too');
+    // Per-agent startupContext is NOT in openclaw's schema (verified
+    // against src/config/types.agents.ts + zod-schema.agent-defaults.ts:
+    // the field lives only under agents.defaults and the schema is
+    // .strict()). Stamping it agent-side gets rejected on reload and
+    // takes out the rest of our changes as collateral. To disable
+    // daily-memory bootstrap, set it globally at agents.defaults.
+    assert.equal(runnerStable.startupContext, undefined, 'runner must NOT have agent-level startupContext (not in openclaw schema)');
+    assert.equal(runnerDev.startupContext, undefined, 'dev runner must NOT have agent-level startupContext (not in openclaw schema)');
     // Skills pinned to the canonical RUNNER_SKILLS list — old-skill-to-be-pruned dropped.
     const expectedSkills = ['acp-router', 'github', 'healthcheck', 'node-connect', 'peekaboo', 'tmux', 'video-frames', 'native-data-fetching', 'taskflow'];
     assert.deepEqual(runnerStable.skills, expectedSkills, 'runner skills must match canonical list');


### PR DESCRIPTION
## Summary

Reverts the PR #226 reapply. Verified against \`/Users/Shared/git/openclaw\`:

- \`src/config/types.agents.ts\` — \`AgentConfig\` type has NO \`startupContext\` field.
- \`src/config/zod-schema.agent-defaults.ts:115\` — \`startupContext\` schema is \`.strict()\`, lives only under \`agents.defaults\`.
- \`src/auto-reply/reply/startup-context.ts:21\` — loader reads only \`cfg?.agents?.defaults?.startupContext\`.

2026.427's release notes were misleading. Per-agent isn't a thing.

## To actually disable daily-memory

Set globally in \`~/.openclaw/openclaw.json\` (affects every agent including PM):

\`\`\`json
"agents": {
  "defaults": {
    "startupContext": { "enabled": false }
  }
}
\`\`\`

## Test plan

- [x] 9/9 script tests pass.
- [x] Comment block records schema verification so we don't oscillate again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)