### PR TITLE
feat(initiatives): Investigate UI — narrow-mode button + modal

### DIFF
--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -29,12 +29,18 @@ import {
   Shuffle,
   CornerUpLeft,
   Trash2,
+  Search,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import DecomposeWithPmModal from '@/components/DecomposeWithPmModal';
 import DecomposeStoryToTasksModal from '@/components/DecomposeStoryToTasksModal';
 import { DecomposerAgentPicker, type DecomposerOption } from '@/components/inline/DecomposerAgentPicker';
+import { InvestigatePicker, type InvestigateOption } from '@/components/inline/InvestigatePicker';
+import InvestigateModal from '@/components/InvestigateModal';
+import { NotesRail } from '@/components/notes/NotesRail';
+import { useAgentNotes } from '@/hooks/useAgentNotes';
+import { countPriorAudits } from '@/components/inline/investigate-helpers';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { TaskModal } from '@/components/TaskModal';
 import type { Task } from '@/lib/types';
@@ -282,6 +288,9 @@ export function InitiativeDetailView({
   // Operator guidance for the initial Decompose dispatch. Same idea
   // as planGuidance but persists for the lifetime of the modal.
   const [decomposeHint, setDecomposeHint] = useState<string | null>(null);
+  // Investigate ▾ — narrow-mode audit modal (PR 3 of
+  // specs/initiative-investigate.md). Subtree mode lives in PR 4.
+  const [showInvestigateModal, setShowInvestigateModal] = useState(false);
   // Selected task for the inline TaskModal — clicking a task in the
   // children list opens it here instead of navigating away.
   const [taskModalTask, setTaskModalTask] = useState<Task | null>(null);
@@ -394,6 +403,14 @@ export function InitiativeDetailView({
   // workspace PM has a task-decomposition prompt; other agents will be
   // added once Builder/Coordinator/custom prompts exist (the picker is
   // already shaped for it).
+  // Notes scoped to this initiative — drives the NotesRail at the
+  // bottom of the page and the "Build on prior audit" gate inside
+  // the Investigate modal. Fetches even before `initiative` resolves
+  // so the rail can render its own loading state; `id` alone is enough
+  // since the API filters server-side by initiative_id.
+  const initiativeNotes = useAgentNotes({ initiative_id: id, limit: 50 });
+  const priorAuditCount = countPriorAudits(initiativeNotes.notes);
+
   const decomposerOptions: DecomposerOption[] = (() => {
     const out: DecomposerOption[] = [];
     const pm = agents.find(a => a.is_pm === 1 || a.is_pm === true || a.role === 'pm');
@@ -727,6 +744,16 @@ or "carve out the onboarding flow as its own story first"`}
                 Decompose to tasks
               </DecomposerAgentPicker>
             )}
+            <InvestigatePicker
+              options={INVESTIGATE_OPTIONS}
+              onPick={(scope) => {
+                if (scope === 'narrow') setShowInvestigateModal(true);
+                // 'subtree' is currently disabled in INVESTIGATE_OPTIONS
+                // (PR 4 enables it); the picker will not invoke onPick
+                // for disabled entries, so this branch is effectively
+                // dead code today and kept only as a forward-compat hook.
+              }}
+            />
             <span className="w-px h-5 bg-mc-border/60 mx-1" aria-hidden />
             <ToolbarButton icon={<MoveRight className="w-3.5 h-3.5" />} onClick={() => setShowMoveModal(true)}>
               Move
@@ -1072,6 +1099,19 @@ or "carve out the onboarding flow as its own story first"`}
           )}
         </Section>
 
+        {/* Notes — agent-generated observations for this initiative.
+            Surface for the Investigate flow's take_note output. Filters
+            to scoped notes only (no child-task rollup) since the audit
+            writes its report row directly against this initiative_id. */}
+        <Section title="Notes" icon={<Search className="w-4 h-4" />}>
+          <NotesRail
+            initiative_id={initiative.id}
+            workspace_id={initiative.workspace_id}
+            limit={50}
+            title=""
+          />
+        </Section>
+
         {/* History */}
         <Section title="Parent-change history" icon={<History className="w-4 h-4" />}>
           {history.length === 0 ? (
@@ -1174,6 +1214,25 @@ or "carve out the onboarding flow as its own story first"`}
           }}
         />
       )}
+      {showInvestigateModal && (
+        <InvestigateModal
+          initiative={{
+            id: initiative.id,
+            title: initiative.title,
+            workspace_id: initiative.workspace_id,
+          }}
+          priorAuditCount={priorAuditCount}
+          onClose={() => setShowInvestigateModal(false)}
+          onDispatched={() => {
+            // Route is fire-and-forget; close immediately so the
+            // operator returns to the detail view and watches the
+            // NotesRail for the take_note row that lands when the
+            // researcher finishes (1–15 min). The toast inside the
+            // modal communicates dispatch success.
+            setShowInvestigateModal(false);
+          }}
+        />
+      )}
       {showHistoryDrawer && (
         <HistoryDrawer
           initiative={initiative as ListInitiative}
@@ -1209,6 +1268,24 @@ or "carve out the onboarding flow as its own story first"`}
     </div>
   );
 }
+
+// Investigate ▾ menu items. Subtree is intentionally kept visible but
+// disabled so operators see the path exists — PR 4 of
+// specs/initiative-investigate.md enables it.
+const INVESTIGATE_OPTIONS: InvestigateOption[] = [
+  {
+    id: 'narrow',
+    label: 'Just this initiative (narrow)',
+    description: 'One researcher dispatch. Reads description, status check, and direct child tasks.',
+  },
+  {
+    id: 'subtree',
+    label: 'Whole subtree (bottom-up)',
+    description: 'Per-level fan-out across descendants, then a roll-up.',
+    disabled: true,
+    disabledReason: 'Coming soon — subtree mode lands in a follow-up PR',
+  },
+];
 
 function ToolbarButton({
   icon,

--- a/src/components/InvestigateModal.tsx
+++ b/src/components/InvestigateModal.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+/**
+ * Narrow-mode investigate modal.
+ *
+ * PR 3 of specs/initiative-investigate.md. Wires the existing
+ * POST /api/initiatives/:id/investigate endpoint (mode='narrow') into
+ * the initiative detail page action toolbar.
+ *
+ * Subtree mode lands in PR 4 — the radio for it is intentionally absent
+ * here to keep the modal lean. The toolbar's split-button shows a
+ * disabled "Whole subtree (bottom-up)" entry so operators see the path
+ * exists.
+ *
+ * The audit dispatch is fire-and-forget at the route layer; we close
+ * the modal on 202 and let the operator watch for the take_note row to
+ * land in the NotesRail on the same page.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Search, X, Loader2 } from 'lucide-react';
+import { useToast } from '@/components/Toast';
+import { buildInvestigateBody } from '@/components/inline/investigate-helpers';
+
+interface InitiativeLite {
+  id: string;
+  title: string;
+  workspace_id: string;
+}
+
+export interface InvestigateModalProps {
+  initiative: InitiativeLite;
+  /**
+   * Number of prior audit notes for this initiative (kind='observation',
+   * audience='pm', importance=2). Used to enable the "Build on prior
+   * audit" radio. Caller derives this from the initiative's notes.
+   */
+  priorAuditCount: number;
+  onClose: () => void;
+  onDispatched: (result: { scope_key: string; attempt: number }) => void;
+}
+
+type Reaudit = 'fresh' | 'build_on';
+
+const GUIDANCE_MAX = 2000;
+
+export default function InvestigateModal({
+  initiative,
+  priorAuditCount,
+  onClose,
+  onDispatched,
+}: InvestigateModalProps) {
+  const [reaudit, setReaudit] = useState<Reaudit>('fresh');
+  const [guidance, setGuidance] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const { addToast } = useToast();
+
+  const canBuildOn = priorAuditCount > 0;
+
+  // Keep the radio in a valid state if the prior count drops to zero
+  // mid-modal (rare but possible if SSE archives the only prior).
+  useEffect(() => {
+    if (!canBuildOn && reaudit === 'build_on') setReaudit('fresh');
+  }, [canBuildOn, reaudit]);
+
+  // Esc to close. Stash onClose in a ref so the keydown subscription
+  // doesn't churn on every parent render (matches DecomposeWithPmModal).
+  const onCloseRef = useRef(onClose);
+  useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCloseRef.current();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, []);
+
+  const submit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/initiatives/${initiative.id}/investigate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildInvestigateBody({ reaudit, guidance })),
+      });
+      // The route returns 200 (not 202) once the dispatch is queued.
+      // Treat any 2xx as success.
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(
+          (body as { error?: string }).error || `Investigate failed (${res.status})`,
+        );
+      }
+      const { scope_key, attempt } = body as { scope_key: string; attempt: number };
+      addToast({
+        type: 'success',
+        title: 'Audit dispatched to researcher',
+        message:
+          'Note will appear in this initiative’s notes panel when the researcher finishes (typically 1–15 min).',
+        duration: 8000,
+      });
+      onDispatched({ scope_key, attempt });
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Investigate failed');
+      // Leave the modal open so the operator can adjust + retry.
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Investigate initiative"
+    >
+      <div
+        className="bg-mc-bg-secondary border border-mc-border rounded-lg w-full max-w-lg flex flex-col text-mc-text"
+        onClick={e => e.stopPropagation()}
+      >
+        <header className="flex items-start justify-between gap-2 px-5 py-3 border-b border-mc-border">
+          <div className="flex items-start gap-2">
+            <Search className="w-4 h-4 mt-0.5 text-mc-accent shrink-0" />
+            <div className="min-w-0">
+              <h2 className="text-base font-semibold leading-tight">Investigate initiative</h2>
+              <p className="text-xs text-mc-text-secondary mt-0.5 truncate" title={initiative.title}>
+                {initiative.title}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            title="Close (Esc)"
+            className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text shrink-0"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </header>
+
+        <div className="px-5 py-4 flex flex-col gap-4">
+          {err && (
+            <div
+              className="p-3 rounded bg-red-500/10 border border-red-500/30 text-red-300 text-sm"
+              role="alert"
+            >
+              {err}
+            </div>
+          )}
+
+          <fieldset className="flex flex-col gap-2">
+            <legend className="text-xs uppercase tracking-wide text-mc-text-secondary/80">
+              Re-audit policy
+            </legend>
+            <label className="flex items-start gap-2 cursor-pointer text-sm">
+              <input
+                type="radio"
+                name="reaudit"
+                value="fresh"
+                checked={reaudit === 'fresh'}
+                onChange={() => setReaudit('fresh')}
+                className="mt-1"
+              />
+              <span>
+                <span className="text-mc-text">Fresh context</span>
+                <span className="block text-xs text-mc-text-secondary mt-0.5 leading-snug">
+                  Researcher starts clean. New attempt suffix; no prior audit findings inlined.
+                </span>
+              </span>
+            </label>
+            <label
+              className={`flex items-start gap-2 text-sm ${
+                canBuildOn ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'
+              }`}
+              title={canBuildOn ? undefined : 'No prior audit yet for this initiative'}
+            >
+              <input
+                type="radio"
+                name="reaudit"
+                value="build_on"
+                checked={reaudit === 'build_on'}
+                onChange={() => canBuildOn && setReaudit('build_on')}
+                disabled={!canBuildOn}
+                className="mt-1"
+              />
+              <span>
+                <span className="text-mc-text">Build on prior audit</span>
+                <span className="block text-xs text-mc-text-secondary mt-0.5 leading-snug">
+                  {canBuildOn
+                    ? `Inlines the latest audit note(s) so the researcher refines instead of re-deriving. (${priorAuditCount} prior)`
+                    : 'No prior audit yet — run a fresh audit first.'}
+                </span>
+              </span>
+            </label>
+          </fieldset>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-mc-text-secondary/80">
+              Guidance <span className="normal-case opacity-70">(optional)</span>
+            </span>
+            <textarea
+              value={guidance}
+              onChange={e => setGuidance(e.target.value.slice(0, GUIDANCE_MAX))}
+              rows={5}
+              placeholder="Optional &mdash; focus the audit (e.g. &lsquo;check for unused stories, look at db migrations&rsquo;)"
+              className="w-full px-2 py-1.5 rounded bg-mc-bg border border-mc-border text-sm text-mc-text outline-none focus:border-mc-accent/60 resize-y leading-relaxed"
+              maxLength={GUIDANCE_MAX}
+            />
+            <span className="text-[10px] text-mc-text-secondary/70 self-end">
+              {guidance.length}/{GUIDANCE_MAX}
+            </span>
+          </label>
+
+          <p className="text-xs italic text-mc-text-secondary">
+            May take 1–15 minutes. The note will appear in this initiative&apos;s notes panel when complete.
+          </p>
+        </div>
+
+        <footer className="border-t border-mc-border px-5 py-3 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={submitting}
+            className="inline-flex items-center gap-1.5 px-3 py-2 rounded bg-mc-accent text-white text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="w-3.5 h-3.5 animate-spin" /> Dispatching…
+              </>
+            ) : (
+              <>
+                <Search className="w-3.5 h-3.5" /> Investigate
+              </>
+            )}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/inline/InvestigatePicker.tsx
+++ b/src/components/inline/InvestigatePicker.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+/**
+ * Two-item dropdown for the Investigate ▾ split-button.
+ *
+ * Shape mirrors DecomposerAgentPicker so the action toolbar reads
+ * uniformly: a left-face "primary action" button plus a chevron that
+ * opens a small popover. The primary action defaults to the first
+ * enabled item ("Just this initiative (narrow)"); the chevron lists
+ * all options including the disabled "Whole subtree" entry so
+ * operators see that the path exists even before PR 4 turns it on.
+ */
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { ChevronDown, Search } from 'lucide-react';
+
+export interface InvestigateOption {
+  id: 'narrow' | 'subtree';
+  label: string;
+  description: string;
+  disabled?: boolean;
+  disabledReason?: string;
+}
+
+export function InvestigatePicker({
+  options,
+  onPick,
+  disabled,
+}: {
+  options: InvestigateOption[];
+  onPick: (id: InvestigateOption['id']) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDoc);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const firstEnabled = options.find(o => !o.disabled);
+  const palette = 'border-mc-accent/40 text-mc-accent bg-mc-accent/5 hover:bg-mc-accent/10';
+
+  return (
+    <div ref={wrapRef} className="relative inline-flex">
+      <button
+        type="button"
+        onClick={() => firstEnabled && onPick(firstEnabled.id)}
+        disabled={disabled || !firstEnabled}
+        title="Audit this initiative against the codebase"
+        className={`inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-l border border-r-0 ${palette} disabled:opacity-50 disabled:cursor-not-allowed`}
+      >
+        <Search className="w-3.5 h-3.5" />
+        <span>Investigate</span>
+      </button>
+      <button
+        type="button"
+        aria-label="Choose investigate scope"
+        aria-expanded={open}
+        onClick={() => setOpen(o => !o)}
+        disabled={disabled}
+        className={`inline-flex items-center px-1.5 rounded-r border ${palette} disabled:opacity-50 ${open ? 'bg-mc-accent/15' : ''}`}
+      >
+        <ChevronDown className="w-3.5 h-3.5" />
+      </button>
+      {open && (
+        <div
+          className="absolute top-full left-0 mt-1 z-30 w-72 rounded border border-mc-border bg-mc-bg-secondary shadow-lg p-1"
+          role="menu"
+        >
+          <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-mc-text-secondary/70">
+            Investigate scope
+          </div>
+          {options.map(o => (
+            <button
+              key={o.id}
+              type="button"
+              role="menuitem"
+              disabled={o.disabled}
+              title={o.disabled ? o.disabledReason : undefined}
+              onClick={() => {
+                if (o.disabled) return;
+                setOpen(false);
+                onPick(o.id);
+              }}
+              className="w-full text-left px-2 py-2 rounded hover:bg-mc-bg disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <div className="text-sm text-mc-text">{o.label}</div>
+              <div className="text-[11px] text-mc-text-secondary mt-0.5 leading-snug">
+                {o.description}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/inline/investigate-helpers.test.ts
+++ b/src/components/inline/investigate-helpers.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the Investigate-flow helpers (PR 3 of
+ * specs/initiative-investigate.md).
+ *
+ * The project doesn't ship React component tests today (no .test.tsx
+ * suites), so we cover the modal's gating + body shape via these pure
+ * helpers. The modal itself is exercised manually via the dogfood loop
+ * documented in the PR body.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  countPriorAudits,
+  buildInvestigateBody,
+} from './investigate-helpers';
+import type { AgentNoteRecord } from '@/hooks/useAgentNotes';
+
+function note(over: Partial<AgentNoteRecord>): AgentNoteRecord {
+  return {
+    id: 'n-x',
+    workspace_id: 'ws-1',
+    agent_id: 'a-1',
+    task_id: null,
+    initiative_id: 'init-1',
+    scope_key: 'sk',
+    role: 'researcher',
+    run_group_id: 'rg',
+    kind: 'observation',
+    audience: 'pm',
+    body: 'body',
+    attached_files: [],
+    importance: 2,
+    archived_at: null,
+    created_at: '2026-05-05T00:00:00Z',
+    ...over,
+  };
+}
+
+test('countPriorAudits — counts only kind=observation, audience=pm, importance>=2, not archived', () => {
+  const notes: AgentNoteRecord[] = [
+    note({ id: '1' }),                                         // ✓ qualifies
+    note({ id: '2', kind: 'breadcrumb' }),                     // ✗ wrong kind
+    note({ id: '3', audience: 'self' }),                       // ✗ wrong audience
+    note({ id: '4', importance: 1 }),                          // ✗ low importance
+    note({ id: '5', importance: 0 }),                          // ✗ low importance
+    note({ id: '6', archived_at: '2026-05-04T00:00:00Z' }),    // ✗ archived
+    note({ id: '7' }),                                         // ✓ qualifies
+  ];
+  assert.equal(countPriorAudits(notes), 2);
+});
+
+test('countPriorAudits — empty list returns 0', () => {
+  assert.equal(countPriorAudits([]), 0);
+});
+
+test('buildInvestigateBody — fresh + no guidance omits guidance key', () => {
+  const body = buildInvestigateBody({ reaudit: 'fresh', guidance: '' });
+  assert.deepEqual(body, { mode: 'narrow', reaudit: 'fresh' });
+  assert.equal('guidance' in body, false);
+});
+
+test('buildInvestigateBody — whitespace-only guidance is treated as empty', () => {
+  const body = buildInvestigateBody({ reaudit: 'fresh', guidance: '   \n\t  ' });
+  assert.deepEqual(body, { mode: 'narrow', reaudit: 'fresh' });
+});
+
+test('buildInvestigateBody — build_on with guidance trims and includes', () => {
+  const body = buildInvestigateBody({
+    reaudit: 'build_on',
+    guidance: '  check db migrations  ',
+  });
+  assert.deepEqual(body, {
+    mode: 'narrow',
+    reaudit: 'build_on',
+    guidance: 'check db migrations',
+  });
+});
+
+test('buildInvestigateBody — mode is hard-coded to narrow (PR 3 scope)', () => {
+  const body = buildInvestigateBody({ reaudit: 'fresh', guidance: 'x' });
+  assert.equal(body.mode, 'narrow');
+});

--- a/src/components/inline/investigate-helpers.ts
+++ b/src/components/inline/investigate-helpers.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure helpers for the Investigate flow. Extracted from
+ * InvestigateModal/InitiativeDetailView so they can be unit-tested
+ * without spinning up a React renderer (the project doesn't ship
+ * React component tests today — only `.test.ts` Node suites).
+ */
+
+import type { AgentNoteRecord } from '@/hooks/useAgentNotes';
+
+/**
+ * Count notes that qualify as "prior audit findings" for this
+ * initiative — kind='observation', audience='pm', importance=2.
+ *
+ * Mirrors the criteria the investigate route uses when build_on mode
+ * fetches priors via listNotes(initiative_id, audience:'pm',
+ * min_importance:2). The audit prompt template only consumes
+ * observations at or above importance 2, so this is the right
+ * predicate to gate the "Build on prior audit" radio.
+ */
+export function countPriorAudits(notes: AgentNoteRecord[]): number {
+  let n = 0;
+  for (const note of notes) {
+    if (note.kind !== 'observation') continue;
+    if (note.audience !== 'pm') continue;
+    if (note.importance < 2) continue;
+    if (note.archived_at) continue;
+    n += 1;
+  }
+  return n;
+}
+
+/**
+ * Build the JSON body for POST /api/initiatives/:id/investigate. Kept
+ * separate from the modal so the contract is easy to assert.
+ */
+export interface InvestigateRequestBody {
+  mode: 'narrow';
+  reaudit: 'fresh' | 'build_on';
+  guidance?: string;
+}
+export function buildInvestigateBody(opts: {
+  reaudit: 'fresh' | 'build_on';
+  guidance: string;
+}): InvestigateRequestBody {
+  const trimmed = opts.guidance.trim();
+  return {
+    mode: 'narrow',
+    reaudit: opts.reaudit,
+    ...(trimmed ? { guidance: trimmed } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

PR 3 of [specs/initiative-investigate.md](../blob/main/specs/initiative-investigate.md). Wires the existing `POST /api/initiatives/:id/investigate` endpoint (landed in #241) into the initiative detail page so an operator can dispatch a researcher audit without dropping to curl.

- **Investigate ▾** split-button alongside Plan / Decompose with PM. Same visual treatment via a new `InvestigatePicker` (mirrors `DecomposerAgentPicker`'s shape).
- Menu has two items:
  - **Just this initiative (narrow)** — opens the audit modal.
  - **Whole subtree (bottom-up)** — disabled with a "coming soon" tooltip. Kept visible so operators see the path exists (PR 4 turns it on).
- New `InvestigateModal`:
  - Re-audit policy radio: **Fresh context** (default) / **Build on prior audit**. Build-on is greyed out with a tooltip when there are no qualifying prior audit notes (`kind='observation'` + `audience='pm'` + `importance>=2` + not archived).
  - Optional 2000-char guidance textarea (with character counter).
  - 1–15 min ETA hint pointing operators at the notes panel.
  - On success: closes the modal + fires a Toast ("Audit dispatched to researcher…"). On error: keeps the modal open with the error inline so the operator can adjust + retry.
- New **Notes** section on `InitiativeDetailView` via the existing `NotesRail` — gives the audit's `take_note` row a surface to land on. (None existed before; the only audit output is that note.)
- Pure helpers (`countPriorAudits`, `buildInvestigateBody`) extracted to `inline/investigate-helpers.ts` and covered by 6 new `node:test` cases.

## Anti-scope (per spec)

- No subtree mode (PR 4).
- No live in-flight progress strip / SSE wiring — the NotesRail auto-poll + ↻ refresh button is the feedback path for now.
- No PM SOUL changes (PR 5).
- No new API endpoints.

## Test plan

- [x] `yarn test` — 750/751 pass. The single failure is the documented pre-existing `schedule-runner: produces a brief and advances run_count` (called out in `CLAUDE.md` as ignorable).
- [x] `yarn tsc --noEmit` — no new errors. The 3 errors that exist are pre-existing and unrelated (`pm/proposals/[id]/route.ts` SSEEventType, `pm-decompose.test.ts` two cases).
- [x] New helper test cases (in `src/components/inline/investigate-helpers.test.ts`):
  - `countPriorAudits` — counts only kind=observation, audience=pm, importance>=2, not archived.
  - `countPriorAudits` — empty list returns 0.
  - `buildInvestigateBody` — fresh + no guidance omits guidance key.
  - `buildInvestigateBody` — whitespace-only guidance is treated as empty.
  - `buildInvestigateBody` — build_on with guidance trims and includes.
  - `buildInvestigateBody` — mode is hard-coded to narrow (PR 3 scope).
- [ ] **Operator manual verification (dogfood loop)** — see `specs/initiative-investigate.md` §"Verification pipeline":
  1. Restore fixture: `yarn db:checkpoint:restore audit-fixture`, `yarn dev`.
  2. Open `/initiatives?selected=0c9419ff-d511-4511-86c6-57a6387e19f7`.
  3. Confirm Investigate ▾ aligns with Plan / Decompose visually.
  4. Click → menu shows narrow + (greyed) subtree with tooltip.
  5. "Just this initiative" → modal opens with the initiative title in subhead.
  6. Build-on radio is disabled the first time (no priors). Tooltip explains.
  7. Type guidance → click Investigate. Modal closes, success toast fires.
  8. Wait 1-15 min → take_note row lands in the Notes section.
  9. Re-run audit → Build-on radio is now enabled. Pick it. Verify the second audit's note (a) was generated with priors inlined, (b) is a single observation row (PR 2's tightening holding).

## Edge cases addressed

- **Double-click Investigate**: the button is disabled while the request is in flight (spinner shown) and re-enabled once the API responds, so a fresh dispatch is allowed immediately afterwards. The route already mints unique `:audit:N` attempt suffixes for fresh mode, so a deliberate second click produces a second attempt rather than collision.
- **Modal dismiss while submitting**: the fetch promise is not aborted; the route is fire-and-forget at the dispatch layer anyway, so the audit lands regardless.
- **Planned-only initiative (no tasks)**: the audit dispatches normally; the researcher early-exits per PR 2's prompt with a "never built" verdict, and the resulting note still lands in the rail.
- **`canBuildOn` flips false mid-modal** (e.g. SSE archives the only prior): a small effect resets the radio to `fresh` so the form can't submit an invalid combination.

## Files

- New: `src/components/InvestigateModal.tsx`
- New: `src/components/inline/InvestigatePicker.tsx`
- New: `src/components/inline/investigate-helpers.ts`
- New: `src/components/inline/investigate-helpers.test.ts`
- Modified: `src/components/InitiativeDetailView.tsx` (toolbar wiring + NotesRail section + modal mount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)