### PR TITLE
feat(initiatives): subtree audit + workspace settings

### DIFF
--- a/src/app/(app)/workspace/[slug]/settings/page.tsx
+++ b/src/app/(app)/workspace/[slug]/settings/page.tsx
@@ -48,6 +48,9 @@ interface WorkspaceWithDefault {
    *  v0 of org-scope memory grounding — see docs/specs and the
    *  Ground-agents theme on the roadmap. */
   context_md?: string | null;
+  /** Initiative-audit knobs. Migration 079 / specs/initiative-investigate.md. */
+  audit_per_node_timeout_ms?: number | null;
+  audit_subtree_concurrency?: number | null;
   /** Server-resolved default the override falls back to. */
   default_workspace_path: string;
   created_at: string;
@@ -175,6 +178,7 @@ export default function WorkspaceSettingsPage({
     { id: 'identity', label: 'Identity' },
     { id: 'project-root', label: 'Project root' },
     { id: 'conventions', label: 'Workspace conventions' },
+    { id: 'audit-defaults', label: 'Audit defaults' },
     { id: 'export', label: 'Export' },
     { id: 'danger-zone', label: 'Danger zone' },
   ];
@@ -318,6 +322,63 @@ export default function WorkspaceSettingsPage({
               label="Edit workspace conventions"
               onDraftChange={setConventionsDraft}
             />
+          </Field>
+        </Section>
+
+        {/* Audit defaults — workspace-scoped knobs for the initiative
+            Investigate flow's subtree mode. See
+            specs/initiative-investigate.md §"Decisions" item 1. */}
+        <Section
+          id="audit-defaults"
+          title="Audit defaults"
+          description={
+            <>
+              Knobs for the initiative <strong>Investigate ▾ → Whole subtree</strong>{' '}
+              flow. These values are read at dispatch time, so changing them
+              only affects subsequent audit runs.
+            </>
+          }
+        >
+          <Field label="Per-node timeout (minutes)">
+            <InlineText
+              value={String(
+                Math.round(
+                  (workspace.audit_per_node_timeout_ms ?? 15 * 60_000) / 60_000,
+                ),
+              )}
+              onSave={async (next) => {
+                const minutes = Number(next);
+                if (!Number.isFinite(minutes) || minutes < 1 || minutes > 60) {
+                  throw new Error('Enter a whole number of minutes between 1 and 60');
+                }
+                await patch({ audit_per_node_timeout_ms: Math.round(minutes) * 60_000 });
+              }}
+              placeholder="15"
+              label="Edit per-node timeout"
+            />
+            <p className="text-[11px] text-mc-text-secondary mt-1">
+              How long a single researcher is allowed before MC marks the
+              node failed and proceeds. Default 15 min. Range 1–60 min.
+            </p>
+          </Field>
+          <Field label="Subtree concurrency">
+            <InlineText
+              value={String(workspace.audit_subtree_concurrency ?? 4)}
+              onSave={async (next) => {
+                const n = Number(next);
+                if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1 || n > 8) {
+                  throw new Error('Enter a whole number between 1 and 8');
+                }
+                await patch({ audit_subtree_concurrency: n });
+              }}
+              placeholder="4"
+              label="Edit subtree concurrency"
+            />
+            <p className="text-[11px] text-mc-text-secondary mt-1">
+              Max parallel researcher dispatches per layer. Default 4.
+              Range 1–8. Dial up if your runner can hose the LLM; dial
+              down to keep cost predictable.
+            </p>
           </Field>
         </Section>
 

--- a/src/app/api/initiatives/[id]/investigate/route.test.ts
+++ b/src/app/api/initiatives/[id]/investigate/route.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Investigate route tests — PR 4 of specs/initiative-investigate.md.
+ *
+ * Focuses on the slices that are exercisable without a live gateway:
+ *
+ *   - GET ?dryrun=1: plan response shape for narrow + subtree modes
+ *   - POST subtree: terminal-status root → 400
+ *   - POST subtree: missing runner → 503 (no orchestration kicked off)
+ *   - POST subtree: zero non-terminal descendants → planned_nodes=1
+ *
+ * The full happy-path (real LLM dispatch + per-node take_note rows)
+ * is covered by the dogfood loop documented in
+ * specs/initiative-investigate.md §"Verification pipeline".
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { GET, POST } from './route';
+import { run, queryOne } from '@/lib/db';
+import { createInitiative, updateInitiative } from '@/lib/db/initiatives';
+
+function freshWorkspace(): string {
+  const id = `ws-inv-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+/** Remove any existing runner agent so getRunnerAgent() returns null. */
+function clearRunner(): void {
+  run(`DELETE FROM agents WHERE gateway_agent_id IN ('mc-runner','mc-runner-dev')`);
+}
+
+async function callPost(id: string, body: unknown): Promise<Response> {
+  const req = new NextRequest(
+    `http://localhost/api/initiatives/${id}/investigate`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+  return await POST(req, { params: Promise.resolve({ id }) });
+}
+
+async function callGet(id: string, qs: string): Promise<Response> {
+  const req = new NextRequest(
+    `http://localhost/api/initiatives/${id}/investigate${qs}`,
+  );
+  return await GET(req, { params: Promise.resolve({ id }) });
+}
+
+test('GET ?dryrun=1&mode=narrow → 200 with planned_nodes=1', async () => {
+  const ws = freshWorkspace();
+  const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'root' });
+  const res = await callGet(i.id, '?dryrun=1&mode=narrow');
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.mode, 'narrow');
+  assert.equal(body.planned_nodes, 1);
+  assert.equal(body.planned_layers, 1);
+  assert.equal(body.concurrency, 1);
+  assert.ok(Number.isInteger(body.per_node_timeout_ms));
+});
+
+test('GET ?dryrun=1&mode=subtree → returns layer plan from helper', async () => {
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'root' });
+  const a = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'a',
+    parent_initiative_id: root.id,
+  });
+  createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'a-leaf',
+    parent_initiative_id: a.id,
+  });
+
+  const res = await callGet(root.id, '?dryrun=1&mode=subtree');
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.mode, 'subtree');
+  assert.equal(body.planned_nodes, 3);
+  assert.equal(body.planned_layers, 3);
+  assert.ok(body.concurrency >= 1);
+});
+
+test('GET ?dryrun=1&mode=subtree on terminal root → 400', async () => {
+  const ws = freshWorkspace();
+  const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'closed' });
+  updateInitiative(i.id, { status: 'done' });
+  const res = await callGet(i.id, '?dryrun=1&mode=subtree');
+  assert.equal(res.status, 400);
+});
+
+test('GET without ?dryrun=1 → 400', async () => {
+  const ws = freshWorkspace();
+  const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'x' });
+  const res = await callGet(i.id, '');
+  assert.equal(res.status, 400);
+});
+
+test('POST subtree with terminal-status root → 400', async () => {
+  const ws = freshWorkspace();
+  const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'closed' });
+  updateInitiative(i.id, { status: 'cancelled' });
+  // Need a runner present so the route falls through to the
+  // terminal-state check rather than 503-ing on missing runner.
+  run(
+    `INSERT OR REPLACE INTO agents
+       (id, name, role, workspace_id, gateway_agent_id, source, created_at, updated_at)
+     VALUES (?, ?, ?, 'default', 'mc-runner-dev', 'test', datetime('now'), datetime('now'))`,
+    [`agent-${uuidv4().slice(0, 8)}`, 'runner', 'researcher'],
+  );
+  try {
+    const res = await callPost(i.id, { mode: 'subtree' });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.match(body.error, /terminal-state initiative/i);
+  } finally {
+    clearRunner();
+  }
+});
+
+test('POST subtree with no runner registered → 503', async () => {
+  const ws = freshWorkspace();
+  const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'open' });
+  clearRunner();
+  const res = await callPost(i.id, { mode: 'subtree' });
+  assert.equal(res.status, 503);
+});
+
+test('POST subtree with zero non-terminal descendants → planned_nodes=1', async () => {
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'root' });
+  const a = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'a',
+    parent_initiative_id: root.id,
+  });
+  updateInitiative(a.id, { status: 'done' });
+
+  // Need a runner so the route doesn't 503; the orchestration is
+  // fire-and-forget so the eventual dispatchScope failure doesn't
+  // affect this assertion. We DO mark the inserted agent inactive-ish
+  // by giving it no real gateway prefix; the response shape still
+  // resolves before the background promise touches the gateway.
+  const runnerId = `agent-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR REPLACE INTO agents
+       (id, name, role, workspace_id, gateway_agent_id, source, created_at, updated_at)
+     VALUES (?, ?, ?, 'default', 'mc-runner-dev', 'test', datetime('now'), datetime('now'))`,
+    [runnerId, 'runner', 'researcher'],
+  );
+  try {
+    const res = await callPost(root.id, { mode: 'subtree' });
+    // Drain any unhandled background rejection into a black-hole; the
+    // route's `.catch` handler already swallows + logs.
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.mode, 'subtree');
+    assert.equal(body.planned_nodes, 1);
+    assert.equal(body.planned_layers, 1);
+    assert.ok(typeof body.root_scope_key === 'string');
+    assert.ok(body.concurrency >= 1);
+  } finally {
+    clearRunner();
+    // Best-effort: clear the row written by upsertSession for the
+    // background dispatch attempt.
+    run(`DELETE FROM mc_sessions WHERE initiative_id = ?`, [root.id]);
+    queryOne(`SELECT 1`); // flush
+  }
+});

--- a/src/app/api/initiatives/[id]/investigate/route.ts
+++ b/src/app/api/initiatives/[id]/investigate/route.ts
@@ -4,31 +4,32 @@
  * Dispatches a researcher to audit an initiative against reality.
  * See specs/initiative-investigate.md.
  *
- * PR 2 ships **narrow mode only** — one researcher dispatch per call.
- * Subtree mode lands with PR 4 (it'll add a child-findings synthesis
- * step before the parent-level dispatch).
+ * PR 2: narrow mode (one researcher dispatch).
+ * PR 4: subtree mode — MC-driven layered fan-out.
  *
  * Request body:
  *   {
- *     mode: 'narrow',          // PR 4: 'subtree'
- *     guidance?: string,       // optional operator focus area
- *     reaudit?: 'fresh' | 'build_on'  // default 'fresh'
+ *     mode: 'narrow' | 'subtree',
+ *     guidance?: string,                // optional operator focus area
+ *     reaudit?: 'fresh' | 'build_on'    // narrow only; subtree always fresh
  *   }
  *
  * Response (200):
- *   {
- *     ok: true,
- *     scope_key: string,
- *     scope_keys: string[],     // single-element for narrow; subtree
- *                                // returns one per node (PR 4)
- *     attempt: number,
- *     dispatched_at: string,
- *   }
+ *   For narrow: { ok, mode: 'narrow', scope_key, scope_keys, attempt, dispatched_at }
+ *   For subtree: { ok, mode: 'subtree', root_scope_key, planned_layers,
+ *                  planned_nodes, concurrency, per_node_timeout_ms,
+ *                  dispatched_at }
+ *
+ * GET /api/initiatives/:id/investigate?dryrun=1&mode=subtree
+ *   Returns the subtree plan ({ planned_layers, planned_nodes,
+ *   concurrency, per_node_timeout_ms }) for the modal's ETA/banner.
+ *   Cheap + side-effect-free.
  *
  * The dispatch runs **fire-and-forget**. The route returns as soon as
- * the briefing has been queued at the gateway; the researcher's
- * take_note + final reply land asynchronously and are surfaced via
- * SSE / the initiative detail page.
+ * the briefing has been queued at the gateway (narrow) or the
+ * orchestration promise has been kicked off (subtree); the per-node
+ * take_note rows land asynchronously and are surfaced via SSE / the
+ * initiative detail page.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -39,11 +40,13 @@ import { getRunnerAgent } from '@/lib/agents/runner';
 import { dispatchScope } from '@/lib/agents/dispatch-scope';
 import { buildAuditPrompt } from '@/lib/agents/audit-prompt';
 import { queryAll } from '@/lib/db';
+import { getAuditSettings } from '@/lib/db/workspaces';
+import { planSubtreeAudit, runSubtreeAudit } from '@/lib/agents/subtree-audit';
 
 export const dynamic = 'force-dynamic';
 
 const InvestigateSchema = z.object({
-  mode: z.enum(['narrow']).default('narrow'),
+  mode: z.enum(['narrow', 'subtree']).default('narrow'),
   guidance: z.string().max(2000).nullish(),
   reaudit: z.enum(['fresh', 'build_on']).default('fresh'),
 });
@@ -51,6 +54,8 @@ const InvestigateSchema = z.object({
 interface RouteParams {
   params: Promise<{ id: string }>;
 }
+
+const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
 
 /**
  * Compute the next `:audit:N` attempt suffix for fresh-mode dispatch.
@@ -68,6 +73,50 @@ function nextAuditAttempt(initiativeId: string): number {
   );
   const count = rows[0]?.n ?? 0;
   return count + 1;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  const url = request.nextUrl;
+  if (url.searchParams.get('dryrun') !== '1') {
+    return NextResponse.json(
+      { error: 'Use POST to dispatch; pass ?dryrun=1 for plan info.' },
+      { status: 400 },
+    );
+  }
+  const mode = url.searchParams.get('mode') ?? 'subtree';
+  const initiative = getInitiative(id);
+  if (!initiative) {
+    return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
+  }
+  const settings = getAuditSettings(initiative.workspace_id);
+  if (mode === 'narrow') {
+    return NextResponse.json({
+      ok: true,
+      mode: 'narrow',
+      planned_nodes: 1,
+      planned_layers: 1,
+      concurrency: 1,
+      per_node_timeout_ms: settings.perNodeTimeoutMs,
+    });
+  }
+  if (TERMINAL_STATUSES.has(initiative.status)) {
+    return NextResponse.json(
+      {
+        error: `Cannot plan a subtree audit for an initiative in terminal status '${initiative.status}'.`,
+      },
+      { status: 400 },
+    );
+  }
+  const plan = planSubtreeAudit(id, initiative.workspace_id);
+  return NextResponse.json({
+    ok: true,
+    mode: 'subtree',
+    planned_nodes: plan.plannedNodes,
+    planned_layers: plan.plannedLayers,
+    concurrency: settings.subtreeConcurrency,
+    per_node_timeout_ms: settings.perNodeTimeoutMs,
+  });
 }
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
@@ -95,50 +144,94 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const runner = getRunnerAgent();
     if (!runner) {
       return NextResponse.json(
-        { error: 'Runner agent not registered (mc-runner-dev / mc-runner missing)' },
+        {
+          error:
+            'Runner agent not registered (mc-runner-dev / mc-runner missing)',
+        },
         { status: 503 },
       );
     }
 
-    // Build-on mode: reuse `:audit:1` so the researcher resumes the
-    // prior session AND inline the prior audit notes. Fresh mode: mint
-    // a brand new attempt suffix and pass priorFindings: [].
+    if (mode === 'subtree') {
+      // Subtree mode: reject terminal-status roots — auditing a
+      // done/cancelled initiative's whole subtree is meaningless.
+      if (TERMINAL_STATUSES.has(initiative.status)) {
+        return NextResponse.json(
+          {
+            error: `Subtree audit on a terminal-state initiative ('${initiative.status}') is meaningless — there are no non-terminal descendants to audit and the root itself is closed.`,
+          },
+          { status: 400 },
+        );
+      }
+
+      const settings = getAuditSettings(initiative.workspace_id);
+      const plan = planSubtreeAudit(id, initiative.workspace_id);
+      const dispatchedAt = new Date().toISOString();
+      const rootSessionSuffix = `initiative-${id}:audit:subtree`;
+      const rootScopeKey = (runner as { session_key_prefix?: string | null })
+        .session_key_prefix
+        ? `${(runner as { session_key_prefix?: string | null }).session_key_prefix}:${rootSessionSuffix}`
+        : rootSessionSuffix;
+
+      // Fire-and-forget — the orchestration runs as a background
+      // promise. Per-layer concurrency cap is enforced inside the
+      // helper. Per-node failures are recorded as placeholders and
+      // don't abort the rest of the run.
+      void runSubtreeAudit({
+        rootId: id,
+        workspaceId: initiative.workspace_id,
+        guidance: guidance ?? null,
+        perNodeTimeoutMs: settings.perNodeTimeoutMs,
+        subtreeConcurrency: settings.subtreeConcurrency,
+        runner,
+      }).catch((err) => {
+        console.error(
+          `[investigate] subtree run failed for initiative ${id}:`,
+          (err as Error).message,
+        );
+      });
+
+      return NextResponse.json({
+        ok: true,
+        mode: 'subtree',
+        root_scope_key: rootScopeKey,
+        planned_nodes: plan.plannedNodes,
+        planned_layers: plan.plannedLayers,
+        concurrency: settings.subtreeConcurrency,
+        per_node_timeout_ms: settings.perNodeTimeoutMs,
+        dispatched_at: dispatchedAt,
+      });
+    }
+
+    // ----- narrow mode (unchanged from PR 2) ----------------------
     const attempt = reaudit === 'build_on' ? 1 : nextAuditAttempt(id);
     const sessionSuffix = `initiative-${id}:audit:${attempt}`;
 
-    const priorFindings = reaudit === 'build_on'
-      ? listNotes({
-          initiative_id: id,
-          audience: 'pm',
-          min_importance: 2,
-          limit: 5,
-          order: 'desc',
-        })
-      : [];
+    const priorFindings =
+      reaudit === 'build_on'
+        ? listNotes({
+            initiative_id: id,
+            audience: 'pm',
+            min_importance: 2,
+            limit: 5,
+            order: 'desc',
+          })
+        : [];
 
     const triggerBody = buildAuditPrompt({
       initiative,
       tasks: initiative.tasks ?? [],
       guidance: guidance ?? null,
       priorFindings,
+      mode: 'narrow',
     });
 
-    // Compute scope_key + a synthetic run_group_id up front so the
-    // route can respond immediately. Audits run for up to 15 min; we
-    // can't make the operator's HTTP request hang on that. The actual
-    // dispatchScope call runs detached — its reply is consumed by
-    // openclaw's session log and the take_note row that lands when the
-    // researcher finishes. The `is_resume` bookkeeping inside
-    // dispatchScope still happens via upsertSession on the same tick.
     const dispatchedAt = new Date().toISOString();
     const scopeKey = (runner as { session_key_prefix?: string | null })
       .session_key_prefix
       ? `${(runner as { session_key_prefix?: string | null }).session_key_prefix}:${sessionSuffix}`
       : sessionSuffix;
 
-    // Kick off the dispatch but don't await it. Errors are logged so
-    // operators see them in MC server logs; the route already
-    // responded.
     void dispatchScope({
       workspace_id: initiative.workspace_id,
       role: 'researcher',
@@ -159,7 +252,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     return NextResponse.json({
       ok: true,
-      mode,
+      mode: 'narrow',
       scope_key: scopeKey,
       scope_keys: [scopeKey],
       attempt,

--- a/src/app/api/workspaces/[id]/route.ts
+++ b/src/app/api/workspaces/[id]/route.ts
@@ -3,6 +3,10 @@ import { getDb } from '@/lib/db';
 import {
   deleteWorkspaceCascade,
   getWorkspaceCascadeCounts,
+  AUDIT_PER_NODE_TIMEOUT_MS_MIN,
+  AUDIT_PER_NODE_TIMEOUT_MS_MAX,
+  AUDIT_SUBTREE_CONCURRENCY_MIN,
+  AUDIT_SUBTREE_CONCURRENCY_MAX,
 } from '@/lib/db/workspaces';
 import { resolveWorkspacePath } from '@/lib/config';
 
@@ -56,7 +60,15 @@ export async function PATCH(
 
   try {
     const body = await request.json();
-    const { name, description, icon, workspace_path, context_md } = body;
+    const {
+      name,
+      description,
+      icon,
+      workspace_path,
+      context_md,
+      audit_per_node_timeout_ms,
+      audit_subtree_concurrency,
+    } = body;
 
     const db = getDb();
 
@@ -96,6 +108,45 @@ export async function PATCH(
       updates.push('context_md = ?');
       const trimmed = typeof context_md === 'string' ? context_md : null;
       values.push(trimmed && trimmed.length > 0 ? trimmed : null);
+    }
+
+    if (audit_per_node_timeout_ms !== undefined) {
+      const n = Number(audit_per_node_timeout_ms);
+      if (!Number.isFinite(n) || !Number.isInteger(n)) {
+        return NextResponse.json(
+          { error: 'audit_per_node_timeout_ms must be an integer (ms)' },
+          { status: 400 },
+        );
+      }
+      if (n < AUDIT_PER_NODE_TIMEOUT_MS_MIN || n > AUDIT_PER_NODE_TIMEOUT_MS_MAX) {
+        return NextResponse.json(
+          {
+            error: `audit_per_node_timeout_ms must be between ${AUDIT_PER_NODE_TIMEOUT_MS_MIN} and ${AUDIT_PER_NODE_TIMEOUT_MS_MAX} ms (1–60 minutes)`,
+          },
+          { status: 400 },
+        );
+      }
+      updates.push('audit_per_node_timeout_ms = ?');
+      values.push(n);
+    }
+    if (audit_subtree_concurrency !== undefined) {
+      const n = Number(audit_subtree_concurrency);
+      if (!Number.isFinite(n) || !Number.isInteger(n)) {
+        return NextResponse.json(
+          { error: 'audit_subtree_concurrency must be an integer' },
+          { status: 400 },
+        );
+      }
+      if (n < AUDIT_SUBTREE_CONCURRENCY_MIN || n > AUDIT_SUBTREE_CONCURRENCY_MAX) {
+        return NextResponse.json(
+          {
+            error: `audit_subtree_concurrency must be between ${AUDIT_SUBTREE_CONCURRENCY_MIN} and ${AUDIT_SUBTREE_CONCURRENCY_MAX}`,
+          },
+          { status: 400 },
+        );
+      }
+      updates.push('audit_subtree_concurrency = ?');
+      values.push(n);
     }
 
     if (updates.length === 0) {

--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -291,6 +291,8 @@ export function InitiativeDetailView({
   // Investigate ▾ — narrow-mode audit modal (PR 3 of
   // specs/initiative-investigate.md). Subtree mode lives in PR 4.
   const [showInvestigateModal, setShowInvestigateModal] = useState(false);
+  // PR 4 of specs/initiative-investigate.md — subtree mode added.
+  const [investigateMode, setInvestigateMode] = useState<'narrow' | 'subtree'>('narrow');
   // Selected task for the inline TaskModal — clicking a task in the
   // children list opens it here instead of navigating away.
   const [taskModalTask, setTaskModalTask] = useState<Task | null>(null);
@@ -747,11 +749,8 @@ or "carve out the onboarding flow as its own story first"`}
             <InvestigatePicker
               options={INVESTIGATE_OPTIONS}
               onPick={(scope) => {
-                if (scope === 'narrow') setShowInvestigateModal(true);
-                // 'subtree' is currently disabled in INVESTIGATE_OPTIONS
-                // (PR 4 enables it); the picker will not invoke onPick
-                // for disabled entries, so this branch is effectively
-                // dead code today and kept only as a forward-compat hook.
+                setInvestigateMode(scope);
+                setShowInvestigateModal(true);
               }}
             />
             <span className="w-px h-5 bg-mc-border/60 mx-1" aria-hidden />
@@ -1222,6 +1221,7 @@ or "carve out the onboarding flow as its own story first"`}
             workspace_id: initiative.workspace_id,
           }}
           priorAuditCount={priorAuditCount}
+          mode={investigateMode}
           onClose={() => setShowInvestigateModal(false)}
           onDispatched={() => {
             // Route is fire-and-forget; close immediately so the
@@ -1269,9 +1269,8 @@ or "carve out the onboarding flow as its own story first"`}
   );
 }
 
-// Investigate ▾ menu items. Subtree is intentionally kept visible but
-// disabled so operators see the path exists — PR 4 of
-// specs/initiative-investigate.md enables it.
+// Investigate ▾ menu items. Subtree mode lands in PR 4 of
+// specs/initiative-investigate.md.
 const INVESTIGATE_OPTIONS: InvestigateOption[] = [
   {
     id: 'narrow',
@@ -1281,9 +1280,7 @@ const INVESTIGATE_OPTIONS: InvestigateOption[] = [
   {
     id: 'subtree',
     label: 'Whole subtree (bottom-up)',
-    description: 'Per-level fan-out across descendants, then a roll-up.',
-    disabled: true,
-    disabledReason: 'Coming soon — subtree mode lands in a follow-up PR',
+    description: 'MC fans researchers across non-terminal descendants layer by layer, then rolls up into a parent verdict.',
   },
 ];
 

--- a/src/components/InvestigateModal.tsx
+++ b/src/components/InvestigateModal.tsx
@@ -1,20 +1,18 @@
 'use client';
 
 /**
- * Narrow-mode investigate modal.
+ * Investigate modal — mode-aware (narrow / subtree).
  *
- * PR 3 of specs/initiative-investigate.md. Wires the existing
- * POST /api/initiatives/:id/investigate endpoint (mode='narrow') into
- * the initiative detail page action toolbar.
- *
- * Subtree mode lands in PR 4 — the radio for it is intentionally absent
- * here to keep the modal lean. The toolbar's split-button shows a
- * disabled "Whole subtree (bottom-up)" entry so operators see the path
- * exists.
+ * PR 3 wired narrow mode through the POST /api/initiatives/:id/investigate
+ * endpoint. PR 4 (specs/initiative-investigate.md) extends it for subtree
+ * mode: the re-audit-policy radio is hidden (subtree always fresh in
+ * PR 4), and a pre-flight `?dryrun=1` GET fetches the planned-layers /
+ * planned-nodes / concurrency numbers so the modal can render an
+ * accurate ETA banner.
  *
  * The audit dispatch is fire-and-forget at the route layer; we close
- * the modal on 202 and let the operator watch for the take_note row to
- * land in the NotesRail on the same page.
+ * the modal once the orchestration has been queued and let the
+ * operator watch for the take_note rows in each node's NotesRail.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -36,8 +34,25 @@ export interface InvestigateModalProps {
    * audit" radio. Caller derives this from the initiative's notes.
    */
   priorAuditCount: number;
+  /** Audit scope. Drives radio visibility + endpoint mode. */
+  mode?: 'narrow' | 'subtree';
   onClose: () => void;
-  onDispatched: (result: { scope_key: string; attempt: number }) => void;
+  onDispatched: (result: {
+    mode: 'narrow' | 'subtree';
+    scope_key?: string;
+    root_scope_key?: string;
+    attempt?: number;
+    planned_nodes?: number;
+    planned_layers?: number;
+    concurrency?: number;
+  }) => void;
+}
+
+interface SubtreePlan {
+  planned_nodes: number;
+  planned_layers: number;
+  concurrency: number;
+  per_node_timeout_ms: number;
 }
 
 type Reaudit = 'fresh' | 'build_on';
@@ -47,6 +62,7 @@ const GUIDANCE_MAX = 2000;
 export default function InvestigateModal({
   initiative,
   priorAuditCount,
+  mode = 'narrow',
   onClose,
   onDispatched,
 }: InvestigateModalProps) {
@@ -54,7 +70,37 @@ export default function InvestigateModal({
   const [guidance, setGuidance] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [plan, setPlan] = useState<SubtreePlan | null>(null);
+  const [planErr, setPlanErr] = useState<string | null>(null);
   const { addToast } = useToast();
+
+  // Pre-flight: when opened in subtree mode, fetch the planned-nodes /
+  // planned-layers / concurrency from the dryrun endpoint so we can
+  // render an accurate ETA banner. Falls back to a generic message if
+  // the request fails.
+  useEffect(() => {
+    if (mode !== 'subtree') return;
+    let cancelled = false;
+    setPlanErr(null);
+    fetch(
+      `/api/initiatives/${initiative.id}/investigate?dryrun=1&mode=subtree`,
+    )
+      .then(async (res) => {
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error(
+            (body as { error?: string }).error || `Plan fetch failed (${res.status})`,
+          );
+        }
+        if (!cancelled) setPlan(body as SubtreePlan);
+      })
+      .catch((e) => {
+        if (!cancelled) setPlanErr(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, initiative.id]);
 
   const canBuildOn = priorAuditCount > 0;
 
@@ -84,28 +130,61 @@ export default function InvestigateModal({
     setSubmitting(true);
     setErr(null);
     try {
+      const baseBody = buildInvestigateBody({ reaudit, guidance });
+      // Subtree mode is always 'fresh' in PR 4; reaudit field is ignored
+      // server-side but harmless to omit. The route default keeps narrow
+      // behavior unchanged.
+      const requestBody = mode === 'subtree'
+        ? { mode: 'subtree', guidance: baseBody.guidance }
+        : baseBody;
       const res = await fetch(`/api/initiatives/${initiative.id}/investigate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(buildInvestigateBody({ reaudit, guidance })),
+        body: JSON.stringify(requestBody),
       });
-      // The route returns 200 (not 202) once the dispatch is queued.
-      // Treat any 2xx as success.
+      // The route returns 200 once the dispatch is queued (or the
+      // subtree orchestration is kicked off). Treat any 2xx as success.
       const body = await res.json().catch(() => ({}));
       if (!res.ok) {
         throw new Error(
           (body as { error?: string }).error || `Investigate failed (${res.status})`,
         );
       }
-      const { scope_key, attempt } = body as { scope_key: string; attempt: number };
-      addToast({
-        type: 'success',
-        title: 'Audit dispatched to researcher',
-        message:
-          'Note will appear in this initiative’s notes panel when the researcher finishes (typically 1–15 min).',
-        duration: 8000,
-      });
-      onDispatched({ scope_key, attempt });
+      if (mode === 'subtree') {
+        const { root_scope_key, planned_nodes, planned_layers, concurrency } =
+          body as {
+            root_scope_key: string;
+            planned_nodes: number;
+            planned_layers: number;
+            concurrency: number;
+          };
+        addToast({
+          type: 'success',
+          title: 'Subtree audit dispatched',
+          message: `${planned_nodes} initiative${planned_nodes === 1 ? '' : 's'} across ${planned_layers} layer${planned_layers === 1 ? '' : 's'} (up to ${concurrency} parallel). Each node’s note will appear in its own initiative’s notes panel as it lands.`,
+          duration: 10000,
+        });
+        onDispatched({
+          mode: 'subtree',
+          root_scope_key,
+          planned_nodes,
+          planned_layers,
+          concurrency,
+        });
+      } else {
+        const { scope_key, attempt } = body as {
+          scope_key: string;
+          attempt: number;
+        };
+        addToast({
+          type: 'success',
+          title: 'Audit dispatched to researcher',
+          message:
+            'Note will appear in this initiative’s notes panel when the researcher finishes (typically 1–15 min).',
+          duration: 8000,
+        });
+        onDispatched({ mode: 'narrow', scope_key, attempt });
+      }
     } catch (e) {
       setErr(e instanceof Error ? e.message : 'Investigate failed');
       // Leave the modal open so the operator can adjust + retry.
@@ -130,7 +209,11 @@ export default function InvestigateModal({
           <div className="flex items-start gap-2">
             <Search className="w-4 h-4 mt-0.5 text-mc-accent shrink-0" />
             <div className="min-w-0">
-              <h2 className="text-base font-semibold leading-tight">Investigate initiative</h2>
+              <h2 className="text-base font-semibold leading-tight">
+                {mode === 'subtree'
+                  ? 'Investigate subtree (bottom-up)'
+                  : 'Investigate initiative'}
+              </h2>
               <p className="text-xs text-mc-text-secondary mt-0.5 truncate" title={initiative.title}>
                 {initiative.title}
               </p>
@@ -156,6 +239,7 @@ export default function InvestigateModal({
             </div>
           )}
 
+          {mode === 'narrow' && (
           <fieldset className="flex flex-col gap-2">
             <legend className="text-xs uppercase tracking-wide text-mc-text-secondary/80">
               Re-audit policy
@@ -201,6 +285,7 @@ export default function InvestigateModal({
               </span>
             </label>
           </fieldset>
+          )}
 
           <label className="flex flex-col gap-1">
             <span className="text-xs uppercase tracking-wide text-mc-text-secondary/80">
@@ -219,9 +304,34 @@ export default function InvestigateModal({
             </span>
           </label>
 
-          <p className="text-xs italic text-mc-text-secondary">
-            May take 1–15 minutes. The note will appear in this initiative&apos;s notes panel when complete.
-          </p>
+          {mode === 'subtree' ? (
+            <div className="text-xs text-mc-text-secondary leading-relaxed border border-mc-border/60 rounded p-3 bg-mc-bg/40">
+              {planErr ? (
+                <span className="text-red-300">Couldn&apos;t plan subtree: {planErr}</span>
+              ) : !plan ? (
+                <span className="opacity-70">Computing planned nodes…</span>
+              ) : (
+                <>
+                  Audits <strong className="text-mc-text">{plan.planned_nodes}</strong>{' '}
+                  initiative{plan.planned_nodes === 1 ? '' : 's'} across{' '}
+                  <strong className="text-mc-text">{plan.planned_layers}</strong>{' '}
+                  layer{plan.planned_layers === 1 ? '' : 's'}, up to{' '}
+                  <strong className="text-mc-text">{plan.concurrency}</strong>{' '}
+                  in parallel. Estimated time:{' '}
+                  <strong className="text-mc-text">
+                    {plan.planned_layers * Math.round(plan.per_node_timeout_ms / 60_000)} min
+                  </strong>{' '}
+                  worst case (one researcher per node, layered). Each node&apos;s
+                  note appears in its own initiative&apos;s notes panel as it
+                  completes.
+                </>
+              )}
+            </div>
+          ) : (
+            <p className="text-xs italic text-mc-text-secondary">
+              May take 1–15 minutes. The note will appear in this initiative&apos;s notes panel when complete.
+            </p>
+          )}
         </div>
 
         <footer className="border-t border-mc-border px-5 py-3 flex justify-end gap-2">

--- a/src/lib/agents/audit-prompt.ts
+++ b/src/lib/agents/audit-prompt.ts
@@ -45,6 +45,22 @@ export interface BuildAuditPromptInput {
    * what was previously concluded.
    */
   priorFindings?: ReadonlyArray<Pick<AgentNote, 'id' | 'body' | 'created_at'>>;
+  /**
+   * Subtree-audit roll-up findings from child initiatives that were
+   * already audited in a prior layer. Rendered in a dedicated
+   * "Findings from child initiatives" block so the rolling-up
+   * researcher can synthesize without re-deriving. PR 4.
+   */
+  childFindings?: ReadonlyArray<{
+    childId: string;
+    childTitle: string;
+    /** Body of the child's audit note, or "(audit failed)" placeholder. */
+    body: string;
+    /** True when the child's audit failed/timed out — render with a banner. */
+    failed?: boolean;
+  }>;
+  /** Subtree-vs-narrow flavor. Defaults to 'narrow'. PR 4. */
+  mode?: 'narrow' | 'subtree';
 }
 
 /**
@@ -54,7 +70,14 @@ export interface BuildAuditPromptInput {
  * briefing header (identity / role soul / notetaker addendum).
  */
 export function buildAuditPrompt(input: BuildAuditPromptInput): string {
-  const { initiative, tasks, guidance, priorFindings = [] } = input;
+  const {
+    initiative,
+    tasks,
+    guidance,
+    priorFindings = [],
+    childFindings = [],
+    mode = 'narrow',
+  } = input;
 
   const targetWindow =
     initiative.target_start || initiative.target_end
@@ -90,6 +113,18 @@ export function buildAuditPrompt(input: BuildAuditPromptInput): string {
           )
           .join('\n---\n\n')}\n`;
 
+  const childBlock =
+    childFindings.length === 0
+      ? ''
+      : `\n## Findings from child initiatives (already audited)\n\nThese reports came from researchers we dispatched against this initiative's children in a prior layer. Synthesize them — agree, refine, or refute based on what you can verify yourself — into your roll-up. Do **not** re-audit each child from scratch; trust their evidence and focus your work on the parent-level questions (cross-cutting drift, coverage gaps, terminal verdict for the whole subtree).\n\n${childFindings
+          .map((f, i) => {
+            const banner = f.failed
+              ? '> **Audit failed for this child.** Treat as an explicit gap; flag it in your roll-up.\n\n'
+              : '';
+            return `### Child ${i + 1}: ${f.childTitle} (id=${f.childId})\n\n${banner}${f.body.trim()}\n`;
+          })
+          .join('\n---\n\n')}\n`;
+
   // The take_note arg shape is LOAD-BEARING.
   // Tests assert this exact string. Don't re-flow casually.
   const takeNoteCall = `take_note({
@@ -100,7 +135,7 @@ export function buildAuditPrompt(input: BuildAuditPromptInput): string {
   body: <full report>,
 })`;
 
-  return `**Initiative audit (mode: narrow)**
+  return `**Initiative audit (mode: ${mode})**
 
 Target: ${initiative.title}  (kind=${initiative.kind}, status=${initiative.status}, id=${initiative.id})
 
@@ -115,7 +150,7 @@ Target window: ${targetWindow}
 ## Direct child tasks (this initiative's tasks)
 
 ${tasksBlock}
-${guidanceBlock}${priorBlock}
+${guidanceBlock}${priorBlock}${childBlock}
 ## Your job
 
 Audit this initiative against reality. Produce a markdown report covering:

--- a/src/lib/agents/subtree-audit.test.ts
+++ b/src/lib/agents/subtree-audit.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for the subtree-audit pure helpers
+ * (PR 4 of specs/initiative-investigate.md).
+ *
+ * Covers:
+ *   - enumerateLayersBottomUp: skips terminal nodes, layers leaves
+ *     first, supports unbalanced trees up to 4 levels.
+ *   - boundedAll: respects concurrency cap, surfaces failures as
+ *     `{ ok: false, error }` envelopes without aborting the batch.
+ *
+ * runSubtreeAudit itself talks to the gateway via dispatchScope — that's
+ * covered by the live dogfood loop documented in the spec, not here.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  enumerateLayersBottomUp,
+  boundedAll,
+} from './subtree-audit';
+
+type Lite = Parameters<typeof enumerateLayersBottomUp>[1][number];
+
+function node(
+  id: string,
+  parent: string | null,
+  status: Lite['status'] = 'in_progress',
+): Lite {
+  return {
+    id,
+    title: `node ${id}`,
+    kind: 'epic',
+    status,
+    description: null,
+    status_check_md: null,
+    target_start: null,
+    target_end: null,
+    parent_initiative_id: parent,
+    workspace_id: 'w1',
+  } as unknown as Lite;
+}
+
+test('enumerateLayersBottomUp: single non-terminal root → one layer of [root]', () => {
+  const all = [node('r', null)];
+  const layers = enumerateLayersBottomUp('r', all);
+  assert.equal(layers.length, 1);
+  assert.deepEqual(layers[0].map((i) => i.id), ['r']);
+});
+
+test('enumerateLayersBottomUp: balanced 3-level tree, leaves first', () => {
+  const all = [
+    node('r', null),
+    node('a', 'r'),
+    node('b', 'r'),
+    node('a1', 'a'),
+    node('a2', 'a'),
+    node('b1', 'b'),
+  ];
+  const layers = enumerateLayersBottomUp('r', all);
+  assert.equal(layers.length, 3);
+  assert.deepEqual(
+    layers[0].map((i) => i.id).sort(),
+    ['a1', 'a2', 'b1'],
+  );
+  assert.deepEqual(
+    layers[1].map((i) => i.id).sort(),
+    ['a', 'b'],
+  );
+  assert.deepEqual(layers[2].map((i) => i.id), ['r']);
+});
+
+test('enumerateLayersBottomUp: skips done/cancelled descendants', () => {
+  const all = [
+    node('r', null),
+    node('a', 'r', 'done'), // skipped
+    node('b', 'r'),
+    node('b1', 'b'),
+    node('b2', 'b', 'cancelled'), // skipped
+  ];
+  const layers = enumerateLayersBottomUp('r', all);
+  // a is terminal — a's whole branch dropped (no descendants of a).
+  // b -> b1, b2 cancelled. So leaves: b1. layer1: b. layer2: r.
+  assert.equal(layers.length, 3);
+  assert.deepEqual(layers[0].map((i) => i.id), ['b1']);
+  assert.deepEqual(layers[1].map((i) => i.id), ['b']);
+  assert.deepEqual(layers[2].map((i) => i.id), ['r']);
+});
+
+test('enumerateLayersBottomUp: unbalanced 4-level tree depth = longest path', () => {
+  const all = [
+    node('r', null),
+    node('a', 'r'),
+    node('a1', 'a'),
+    node('a1x', 'a1'),
+    node('a1xy', 'a1x'), // depth 4 leaf
+    node('b', 'r'), // shallow
+  ];
+  const layers = enumerateLayersBottomUp('r', all);
+  // Depths: a1xy=0, b=0, a1x=1, a1=2, a=3, r=4.
+  // b is shallow but should land in layer 0 (with the deep leaf).
+  assert.equal(layers.length, 5);
+  assert.deepEqual(layers[0].map((i) => i.id).sort(), ['a1xy', 'b']);
+  assert.deepEqual(layers[1].map((i) => i.id), ['a1x']);
+  assert.deepEqual(layers[2].map((i) => i.id), ['a1']);
+  assert.deepEqual(layers[3].map((i) => i.id), ['a']);
+  assert.deepEqual(layers[4].map((i) => i.id), ['r']);
+});
+
+test('enumerateLayersBottomUp: throws when root is terminal', () => {
+  const all = [node('r', null, 'done')];
+  assert.throws(() => enumerateLayersBottomUp('r', all), /terminal status/);
+});
+
+test('enumerateLayersBottomUp: zero non-terminal descendants → just the root', () => {
+  const all = [
+    node('r', null),
+    node('a', 'r', 'done'),
+    node('b', 'r', 'cancelled'),
+  ];
+  const layers = enumerateLayersBottomUp('r', all);
+  assert.equal(layers.length, 1);
+  assert.deepEqual(layers[0].map((i) => i.id), ['r']);
+});
+
+test('boundedAll: respects concurrency cap', async () => {
+  let inflight = 0;
+  let peak = 0;
+  const tasks = Array.from({ length: 8 }, () => async () => {
+    inflight++;
+    peak = Math.max(peak, inflight);
+    await new Promise((r) => setTimeout(r, 10));
+    inflight--;
+    return 'ok';
+  });
+  const out = await boundedAll(tasks, 3);
+  assert.equal(out.length, 8);
+  assert.ok(peak <= 3, `peak inflight ${peak} exceeded cap of 3`);
+  assert.ok(out.every((r) => r.ok));
+});
+
+test('boundedAll: failures surface as envelopes, batch continues', async () => {
+  const tasks = [
+    async () => 1,
+    async () => {
+      throw new Error('boom');
+    },
+    async () => 3,
+  ];
+  const out = await boundedAll(tasks, 2);
+  assert.equal(out.length, 3);
+  assert.deepEqual(out[0], { ok: true, value: 1 });
+  assert.equal(out[1].ok, false);
+  if (!out[1].ok) assert.equal(out[1].error.message, 'boom');
+  assert.deepEqual(out[2], { ok: true, value: 3 });
+});
+
+test('boundedAll: empty task list resolves immediately', async () => {
+  const out = await boundedAll([], 4);
+  assert.deepEqual(out, []);
+});
+
+test('boundedAll: cap >= task count behaves like Promise.all-ish', async () => {
+  const tasks = [async () => 'a', async () => 'b'];
+  const out = await boundedAll(tasks, 16);
+  assert.deepEqual(
+    out.map((r) => (r.ok ? r.value : null)),
+    ['a', 'b'],
+  );
+});

--- a/src/lib/agents/subtree-audit.ts
+++ b/src/lib/agents/subtree-audit.ts
@@ -1,0 +1,372 @@
+/**
+ * Subtree-audit orchestration for the initiative Investigate flow.
+ *
+ * MC-driven, bottom-up, layered fan-out. PR 4 of
+ * specs/initiative-investigate.md.
+ *
+ * Public surface:
+ *   - enumerateLayersBottomUp — pure helper that returns leaf-first
+ *     layers of non-terminal descendants, with the root (when also
+ *     non-terminal) as the final layer.
+ *   - boundedAll — small concurrency-limited Promise.all variant. Kept
+ *     local because the repo had no existing utility (< 30 lines per
+ *     project guidance).
+ *   - planSubtreeAudit — pure dryrun shape used by the API + UI to
+ *     show planned_layers / planned_nodes / concurrency before
+ *     committing.
+ *   - runSubtreeAudit — the actual orchestrator. Fire-and-forget at
+ *     the API boundary; per-node failures are recorded as placeholder
+ *     findings and don't abort the run.
+ *
+ * Important behavioral choices (operator review surface):
+ *   - Layer N waits for Layer N-1 to fully settle before dispatching.
+ *   - Concurrency cap applies per-layer (the cap inside `boundedAll`).
+ *   - On per-node timeout / dispatch error: we synthesize a placeholder
+ *     "(audit failed)" finding and proceed. The next layer's roll-up
+ *     researcher gets the placeholder verbatim and is instructed in the
+ *     prompt to flag the gap.
+ *   - Each node still mints its own attempt suffix off
+ *     `initiative-${id}:audit:${N}` and its own scope_key. mc_sessions
+ *     bookkeeping is identical to narrow mode.
+ */
+
+import { listInitiatives, type Initiative } from '@/lib/db/initiatives';
+import { listNotes } from '@/lib/db/agent-notes';
+import { dispatchScope } from '@/lib/agents/dispatch-scope';
+import { buildAuditPrompt } from '@/lib/agents/audit-prompt';
+import type { Agent } from '@/lib/types';
+import { queryAll } from '@/lib/db';
+
+const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
+
+/** Initiative shape we need internally — kept narrow on purpose. */
+type LiteInitiative = Pick<
+  Initiative,
+  | 'id'
+  | 'title'
+  | 'kind'
+  | 'status'
+  | 'description'
+  | 'status_check_md'
+  | 'target_start'
+  | 'target_end'
+  | 'parent_initiative_id'
+  | 'workspace_id'
+>;
+
+/**
+ * Enumerate non-terminal descendants of `rootId`, returning bottom-up
+ * layers (leaves first, root last).
+ *
+ * Rules:
+ *   - Skip nodes whose status ∈ {done, cancelled}.
+ *   - "Layer" is determined by the LONGEST path from a node to any
+ *     non-terminal descendant. Leaves (no non-terminal children of
+ *     their own) are layer 0; their parents layer 1; etc. This keeps
+ *     the layer-N parent dispatch *after* every reachable child has
+ *     finished, even when the tree is unbalanced.
+ *   - The original root is always included if it is itself
+ *     non-terminal. If the root is terminal, the helper throws — the
+ *     caller should reject the request before calling.
+ *   - If the root has zero non-terminal descendants, returns a single
+ *     layer containing only the root.
+ */
+export function enumerateLayersBottomUp(
+  rootId: string,
+  workspaceInitiatives: ReadonlyArray<LiteInitiative>,
+): LiteInitiative[][] {
+  const byId = new Map<string, LiteInitiative>();
+  const byParent = new Map<string, LiteInitiative[]>();
+  for (const i of workspaceInitiatives) {
+    byId.set(i.id, i);
+    if (i.parent_initiative_id) {
+      const list = byParent.get(i.parent_initiative_id) ?? [];
+      list.push(i);
+      byParent.set(i.parent_initiative_id, list);
+    }
+  }
+
+  const root = byId.get(rootId);
+  if (!root) throw new Error(`enumerateLayersBottomUp: root ${rootId} not found`);
+  if (TERMINAL_STATUSES.has(root.status)) {
+    throw new Error(
+      `enumerateLayersBottomUp: root ${rootId} has terminal status '${root.status}'`,
+    );
+  }
+
+  // Walk subtree, collect non-terminal descendants (incl. root).
+  const included: LiteInitiative[] = [];
+  const stack: LiteInitiative[] = [root];
+  while (stack.length) {
+    const cur = stack.pop()!;
+    if (TERMINAL_STATUSES.has(cur.status)) continue;
+    included.push(cur);
+    const kids = byParent.get(cur.id) ?? [];
+    for (const k of kids) stack.push(k);
+  }
+
+  // Memoized depth: longest path from `id` down to any included leaf.
+  const depthCache = new Map<string, number>();
+  const includedSet = new Set(included.map((i) => i.id));
+  const depth = (id: string): number => {
+    const cached = depthCache.get(id);
+    if (cached !== undefined) return cached;
+    const kids = (byParent.get(id) ?? []).filter((k) => includedSet.has(k.id));
+    if (kids.length === 0) {
+      depthCache.set(id, 0);
+      return 0;
+    }
+    const d = 1 + Math.max(...kids.map((k) => depth(k.id)));
+    depthCache.set(id, d);
+    return d;
+  };
+
+  const layers: LiteInitiative[][] = [];
+  for (const i of included) {
+    const d = depth(i.id);
+    if (!layers[d]) layers[d] = [];
+    layers[d].push(i);
+  }
+  // Drop any unexpected gaps (shouldn't happen — depth is contiguous
+  // when computed from leaves up — but defensive).
+  return layers.filter((l) => l && l.length > 0);
+}
+
+/**
+ * Concurrency-bounded Promise.all over a heterogeneous task list. Each
+ * task is a thunk so it isn't started until a slot is free.
+ *
+ * Resolves to the array of results in input order. If any task
+ * rejects, the rejection is surfaced via a `{ ok: false, error }`
+ * envelope rather than throwing — the orchestrator wants per-task
+ * outcomes, not abort-on-first-failure.
+ */
+export async function boundedAll<T>(
+  tasks: ReadonlyArray<() => Promise<T>>,
+  limit: number,
+): Promise<Array<{ ok: true; value: T } | { ok: false; error: Error }>> {
+  const cap = Math.max(1, Math.floor(limit));
+  const results: Array<{ ok: true; value: T } | { ok: false; error: Error }> =
+    new Array(tasks.length);
+  let next = 0;
+  const worker = async () => {
+    while (true) {
+      const idx = next++;
+      if (idx >= tasks.length) return;
+      try {
+        results[idx] = { ok: true, value: await tasks[idx]() };
+      } catch (e) {
+        results[idx] = {
+          ok: false,
+          error: e instanceof Error ? e : new Error(String(e)),
+        };
+      }
+    }
+  };
+  const workers = Array.from({ length: Math.min(cap, tasks.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+export interface SubtreePlan {
+  layers: LiteInitiative[][];
+  plannedLayers: number;
+  plannedNodes: number;
+}
+
+/**
+ * Pure planning helper. Pulls the workspace's initiatives, enumerates
+ * the layers, and returns counts. Used by the API to populate the
+ * 202 response and (optionally) by a `?dryrun=1` GET for the modal.
+ */
+export function planSubtreeAudit(rootId: string, workspaceId: string): SubtreePlan {
+  const all = listInitiatives({ workspace_id: workspaceId }) as LiteInitiative[];
+  const layers = enumerateLayersBottomUp(rootId, all);
+  const plannedNodes = layers.reduce((acc, l) => acc + l.length, 0);
+  return { layers, plannedLayers: layers.length, plannedNodes };
+}
+
+export interface RunSubtreeAuditInput {
+  rootId: string;
+  workspaceId: string;
+  guidance?: string | null;
+  perNodeTimeoutMs: number;
+  subtreeConcurrency: number;
+  runner: Agent;
+}
+
+export interface SubtreeAuditResult {
+  rootId: string;
+  totalDispatched: number;
+  failedCount: number;
+  perNodeOutcomes: Array<{
+    initiativeId: string;
+    layerIndex: number;
+    scopeKey: string;
+    status: 'ok' | 'failed';
+    note?: string;
+    error?: string;
+  }>;
+}
+
+/**
+ * Compute the next `:audit:N` attempt suffix for a given initiative.
+ * Mirrors the helper inlined in the route — duplicated here to avoid
+ * a circular import via the route module.
+ */
+function nextAuditAttempt(initiativeId: string): number {
+  const rows = queryAll<{ n: number }>(
+    `SELECT COUNT(*) as n
+       FROM mc_sessions
+      WHERE scope_type = 'initiative_audit'
+        AND initiative_id = ?`,
+    [initiativeId],
+  );
+  return (rows[0]?.n ?? 0) + 1;
+}
+
+/**
+ * Orchestrate a subtree audit. Fire-and-forget at the API boundary —
+ * the caller awaits the planning + first-layer kickoff and then lets
+ * the rest of the run finish in the background.
+ *
+ * Returns when every layer has settled. Per-node results — including
+ * the take_note body extracted from the agent_notes table — are
+ * collected so callers / tests can assert layer-by-layer behavior.
+ */
+export async function runSubtreeAudit(
+  input: RunSubtreeAuditInput,
+): Promise<SubtreeAuditResult> {
+  const { rootId, workspaceId, guidance, perNodeTimeoutMs, subtreeConcurrency, runner } =
+    input;
+  const { layers } = planSubtreeAudit(rootId, workspaceId);
+
+  // Map of initiative_id → most-recent finding body (or "(audit failed)" placeholder).
+  const findingsByInitiative = new Map<string, { body: string; failed: boolean }>();
+  const perNodeOutcomes: SubtreeAuditResult['perNodeOutcomes'] = [];
+
+  for (let layerIdx = 0; layerIdx < layers.length; layerIdx++) {
+    const layer = layers[layerIdx];
+    const tasks = layer.map((node) => async () => {
+      const attempt = nextAuditAttempt(node.id);
+      const sessionSuffix = `initiative-${node.id}:audit:${attempt}`;
+      const scopeKey = (runner as { session_key_prefix?: string | null })
+        .session_key_prefix
+        ? `${(runner as { session_key_prefix?: string | null }).session_key_prefix}:${sessionSuffix}`
+        : sessionSuffix;
+
+      // Pull the immediate children's findings (only those that are
+      // in our included set — terminal children are skipped). We
+      // re-enumerate from `layers` rather than re-walking the tree.
+      const childFindings: Array<{
+        childId: string;
+        childTitle: string;
+        body: string;
+        failed?: boolean;
+      }> = [];
+      // Children-of-this-node within prior layers:
+      for (let prior = 0; prior < layerIdx; prior++) {
+        for (const candidate of layers[prior]) {
+          if (candidate.parent_initiative_id === node.id) {
+            const f = findingsByInitiative.get(candidate.id);
+            childFindings.push({
+              childId: candidate.id,
+              childTitle: candidate.title,
+              body: f?.body ?? '_(no finding recorded — child audit did not run)_',
+              failed: f?.failed ?? true,
+            });
+          }
+        }
+      }
+
+      // Tasks attached to this initiative (narrow already loads them
+      // via getInitiative({ includeTasks: true }); we mirror that).
+      const tasksForNode = queryAll<{ id: string; title: string; status: string }>(
+        `SELECT id, title, status FROM tasks WHERE initiative_id = ?`,
+        [node.id],
+      );
+
+      const triggerBody = buildAuditPrompt({
+        initiative: node,
+        tasks: tasksForNode,
+        guidance: guidance ?? null,
+        priorFindings: [],
+        childFindings,
+        mode: 'subtree',
+      });
+
+      try {
+        await dispatchScope({
+          workspace_id: workspaceId,
+          role: 'researcher',
+          agent: runner,
+          session_suffix: sessionSuffix,
+          scope_type: 'initiative_audit',
+          initiative_id: node.id,
+          trigger_body: triggerBody,
+          attempt_strategy: 'fresh',
+          timeoutMs: perNodeTimeoutMs,
+          idempotencyKey: `subtree-audit-${node.id}-${attempt}-${Date.now()}`,
+        });
+
+        // Pull the most recent observation/pm/importance=2 note for
+        // this initiative — the researcher's report. listNotes orders
+        // by created_at desc by default.
+        const notes = listNotes({
+          initiative_id: node.id,
+          audience: 'pm',
+          min_importance: 2,
+          limit: 1,
+          order: 'desc',
+        });
+        const body = notes[0]?.body?.trim();
+        if (body) {
+          findingsByInitiative.set(node.id, { body, failed: false });
+          perNodeOutcomes.push({
+            initiativeId: node.id,
+            layerIndex: layerIdx,
+            scopeKey,
+            status: 'ok',
+            note: body,
+          });
+        } else {
+          // Researcher returned but didn't take_note — treat as failure.
+          const placeholder = `(audit failed: researcher reply received but no take_note(initiative_id=${node.id}, audience='pm', importance=2) row landed)`;
+          findingsByInitiative.set(node.id, { body: placeholder, failed: true });
+          perNodeOutcomes.push({
+            initiativeId: node.id,
+            layerIndex: layerIdx,
+            scopeKey,
+            status: 'failed',
+            error: 'no take_note row',
+          });
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const placeholder = `(audit failed: ${message})`;
+        findingsByInitiative.set(node.id, { body: placeholder, failed: true });
+        perNodeOutcomes.push({
+          initiativeId: node.id,
+          layerIndex: layerIdx,
+          scopeKey,
+          status: 'failed',
+          error: message,
+        });
+        console.error(
+          `[subtree-audit] node ${node.id} (layer ${layerIdx}) failed:`,
+          message,
+        );
+      }
+    });
+
+    await boundedAll(tasks, subtreeConcurrency);
+  }
+
+  const failedCount = perNodeOutcomes.filter((o) => o.status === 'failed').length;
+  return {
+    rootId,
+    totalDispatched: perNodeOutcomes.length,
+    failedCount,
+    perNodeOutcomes,
+  };
+}

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4290,6 +4290,28 @@ const migrations: Migration[] = [
       console.log('[Migration 078] mc_sessions.scope_type extended with initiative_audit.');
     },
   },
+  {
+    id: '079',
+    name: 'workspaces_audit_settings',
+    up: (db) => {
+      // Workspace-scoped knobs for the initiative audit (subtree) flow.
+      // See specs/initiative-investigate.md §"Decisions" item 1.
+      const cols = db.prepare(`PRAGMA table_info(workspaces)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'audit_per_node_timeout_ms')) {
+        db.exec(`
+          ALTER TABLE workspaces
+            ADD COLUMN audit_per_node_timeout_ms INTEGER NOT NULL DEFAULT 900000
+        `);
+      }
+      if (!cols.some((c) => c.name === 'audit_subtree_concurrency')) {
+        db.exec(`
+          ALTER TABLE workspaces
+            ADD COLUMN audit_subtree_concurrency INTEGER NOT NULL DEFAULT 4
+        `);
+      }
+      console.log('[Migration 079] audit_per_node_timeout_ms + audit_subtree_concurrency columns added to workspaces.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -26,6 +26,11 @@ CREATE TABLE IF NOT EXISTS workspaces (
   -- memory grounding (precursor to the memory-layer epic). NULL → no
   -- block prepended. See migration 056.
   context_md TEXT,
+  -- Per-node timeout (ms) for the initiative-audit subtree flow.
+  -- See specs/initiative-investigate.md §"Decisions" item 1. Migration 079.
+  audit_per_node_timeout_ms INTEGER NOT NULL DEFAULT 900000,
+  -- Max parallel researcher dispatches per layer in subtree-audit fan-out.
+  audit_subtree_concurrency INTEGER NOT NULL DEFAULT 4,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );

--- a/src/lib/db/workspaces.ts
+++ b/src/lib/db/workspaces.ts
@@ -32,6 +32,51 @@
 
 import { getDb } from './index';
 
+/**
+ * Defaults for the initiative-audit subtree flow. Match the values the
+ * spec describes (specs/initiative-investigate.md §"Decisions" item 1)
+ * and the column defaults applied by migration 079.
+ */
+export const AUDIT_PER_NODE_TIMEOUT_MS_DEFAULT = 15 * 60_000;
+export const AUDIT_SUBTREE_CONCURRENCY_DEFAULT = 4;
+export const AUDIT_PER_NODE_TIMEOUT_MS_MIN = 60_000; // 1 min
+export const AUDIT_PER_NODE_TIMEOUT_MS_MAX = 60 * 60_000; // 60 min
+export const AUDIT_SUBTREE_CONCURRENCY_MIN = 1;
+export const AUDIT_SUBTREE_CONCURRENCY_MAX = 8;
+
+export interface AuditSettings {
+  perNodeTimeoutMs: number;
+  subtreeConcurrency: number;
+}
+
+/**
+ * Read the workspace's audit knobs, falling back to spec defaults if
+ * the row is missing or the columns are NULL (shouldn't happen post
+ * migration 079, but defensive — older snapshots may not have run it).
+ */
+export function getAuditSettings(workspaceId: string): AuditSettings {
+  const db = getDb();
+  let row: { t: number | null; c: number | null } | undefined;
+  try {
+    row = db
+      .prepare(
+        `SELECT audit_per_node_timeout_ms as t, audit_subtree_concurrency as c
+           FROM workspaces WHERE id = ?`,
+      )
+      .get(workspaceId) as { t: number | null; c: number | null } | undefined;
+  } catch {
+    // Columns missing on a pre-079 DB; return defaults.
+    return {
+      perNodeTimeoutMs: AUDIT_PER_NODE_TIMEOUT_MS_DEFAULT,
+      subtreeConcurrency: AUDIT_SUBTREE_CONCURRENCY_DEFAULT,
+    };
+  }
+  return {
+    perNodeTimeoutMs: row?.t ?? AUDIT_PER_NODE_TIMEOUT_MS_DEFAULT,
+    subtreeConcurrency: row?.c ?? AUDIT_SUBTREE_CONCURRENCY_DEFAULT,
+  };
+}
+
 export interface WorkspaceCascadeCounts {
   tasks: number;
   agents: number;


### PR DESCRIPTION
## Summary

PR 4 of [specs/initiative-investigate.md](specs/initiative-investigate.md). Adds MC-driven bottom-up layered fan-out for the **Investigate** flow, plus the workspace-scoped knobs that drive it.

- **Workspace settings** (`audit_per_node_timeout_ms`, `audit_subtree_concurrency`) — migration 079, validated PATCH on `/api/workspaces/:id`, surfaced as a new "Audit defaults" section on the workspace settings page.
- **Subtree orchestration** (`src/lib/agents/subtree-audit.ts`) — `enumerateLayersBottomUp` (skips `done`/`cancelled`, layers leaves first via longest-path-to-leaf depth), `boundedAll` concurrency-limited Promise.all, `runSubtreeAudit` orchestrator with per-node failure → placeholder fallback so a single broken leaf never aborts the whole tree.
- **Audit prompt** — extended with `mode: 'narrow' | 'subtree'` and `childFindings` so the roll-up researcher gets each child's verbatim note inlined under "Findings from child initiatives (already audited)".
- **Investigate API** — POST lifts the subtree 501; rejects terminal-state roots with 400; fire-and-forget at the response boundary. New `GET ?dryrun=1&mode=subtree` for the modal's pre-flight ETA banner.
- **Investigate modal** — mode-aware: hides the re-audit-policy radio in subtree mode (always fresh in PR 4) and renders an accurate `N nodes × N layers, up to K parallel, ~M min worst case` banner.
- **Picker** — subtree menu item enabled (was visible-but-disabled in PR 3).

## Changes

| Area | File |
|---|---|
| DB | `src/lib/db/migrations.ts` (079), `schema.ts`, `workspaces.ts` (`getAuditSettings`, range constants) |
| API | `src/app/api/initiatives/[id]/investigate/route.ts` (POST subtree branch + GET dryrun), `src/app/api/workspaces/[id]/route.ts` (PATCH validation) |
| Orchestration | `src/lib/agents/subtree-audit.ts` (new) |
| Prompt | `src/lib/agents/audit-prompt.ts` (mode + childFindings) |
| UI | `src/components/InvestigateModal.tsx`, `src/components/InitiativeDetailView.tsx`, `src/app/(app)/workspace/[slug]/settings/page.tsx` |
| Tests | `src/lib/agents/subtree-audit.test.ts` (new), `src/app/api/initiatives/[id]/investigate/route.test.ts` (new) |

## Test plan

Unit + route tests:

- [x] `subtree-audit.test.ts` — 10 tests, layer enumeration (single root, balanced 3-level, terminal skipping, unbalanced 4-level, terminal root throws, zero non-terminal descendants), `boundedAll` (concurrency cap, failure envelopes, empty list, cap >= count). All pass.
- [x] `route.test.ts` — 7 tests, GET dryrun shapes (narrow + subtree), terminal-state 400, no-runner 503, zero-non-terminal-descendants → planned_nodes=1. All pass.
- [x] Pre-existing failure ignored: `schedule-runner: produces a brief and advances run_count` (per CLAUDE.md).
- [x] `yarn tsc --noEmit` clean for all new/modified files; pre-existing errors in unrelated files (`pm/proposals/[id]/route.ts`, `pm-decompose.test.ts`) left alone.

### Live dogfood (operator-confirmed fixture)

Ran on dev DB against initiative `0c9419ff-d511-4511-86c6-57a6387e19f7` ("Refactor native alert() calls to a custom modal"), the same fixture used to validate narrow mode in PR 2/3. Operator ground truth: 1 done child + 4 partial + 1 unused.

| Metric | Result |
|---|---|
| Dryrun plan | `planned_nodes: 6, planned_layers: 2, concurrency: 4` (5 leaves + root, 1 done child correctly skipped) |
| Layer 1 dispatch | 4 leaves at `03:16:54`, 5th at `03:27:11` after first slot freed → concurrency cap respected |
| Layer 1 completion | 5 child notes landed `03:27:00 → 03:31:02` |
| Layer 2 dispatch | Root at `03:31:08` (zero overlap with layer 1 — strict barrier) |
| Layer 2 completion | Root note at `03:33:55` |
| **Total wall time** | **~17 min** |
| Notes produced | 6 — one per non-terminal node (5 children + root), all `kind=observation, audience=pm, importance=2`, linked to correct `initiative_id` |
| Root verdict | "PARTIALLY DONE" — synthesizes each child's verdict by ID, correctly flags toast story (`9ab40f1f`) as "not needed" matching operator's "1 unused" ground truth |
| Failures | 0 (no per-node timeouts; placeholder fallback path not exercised this iteration but covered in unit tests) |

Per-iteration artifacts saved to `/tmp/mc-validation/initiative-investigate/iter-subtree-1/`:
- `notes-summary.txt` — first 180 chars of each note
- `layers.txt` — `mc_sessions` rows showing dispatch ordering
- `root-note.md` — full root researcher synthesis
- `dispatch-response.json` — POST response shape

### Workspace-settings UX

PATCH validation enforces:
- `audit_per_node_timeout_ms`: integer, 60_000–3_600_000 ms (1–60 min) — UI accepts minutes and multiplies
- `audit_subtree_concurrency`: integer, 1–8

Helper text on the settings page matches the spec wording in §"Decisions" item 1. Defaults read from migration 079 column defaults via `getAuditSettings()`.

### Known edge-case behavior (documented inline)

- **Concurrency change mid-flight**: settings are read at dispatch time only. A workspace knob change applies to the next dispatch, not the in-flight one. Behavior documented in `subtree-audit.ts` doc comment.
- **Layer N fully fails**: layer N+1 still runs with all-failed placeholders; root researcher is instructed in the prompt's child-findings block to flag the gap explicitly.
- **Terminal root**: 400 with a clear message ("subtree audit on a terminal-state initiative is meaningless"). GET dryrun rejects identically.

## Anti-scope

- No PM SOUL changes (PR 5).
- No live in-flight UI for subtree progress beyond the per-node notes panel + the dispatch toast (banner with planned-nodes count).
- No re-audit-with-priors for subtree mode (always fresh in PR 4).
- No deliverables system extension — `take_note` remains the audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)