### PR TITLE
perf(briefing): skip static blocks on resume dispatches

### DIFF
--- a/src/lib/agents/briefing.test.ts
+++ b/src/lib/agents/briefing.test.ts
@@ -165,6 +165,57 @@ test('buildBriefing: is_resume adds resume hint', () => {
   }
 });
 
+test('buildBriefing: is_resume skips identity preamble + role section + notetaker addendum', () => {
+  const fx = makeFixtureTemplates();
+  __setTemplatesDirForTests(fx.dir);
+  const ws = freshWorkspace();
+  try {
+    const fresh = buildBriefing({
+      workspace_id: ws,
+      role: 'builder',
+      scope_key: 'sk',
+      agent_id: 'aid-123',
+      gateway_agent_id: 'mc-runner-dev',
+      run_group_id: 'rg',
+      trigger_body: 'body',
+      is_resume: false,
+    });
+    // Fresh dispatch: all static blocks present.
+    assert.match(fresh, /Your agent_id is: aid-123/);
+    assert.match(fresh, /# Role: builder/);
+    assert.match(fresh, /Builder soul/);
+    assert.match(fresh, /Take notes/);
+
+    const resume = buildBriefing({
+      workspace_id: ws,
+      role: 'builder',
+      scope_key: 'sk',
+      agent_id: 'aid-123',
+      gateway_agent_id: 'mc-runner-dev',
+      run_group_id: 'rg',
+      trigger_body: 'body',
+      is_resume: true,
+    });
+    // Resume dispatch: static blocks omitted, dynamic content kept.
+    assert.doesNotMatch(resume, /Your agent_id is/);
+    assert.doesNotMatch(resume, /# Role: builder/);
+    assert.doesNotMatch(resume, /Builder soul/);
+    assert.doesNotMatch(resume, /Take notes/);
+    assert.match(resume, /body/);
+    assert.match(resume, /prior trajectory/);
+    // Resume briefing must be shorter than fresh — that's the whole point.
+    // The exact ratio depends on the fixture template sizes; in production
+    // (real PM SOUL.md / AGENTS.md), the savings are 3–10K+ tokens.
+    assert.ok(
+      resume.length < fresh.length,
+      `expected resume (${resume.length}b) < fresh (${fresh.length}b)`,
+    );
+  } finally {
+    __setTemplatesDirForTests(null);
+    fx.cleanup();
+  }
+});
+
 test('buildBriefing: role + addendum + trigger order is identity → role → addendum → trigger', () => {
   const fx = makeFixtureTemplates();
   __setTemplatesDirForTests(fx.dir);

--- a/src/lib/agents/briefing.ts
+++ b/src/lib/agents/briefing.ts
@@ -209,24 +209,37 @@ function buildResumeHint(input: BuildBriefingInput): string {
 /**
  * Build the dispatch briefing. Synchronous — file reads are fast and
  * the call site is already inside an async dispatch handler.
+ *
+ * Resume optimization: when `is_resume=true`, the gateway session
+ * already absorbed the identity preamble + role section + notetaker
+ * addendum on the first dispatch under this scope key. Re-sending
+ * them on every turn just inflates the input prompt by 3–10K tokens
+ * for a long-lived agent like the PM. We skip the static blocks and
+ * send only dynamic content (active-subagent manifest, trigger body,
+ * resume hint). The agent can re-read its own SOUL/AGENTS via the
+ * read tool if compaction ever drops the early turn.
  */
 export function buildBriefing(input: BuildBriefingInput): string {
   const parts: string[] = [];
-  parts.push(buildIdentityPreamble(input));
 
-  const roleSection = buildRoleSection(input);
-  if (roleSection) {
-    parts.push(`# Role: ${input.role}\n\n${roleSection}`);
-  }
+  if (!input.is_resume) {
+    parts.push(buildIdentityPreamble(input));
 
-  const notetaker = buildNotetakerAddendum(input);
-  if (notetaker) {
-    parts.push(`---\n\n${notetaker}`);
+    const roleSection = buildRoleSection(input);
+    if (roleSection) {
+      parts.push(`# Role: ${input.role}\n\n${roleSection}`);
+    }
+
+    const notetaker = buildNotetakerAddendum(input);
+    if (notetaker) {
+      parts.push(`---\n\n${notetaker}`);
+    }
   }
 
   // Phase J2: active-subagent manifest precedes the trigger body so
   // the PM sees the orchestration state before it reads what MC is
-  // asking it to do next.
+  // asking it to do next. Always included — it's dynamic and
+  // authoritative state the agent shouldn't try to remember.
   const manifest = buildActiveSubagentManifest(input);
   if (manifest) {
     parts.push(`---\n\n${manifest}`);


### PR DESCRIPTION
## Summary

The PM (and any other long-lived scope-keyed agent) was getting its full \`SOUL.md\` + \`AGENTS.md\` + identity preamble re-injected as a user-role message on **every** turn, not just the first. Confirmed by inspecting a PM chat export — same session, three consecutive turns, full briefing each time.

## Fix

\`buildBriefing\` now gates the static blocks (identity preamble, role section, notetaker addendum) on \`!is_resume\`. Dynamic content (active-subagent manifest, trigger body, resume hint) stays on every dispatch.

## Savings

For a typical PM dispatch, the static blocks total ~3-10K tokens. They're now sent only on the first dispatch under each scope key (or on attempt_strategy='fresh' resets); subsequent turns under the same scope receive only the dynamic content + the resume hint.

## Test plan

- [x] New test: resume briefing omits agent_id / role header / SOUL body / notetaker body, keeps trigger body + resume hint, is shorter than fresh.
- [x] Full suite: 734/735 (only pre-existing schedule-runner flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)