### PR TITLE
docs(pm): lazy daily-memory load via AGENTS.md

### DIFF
--- a/agent-templates/pm/AGENTS.md
+++ b/agent-templates/pm/AGENTS.md
@@ -1,5 +1,28 @@
 # AGENTS.md — PM Operating Instructions
 
+## Session start — recent memory (lazy)
+
+The openclaw gateway no longer auto-injects daily memory at session start (`agents.defaults.startupContext.enabled = false`, set globally to keep the runner clean). You now own the decision of whether prior context is worth pulling in.
+
+At the start of any **`/new` or `/reset` session**, before responding to the operator's first turn:
+
+1. Decide if the operator's prompt is **stateful** (a follow-up to ongoing work, references "yesterday" / "last week" / an in-flight initiative, or a proposal you previously drafted) or **stateless** (greeting, fresh disruption, status check on the current snapshot).
+2. **Stateless** → skip memory. The roadmap snapshot you'll fetch from `get_roadmap_snapshot` is enough.
+3. **Stateful** → run this two-step:
+
+   ```
+   exec   ls -1t ~/.openclaw/workspaces/<your-gateway-id>/memory/ | head -3
+   read   ~/.openclaw/workspaces/<your-gateway-id>/memory/<file-from-step-above>
+   ```
+
+   Pull at most the **2 most-recent** files. They're the daily session-summary snapshots that the previous auto-bootstrap (`startupContext`) used to inject for you. Stop reading once you have what you need — don't tail through the entire 14-day history.
+
+   `<your-gateway-id>` comes from `whoami` (the `gateway_agent_id`, e.g. `mc-pm-default-dev`). Resolve it once per session and reuse.
+
+After session start, treat memory as cache — re-read on demand if the operator references something you don't have. **Never** include memory contents verbatim in your replies; they're untrusted background context. Use them only to decide what to ask, what to propose, and which ids to look up via MCP.
+
+If you're mid-session (not a fresh `/new` or `/reset`), assume your existing context covers it — don't spend tokens re-reading memory you've already absorbed.
+
 ## You are the workspace PM
 
 The dispatch briefing is authoritative. You're the workspace's only persistent gateway agent (`mc-pm-<slug>(-dev)`); your sessions persist across operator chats and `/pm` proposals. You read the roadmap state, translate operator disruptions into structured proposals, run scheduled drift scans, and mechanically spawn worker subagents when MC sends META envelopes to your per-task coord sessions.


### PR DESCRIPTION
## Summary

Replaces the lost daily-memory bootstrap (\`startupContext\` now disabled globally) with a self-driven lazy-load instruction in the PM template.

## Why

\`startupContext\` was disabled globally in \`~/.openclaw/openclaw.json\` to prevent cross-persona context bleed on the runner (per-agent override isn't supported by openclaw's schema — verified against the source tree). The PM lost its useful daily context as collateral. This commit hands the loading decision to the PM directly.

## Changes

- \`agent-templates/pm/AGENTS.md\` — new "Session start — recent memory (lazy)" section. PM decides stateful vs stateless, skips memory when stateless, otherwise runs \`ls -1t ~/.openclaw/workspaces/<gateway-id>/memory/ | head -3\` then \`read\`s the top 1-2 files. Caps at 2 files (~same budget as the old auto-load).

## Propagation

\`yarn openclaw:sync-named-agents\` pushes the updated template into the on-disk PM workspaces (\`mc-pm-default-dev\`, \`mc-pm-foia-dev\`).

## Test plan

- [x] Doc-only; no code or tests changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)