### PR TITLE
fix(pm): hide 0-change proposals from list endpoint (any status)

### DIFF
--- a/src/app/api/pm/proposals/route.ts
+++ b/src/app/api/pm/proposals/route.ts
@@ -68,16 +68,18 @@ export async function GET(request: NextRequest) {
       limit: limitRaw ? Math.max(1, parseInt(limitRaw, 10) || 50) : undefined,
     };
     const rows = listProposals(filters);
-    // Filter out empty synth_only placeholders. Pre-PR234 every PM
-    // dispatch persisted a synth row even when the agent replied in
-    // Mode B with nothing actionable; those rows shouldn't pollute
-    // the recents sidebar / activity feed. New dispatches delete the
-    // empty placeholder up front; this filter handles legacy rows
-    // already in the DB. Operators can still view them via direct
-    // /pm/proposals/<id> links if needed.
-    const visible = rows.filter(
-      (p) => !(p.dispatch_state === 'synth_only' && p.proposed_changes.length === 0),
-    );
+    // Hide proposals with zero structured changes from the list views.
+    // These are pure noise — Mode B placeholders that pre-date PR #234's
+    // auto-cleanup, accepted-but-empty rows from older dispatches, etc.
+    // Affects both the /pm recents sidebar (status=draft) and the
+    // /pm/activity page (status=accepted): a 0-change accepted proposal
+    // doesn't represent a roadmap mutation worth surfacing in audit, and
+    // a 0-change draft is just dead weight.
+    //
+    // Operators can still view individual rows via direct
+    // /pm/proposals/<id> URLs, and can hard-delete via DELETE
+    // /api/pm/proposals/<id> (PR #235).
+    const visible = rows.filter((p) => p.proposed_changes.length > 0);
     return NextResponse.json(visible);
   } catch (error) {
     console.error('Failed to list PM proposals:', error);


### PR DESCRIPTION
## Summary

PR #234's filter was scoped to \`dispatch_state==='synth_only'\` only. \`/pm/activity\` was still showing blank accepted rows for empty proposals that pre-dated the cleanup. Broadens the filter to drop any \`proposed_changes.length === 0\` row regardless of status.

## Test plan

- [x] No code logic changes beyond the filter; existing tests cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)