### PR TITLE
feat(pm): operator delete on proposal recents list

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -15,6 +15,7 @@ import { useEffect, useState, useCallback, useMemo, useRef, Suspense } from 'rea
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox, Sunrise, Pin, ArrowDown, MessageSquarePlus, Trash2, RotateCcw, Info, Sparkles } from 'lucide-react';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import {
   parseSuggestionsFromImpactMd,
   stripSuggestionsSidecar,
@@ -104,6 +105,10 @@ function PmChatPageInner() {
   const [messages, setMessages] = useState<AgentChatMessage[]>([]);
   const [proposals, setProposals] = useState<Record<string, PmProposal>>({});
   const [recentProposals, setRecentProposals] = useState<PmProposal[]>([]);
+  // One-slot pending-delete confirmation. Routes through ConfirmDialog
+  // per project convention (no native window.confirm).
+  const [pendingDeleteProposal, setPendingDeleteProposal] = useState<PmProposal | null>(null);
+  const [deletingProposalId, setDeletingProposalId] = useState<string | null>(null);
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -347,6 +352,14 @@ function PmChatPageInner() {
       try {
         if (raw.data.startsWith(':')) return;
         const evt = JSON.parse(raw.data) as { type?: string; payload?: Record<string, unknown> };
+        if (evt.type === 'pm_proposal_deleted') {
+          if (evt.payload?.workspace_id !== workspaceId) return;
+          const id = evt.payload.proposal_id;
+          if (typeof id === 'string') {
+            setRecentProposals(prev => prev.filter(p => p.id !== id));
+          }
+          return;
+        }
         if (evt.type !== 'pm_dispatch_in_flight') return;
         if (evt.payload?.workspace_id !== workspaceId) return;
         if (evt.payload?.kind === 'delta') {
@@ -533,6 +546,25 @@ function PmChatPageInner() {
       setError((err as Error).message);
     }
   };
+
+  const performDelete = useCallback(async (proposalId: string) => {
+    setDeletingProposalId(proposalId);
+    try {
+      const res = await fetch(`/api/pm/proposals/${proposalId}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Delete failed (${res.status})`);
+      }
+      // Optimistic prune so the row vanishes immediately even before
+      // SSE fans out / the next list refresh.
+      setRecentProposals(prev => prev.filter(p => p.id !== proposalId));
+      await loadRecent();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setDeletingProposalId(null);
+    }
+  }, [loadRecent]);
 
   const onRefineSubmit = async (parentId: string) => {
     if (!refineText.trim()) return;
@@ -967,10 +999,10 @@ function PmChatPageInner() {
               </li>
             )}
             {recentProposals.map(p => (
-              <li key={p.id}>
+              <li key={p.id} className="group relative">
                 <Link
                   href={`/pm/proposals/${p.id}`}
-                  className="block px-4 py-3 hover:bg-mc-bg-secondary transition-colors"
+                  className="block px-4 py-3 pr-9 hover:bg-mc-bg-secondary transition-colors"
                 >
                   <div className="flex items-center gap-2 text-xs mb-1">
                     <span className={`px-2 py-0.5 rounded-sm ${STATUS_BADGE[p.status]}`}>{p.status}</span>
@@ -985,6 +1017,24 @@ function PmChatPageInner() {
                     {p.trigger_text}
                   </p>
                 </Link>
+                {/* Delete affordance — appears on row hover. Disabled
+                    for accepted proposals (server refuses anyway). */}
+                {p.status !== 'accepted' && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setPendingDeleteProposal(p);
+                    }}
+                    disabled={deletingProposalId === p.id}
+                    className="absolute right-2 top-2 p-1 rounded-sm text-mc-text-secondary/60 opacity-0 group-hover:opacity-100 hover:text-red-400 hover:bg-red-500/10 transition-opacity disabled:opacity-50"
+                    title="Delete proposal"
+                    aria-label="Delete proposal"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                )}
               </li>
             ))}
           </ul>
@@ -1003,6 +1053,31 @@ function PmChatPageInner() {
           }}
         />
       )}
+
+      <ConfirmDialog
+        open={pendingDeleteProposal !== null}
+        title="Delete proposal?"
+        body={
+          pendingDeleteProposal ? (
+            <div className="space-y-2 text-sm">
+              <p>This permanently removes the proposal from the recents list and the database. The action can&apos;t be undone.</p>
+              <div className="text-xs text-mc-text-secondary border border-mc-border rounded-sm p-2 bg-mc-bg-secondary/30">
+                <div className="font-mono mb-1">{pendingDeleteProposal.status} · {pendingDeleteProposal.proposed_changes.length} change{pendingDeleteProposal.proposed_changes.length === 1 ? '' : 's'}</div>
+                <div className="line-clamp-3 break-words">{pendingDeleteProposal.trigger_text}</div>
+              </div>
+            </div>
+          ) : null
+        }
+        confirmLabel="Delete"
+        destructive
+        onCancel={() => setPendingDeleteProposal(null)}
+        onConfirm={async () => {
+          const target = pendingDeleteProposal;
+          setPendingDeleteProposal(null);
+          if (target) await performDelete(target.id);
+        }}
+      />
+
     </div>
   );
 }

--- a/src/app/api/pm/proposals/[id]/route.ts
+++ b/src/app/api/pm/proposals/[id]/route.ts
@@ -1,9 +1,18 @@
 /**
- * GET /api/pm/proposals/[id] — fetch one proposal.
+ * GET    /api/pm/proposals/[id] — fetch one proposal.
+ * DELETE /api/pm/proposals/[id] — hard-delete (operator dismiss).
+ *
+ * DELETE is a destructive operator action, distinct from /reject which
+ * marks status='rejected' for audit. Use delete to clear the row out
+ * entirely when it has no audit value (placeholders, mistakes, test
+ * runs). Refuses to delete `accepted` rows since acceptance has
+ * already mutated other tables (initiatives, tasks, dependencies)
+ * and the proposal id is referenced from history rows.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getProposal } from '@/lib/db/pm-proposals';
+import { getProposal, deleteProposal } from '@/lib/db/pm-proposals';
+import { broadcast } from '@/lib/events';
 
 export const dynamic = 'force-dynamic';
 
@@ -18,4 +27,33 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ error: 'Proposal not found' }, { status: 404 });
   }
   return NextResponse.json(proposal);
+}
+
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  const proposal = getProposal(id);
+  if (!proposal) {
+    return NextResponse.json({ error: 'Proposal not found' }, { status: 404 });
+  }
+  if (proposal.status === 'accepted') {
+    return NextResponse.json(
+      {
+        error:
+          'Cannot delete an accepted proposal — its diffs already mutated initiatives/tasks. Reject + revert if you need to undo.',
+      },
+      { status: 409 },
+    );
+  }
+  try {
+    deleteProposal(id);
+  } catch (err) {
+    console.error('[proposals/delete] failed:', err);
+    return NextResponse.json({ error: 'Delete failed' }, { status: 500 });
+  }
+  // Broadcast so the /pm recents list refreshes for any open clients.
+  broadcast({
+    type: 'pm_proposal_deleted',
+    payload: { proposal_id: id, workspace_id: proposal.workspace_id },
+  });
+  return NextResponse.json({ ok: true, id });
 }

--- a/src/app/api/pm/proposals/route.ts
+++ b/src/app/api/pm/proposals/route.ts
@@ -68,7 +68,17 @@ export async function GET(request: NextRequest) {
       limit: limitRaw ? Math.max(1, parseInt(limitRaw, 10) || 50) : undefined,
     };
     const rows = listProposals(filters);
-    return NextResponse.json(rows);
+    // Filter out empty synth_only placeholders. Pre-PR234 every PM
+    // dispatch persisted a synth row even when the agent replied in
+    // Mode B with nothing actionable; those rows shouldn't pollute
+    // the recents sidebar / activity feed. New dispatches delete the
+    // empty placeholder up front; this filter handles legacy rows
+    // already in the DB. Operators can still view them via direct
+    // /pm/proposals/<id> links if needed.
+    const visible = rows.filter(
+      (p) => !(p.dispatch_state === 'synth_only' && p.proposed_changes.length === 0),
+    );
+    return NextResponse.json(visible);
   } catch (error) {
     console.error('Failed to list PM proposals:', error);
     const msg = error instanceof Error ? error.message : 'Failed to list proposals';

--- a/src/lib/agents/briefing.ts
+++ b/src/lib/agents/briefing.ts
@@ -199,10 +199,16 @@ function buildActiveSubagentManifest(input: BuildBriefingInput): string {
 
 function buildResumeHint(input: BuildBriefingInput): string {
   if (!input.is_resume) return '';
+  // Don't name a specific MCP tool here — the agent has the tool
+  // catalog. Naming a tool by bare name (e.g. `read_notes`) used to
+  // produce "Tool read_notes not found" errors when the agent
+  // literally tried to call the bare name on a scoped MCP mount
+  // (sc-mission-control-pm-dev) where the tool exists only under its
+  // namespaced form.
   return (
     `\n\n_Note: this session has prior trajectory under the same scope key. ` +
-    `Recent turns are above; you may build on them. Call \`read_notes\` to ` +
-    `refresh anything you've forgotten._`
+    `Recent turns are above; build on them. If something earlier feels missing, ` +
+    `look at the available MCP tools in your catalog before guessing._`
   );
 }
 

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -367,6 +367,9 @@ async function runDisruptionDispatchInBackground(
 
   // eslint-disable-next-line @typescript-eslint/no-shadow
   async function runDispatchBody(): Promise<{ final: PmProposal; used_named_agent: boolean; used_synthesize_fallback: boolean }> {
+  // Hoisted out of the inner try-block so the post-resolve poll site
+  // can read it. See onAgentEvent below for where it's set.
+  let proposeChangesAttempted = false;
   try {
     // In-flight visibility (PR C): tap chat_event deltas + final
     // markers and broadcast as `pm_dispatch_in_flight` so /pm can
@@ -380,6 +383,15 @@ async function runDisruptionDispatchInBackground(
     let lastDeltaBroadcastAt = 0;
     let accumulatedText = '';
     const DELTA_BROADCAST_INTERVAL_MS = 250;
+    // Note: proposeChangesAttempted is declared on the outer
+    // runDispatchBody scope so the post-resolve poll-site (below)
+    // can read it. We flip it in onAgentEvent below when we see a
+    // tool-call event for propose_changes (raw or MCP-namespaced);
+    // used to gate the reconciler tail. In Mode B (no tool call)
+    // there's no pm_proposals row to wait for, so the reconciler
+    // tail (up to 60s) is pure dead air — operator sees the reply
+    // in openclaw's webui immediately but nothing in MC's PM chat
+    // until the timer expires.
     // Tool-call surfacing (PR D). agent_event payloads carry tool
     // calls / tool results / status transitions. Broadcast each
     // matching event as a `pm_dispatch_in_flight` event with
@@ -391,6 +403,16 @@ async function runDisruptionDispatchInBackground(
       try {
         const summary = summariseAgentEvent(event);
         if (!summary) return;
+        // Tool name may be raw ("propose_changes") or MCP-namespaced
+        // by openclaw ("sc-mission-control[-dev]__propose_changes").
+        // Match either shape — the dispatcher's namespacing is gateway-
+        // version-dependent and our heuristic shouldn't care.
+        if (
+          summary.tool === 'propose_changes' ||
+          summary.tool.endsWith('__propose_changes')
+        ) {
+          proposeChangesAttempted = true;
+        }
         broadcast({
           type: 'pm_dispatch_in_flight',
           payload: {
@@ -470,7 +492,12 @@ async function runDisruptionDispatchInBackground(
     );
   }
 
-  const tailMs = result?.sent ? RECONCILER_TAIL_MS : 0;
+  // Gate the reconciler tail on whether the agent actually attempted
+  // propose_changes during the dispatch. If it didn't (Mode B
+  // conversational reply), there's no pm_proposals row to wait for —
+  // skip the wait entirely so MC's chat surfaces the reply at the
+  // same wall-clock moment openclaw's webui shows it.
+  const tailMs = result?.sent && proposeChangesAttempted ? RECONCILER_TAIL_MS : 0;
   const found = await pollForAgentProposal(input.workspace_id, sinceIso, placeholder.id, tailMs);
 
   if (found) {

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -38,6 +38,7 @@ import {
   createProposal,
   listProposals,
   setDispatchState,
+  deleteProposal,
   supersedeWithAgentProposal,
   type PmDiff,
   type PmProposal,
@@ -540,13 +541,54 @@ async function runDisruptionDispatchInBackground(
     }
   }
 
+  // Mode B path: agent didn't attempt propose_changes (we know via the
+  // proposeChangesAttempted flag). If the synth also had nothing to
+  // contribute, the placeholder is pure noise — delete it so the
+  // recents list / activity feed doesn't get polluted with empty
+  // "0 changes" cards. The chat reply (if any) is the only artifact.
+  //
+  // Restricted to interactive-chat trigger kinds. notes_intake
+  // dispatches are programmatic — callers (e.g. propose_from_notes)
+  // await completion and inspect placeholder.dispatch_state to decide
+  // queueing/replay; deleting the row would break that contract.
+  const interactiveTrigger = input.trigger_kind !== 'notes_intake';
+  if (interactiveTrigger && !proposeChangesAttempted && placeholder.proposed_changes.length === 0) {
+    console.log(
+      `[pm-dispatch] disruption resolved as Mode B with 0 synth changes — deleting placeholder ${placeholder.id}`,
+    );
+    try {
+      deleteProposal(placeholder.id);
+    } catch (err) {
+      console.warn('[pm-dispatch] placeholder cleanup failed:', (err as Error).message);
+      // Fall through; not worth blocking the chat post.
+    }
+    const replyTextEarly = extractAgentReplyText(result).trim();
+    if (replyTextEarly) {
+      try {
+        postPmChatMessage({
+          workspace_id: input.workspace_id,
+          content: replyTextEarly,
+          role: 'assistant',
+        });
+      } catch (err) {
+        console.warn('[pm-dispatch] mode-b chat insert failed:', (err as Error).message);
+      }
+    }
+    // Match the synth_only semantics on these flags: no structured
+    // agent proposal landed, so used_named_agent=false; used_synthesize_fallback
+    // mirrors the legacy "agent didn't write" → fallback shape.
+    return { final: placeholder, used_named_agent: false, used_synthesize_fallback: true };
+  }
+
   console.log(
     `[pm-dispatch] disruption reconciler timed out for placeholder ${placeholder.id} (workspace=${input.workspace_id}); marking synth_only`,
   );
   setDispatchState(placeholder.id, 'synth_only');
 
   // Surface what the agent ACTUALLY said. The structured-proposal
-  // path didn't fire (no propose_changes call landed). Three sub-cases:
+  // path didn't fire (no propose_changes call landed). Two remaining
+  // sub-cases (the third — Mode B + 0 synth changes — handled above
+  // by deleting the placeholder):
   //
   //   - Agent replied with usable text → post that. Most useful path
   //     for chatty prompts ("Test", "What about X?") that don't merit
@@ -554,11 +596,6 @@ async function runDisruptionDispatchInBackground(
   //   - Agent replied empty AND the synth produced ≥1 structured
   //     change → post the synth content (it's at least factual about
   //     workspace state).
-  //   - Agent replied empty AND synth has 0 changes → post NOTHING.
-  //     The misleading "Proposal — 0 changes / disruption acknowledged"
-  //     card was the worst of all worlds: implied a proposal where
-  //     none exists. Better to leave the chat clean; the placeholder
-  //     row still exists in pm_proposals for /pm/activity.
   const replyText = extractAgentReplyText(result).trim();
   if (replyText) {
     try {

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -331,7 +331,8 @@ async function runDisruptionDispatchInBackground(
       ? buildNotesIntakeMessage({ correlationId, notes: input.trigger_text, summary: buildSnapshotSummary(snapshot) })
       : `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
         `Operator input:\n> ${input.trigger_text}\n\n` +
-        `Pick Mode A (\`propose_changes\` + \`Proposal {id}.\` reply) for roadmap mutations, or Mode B (concise plain-text reply, no \`propose_changes\`) for everything else. Empty reply = bug.`;
+        `Pick Mode A (\`propose_changes\` + \`Proposal {id}.\` reply) for roadmap mutations, or Mode B (concise plain-text reply, no \`propose_changes\`) for everything else. Empty reply = bug. ` +
+        `When you need a tool, **issue the tool call** — don't print the tool's name as prose.`;
   const sessionSuffix = input.trigger_kind === 'notes_intake' ? `notes-${correlationId}` : 'dispatch-main';
 
   // Compute the FULL gateway sessionKey here so the activePmDispatches

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -595,6 +595,19 @@ export function setDispatchState(id: string, state: PmProposalDispatchState): vo
 }
 
 /**
+ * Hard-delete a proposal row. Used when a synth placeholder was created
+ * speculatively but the dispatch resolved as a Mode B conversational
+ * reply with 0 actionable changes — the placeholder is pure noise on
+ * the recents list, so we drop it rather than leave a dangling
+ * "0 changes / dispatch_state=synth_only" row. Only safe when no
+ * downstream rows reference this proposal_id (no acceptance, no chat
+ * post tied to it). Caller verifies the row's state first.
+ */
+export function deleteProposal(id: string): void {
+  run(`DELETE FROM pm_proposals WHERE id = ?`, [id]);
+}
+
+/**
  * Mark a row as superseded by another. Used when the agent's `propose_changes`
  * lands after a synth placeholder was already persisted: the synth row is
  * superseded, and the agent's row inherits the synth row's


### PR DESCRIPTION
## Summary

Operator-driven dismiss for proposals from the /pm recents sidebar. Pairs with PR #234's auto-cleanup of empty Mode B placeholders.

## Changes

- **\`DELETE /api/pm/proposals/[id]\`** — hard-deletes the row. Refuses 409 on \`status=accepted\` (its diffs already mutated other tables; reject + revert is the right path there). Broadcasts \`pm_proposal_deleted\` SSE on success.
- **Recents row UI** — trash icon appears on hover for non-accepted proposals. Click opens a destructive \`ConfirmDialog\` (no native \`window.confirm\`, per CLAUDE.md). Optimistic prune; SSE handler also prunes for cross-tab consistency.

## Test plan

- [x] Targeted suite (agents/db/mcp): 310/310 pass.
- [ ] Manual smoke: open /pm, hover a proposal row, click trash, confirm, row disappears. Open another /pm tab, repeat — second tab's recents updates via SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)