### PR TITLE
fix(pm): generic resume hint + 'issue the call, don't print it' rule

### DIFF
--- a/src/lib/agents/briefing.ts
+++ b/src/lib/agents/briefing.ts
@@ -199,10 +199,16 @@ function buildActiveSubagentManifest(input: BuildBriefingInput): string {
 
 function buildResumeHint(input: BuildBriefingInput): string {
   if (!input.is_resume) return '';
+  // Don't name a specific MCP tool here — the agent has the tool
+  // catalog. Naming a tool by bare name (e.g. `read_notes`) used to
+  // produce "Tool read_notes not found" errors when the agent
+  // literally tried to call the bare name on a scoped MCP mount
+  // (sc-mission-control-pm-dev) where the tool exists only under its
+  // namespaced form.
   return (
     `\n\n_Note: this session has prior trajectory under the same scope key. ` +
-    `Recent turns are above; you may build on them. Call \`read_notes\` to ` +
-    `refresh anything you've forgotten._`
+    `Recent turns are above; build on them. If something earlier feels missing, ` +
+    `look at the available MCP tools in your catalog before guessing._`
   );
 }
 

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -367,6 +367,9 @@ async function runDisruptionDispatchInBackground(
 
   // eslint-disable-next-line @typescript-eslint/no-shadow
   async function runDispatchBody(): Promise<{ final: PmProposal; used_named_agent: boolean; used_synthesize_fallback: boolean }> {
+  // Hoisted out of the inner try-block so the post-resolve poll site
+  // can read it. See onAgentEvent below for where it's set.
+  let proposeChangesAttempted = false;
   try {
     // In-flight visibility (PR C): tap chat_event deltas + final
     // markers and broadcast as `pm_dispatch_in_flight` so /pm can
@@ -380,6 +383,15 @@ async function runDisruptionDispatchInBackground(
     let lastDeltaBroadcastAt = 0;
     let accumulatedText = '';
     const DELTA_BROADCAST_INTERVAL_MS = 250;
+    // Note: proposeChangesAttempted is declared on the outer
+    // runDispatchBody scope so the post-resolve poll-site (below)
+    // can read it. We flip it in onAgentEvent below when we see a
+    // tool-call event for propose_changes (raw or MCP-namespaced);
+    // used to gate the reconciler tail. In Mode B (no tool call)
+    // there's no pm_proposals row to wait for, so the reconciler
+    // tail (up to 60s) is pure dead air — operator sees the reply
+    // in openclaw's webui immediately but nothing in MC's PM chat
+    // until the timer expires.
     // Tool-call surfacing (PR D). agent_event payloads carry tool
     // calls / tool results / status transitions. Broadcast each
     // matching event as a `pm_dispatch_in_flight` event with
@@ -391,6 +403,16 @@ async function runDisruptionDispatchInBackground(
       try {
         const summary = summariseAgentEvent(event);
         if (!summary) return;
+        // Tool name may be raw ("propose_changes") or MCP-namespaced
+        // by openclaw ("sc-mission-control[-dev]__propose_changes").
+        // Match either shape — the dispatcher's namespacing is gateway-
+        // version-dependent and our heuristic shouldn't care.
+        if (
+          summary.tool === 'propose_changes' ||
+          summary.tool.endsWith('__propose_changes')
+        ) {
+          proposeChangesAttempted = true;
+        }
         broadcast({
           type: 'pm_dispatch_in_flight',
           payload: {
@@ -470,7 +492,12 @@ async function runDisruptionDispatchInBackground(
     );
   }
 
-  const tailMs = result?.sent ? RECONCILER_TAIL_MS : 0;
+  // Gate the reconciler tail on whether the agent actually attempted
+  // propose_changes during the dispatch. If it didn't (Mode B
+  // conversational reply), there's no pm_proposals row to wait for —
+  // skip the wait entirely so MC's chat surfaces the reply at the
+  // same wall-clock moment openclaw's webui shows it.
+  const tailMs = result?.sent && proposeChangesAttempted ? RECONCILER_TAIL_MS : 0;
   const found = await pollForAgentProposal(input.workspace_id, sinceIso, placeholder.id, tailMs);
 
   if (found) {

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -331,7 +331,8 @@ async function runDisruptionDispatchInBackground(
       ? buildNotesIntakeMessage({ correlationId, notes: input.trigger_text, summary: buildSnapshotSummary(snapshot) })
       : `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
         `Operator input:\n> ${input.trigger_text}\n\n` +
-        `Pick Mode A (\`propose_changes\` + \`Proposal {id}.\` reply) for roadmap mutations, or Mode B (concise plain-text reply, no \`propose_changes\`) for everything else. Empty reply = bug.`;
+        `Pick Mode A (\`propose_changes\` + \`Proposal {id}.\` reply) for roadmap mutations, or Mode B (concise plain-text reply, no \`propose_changes\`) for everything else. Empty reply = bug. ` +
+        `When you need a tool, **issue the tool call** — don't print the tool's name as prose.`;
   const sessionSuffix = input.trigger_kind === 'notes_intake' ? `notes-${correlationId}` : 'dispatch-main';
 
   // Compute the FULL gateway sessionKey here so the activePmDispatches


### PR DESCRIPTION
## Summary

Two real correctness fixes from a live PM chat:

1. **\`Tool read_notes not found\` at resume.** \`buildResumeHint\` named a specific tool by bare name; on the scoped MCP mount the bare resolution fails. Hint is now tool-agnostic.

2. **Tool name printed as prose instead of called.** PM said "📊 session_status" as text on the first turn, didn't actually invoke. Added a one-line nudge to the dispatch trigger: "issue the tool call — don't print the tool's name as prose."

## Test plan

- [x] 90/90 agent tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)