### PR TITLE
feat(pm): allow done/cancelled in set_initiative_status PmDiff

### DIFF
--- a/src/lib/agents/pm-e2e.test.ts
+++ b/src/lib/agents/pm-e2e.test.ts
@@ -18,7 +18,7 @@ import { createInitiative } from '@/lib/db/initiatives';
 import { acceptProposal, getProposal, listProposals } from '@/lib/db/pm-proposals';
 import { dispatchPm } from './pm-dispatch';
 import { ensurePmAgent } from '@/lib/bootstrap-agents';
-import { createProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { createProposal } from '@/lib/db/pm-proposals';
 
 function freshWorkspace(): string {
   const id = `ws-${uuidv4().slice(0, 8)}`;
@@ -133,35 +133,44 @@ test('PM lifecycle: PM is seeded once per workspace and ensurePmAgent is idempot
   assert.equal(pms.length, 1);
 });
 
-test('PM lifecycle: refused diffs (done/cancelled status) never reach the DB', () => {
+test('PM lifecycle: done/cancelled status diffs reach the DB on accept', () => {
+  // Policy as of feat(pm) allow done/cancelled: PM may propose any of
+  // the 6 InitiativeStatus values; the operator's accept click is the
+  // gate. The validator no longer refuses done/cancelled.
   const ws = freshWorkspace();
-  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  const initDone = createInitiative({ workspace_id: ws, kind: 'story', title: 'D' });
+  const initCancelled = createInitiative({ workspace_id: ws, kind: 'story', title: 'C' });
 
-  // Direct API call — simulates an LLM trying to slip a forbidden diff
-  // through propose_changes. Validation must reject before any write.
-  let threw = false;
-  try {
-    createProposal({
-      workspace_id: ws,
-      trigger_text: 'sneaky',
-      impact_md: '.',
-      proposed_changes: [
-        // Forbidden status from the PM. The diff is well-formed JSON
-        // but the validator rejects 'done'/'cancelled'.
-        { kind: 'set_initiative_status', initiative_id: init.id, status: 'done' as never },
-      ],
-    });
-  } catch (err) {
-    threw = err instanceof PmProposalValidationError;
-  }
-  assert.equal(threw, true);
-
-  // Initiative status untouched, no proposal row written.
-  const fresh = queryOne<{ status: string }>(
+  const pDone = createProposal({
+    workspace_id: ws,
+    trigger_text: 'mark done',
+    impact_md: '.',
+    proposed_changes: [
+      { kind: 'set_initiative_status', initiative_id: initDone.id, status: 'done' },
+    ],
+  });
+  acceptProposal(pDone.id);
+  const afterDone = queryOne<{ status: string }>(
     'SELECT status FROM initiatives WHERE id = ?',
-    [init.id],
+    [initDone.id],
   );
-  assert.equal(fresh?.status, 'planned');
+  assert.equal(afterDone?.status, 'done');
+
+  const pCancelled = createProposal({
+    workspace_id: ws,
+    trigger_text: 'cancel it',
+    impact_md: '.',
+    proposed_changes: [
+      { kind: 'set_initiative_status', initiative_id: initCancelled.id, status: 'cancelled' },
+    ],
+  });
+  acceptProposal(pCancelled.id);
+  const afterCancelled = queryOne<{ status: string }>(
+    'SELECT status FROM initiatives WHERE id = ?',
+    [initCancelled.id],
+  );
+  assert.equal(afterCancelled?.status, 'cancelled');
+
   const all = listProposals({ workspace_id: ws });
-  assert.equal(all.length, 0);
+  assert.equal(all.length, 2);
 });

--- a/src/lib/db/pm-proposals.test.ts
+++ b/src/lib/db/pm-proposals.test.ts
@@ -161,21 +161,43 @@ test('acceptProposal: set_initiative_status flips status', () => {
   assert.equal(after?.status, 'at_risk');
 });
 
-test('acceptProposal rejects done/cancelled status (PM never marks done)', () => {
+test('acceptProposal: set_initiative_status accepts done and cancelled end-to-end', () => {
+  // Policy as of feat(pm) allow done/cancelled: the PM may propose any of
+  // the 6 InitiativeStatus values; the operator's accept click is the
+  // gate, not the validator. See specs/initiative-investigate.md.
   const ws = freshWorkspace();
-  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
-  assert.throws(
-    () => createProposal({
-      workspace_id: ws,
-      trigger_text: '.',
-      impact_md: '.',
-      // done is not in the PM-allowed enum at the type level — cast for the test.
-      proposed_changes: [
-        { kind: 'set_initiative_status', initiative_id: init.id, status: 'done' as never },
-      ],
-    }),
-    PmProposalValidationError,
+  const initDone = createInitiative({ workspace_id: ws, kind: 'story', title: 'D' });
+  const initCancelled = createInitiative({ workspace_id: ws, kind: 'story', title: 'C' });
+
+  const pDone = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [
+      { kind: 'set_initiative_status', initiative_id: initDone.id, status: 'done' },
+    ],
+  });
+  acceptProposal(pDone.id);
+  const afterDone = queryOne<{ status: string }>(
+    'SELECT status FROM initiatives WHERE id = ?',
+    [initDone.id],
   );
+  assert.equal(afterDone?.status, 'done');
+
+  const pCancelled = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [
+      { kind: 'set_initiative_status', initiative_id: initCancelled.id, status: 'cancelled' },
+    ],
+  });
+  acceptProposal(pCancelled.id);
+  const afterCancelled = queryOne<{ status: string }>(
+    'SELECT status FROM initiatives WHERE id = ?',
+    [initCancelled.id],
+  );
+  assert.equal(afterCancelled?.status, 'cancelled');
 });
 
 test('acceptProposal: add_dependency inserts row, dup is idempotent', () => {

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -221,8 +221,6 @@ export class PmProposalValidationError extends Error {
   }
 }
 
-const STATUS_ALLOWED_FROM_PM = new Set(['planned', 'in_progress', 'at_risk', 'blocked']);
-
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
 
 function isValidDateString(s: unknown): s is string {
@@ -324,20 +322,25 @@ export function validateProposedChanges(
           break;
         }
         assertInitiativeInWorkspace(workspaceId, c.initiative_id, errors, initiativeCache);
-        // Forward proposals are PM-restricted to the four working statuses.
-        // Revert proposals legitimately need to restore done/cancelled when
-        // the captured prev_status was one of those — keep the diff shape
-        // honest here and trust the operator's accept review.
-        const isRevert = options.trigger_kind === 'revert';
-        const allowed = isRevert
-          ? new Set(['planned', 'in_progress', 'at_risk', 'blocked', 'done', 'cancelled'])
-          : STATUS_ALLOWED_FROM_PM;
+        // Policy: PM may propose any of the 6 InitiativeStatus values,
+        // including done/cancelled. Operator approval (accept/refine on
+        // the diff) is the gate — not the validator. See
+        // specs/initiative-investigate.md (schema-gap section) for the
+        // rationale: the PM's job is to surface the right next move and
+        // package it as a reviewable diff; restricting which statuses
+        // it can propose forced ergonomic workarounds (status_check
+        // notes saying "we should mark this done") instead of letting
+        // the operator just click accept.
+        const allowed = new Set([
+          'planned',
+          'in_progress',
+          'at_risk',
+          'blocked',
+          'done',
+          'cancelled',
+        ]);
         if (!allowed.has(c.status)) {
-          errors.push(
-            isRevert
-              ? `changes[${i}]: status "${c.status}" is not a valid initiative status`
-              : `changes[${i}]: status "${c.status}" not allowed from PM (planned/in_progress/at_risk/blocked only)`,
-          );
+          errors.push(`changes[${i}]: status "${c.status}" is not a valid initiative status`);
         }
         break;
       }
@@ -923,10 +926,9 @@ function applyDiff(diff: PmDiff, now: string): void {
       return;
     }
     case 'set_initiative_status': {
-      // Capture previous status so revert can restore it. PM-driven
-      // statuses are limited (planned|in_progress|at_risk|blocked) but
-      // an operator could have left the row in done/cancelled before the
-      // proposal lands — `prev_status` covers all six values.
+      // Capture previous status so revert can restore it. The PM may
+      // propose any of the 6 InitiativeStatus values, and the row may
+      // already be in any of them — `prev_status` covers all six.
       const prev = queryOne<{ status: PmDiffCapture['prev_status'] }>(
         `SELECT status FROM initiatives WHERE id = ?`,
         [diff.initiative_id],

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -16,8 +16,10 @@
  *   - `shift_initiative_target` — UPDATE initiatives SET target_*
  *   - `add_availability` — INSERT INTO owner_availability
  *   - `set_initiative_status` — UPDATE initiatives SET status
- *       (planned | in_progress | at_risk | blocked only — done/cancelled
- *       are off-limits for the PM)
+ *       (any of planned | in_progress | at_risk | blocked | done | cancelled;
+ *       operator approves at the proposal level — see
+ *       specs/initiative-investigate.md §"Schema gap" for why the prior
+ *       PM-side `done`/`cancelled` block was lifted)
  *   - `add_dependency` — INSERT INTO initiative_dependencies
  *   - `remove_dependency` — DELETE by id
  *   - `reorder_initiatives` — UPDATE sort_order across siblings

--- a/src/lib/mcp/shared.ts
+++ b/src/lib/mcp/shared.ts
@@ -223,7 +223,7 @@ export const DiffSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('set_initiative_status'),
     initiative_id: z.string().min(1),
-    status: z.enum(['planned', 'in_progress', 'at_risk', 'blocked']),
+    status: z.enum(['planned', 'in_progress', 'at_risk', 'blocked', 'done', 'cancelled']),
   }),
   z.object({
     kind: z.literal('add_dependency'),


### PR DESCRIPTION
## Summary

Lift the PM-side restriction on proposing `done` or `cancelled` status. The PM may now propose any of the 6 `InitiativeStatus` values via `set_initiative_status`. The operator's accept/refine on the proposal remains the gate. See `specs/initiative-investigate.md` (schema-gap section) for the rationale; previously the PM had to package terminal-state suggestions as freeform `status_check` notes instead of a clean reviewable diff.

## Changes

- `src/lib/mcp/shared.ts` — extend the Zod `set_initiative_status.status` enum to all 6 values (`planned`, `in_progress`, `at_risk`, `blocked`, `done`, `cancelled`).
- `src/lib/db/pm-proposals.ts` — drop `STATUS_ALLOWED_FROM_PM` and the forward-vs-revert branch in `validateProposedChanges`; allow all 6 values uniformly. Revert pathway untouched (it already allowed all 6). Comments updated to reflect the new policy.
- `src/lib/db/pm-proposals.test.ts` — invert the rejection test; now asserts that `done` / `cancelled` proposals validate and the accept path flips the initiative status end-to-end.
- `src/lib/agents/pm-e2e.test.ts` — invert the e2e refusal test; now asserts that the diffs DO reach the DB and the initiatives end up in the proposed terminal state.

## Test plan

Targeted tests (all green):

```
$ NODE_ENV=test npx tsx --test src/lib/db/pm-proposals.test.ts
# tests 35 / pass 35 / fail 0

$ NODE_ENV=test npx tsx --test src/lib/agents/pm-e2e.test.ts
# tests 3 / pass 3 / fail 0

$ NODE_ENV=test npx tsx --test src/lib/mcp/mcp.test.ts
# tests 21 / pass 21 / fail 0
```

(Note: pre-existing typecheck errors unrelated to this change in `src/app/api/pm/proposals/[id]/route.ts:55` and `src/lib/agents/pm-decompose.test.ts:169-173` — they reproduce on `main`.)

### Live MCP-wire smoke (dev :4010)

Seeded a throwaway workspace + two initiatives at `status='planned'`. Then proposed via the live MCP HTTP wire (`/api/mcp/pm` → `propose_changes`) and accepted via `/api/pm/proposals/{id}/accept`.

Before:

```
init-smoke-done-1778100815|planned
init-smoke-cancel-1778100815|planned
```

`propose_changes` (status=done) returned a `draft` proposal:

```json
{"result":{...,"structuredContent":{"id":"2eb47dfd-3490-42f3-9467-547024c6efe7",...,"proposed_changes":[{"kind":"set_initiative_status","initiative_id":"init-smoke-done-1778100815","status":"done"}],...,"status":"draft",...}}}
```

`propose_changes` (status=cancelled) returned a `draft` proposal:

```json
{"result":{...,"structuredContent":{"id":"0adc5cf2-ea1c-4c67-825e-9bc1b4a2ca7b",...,"proposed_changes":[{"kind":"set_initiative_status","initiative_id":"init-smoke-cancel-1778100815","status":"cancelled"}],...,"status":"draft",...}}}
```

Accept results — `changes_applied: 1`, status flipped:

```
=== AFTER initiatives ===
init-smoke-done-1778100815|done
init-smoke-cancel-1778100815|cancelled

=== AFTER proposals ===
2eb47dfd-…|accepted|2026-05-06T20:55:02.820Z
0adc5cf2-…|accepted|2026-05-06T20:55:02.840Z
```

### Revert pathway sanity

`POST /api/pm/proposals/{done-proposal-id}/revert` produced a fresh draft revert proposal with the inverse diff (`status: 'planned'`, `prev_status: 'done'`). The revert branch in `validateProposedChanges` already allowed all 6 statuses and is unchanged here.

```
=== AFTER revert: proposals ===
2eb47dfd-…|accepted|manual|
0adc5cf2-…|accepted|manual|
a43a0f75-…|draft|revert|2eb47dfd-…
```

### Derivation engine

Confirmed: `done` and `cancelled` were already valid `InitiativeStatus` values throughout the codebase (`src/lib/db/initiatives.ts:23`, `src/lib/db/roadmap.ts:31`). The apply path in `pm-proposals.ts` already captured `prev_status` from the full 6-value union. No engine changes needed.

## Notes

- Stays within scope of the schema-gap remediation. Does **not** include the follow-on initiative-audit work (PR 2).
- Do not merge — operator will review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)