### PR TITLE
feat(initiatives): scope_type=initiative_audit + dispatch endpoint (narrow)

### DIFF
--- a/specs/initiative-investigate.md
+++ b/specs/initiative-investigate.md
@@ -23,7 +23,7 @@ No automatic PM hand-off. The audit produces evidence; the operator chooses the 
 "Audit this whole epic." MC orchestrates a per-level researcher fan-out:
 
 1. Enumerate leaves (descendants with no children of their own that are still `planned` / `in_progress` / `at_risk` / `blocked` — skip `done`/`cancelled`).
-2. **Layer 1**: dispatch N narrow researchers in parallel, one per leaf. Each writes a `take_note` + `register_deliverable` against its own initiative_id.
+2. **Layer 1**: dispatch N narrow researchers in parallel, one per leaf. Each writes a `take_note` against its own initiative_id.
 3. **Wait** for all Layer 1 dispatches to complete (or hit per-node timeout).
 4. **Layer 2**: for each parent of Layer 1 leaves, dispatch a roll-up researcher. Brief includes the parent's own description + a synthesized digest of children's findings (from their notes, fetched by MC and inlined).
 5. Repeat upward until the original target initiative is reached.
@@ -136,10 +136,11 @@ Audit this initiative against reality. Produce a markdown report covering:
 5. **Verdict** — one of: **on track**, **partially done**, **stale (rescope)**, **done in entirety**, **never built**, **cancelled-in-effect**.
 6. **Recommended next action** — concrete suggestion the PM can act on. Phrased as "Suggest: …", not a tool call.
 
-Save the report two ways:
+Save the report by calling:
 
-- `register_deliverable({ task_id: null, title: "Audit: {{initiative.title}}", deliverable_type: "note" })` for the audit trail.
-- `take_note({ initiative_id: "{{initiative.id}}", kind: 'observation', audience: 'pm', importance: 2, body: <full report> })` so it surfaces on the initiative detail page and feeds the PM on a later Plan dispatch.
+- `take_note({ initiative_id: "{{initiative.id}}", kind: 'observation', audience: 'pm', importance: 2, body: <full report> })`
+
+The note is the audit trail for now. **No `register_deliverable` call** — see "Output capture" below for why.
 
 Don't call propose_changes; you don't have it on your mount. The PM will pick up your note when the operator decides to act.
 
@@ -170,10 +171,9 @@ After submit → in-flight tray on the initiative detail page (mirrors the PM in
 
 ### Output capture
 
-Each audit writes:
+Each audit writes a single **`take_note`** with `initiative_id`, `kind: 'observation'`, `audience: 'pm'`, `importance: 2`. Renders on the initiative detail page's notes panel (already wired to show notes filtered by `initiative_id`).
 
-1. **`take_note`** with `initiative_id`, `kind: 'observation'`, `audience: 'pm'`, `importance: 2`. Renders on the initiative detail page's notes panel (already wired to show notes filtered by `initiative_id`).
-2. **`register_deliverable`** with `kind: 'note'` and the full report body. Becomes part of the audit history; can be exported / archived later.
+**No `register_deliverable`.** The original spec called for a parallel deliverable row as the audit trail, but the deliverables system is task-scoped today (no `initiative_id` column on the deliverables table) and won't accept an initiative-only deliverable. The note carries the full report body and serves as the audit trail. Revisit if/when deliverables grow initiative scope. (Decision landed in PR 2; the prompt no longer instructs the researcher to call `register_deliverable`.)
 
 Subtree mode produces N notes (one per audited node), all linked to their respective initiative_ids. The root-level note synthesizes children's findings into a single report; the operator can drill into per-child notes if they want detail.
 
@@ -270,7 +270,6 @@ curl -sS -H "Authorization: Bearer $TOKEN" -X POST \
 ### Pass criteria for narrow mode
 
 - Note lands with `initiative_id = 0c9419ff…`, `kind = 'observation'`, `audience = 'pm'`, `importance = 2`.
-- Deliverable registered with `deliverable_type = 'note'`.
 - Report includes a per-child breakdown that aligns with the operator's ground truth (1 done, several partial, one unused).
 - Verdict is one of the documented enum values (`partially done` is the expected verdict for this fixture).
 - Total dispatch time under the per-node timeout (15 min default).
@@ -287,7 +286,6 @@ curl -sS -H "Authorization: Bearer $TOKEN" -X POST \
 Save to `/tmp/mc-validation/initiative-investigate/iter-<n>/`:
 
 - `note.md` — the take_note body the researcher produced
-- `deliverable.json` — the deliverable row
 - `transcript.txt` — full chat transcript from openclaw's session log (or webui export)
 - `dispatch-log.txt` — MC server logs filtered to `[investigate]` / `[dispatch-scope]` lines
 - `verdict.txt` — one-line operator assessment of how the audit landed against ground truth ("matched", "missed unused child", "false-positive on partial X", etc.)

--- a/src/app/api/initiatives/[id]/investigate/route.ts
+++ b/src/app/api/initiatives/[id]/investigate/route.ts
@@ -1,0 +1,175 @@
+/**
+ * POST /api/initiatives/:id/investigate
+ *
+ * Dispatches a researcher to audit an initiative against reality.
+ * See specs/initiative-investigate.md.
+ *
+ * PR 2 ships **narrow mode only** — one researcher dispatch per call.
+ * Subtree mode lands with PR 4 (it'll add a child-findings synthesis
+ * step before the parent-level dispatch).
+ *
+ * Request body:
+ *   {
+ *     mode: 'narrow',          // PR 4: 'subtree'
+ *     guidance?: string,       // optional operator focus area
+ *     reaudit?: 'fresh' | 'build_on'  // default 'fresh'
+ *   }
+ *
+ * Response (200):
+ *   {
+ *     ok: true,
+ *     scope_key: string,
+ *     scope_keys: string[],     // single-element for narrow; subtree
+ *                                // returns one per node (PR 4)
+ *     attempt: number,
+ *     dispatched_at: string,
+ *   }
+ *
+ * The dispatch runs **fire-and-forget**. The route returns as soon as
+ * the briefing has been queued at the gateway; the researcher's
+ * take_note + final reply land asynchronously and are surfaced via
+ * SSE / the initiative detail page.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getInitiative } from '@/lib/db/initiatives';
+import { listNotes } from '@/lib/db/agent-notes';
+import { getRunnerAgent } from '@/lib/agents/runner';
+import { dispatchScope } from '@/lib/agents/dispatch-scope';
+import { buildAuditPrompt } from '@/lib/agents/audit-prompt';
+import { queryAll } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+const InvestigateSchema = z.object({
+  mode: z.enum(['narrow']).default('narrow'),
+  guidance: z.string().max(2000).nullish(),
+  reaudit: z.enum(['fresh', 'build_on']).default('fresh'),
+});
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * Compute the next `:audit:N` attempt suffix for fresh-mode dispatch.
+ * Counts all prior `initiative_audit` rows for this initiative across
+ * any status; the next attempt is `count + 1`. Build-on mode reuses
+ * `:audit:1` to inherit the prior trajectory.
+ */
+function nextAuditAttempt(initiativeId: string): number {
+  const rows = queryAll<{ n: number }>(
+    `SELECT COUNT(*) as n
+       FROM mc_sessions
+      WHERE scope_type = 'initiative_audit'
+        AND initiative_id = ?`,
+    [initiativeId],
+  );
+  const count = rows[0]?.n ?? 0;
+  return count + 1;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+
+    const raw = await request.json().catch(() => ({}));
+    const parsed = InvestigateSchema.safeParse(raw);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const { mode, guidance, reaudit } = parsed.data;
+
+    const initiative = getInitiative(id, { includeTasks: true });
+    if (!initiative) {
+      return NextResponse.json(
+        { error: 'Initiative not found' },
+        { status: 404 },
+      );
+    }
+
+    const runner = getRunnerAgent();
+    if (!runner) {
+      return NextResponse.json(
+        { error: 'Runner agent not registered (mc-runner-dev / mc-runner missing)' },
+        { status: 503 },
+      );
+    }
+
+    // Build-on mode: reuse `:audit:1` so the researcher resumes the
+    // prior session AND inline the prior audit notes. Fresh mode: mint
+    // a brand new attempt suffix and pass priorFindings: [].
+    const attempt = reaudit === 'build_on' ? 1 : nextAuditAttempt(id);
+    const sessionSuffix = `initiative-${id}:audit:${attempt}`;
+
+    const priorFindings = reaudit === 'build_on'
+      ? listNotes({
+          initiative_id: id,
+          audience: 'pm',
+          min_importance: 2,
+          limit: 5,
+          order: 'desc',
+        })
+      : [];
+
+    const triggerBody = buildAuditPrompt({
+      initiative,
+      tasks: initiative.tasks ?? [],
+      guidance: guidance ?? null,
+      priorFindings,
+    });
+
+    // Compute scope_key + a synthetic run_group_id up front so the
+    // route can respond immediately. Audits run for up to 15 min; we
+    // can't make the operator's HTTP request hang on that. The actual
+    // dispatchScope call runs detached — its reply is consumed by
+    // openclaw's session log and the take_note row that lands when the
+    // researcher finishes. The `is_resume` bookkeeping inside
+    // dispatchScope still happens via upsertSession on the same tick.
+    const dispatchedAt = new Date().toISOString();
+    const scopeKey = (runner as { session_key_prefix?: string | null })
+      .session_key_prefix
+      ? `${(runner as { session_key_prefix?: string | null }).session_key_prefix}:${sessionSuffix}`
+      : sessionSuffix;
+
+    // Kick off the dispatch but don't await it. Errors are logged so
+    // operators see them in MC server logs; the route already
+    // responded.
+    void dispatchScope({
+      workspace_id: initiative.workspace_id,
+      role: 'researcher',
+      agent: runner,
+      session_suffix: sessionSuffix,
+      scope_type: 'initiative_audit',
+      initiative_id: id,
+      trigger_body: triggerBody,
+      attempt_strategy: reaudit === 'build_on' ? 'reuse' : 'fresh',
+      timeoutMs: 15 * 60_000,
+      idempotencyKey: `investigate-${id}-${attempt}-${Date.now()}`,
+    }).catch((err) => {
+      console.error(
+        `[investigate] dispatch failed for initiative ${id} (attempt ${attempt}):`,
+        (err as Error).message,
+      );
+    });
+
+    return NextResponse.json({
+      ok: true,
+      mode,
+      scope_key: scopeKey,
+      scope_keys: [scopeKey],
+      attempt,
+      dispatched_at: dispatchedAt,
+    });
+  } catch (error) {
+    console.error('[investigate] route error:', error);
+    return NextResponse.json(
+      { error: (error as Error).message ?? 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/agents/audit-prompt.test.ts
+++ b/src/lib/agents/audit-prompt.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for buildAuditPrompt (PR 2 of initiative-investigate).
+ *
+ * The prompt is load-bearing on the take_note arg shape — the
+ * researcher reads it verbatim. These tests guard against accidental
+ * re-flowing that would change what the LLM sees.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAuditPrompt } from './audit-prompt';
+
+const baseInitiative = {
+  id: 'init-abc-123',
+  title: 'Roll out auth v2',
+  kind: 'epic' as const,
+  status: 'in_progress' as const,
+  description: 'Migrate auth to OIDC.',
+  status_check_md: '- IdP wired\n- Migration script TBD',
+  target_start: '2026-04-01',
+  target_end: '2026-05-15',
+};
+
+test('audit-prompt: includes initiative metadata + tasks block', () => {
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [
+      { id: 't-1', title: 'Wire IdP', status: 'done' },
+      { id: 't-2', title: 'Backfill users', status: 'in_progress' },
+    ],
+  });
+  assert.match(out, /\*\*Initiative audit \(mode: narrow\)\*\*/);
+  assert.match(out, /Roll out auth v2/);
+  assert.match(out, /kind=epic/);
+  assert.match(out, /status=in_progress/);
+  assert.match(out, /id=init-abc-123/);
+  assert.match(out, /2026-04-01 → 2026-05-15/);
+  assert.match(out, /Wire IdP \(done\) \[task t-1\]/);
+  assert.match(out, /Backfill users \(in_progress\) \[task t-2\]/);
+});
+
+test('audit-prompt: take_note call shape is exact (load-bearing)', () => {
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+  });
+  // The exact arg shape researchers paste from. Re-flow at your peril.
+  assert.match(
+    out,
+    /take_note\(\{\n {2}initiative_id: "init-abc-123",\n {2}kind: 'observation',\n {2}audience: 'pm',\n {2}importance: 2,\n {2}body: <full report>,\n\}\)/,
+  );
+});
+
+test('audit-prompt: explicitly tells researcher NOT to call register_deliverable', () => {
+  // PR 2 dropped register_deliverable because deliverables are
+  // task-scoped today. The prompt must steer the researcher away
+  // explicitly so a confused LLM doesn't try to call it on its own
+  // and burn cycles on a 400.
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+  });
+  assert.match(out, /register_deliverable/);
+  assert.match(out, /deliverables system is task-scoped today/);
+  // And we must NOT instruct the researcher to actually call it.
+  assert.doesNotMatch(out, /register_deliverable\(\{[^}]*deliverable_type/);
+});
+
+test('audit-prompt: operator guidance flows into prompt when set', () => {
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+    guidance: 'Focus on the migration script — slice 3.',
+  });
+  assert.match(out, /## Operator focus/);
+  assert.match(out, /Focus on the migration script — slice 3\./);
+});
+
+test('audit-prompt: prior findings block omitted when empty', () => {
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+    priorFindings: [],
+  });
+  assert.doesNotMatch(out, /Prior audit findings/);
+});
+
+test('audit-prompt: prior findings block rendered when present', () => {
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+    priorFindings: [
+      {
+        id: 'note-1',
+        body: 'Slice 1 done. Slice 2 partial.',
+        created_at: '2026-04-30T12:00:00Z',
+      },
+      {
+        id: 'note-2',
+        body: 'Slice 4 not started.',
+        created_at: '2026-05-02T09:00:00Z',
+      },
+    ],
+  });
+  assert.match(out, /## Prior audit findings/);
+  assert.match(out, /Prior note 1 \(2026-04-30T12:00:00Z\)/);
+  assert.match(out, /Slice 1 done\. Slice 2 partial\./);
+  assert.match(out, /Prior note 2 \(2026-05-02T09:00:00Z\)/);
+  assert.match(out, /Slice 4 not started\./);
+});
+
+test('audit-prompt: empty tasks renders placeholder, not empty list', () => {
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+  });
+  assert.match(out, /_\(this initiative has no direct child tasks\)_/);
+});
+
+test('audit-prompt: missing description / status_check / target window get placeholders', () => {
+  const out = buildAuditPrompt({
+    initiative: {
+      ...baseInitiative,
+      description: null,
+      status_check_md: null,
+      target_start: null,
+      target_end: null,
+    },
+    tasks: [],
+  });
+  assert.match(out, /_\(no description\)_/);
+  assert.match(out, /_\(none\)_/);
+  assert.match(out, /_\(no target window set\)_/);
+});
+
+test('audit-prompt: includes the 6-section report structure + verdict enum', () => {
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+  });
+  assert.match(out, /1\. \*\*Done with evidence\*\*/);
+  assert.match(out, /2\. \*\*In-flight\*\*/);
+  assert.match(out, /3\. \*\*Not started\*\*/);
+  assert.match(out, /4\. \*\*Drift\*\*/);
+  assert.match(out, /5\. \*\*Verdict\*\*/);
+  assert.match(out, /6\. \*\*Recommended next action\*\*/);
+  // Verdict enum members (the operator decision tree depends on these).
+  for (const v of [
+    'on track',
+    'partially done',
+    'stale \\(rescope\\)',
+    'done in entirety',
+    'never built',
+    'cancelled-in-effect',
+  ]) {
+    assert.match(out, new RegExp(v));
+  }
+});
+
+test('audit-prompt: greenfield early-exit instruction is present', () => {
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+  });
+  assert.match(out, /early-exit/);
+  assert.match(out, /never built — planned-only/);
+});

--- a/src/lib/agents/audit-prompt.ts
+++ b/src/lib/agents/audit-prompt.ts
@@ -1,0 +1,140 @@
+/**
+ * Initiative-audit prompt composer.
+ *
+ * Pure function that builds the researcher's trigger_body for one
+ * initiative audit dispatch. Skeleton tracks the spec at
+ * `specs/initiative-investigate.md` §"Audit prompt template".
+ *
+ * For PR 2 we only handle narrow mode. Subtree / roll-up mode lands
+ * with PR 4 (it'll add a `childFindings` parameter and a `mode` switch).
+ *
+ * Why a TS function and not a `.md` template file: the audit prompt is
+ * load-bearing on a few formatted strings (the take_note arg shape) that
+ * we want covered by snapshot tests. A pure function keeps that tight.
+ *
+ * NOTE: The spec originally called for both `take_note` and
+ * `register_deliverable`. PR 2 ships take_note only — the deliverables
+ * system is task-scoped today (no initiative_id column), so attaching an
+ * audit deliverable to an initiative isn't supported yet. The note is
+ * the audit trail for now. Revisit if/when deliverables grow initiative
+ * scope.
+ */
+
+import type { Initiative } from '@/lib/db/initiatives';
+import type { AgentNote } from '@/lib/db/agent-notes';
+
+export interface BuildAuditPromptInput {
+  initiative: Pick<
+    Initiative,
+    | 'id'
+    | 'title'
+    | 'kind'
+    | 'status'
+    | 'description'
+    | 'status_check_md'
+    | 'target_start'
+    | 'target_end'
+  >;
+  /** Direct child tasks (no nesting). */
+  tasks: ReadonlyArray<{ id: string; title: string; status: string }>;
+  /** Operator-supplied focus area. */
+  guidance?: string | null;
+  /**
+   * Prior audit notes inlined in build-on mode. Pass [] for fresh runs.
+   * Each note's body is rendered verbatim so the researcher can see
+   * what was previously concluded.
+   */
+  priorFindings?: ReadonlyArray<Pick<AgentNote, 'id' | 'body' | 'created_at'>>;
+}
+
+/**
+ * Compose the trigger_body for an `initiative_audit` dispatch.
+ *
+ * Returns a single string. dispatchScope wraps it with the standard
+ * briefing header (identity / role soul / notetaker addendum).
+ */
+export function buildAuditPrompt(input: BuildAuditPromptInput): string {
+  const { initiative, tasks, guidance, priorFindings = [] } = input;
+
+  const targetWindow =
+    initiative.target_start || initiative.target_end
+      ? `${initiative.target_start ?? '?'} → ${initiative.target_end ?? '?'}`
+      : '_(no target window set)_';
+
+  const description = initiative.description?.trim()
+    ? initiative.description.trim()
+    : '_(no description)_';
+
+  const statusCheck = initiative.status_check_md?.trim()
+    ? initiative.status_check_md.trim()
+    : '_(none)_';
+
+  const tasksBlock =
+    tasks.length === 0
+      ? '_(this initiative has no direct child tasks)_'
+      : tasks
+          .map((t) => `- ${t.title} (${t.status}) [task ${t.id}]`)
+          .join('\n');
+
+  const guidanceBlock = guidance?.trim()
+    ? `\n## Operator focus\n\n${guidance.trim()}\n`
+    : '';
+
+  const priorBlock =
+    priorFindings.length === 0
+      ? ''
+      : `\n## Prior audit findings (build on these — do not re-derive)\n\n${priorFindings
+          .map(
+            (n, i) =>
+              `### Prior note ${i + 1} (${n.created_at})\n\n${n.body.trim()}\n`,
+          )
+          .join('\n---\n\n')}\n`;
+
+  // The take_note arg shape is LOAD-BEARING.
+  // Tests assert this exact string. Don't re-flow casually.
+  const takeNoteCall = `take_note({
+  initiative_id: "${initiative.id}",
+  kind: 'observation',
+  audience: 'pm',
+  importance: 2,
+  body: <full report>,
+})`;
+
+  return `**Initiative audit (mode: narrow)**
+
+Target: ${initiative.title}  (kind=${initiative.kind}, status=${initiative.status}, id=${initiative.id})
+
+Description:
+> ${description.replace(/\n/g, '\n> ')}
+
+Status check:
+${statusCheck}
+
+Target window: ${targetWindow}
+
+## Direct child tasks (this initiative's tasks)
+
+${tasksBlock}
+${guidanceBlock}${priorBlock}
+## Your job
+
+Audit this initiative against reality. Produce a markdown report covering:
+
+1. **Done with evidence** — what's been built. Cite commit shas, PR numbers, file paths, test names.
+2. **In-flight** — partial implementations, what's covered vs gaps.
+3. **Not started** — items in description / status_check that have no code yet.
+4. **Drift** — discrepancies between the initiative description and what the codebase actually does. Don't speculate; only flag drift you can prove with a file path / test result / git log.
+5. **Verdict** — one of: **on track**, **partially done**, **stale (rescope)**, **done in entirety**, **never built**, **cancelled-in-effect**.
+6. **Recommended next action** — concrete suggestion the PM can act on. Phrased as "Suggest: …", not a tool call.
+
+Save the report by calling:
+
+- ${takeNoteCall}
+
+This is the audit trail. The note surfaces on the initiative detail page and feeds the PM on a later Plan dispatch. Don't try to call \`register_deliverable\` for this — the deliverables system is task-scoped today and won't accept an initiative-only deliverable.
+
+Don't call propose_changes; you don't have it on your mount. The PM will pick up your note when the operator decides to act.
+
+If the initiative has no associated code yet (planned-only, no tasks, nothing in the repo to point at), early-exit with a short verdict ("never built — planned-only, no audit work to do"). Don't burn ten minutes of exec on greenfield.
+`;
+}

--- a/src/lib/agents/audit-prompt.ts
+++ b/src/lib/agents/audit-prompt.ts
@@ -135,6 +135,12 @@ This is the audit trail. The note surfaces on the initiative detail page and fee
 
 Don't call propose_changes; you don't have it on your mount. The PM will pick up your note when the operator decides to act.
 
+**Strict output discipline for this dispatch:**
+
+- Make **exactly ONE** \`take_note\` call — the summary observation defined above. No \`breadcrumb\`/\`discovery\`/\`question\` notes during the audit, even if you'd normally drop them while researching. Build all observations into the single summary instead.
+- This applies to BOTH fresh runs and re-audits where prior findings are inlined above. On a re-audit, your single \`take_note\` is a fresh standalone summary that supersedes the priors — not an incremental update or set of follow-up breadcrumbs. Read the priors, factor them in, but emit ONE consolidated summary.
+- The audit-trail accumulates by virtue of each summary being its own row; the operator reads them newest-first. Multiple breadcrumbs per dispatch fragment that trail and make it harder to compare audit passes.
+
 If the initiative has no associated code yet (planned-only, no tasks, nothing in the repo to point at), early-exit with a short verdict ("never built — planned-only, no audit work to do"). Don't burn ten minutes of exec on greenfield.
 `;
 }

--- a/src/lib/db/mc-sessions.ts
+++ b/src/lib/db/mc-sessions.ts
@@ -20,7 +20,8 @@ export type ScopeType =
   | 'task_coord'
   | 'task_role'
   | 'recurring'
-  | 'heartbeat';
+  | 'heartbeat'
+  | 'initiative_audit';
 
 export type SessionStatus = 'active' | 'idle' | 'closed' | 'failed';
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4230,6 +4230,66 @@ const migrations: Migration[] = [
       console.log('[Migration 077] recurring_jobs.topic_id + brief_template columns added.');
     },
   },
+  {
+    id: '078',
+    name: 'mc_sessions_initiative_audit_scope_type',
+    up: (db) => {
+      // Extend the mc_sessions.scope_type CHECK constraint to include
+      // 'initiative_audit' for the researcher-driven initiative audit
+      // flow. See specs/initiative-investigate.md.
+      //
+      // SQLite has no ALTER CONSTRAINT, so we rebuild the table.
+      const schemaRow = db
+        .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='mc_sessions'")
+        .get() as { sql: string } | undefined;
+      if (!schemaRow || schemaRow.sql.includes("'initiative_audit'")) {
+        console.log('[Migration 078] mc_sessions.scope_type already includes initiative_audit; skipping.');
+        return;
+      }
+
+      db.exec(`ALTER TABLE mc_sessions RENAME TO _mc_sessions_old_078`);
+      db.exec(`
+        CREATE TABLE mc_sessions (
+          scope_key TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          role TEXT NOT NULL,
+          scope_type TEXT NOT NULL CHECK (scope_type IN (
+            'pm_chat','plan','decompose','decompose_story',
+            'notes_intake','task_coord','task_role',
+            'recurring','heartbeat','initiative_audit'
+          )),
+          task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
+          initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
+          recurring_job_id TEXT,
+          attempt INTEGER NOT NULL DEFAULT 1,
+          status TEXT NOT NULL DEFAULT 'active' CHECK (status IN (
+            'active','idle','closed','failed'
+          )),
+          last_used_at TEXT NOT NULL DEFAULT (datetime('now')),
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          closed_at TEXT,
+          run_id TEXT
+        );
+      `);
+      db.exec(`
+        INSERT INTO mc_sessions (
+          scope_key, workspace_id, role, scope_type,
+          task_id, initiative_id, recurring_job_id,
+          attempt, status, last_used_at, created_at, closed_at, run_id
+        )
+        SELECT scope_key, workspace_id, role, scope_type,
+               task_id, initiative_id, recurring_job_id,
+               attempt, status, last_used_at, created_at, closed_at, run_id
+        FROM _mc_sessions_old_078
+      `);
+      db.exec(`DROP TABLE _mc_sessions_old_078`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_mc_sessions_task ON mc_sessions(task_id) WHERE task_id IS NOT NULL`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_mc_sessions_workspace ON mc_sessions(workspace_id, status)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_mc_sessions_role ON mc_sessions(role, status)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_mc_sessions_run_id ON mc_sessions(run_id) WHERE run_id IS NOT NULL`);
+      console.log('[Migration 078] mc_sessions.scope_type extended with initiative_audit.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */


### PR DESCRIPTION
## Summary

PR 2 of [`specs/initiative-investigate.md`](https://github.com/smb209/mission-control/blob/feat/initiative-audit-narrow/specs/initiative-investigate.md). Adds the researcher-driven audit dispatch (narrow mode only — subtree lands in PR 4). The operator can `POST /api/initiatives/:id/investigate` and a researcher runs against the codebase, produces a structured report, and lands a `take_note` on the initiative.

No UI in this slice — that's PR 3. End-to-end exercisable via curl today.

## Changes

- **Migration 078**: extends `mc_sessions.scope_type` CHECK with `'initiative_audit'`. SQLite has no `ALTER CONSTRAINT`, so we rebuild the table; idempotent guard skips on re-apply.
- **`src/lib/agents/audit-prompt.ts`** + tests: pure prompt composer for the researcher's `trigger_body`. Snapshot-tested for the load-bearing `take_note` arg shape, the 6-section report structure, the verdict enum, the operator-focus + prior-findings inlining, and the explicit "do not call `register_deliverable`" steer.
- **`POST /api/initiatives/:id/investigate`**: validates `{ mode: 'narrow', guidance?, reaudit? }`, looks up the initiative + tasks, resolves the runner agent, computes `:audit:N` (fresh) or reuses `:audit:1` (build_on with prior findings inlined), kicks `dispatchScope` fire-and-forget, returns `{ scope_key, scope_keys, attempt, dispatched_at }` immediately. Errors logged to MC server logs.
- **Spec edit**: dropped `register_deliverable` from §"Audit prompt template" + §"Output capture" + Layer-1 fan-out + verification capture list + pass criteria. Reason inline in spec.

## Spec drift surfaced + handled

The spec called for both `take_note` AND `register_deliverable`. Deliverables are task-scoped today (no `initiative_id` column on `deliverables`), so `register_deliverable` for an audit would 400. Operator confirmed Option 1: drop it from PR 2; the note carries the full report and serves as the audit trail. Spec updated on this branch with the rationale and a pointer to revisit if/when deliverables grow initiative scope.

## Verification

**Unit tests**: 10/10 in `audit-prompt.test.ts` pass. Guards every load-bearing string.

**Full suite**: 744/745 pass. The one failure (`src/lib/research/eval/schedule-runner.test.ts` — `markComplete: agent_run … not found`) is **pre-existing on baseline** (last touched in #220, unrelated to this branch). I verified by reverting my changes locally and rerunning that test alone — same failure.

**Live dogfood** (dev :4010, against initiative `0c9419ff…` — the alert-shim epic, operator's audit fixture):

```
$ curl -X POST http://localhost:4010/api/initiatives/0c9419ff…/investigate \
       -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
       -d '{"mode":"narrow","reaudit":"fresh"}'
{"ok":true,"mode":"narrow","scope_key":"initiative-0c9419ff…:audit:1",
 "scope_keys":[…],"attempt":1,"dispatched_at":"2026-05-06T21:43:56Z"}
```

Route returned in ~7ms (warm) / 734ms (cold) — fire-and-forget worked. Researcher took ~5 minutes, then wrote one `agent_notes` row matching the prescribed shape:

| field | value |
|---|---|
| `kind` | `observation` |
| `audience` | `pm` |
| `importance` | `2` |
| `initiative_id` | `0c9419ff…` |
| `scope_key` | `initiative-0c9419ff…:audit:1` |
| `body` length | 1193 chars |
| verdict | **partially done** (matches operator ground truth) |

Note body correctly identified the `~30 alert() calls → 10 still raw`, the unwired Toast component, and the stale `status_check_md` on the epic. Recommended-next-action proposed concrete follow-ups (update status check, two new stories).

## Edge case noted (not a blocker)

`reaudit=build_on` re-runs the prior `:audit:1` session. In dogfood, the researcher then wrote 6 progress `breadcrumb` notes (`audience=next-stage`, `importance=0`) instead of one summary `observation`. Likely because the prior summary note was already in context and the researcher self-promoted to "incremental update mode." Worth tightening the prompt in a future PR (e.g. "your only `take_note` call must be the summary report — do not write breadcrumbs"). Not blocking — fresh mode produces the canonical shape every time.

## Test plan

- [x] `audit-prompt.test.ts` — 10/10 pass
- [x] Migration 078 applies cleanly on a populated DB
- [x] Live narrow audit produces a usable observation note matching ground truth
- [ ] PR 3 wires this into the initiative detail page UI
- [ ] PR 4 builds subtree mode on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)