### PR TITLE
feat(pm): read recent audit notes during Plan dispatch

### DIFF
--- a/agent-templates/pm/SOUL.md
+++ b/agent-templates/pm/SOUL.md
@@ -155,3 +155,13 @@ propose_changes({
   }
 })
 ```
+
+### Ingest recent audit findings before composing
+
+Before you compose a `plan_initiative` proposal, call `read_notes({ initiative_id: <id>, audience: 'pm', min_importance: 2, limit: 5 })` to pull any recent audit findings produced by the Investigate flow. Audit notes are evidence-grade — they reflect a researcher's actual read of the code and roadmap, so weight them heavily.
+
+- If notes exist, reference the most relevant one or two explicitly in `impact_md` using the form `Per audit on YYYY-MM-DD: "<short quoted finding>"`. Cap inline quoting at one or two findings — don't dump whole audit bodies.
+- When an audit says a story is unused / superseded / done-in-practice, that's a strong signal to propose a corresponding `set_initiative_status` diff (`'cancelled'` for unused, `'done'` for shipped) on that story. The PR 1 schema gap closure makes this proposable now.
+- Newer audits supersede older ones when they conflict — the `limit: 5` window already biases toward recency.
+- If the operator's `guidance` text explicitly says to ignore the audit or plan from scratch, honor that. The audit nudge is advisory, not mandatory.
+- If `read_notes` returns empty, proceed with normal planning prose — don't manufacture audit references.

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -153,6 +153,11 @@ export async function POST(request: NextRequest) {
         (parsed.data.guidance
           ? `Operator guidance — focus the plan on this: ${parsed.data.guidance}\n\n`
           : '') +
+        (parsed.data.target_initiative_id
+          ? `Before composing, call read_notes({ initiative_id: "${parsed.data.target_initiative_id}", audience: 'pm', min_importance: 2, limit: 5 }) ` +
+            `to ingest any recent audit findings; if any are returned, reference one or two explicitly in impact_md (e.g. \`Per audit on YYYY-MM-DD: "<short quoted finding>"\`). ` +
+            `See SOUL.md "Ingest recent audit findings".\n\n`
+          : '') +
         `Call \`propose_changes\` (trigger_kind='plan_initiative') with proposed_changes=[] and ` +
         `pass the structured plan_suggestions parameter directly (do NOT embed JSON in impact_md). ` +
         `See your SOUL.md for the plan_suggestions shape. ` +


### PR DESCRIPTION
## Summary

PR 5 (final) of `specs/initiative-investigate.md`. Hooks the PM
hand-off into the new Investigate flow: when the operator clicks Plan
with PM after an audit, the PM ingests recent audit findings and
references them in its proposal.

Two minimal changes:

- **`agent-templates/pm/SOUL.md`** — adds an "Ingest recent audit
  findings" subsection under `## plan_initiative Flow`. Instructs the
  PM to call `read_notes(audience: 'pm', min_importance: 2, limit: 5)`
  before composing, quote one or two findings explicitly in
  `impact_md`, and treat audit verdicts (e.g. "story X is unused") as
  a strong signal to propose a `set_initiative_status` diff. Operator
  guidance to "ignore the audit" still wins.
- **`src/app/api/pm/plan-initiative/route.ts`** — appends the same
  instruction to the per-turn `agent_prompt` when
  `target_initiative_id` is set. Reinforces the SOUL contract on every
  plan turn (the briefing role section is skipped on resume of the
  long-lived gateway PM session, so a per-turn nudge is the reliable
  carrier).

No changes to `read_notes`, `take_note`, the dispatch pipeline, or
the spec doc. Out-of-scope for PR 5 (and explicitly per spec):
no auto-trigger of Plan after Investigate.

## Changes

- `agent-templates/pm/SOUL.md` — new `### Ingest recent audit findings before composing` subsection.
- `src/app/api/pm/plan-initiative/route.ts` — conditional `read_notes` instruction inlined into `agent_prompt`.

## Test plan

- [x] `grep "read_notes" agent-templates/pm/SOUL.md` confirms the instruction landed.
- [x] **Audit-rich initiative** — fired Plan dispatch against fixture
  initiative `0c9419ff-d511-4511-86c6-57a6387e19f7` (7 audit notes
  attached from PRs 2–4). PM produced an audit-informed proposal:
  - `aeece775-976e-45a0-bd2c-3a5ab709170f` — `### Plan summary — audit-informed replan`
  - References PR #111, commit `f76a484`, merged 2026-04-30 (quoted from audit body).
  - Flags story `9ab40f1f` (toast library) as "unnecessary — custom Toast already exists".
  - Notes that stories `117bc3ba`, `8c35f595`, `68abc586` are "marked planned but work is done in f76a484".
  - `proposed_changes` includes a `create_child_initiative` for the remaining cleanup pass and an `update_status_check` reflecting the audit's "partially done" verdict.

  Excerpt from `impact_md`:
  > **Story 9ab40f1f (toast library) is unnecessary** — custom Toast already exists and is used in 5+ files; no third-party library needed.
  > **Three stories marked "planned" but work is done** — stories 117bc3ba, 8c35f595, 68abc586 were executed in commit f76a484, not via story-level execution.

- [x] **Baseline** — fired Plan dispatch against `a779d5e1` (no audit
  notes). PM produced normal planning prose with zero references to
  audits or quoted findings, confirming the instruction is conditional.

- [x] Pre-existing failure noted in CLAUDE.md (`schedule-runner: produces a brief and advances run_count`) — not run; not touched.