### PR TITLE
fix(pm): show plan_initiative drafts in proposals list

### DIFF
--- a/src/app/api/pm/proposals/route.ts
+++ b/src/app/api/pm/proposals/route.ts
@@ -68,18 +68,21 @@ export async function GET(request: NextRequest) {
       limit: limitRaw ? Math.max(1, parseInt(limitRaw, 10) || 50) : undefined,
     };
     const rows = listProposals(filters);
-    // Hide proposals with zero structured changes from the list views.
-    // These are pure noise — Mode B placeholders that pre-date PR #234's
-    // auto-cleanup, accepted-but-empty rows from older dispatches, etc.
-    // Affects both the /pm recents sidebar (status=draft) and the
-    // /pm/activity page (status=accepted): a 0-change accepted proposal
-    // doesn't represent a roadmap mutation worth surfacing in audit, and
-    // a 0-change draft is just dead weight.
+    // Hide proposals with zero structured changes AND no plan_suggestions
+    // from the list views. These are pure noise — Mode B placeholders that
+    // pre-date PR #234's auto-cleanup, accepted-but-empty rows from older
+    // dispatches, etc.
+    //
+    // plan_initiative drafts intentionally carry empty proposed_changes
+    // (the advisory output lives in plan_suggestions); those are real
+    // drafts and must remain visible in the recents sidebar.
     //
     // Operators can still view individual rows via direct
     // /pm/proposals/<id> URLs, and can hard-delete via DELETE
     // /api/pm/proposals/<id> (PR #235).
-    const visible = rows.filter((p) => p.proposed_changes.length > 0);
+    const visible = rows.filter(
+      (p) => p.proposed_changes.length > 0 || p.plan_suggestions != null,
+    );
     return NextResponse.json(visible);
   } catch (error) {
     console.error('Failed to list PM proposals:', error);


### PR DESCRIPTION
## Summary
- The proposals list filter was hiding any draft with empty \`proposed_changes\`, but \`plan_initiative\` drafts intentionally carry no structured changes — their advisory output lives in \`plan_suggestions\`. Every Plan-with-PM draft was being stripped from the recents sidebar.
- Filter now keeps a proposal if \`proposed_changes.length > 0\` **or** \`plan_suggestions != null\`. Empty Mode-B placeholders stay hidden as before.

## Test plan
- [x] Verified live against dev DB: draft count went 1 → 5 (4 missing \`plan_initiative\` drafts now visible) after the change.
- [x] Empty Mode-B placeholder rows (manual trigger, 0 changes, no plan) remain hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)