### PR TITLE
fix(initiatives): hydration mismatch on /initiatives deep links

### DIFF
--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -194,10 +194,20 @@ export default function InitiativesPage() {
   // right pane always re-renders on click. URL is a synced side-effect for
   // deep links / back-forward (initial value seeds local state once on
   // mount; subsequent clicks push to the URL via window.history).
-  const [selectedId, setSelectedId] = useState<string | null>(() => {
-    if (typeof window === 'undefined') return null;
-    return new URL(window.location.href).searchParams.get('selected');
-  });
+  //
+  // IMPORTANT: initial state must be `null` on both server and client to
+  // avoid a hydration mismatch — the server has no access to
+  // window.location.search, so a lazy initializer that reads it would
+  // make the first paint diverge (server renders empty-state copy while
+  // client renders the InitiativeDetailView loading state). We hydrate
+  // the URL-based selection from a useEffect below on first mount.
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  useEffect(() => {
+    const fromUrl = new URL(window.location.href).searchParams.get('selected');
+    if (fromUrl) setSelectedId(fromUrl);
+    // Run once on mount; subsequent URL changes flow through selectInitiative.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const selectInitiative = useCallback(
     (id: string | null) => {
       setSelectedId(id);


### PR DESCRIPTION
## Summary

Hard reload of \`/initiatives?selected=<id>\` was throwing a hydration error: server rendered the empty-state copy while client rendered the detail view's loading panel.

## Root cause

\`selectedId\`'s lazy useState initializer read \`window.location.href\` — server has no access to it, returns null. Client picks up the URL param. Two trees diverge on first paint.

## Fix

Seed \`selectedId\` to null on both server and client; hydrate from URL via \`useEffect\` after mount. Empty-state flashes for one frame on deep links, which is fine.

## Test plan

- [x] Manual: pages load without hydration error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)