### PR TITLE
feat(jobs): GET /api/jobs + minimal /jobs UI (PR 2/5)

### DIFF
--- a/src/app/(app)/jobs/page.tsx
+++ b/src/app/(app)/jobs/page.tsx
@@ -1,0 +1,409 @@
+'use client';
+
+/**
+ * /jobs — unified queue surface for every in-flight agent dispatch.
+ *
+ * Three sections, polled every 2s against `/api/jobs?workspace_id=…`:
+ *   - Live (queued+running, pm_chat collapsed by scope_key)
+ *   - Scheduled (recurring_jobs due in next 24h)
+ *   - Recent (terminal in last 24h, ungrouped)
+ *
+ * Long-running rows (live elapsed > 5min) get an amber row tint — the
+ * only visual flag in PR 2. Subtree tree view, cancel button, and the
+ * sidebar live-count pip ship in PR 3-5. See specs/jobs-in-progress.md.
+ */
+
+import { useEffect, useState, useMemo } from 'react';
+import { Activity, Clock, Calendar, History, AlertTriangle, Copy, Check } from 'lucide-react';
+import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
+
+const POLL_MS = 2000;
+const AMBER_ELAPSED_MS = 5 * 60 * 1000;
+const RECENT_PAGE_SIZE = 50;
+
+interface JobsLiveItem {
+  id: string;
+  kind: string;
+  status: string;
+  scope_key: string | null;
+  scope_type: string | null;
+  role: string | null;
+  agent_id: string | null;
+  initiative_id: string | null;
+  task_id: string | null;
+  parent_run_id: string | null;
+  label: string | null;
+  derived_label: string;
+  started_at: string | null;
+  group_count: number;
+}
+
+interface JobsRecentItem extends JobsLiveItem {
+  completed_at: string | null;
+  cost_cents: number | null;
+  model_used: string | null;
+  error_md: string | null;
+}
+
+interface JobsScheduledItem {
+  job_id: string;
+  name: string;
+  next_run_at: string;
+  last_run_at: string | null;
+  consecutive_failures: number;
+  role: string;
+}
+
+interface JobsResponse {
+  live: JobsLiveItem[];
+  scheduled: JobsScheduledItem[];
+  recent: JobsRecentItem[];
+}
+
+function shortId(id: string | null): string {
+  if (!id) return '—';
+  return id.length > 8 ? id.slice(0, 8) : id;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 0) return '0s';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  if (m < 60) return `${m}m ${rem}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+function relativeFuture(iso: string, now: number): string {
+  const dt = new Date(iso + (iso.includes('T') ? '' : 'Z')).getTime();
+  const diff = dt - now;
+  if (diff < 0) return 'overdue';
+  if (diff < 60_000) return 'in <1m';
+  if (diff < 3_600_000) return `in ${Math.round(diff / 60_000)}m`;
+  return `in ${Math.round(diff / 3_600_000)}h`;
+}
+
+function relativePast(iso: string | null, now: number): string {
+  if (!iso) return '—';
+  const dt = new Date(iso + (iso.includes('T') ? '' : 'Z')).getTime();
+  const diff = now - dt;
+  if (diff < 0) return 'just now';
+  if (diff < 60_000) return `${Math.round(diff / 1000)}s ago`;
+  if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.round(diff / 3_600_000)}h ago`;
+  return `${Math.round(diff / 86_400_000)}d ago`;
+}
+
+function statusChipClass(status: string): string {
+  switch (status) {
+    case 'complete': return 'bg-emerald-500/20 text-emerald-300';
+    case 'failed': return 'bg-red-500/20 text-red-300';
+    case 'cancelled': return 'bg-zinc-500/20 text-zinc-300';
+    case 'running': return 'bg-cyan-500/20 text-cyan-300';
+    case 'queued': return 'bg-amber-500/20 text-amber-300';
+    default: return 'bg-zinc-500/20 text-zinc-300';
+  }
+}
+
+function CopyableScope({ scopeKey }: { scopeKey: string | null }) {
+  const [copied, setCopied] = useState(false);
+  if (!scopeKey) return <span className="text-mc-text-secondary">—</span>;
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard?.writeText(scopeKey).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        });
+      }}
+      className="inline-flex items-center gap-1 font-mono text-[11px] text-mc-text-secondary hover:text-mc-text"
+      title={scopeKey}
+    >
+      <span className="truncate max-w-[200px]">{scopeKey}</span>
+      {copied ? <Check className="w-3 h-3 text-emerald-400" /> : <Copy className="w-3 h-3" />}
+    </button>
+  );
+}
+
+export default function JobsPage() {
+  const workspaceId = useCurrentWorkspaceId();
+  const [data, setData] = useState<JobsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+  const [recentPage, setRecentPage] = useState(0);
+
+  // Tick `now` every second so live elapsed columns refresh without
+  // waiting on the 2s poll.
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  // Poll /api/jobs every POLL_MS for the active workspace. Skips when
+  // no workspace is selected yet (initial render or onboarding).
+  useEffect(() => {
+    if (!workspaceId) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const fetchOnce = async () => {
+      try {
+        const res = await fetch(`/api/jobs?workspace_id=${encodeURIComponent(workspaceId)}`);
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          if (!cancelled) setError(body.error || `HTTP ${res.status}`);
+        } else {
+          const body: JobsResponse = await res.json();
+          if (!cancelled) {
+            setData(body);
+            setError(null);
+          }
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) timer = setTimeout(fetchOnce, POLL_MS);
+      }
+    };
+    fetchOnce();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [workspaceId]);
+
+  const recentSlice = useMemo(() => {
+    if (!data) return [];
+    const start = recentPage * RECENT_PAGE_SIZE;
+    return data.recent.slice(start, start + RECENT_PAGE_SIZE);
+  }, [data, recentPage]);
+
+  if (!workspaceId) {
+    return (
+      <div className="p-8 text-center text-mc-text-secondary">
+        Select a workspace from the left nav to see jobs.
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <header className="mb-6 flex items-center gap-3">
+        <Activity className="w-5 h-5 text-mc-accent-cyan" />
+        <h1 className="text-xl font-semibold text-mc-text">Jobs</h1>
+        {data && (
+          <span className="text-xs text-mc-text-secondary">
+            {data.live.length} live · {data.scheduled.length} scheduled · {data.recent.length} recent
+          </span>
+        )}
+      </header>
+
+      {error && (
+        <div className="mb-4 px-3 py-2 rounded border border-red-500/40 bg-red-500/10 text-sm text-red-300">
+          Failed to load jobs: {error}
+        </div>
+      )}
+
+      <Section title="Live" icon={<Clock className="w-4 h-4" />}>
+        {!data ? (
+          <EmptyRow>Loading…</EmptyRow>
+        ) : data.live.length === 0 ? (
+          <EmptyRow>No jobs in progress.</EmptyRow>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-[11px] uppercase tracking-wider text-mc-text-secondary">
+              <tr className="text-left">
+                <Th>Kind</Th>
+                <Th>Label</Th>
+                <Th>Agent</Th>
+                <Th>Scope</Th>
+                <Th>Started</Th>
+                <Th>Elapsed</Th>
+                <Th>Actions</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.live.map(row => {
+                const startedMs = row.started_at
+                  ? new Date(row.started_at + (row.started_at.includes('T') ? '' : 'Z')).getTime()
+                  : null;
+                const elapsedMs = startedMs ? now - startedMs : 0;
+                const amber = startedMs && elapsedMs > AMBER_ELAPSED_MS;
+                const labelText =
+                  row.group_count > 1
+                    ? `${(row.scope_key ?? '').split(':').pop() ?? row.scope_key} · ${row.group_count} turns in last hour`
+                    : row.derived_label;
+                return (
+                  <tr key={row.id} className={`border-t border-mc-border ${amber ? 'bg-amber-500/10' : ''}`}>
+                    <Td><KindBadge kind={row.kind} /></Td>
+                    <Td className="text-mc-text">{labelText}</Td>
+                    <Td className="text-mc-text-secondary">
+                      {row.role ?? '—'} · <span className="font-mono text-[11px]">{shortId(row.agent_id)}</span>
+                    </Td>
+                    <Td><CopyableScope scopeKey={row.scope_key} /></Td>
+                    <Td className="text-mc-text-secondary">{relativePast(row.started_at, now)}</Td>
+                    <Td className={amber ? 'text-amber-300 font-medium' : 'text-mc-text-secondary'}>
+                      {startedMs ? formatDuration(elapsedMs) : '—'}
+                    </Td>
+                    <Td className="text-mc-text-secondary text-xs">—</Td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </Section>
+
+      <Section title="Scheduled (next 24h)" icon={<Calendar className="w-4 h-4" />}>
+        {!data ? (
+          <EmptyRow>Loading…</EmptyRow>
+        ) : data.scheduled.length === 0 ? (
+          <EmptyRow>Nothing scheduled in the next 24h.</EmptyRow>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-[11px] uppercase tracking-wider text-mc-text-secondary">
+              <tr className="text-left">
+                <Th>Name</Th>
+                <Th>Next run</Th>
+                <Th>Last run</Th>
+                <Th>Streak</Th>
+                <Th>Role</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.scheduled.map(row => (
+                <tr key={row.job_id} className="border-t border-mc-border">
+                  <Td className="text-mc-text">{row.name}</Td>
+                  <Td className="text-mc-text-secondary" title={row.next_run_at}>
+                    {relativeFuture(row.next_run_at, now)}
+                  </Td>
+                  <Td className="text-mc-text-secondary" title={row.last_run_at ?? ''}>
+                    {row.last_run_at ? relativePast(row.last_run_at, now) : '—'}
+                  </Td>
+                  <Td>
+                    {row.consecutive_failures > 0 ? (
+                      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-red-500/20 text-red-300 text-[11px]">
+                        <AlertTriangle className="w-3 h-3" />✗{row.consecutive_failures}
+                      </span>
+                    ) : (
+                      <span className="text-emerald-400 text-[11px]">✓</span>
+                    )}
+                  </Td>
+                  <Td className="text-mc-text-secondary">{row.role}</Td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Section>
+
+      <Section title="Recent (24h)" icon={<History className="w-4 h-4" />}>
+        {!data ? (
+          <EmptyRow>Loading…</EmptyRow>
+        ) : data.recent.length === 0 ? (
+          <EmptyRow>No jobs completed in the last 24h.</EmptyRow>
+        ) : (
+          <>
+            <table className="w-full text-sm">
+              <thead className="text-[11px] uppercase tracking-wider text-mc-text-secondary">
+                <tr className="text-left">
+                  <Th>Kind</Th>
+                  <Th>Label</Th>
+                  <Th>Agent</Th>
+                  <Th>Scope</Th>
+                  <Th>Completed</Th>
+                  <Th>Status</Th>
+                  <Th>Cost</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {recentSlice.map(row => (
+                  <tr key={row.id} className="border-t border-mc-border">
+                    <Td><KindBadge kind={row.kind} /></Td>
+                    <Td className="text-mc-text">{row.derived_label}</Td>
+                    <Td className="text-mc-text-secondary">
+                      {row.role ?? '—'} · <span className="font-mono text-[11px]">{shortId(row.agent_id)}</span>
+                    </Td>
+                    <Td><CopyableScope scopeKey={row.scope_key} /></Td>
+                    <Td className="text-mc-text-secondary" title={row.completed_at ?? ''}>
+                      {relativePast(row.completed_at, now)}
+                    </Td>
+                    <Td>
+                      <span className={`px-1.5 py-0.5 rounded text-[11px] ${statusChipClass(row.status)}`}>
+                        {row.status}
+                      </span>
+                    </Td>
+                    <Td className="text-mc-text-secondary text-xs">
+                      {row.cost_cents != null ? `${(row.cost_cents / 100).toFixed(2)}¢` : ''}
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {data.recent.length > RECENT_PAGE_SIZE && (
+              <div className="flex items-center justify-between mt-3 text-xs text-mc-text-secondary">
+                <span>
+                  Showing {recentPage * RECENT_PAGE_SIZE + 1}–
+                  {Math.min((recentPage + 1) * RECENT_PAGE_SIZE, data.recent.length)} of {data.recent.length}
+                </span>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    disabled={recentPage === 0}
+                    onClick={() => setRecentPage(p => Math.max(0, p - 1))}
+                    className="px-2 py-1 rounded border border-mc-border hover:bg-mc-bg-tertiary disabled:opacity-50"
+                  >
+                    Prev
+                  </button>
+                  <button
+                    type="button"
+                    disabled={(recentPage + 1) * RECENT_PAGE_SIZE >= data.recent.length}
+                    onClick={() => setRecentPage(p => p + 1)}
+                    className="px-2 py-1 rounded border border-mc-border hover:bg-mc-bg-tertiary disabled:opacity-50"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function Section({ title, icon, children }: { title: string; icon: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <section className="mb-6 rounded border border-mc-border bg-mc-bg-secondary">
+      <header className="px-4 py-2 border-b border-mc-border flex items-center gap-2 text-sm font-medium text-mc-text">
+        {icon}
+        {title}
+      </header>
+      <div className="overflow-x-auto">{children}</div>
+    </section>
+  );
+}
+
+function EmptyRow({ children }: { children: React.ReactNode }) {
+  return <p className="px-4 py-6 text-sm text-mc-text-secondary text-center">{children}</p>;
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return <th className="px-3 py-2 font-medium">{children}</th>;
+}
+
+function Td({ children, className = '', title }: { children: React.ReactNode; className?: string; title?: string }) {
+  return <td className={`px-3 py-2 align-top ${className}`} title={title}>{children}</td>;
+}
+
+function KindBadge({ kind }: { kind: string }) {
+  return (
+    <span className="px-1.5 py-0.5 rounded bg-mc-bg-tertiary text-mc-text-secondary text-[11px] font-mono">
+      {kind}
+    </span>
+  );
+}

--- a/src/app/api/jobs/route.test.ts
+++ b/src/app/api/jobs/route.test.ts
@@ -1,0 +1,69 @@
+/**
+ * /api/jobs route tests.
+ *
+ * Verifies the three-bucket response shape and workspace_id required
+ * validation. Deeper grouping/window logic is exercised by listJobs
+ * unit tests in src/lib/db/agent-runs.test.ts.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+import { run } from '@/lib/db';
+import { startAgentRun } from '@/lib/db/agent-runs';
+
+function freshWorkspace(): string {
+  const id = `ws-jobs-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function jobsReq(params: Record<string, string | undefined>): NextRequest {
+  const url = new URL('http://localhost/api/jobs');
+  for (const [k, v] of Object.entries(params)) {
+    if (v) url.searchParams.set(k, v);
+  }
+  return new NextRequest(url);
+}
+
+test('GET /api/jobs: missing workspace_id → 400', async () => {
+  const res = await GET(jobsReq({}));
+  assert.equal(res.status, 400);
+});
+
+test('GET /api/jobs: empty workspace returns three empty buckets', async () => {
+  const ws = freshWorkspace();
+  const res = await GET(jobsReq({ workspace_id: ws }));
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(Object.keys(body).sort(), ['live', 'recent', 'scheduled']);
+  assert.deepEqual(body.live, []);
+  assert.deepEqual(body.scheduled, []);
+  assert.deepEqual(body.recent, []);
+});
+
+test('GET /api/jobs: live bucket reflects running pm_chat collapse', async () => {
+  const ws = freshWorkspace();
+  const scope = `scope-${uuidv4()}`;
+  for (let i = 0; i < 2; i++) {
+    startAgentRun({
+      workspace_id: ws,
+      kind: 'pm_chat',
+      scope_key: scope,
+      scope_type: 'pm_chat',
+      role: 'pm',
+      agent_id: `a${i}`,
+    });
+  }
+  const res = await GET(jobsReq({ workspace_id: ws }));
+  const body = await res.json();
+  assert.equal(body.live.length, 1);
+  assert.equal(body.live[0].group_count, 2);
+  assert.equal(body.live[0].kind, 'pm_chat');
+  assert.equal(typeof body.live[0].derived_label, 'string');
+});

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,0 +1,33 @@
+/**
+ * GET /api/jobs?workspace_id=…
+ *
+ * Backs the /jobs page. Returns three buckets in one shot:
+ *   - live:      queued+running agent_runs (pm_chat collapsed by scope_key)
+ *   - scheduled: active recurring_jobs with next_run_at within 24h
+ *   - recent:    terminal agent_runs from the last 24h (ungrouped)
+ *
+ * See specs/jobs-in-progress.md §API. Polled every 2s by the page;
+ * SSE upgrade is a follow-up if cost matters.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { listJobs, AgentRunValidationError } from '@/lib/db/agent-runs';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const workspaceId = searchParams.get('workspace_id');
+    if (!workspaceId) {
+      return NextResponse.json({ error: 'workspace_id is required' }, { status: 400 });
+    }
+    return NextResponse.json(listJobs(workspaceId));
+  } catch (error) {
+    if (error instanceof AgentRunValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    console.error('Failed to list jobs:', error);
+    return NextResponse.json({ error: 'Failed to list jobs' }, { status: 500 });
+  }
+}

--- a/src/components/shell/AppNav.tsx
+++ b/src/components/shell/AppNav.tsx
@@ -49,6 +49,7 @@ import {
   Brain,
   Workflow,
   AlertCircle,
+  ListChecks,
 } from 'lucide-react';
 import {
   useCurrentWorkspaceId,
@@ -125,6 +126,7 @@ function buildSections(taskBoardHref: string, workspaceSettingsHref: string): Na
         // dashboard so this entry skips the extra click. Agents are
         // workspace-scoped configuration, so they belong here too.
         { href: '/activity', label: 'Activity', icon: ActivityIcon, prefix: true },
+        { href: '/jobs', label: 'Jobs', icon: ListChecks, prefix: true },
         { href: '/agents', label: 'Agents', icon: Users, prefix: true },
         // Settings here is scoped to the current workspace
         // (/workspace/<slug>/settings). Global / cross-workspace

--- a/src/lib/db/agent-runs.test.ts
+++ b/src/lib/db/agent-runs.test.ts
@@ -24,6 +24,7 @@ import {
   completeAgentRun,
   failAgentRun,
   scopeTypeToRunKind,
+  listJobs,
   AgentRunTransitionError,
   AgentRunValidationError,
 } from './agent-runs';
@@ -330,4 +331,140 @@ test('migration 080 idempotent: kind enum accepts pm_chat after extension', () =
     agent_id: 'a',
   });
   assert.ok(getAgentRun(id));
+});
+
+// ─── listJobs (PR 2) ────────────────────────────────────────────────
+
+test('listJobs: rejects empty workspace_id', () => {
+  assert.throws(() => listJobs('   '), AgentRunValidationError);
+});
+
+test('listJobs: empty workspace returns three empty buckets', () => {
+  const ws = freshWorkspace();
+  const r = listJobs(ws);
+  assert.deepEqual(r.live, []);
+  assert.deepEqual(r.scheduled, []);
+  assert.deepEqual(r.recent, []);
+});
+
+test('listJobs: pm_chat rows collapse by scope_key with group_count + max started_at', () => {
+  const ws = freshWorkspace();
+  const scope = `scope:${uuidv4()}`;
+  // Insert three pm_chat runs against the same scope_key, with
+  // distinct started_at values so we can verify "most recent wins".
+  for (let i = 0; i < 3; i++) {
+    startAgentRun({
+      workspace_id: ws,
+      kind: 'pm_chat',
+      scope_key: scope,
+      scope_type: 'pm_chat',
+      role: 'pm',
+      agent_id: `agent-${i}`,
+    });
+  }
+  // Plus one different-scope pm_chat — must NOT merge.
+  startAgentRun({
+    workspace_id: ws,
+    kind: 'pm_chat',
+    scope_key: `scope:${uuidv4()}`,
+    scope_type: 'pm_chat',
+    role: 'pm',
+    agent_id: 'agent-other',
+  });
+  const r = listJobs(ws);
+  // Two groups total: 1 collapsed (count=3) + 1 standalone.
+  assert.equal(r.live.length, 2);
+  const collapsed = r.live.find(x => x.scope_key === scope);
+  assert.ok(collapsed);
+  assert.equal(collapsed!.group_count, 3);
+  const standalone = r.live.find(x => x.scope_key !== scope);
+  assert.equal(standalone!.group_count, 1);
+});
+
+test('listJobs: non-pm_chat kinds never collapse', () => {
+  const ws = freshWorkspace();
+  const scope = `scope:${uuidv4()}`;
+  for (let i = 0; i < 3; i++) {
+    startAgentRun({
+      workspace_id: ws,
+      kind: 'initiative_audit',
+      scope_key: scope,
+      scope_type: 'initiative_audit',
+      role: 'researcher',
+      agent_id: `r-${i}`,
+    });
+  }
+  const r = listJobs(ws);
+  assert.equal(r.live.length, 3);
+  assert.ok(r.live.every(x => x.group_count === 1));
+});
+
+test('listJobs: recent enforces 24h window and excludes still-running rows', () => {
+  const ws = freshWorkspace();
+  // Run that completed 2h ago — should appear.
+  const fresh = startAgentRun({
+    workspace_id: ws, kind: 'plan',
+    scope_key: 's1', scope_type: 'plan', role: 'pm', agent_id: 'a',
+  });
+  run(`UPDATE agent_runs SET status='complete', completed_at=datetime('now','-2 hours') WHERE id=?`, [fresh]);
+
+  // Run that completed 30h ago — must be excluded.
+  const stale = startAgentRun({
+    workspace_id: ws, kind: 'plan',
+    scope_key: 's2', scope_type: 'plan', role: 'pm', agent_id: 'a',
+  });
+  run(`UPDATE agent_runs SET status='complete', completed_at=datetime('now','-30 hours') WHERE id=?`, [stale]);
+
+  // Still-running row — must not leak into recent.
+  const live = startAgentRun({
+    workspace_id: ws, kind: 'plan',
+    scope_key: 's3', scope_type: 'plan', role: 'pm', agent_id: 'a',
+  });
+
+  const r = listJobs(ws);
+  assert.equal(r.recent.length, 1);
+  assert.equal(r.recent[0].id, fresh);
+  assert.ok(r.live.some(x => x.id === live));
+});
+
+test('listJobs: scheduled excludes paused jobs and far-future runs', () => {
+  const ws = freshWorkspace();
+  // Active, due in 1h → include.
+  run(
+    `INSERT INTO recurring_jobs
+       (id, workspace_id, name, role, scope_key_template, briefing_template,
+        cadence_seconds, status, next_run_at)
+     VALUES (?, ?, 'soon', 'researcher', 't', 'b', 3600, 'active', datetime('now','+1 hour'))`,
+    [`rj-${uuidv4()}`, ws],
+  );
+  // Active, due in 3 days → exclude.
+  run(
+    `INSERT INTO recurring_jobs
+       (id, workspace_id, name, role, scope_key_template, briefing_template,
+        cadence_seconds, status, next_run_at)
+     VALUES (?, ?, 'far', 'researcher', 't', 'b', 3600, 'active', datetime('now','+3 days'))`,
+    [`rj-${uuidv4()}`, ws],
+  );
+  // Paused, due in 1h → exclude.
+  run(
+    `INSERT INTO recurring_jobs
+       (id, workspace_id, name, role, scope_key_template, briefing_template,
+        cadence_seconds, status, next_run_at)
+     VALUES (?, ?, 'paused', 'researcher', 't', 'b', 3600, 'paused', datetime('now','+1 hour'))`,
+    [`rj-${uuidv4()}`, ws],
+  );
+  const r = listJobs(ws);
+  assert.equal(r.scheduled.length, 1);
+  assert.equal(r.scheduled[0].name, 'soon');
+});
+
+test('listJobs: workspace-isolated', () => {
+  const ws1 = freshWorkspace();
+  const ws2 = freshWorkspace();
+  startAgentRun({
+    workspace_id: ws1, kind: 'pm_chat',
+    scope_key: 's', scope_type: 'pm_chat', role: 'pm', agent_id: 'a',
+  });
+  const r = listJobs(ws2);
+  assert.equal(r.live.length, 0);
 });

--- a/src/lib/db/agent-runs.ts
+++ b/src/lib/db/agent-runs.ts
@@ -349,6 +349,190 @@ export function failAgentRun(id: string, errorMd: string): void {
   );
 }
 
+// ─── Jobs-in-Progress: /api/jobs read model (PR 2) ─────────────────
+//
+// listJobs() backs the GET /api/jobs route. Three buckets in one call:
+// live (queued+running, with pm_chat collapsed by scope_key),
+// scheduled (active recurring_jobs ≤24h horizon), recent (terminal in
+// last 24h, ungrouped). See specs/jobs-in-progress.md §API.
+
+export interface JobsLiveItem {
+  /** When `group_count > 1`, this id refers to the most-recent run in the group. */
+  id: string;
+  kind: AgentRunKind;
+  status: AgentRunStatus;
+  scope_key: string | null;
+  scope_type: string | null;
+  role: string | null;
+  agent_id: string | null;
+  initiative_id: string | null;
+  task_id: string | null;
+  parent_run_id: string | null;
+  label: string | null;
+  /** Server-derived fallback label when `label` is null (e.g. "PM chat",
+   *  "Audit: <initiative title>"). UI can prefer this when label is null. */
+  derived_label: string;
+  started_at: string | null;
+  /** 1 for ungrouped rows; N for collapsed pm_chat groups. */
+  group_count: number;
+}
+
+export interface JobsRecentItem extends JobsLiveItem {
+  completed_at: string | null;
+  cost_cents: number | null;
+  model_used: string | null;
+  error_md: string | null;
+}
+
+export interface JobsScheduledItem {
+  job_id: string;
+  name: string;
+  next_run_at: string;
+  last_run_at: string | null;
+  consecutive_failures: number;
+  role: string;
+}
+
+export interface JobsListResponse {
+  live: JobsLiveItem[];
+  scheduled: JobsScheduledItem[];
+  recent: JobsRecentItem[];
+}
+
+interface RawAgentRunRow extends AgentRun {
+  initiative_title: string | null;
+}
+
+function deriveLabel(row: { kind: AgentRunKind; label: string | null; initiative_title: string | null; scope_key: string | null }): string {
+  if (row.label && row.label.trim()) return row.label;
+  switch (row.kind) {
+    case 'pm_chat': return 'PM chat';
+    case 'plan': return row.initiative_title ? `Plan: ${row.initiative_title}` : 'Plan';
+    case 'decompose': return row.initiative_title ? `Decompose: ${row.initiative_title}` : 'Decompose';
+    case 'initiative_audit': return row.initiative_title ? `Audit: ${row.initiative_title}` : 'Audit';
+    case 'recurring': return 'Recurring tick';
+    case 'task_coord': return 'Task coordinator';
+    case 'task_role': return 'Task role';
+    case 'brief': return 'Brief';
+    default: return row.kind;
+  }
+}
+
+export function listJobs(workspaceId: string): JobsListResponse {
+  if (!workspaceId.trim()) {
+    throw new AgentRunValidationError('workspace_id is required');
+  }
+
+  // Live: queued + running. Join initiatives.title for derived_label fallback.
+  const liveRows = queryAll<RawAgentRunRow>(
+    `SELECT ar.*, i.title AS initiative_title
+       FROM agent_runs ar
+       LEFT JOIN initiatives i ON i.id = ar.initiative_id
+      WHERE ar.workspace_id = ?
+        AND ar.status IN ('queued','running')
+      ORDER BY ar.started_at DESC, ar.created_at DESC, ar.rowid DESC`,
+    [workspaceId],
+  );
+
+  // Collapse pm_chat by scope_key. Other kinds pass through.
+  const live: JobsLiveItem[] = [];
+  const pmGroups = new Map<string, { rep: RawAgentRunRow; count: number }>();
+  for (const row of liveRows) {
+    if (row.kind === 'pm_chat' && row.scope_key) {
+      const g = pmGroups.get(row.scope_key);
+      if (g) {
+        g.count += 1;
+        // Keep most-recent started_at as representative (ORDER BY DESC means first seen wins).
+        continue;
+      }
+      pmGroups.set(row.scope_key, { rep: row, count: 1 });
+    } else {
+      live.push({
+        id: row.id,
+        kind: row.kind,
+        status: row.status,
+        scope_key: row.scope_key,
+        scope_type: row.scope_type,
+        role: row.role,
+        agent_id: row.agent_id,
+        initiative_id: row.initiative_id,
+        task_id: row.task_id,
+        parent_run_id: row.parent_run_id,
+        label: row.label,
+        derived_label: deriveLabel(row),
+        started_at: row.started_at,
+        group_count: 1,
+      });
+    }
+  }
+  for (const { rep, count } of pmGroups.values()) {
+    live.push({
+      id: rep.id,
+      kind: rep.kind,
+      status: rep.status,
+      scope_key: rep.scope_key,
+      scope_type: rep.scope_type,
+      role: rep.role,
+      agent_id: rep.agent_id,
+      initiative_id: rep.initiative_id,
+      task_id: rep.task_id,
+      parent_run_id: rep.parent_run_id,
+      label: rep.label,
+      derived_label: deriveLabel(rep),
+      started_at: rep.started_at,
+      group_count: count,
+    });
+  }
+  // Final sort: most recent started_at first.
+  live.sort((a, b) => (b.started_at ?? '').localeCompare(a.started_at ?? ''));
+
+  // Scheduled: recurring_jobs active in next 24h.
+  const scheduled = queryAll<JobsScheduledItem>(
+    `SELECT id AS job_id, name, next_run_at, last_run_at, consecutive_failures, role
+       FROM recurring_jobs
+      WHERE workspace_id = ?
+        AND status = 'active'
+        AND next_run_at <= datetime('now', '+24 hours')
+      ORDER BY next_run_at ASC`,
+    [workspaceId],
+  );
+
+  // Recent: terminal in last 24h, individual rows (NOT grouped). Cap 100.
+  const recentRows = queryAll<RawAgentRunRow>(
+    `SELECT ar.*, i.title AS initiative_title
+       FROM agent_runs ar
+       LEFT JOIN initiatives i ON i.id = ar.initiative_id
+      WHERE ar.workspace_id = ?
+        AND ar.status IN ('complete','failed','cancelled')
+        AND ar.completed_at >= datetime('now', '-24 hours')
+      ORDER BY ar.completed_at DESC, ar.rowid DESC
+      LIMIT 100`,
+    [workspaceId],
+  );
+  const recent: JobsRecentItem[] = recentRows.map(row => ({
+    id: row.id,
+    kind: row.kind,
+    status: row.status,
+    scope_key: row.scope_key,
+    scope_type: row.scope_type,
+    role: row.role,
+    agent_id: row.agent_id,
+    initiative_id: row.initiative_id,
+    task_id: row.task_id,
+    parent_run_id: row.parent_run_id,
+    label: row.label,
+    derived_label: deriveLabel(row),
+    started_at: row.started_at,
+    group_count: 1,
+    completed_at: row.completed_at,
+    cost_cents: row.cost_cents,
+    model_used: row.model_used,
+    error_md: row.error_md,
+  }));
+
+  return { live, scheduled, recent };
+}
+
 export function reapStaleRunning(staleSeconds: number, errorMd: string): number {
   const result = run(
     `UPDATE agent_runs SET


### PR DESCRIPTION
## Summary

PR 2 of the [jobs-in-progress](../blob/feat/jobs-in-progress-pr2/specs/jobs-in-progress.md) feature. Adds `GET /api/jobs` and a minimal `/jobs` page so the operator can see every in-flight agent dispatch (PM chats, plans, audits, recurring ticks) in one queue, polled every 2s. PR 1 (schema + write site) already populates `agent_runs` from every dispatch — this PR turns those rows into a usable surface.

Out of scope (later PRs): cancel button (PR 4), subtree tree view (PR 3), sidebar live-count pip + drill-down (PR 5).

## Changes

- `src/lib/db/agent-runs.ts` — `listJobs(workspace_id)` returns three buckets:
  - `live` — `status IN ('queued','running')`, `pm_chat` rows collapsed by `scope_key` into one entry with `group_count`. Other kinds pass through. Most-recent `started_at` represents each group.
  - `scheduled` — `recurring_jobs.status='active' AND next_run_at <= now+24h`.
  - `recent` — terminal status, `completed_at >= now-24h`, ungrouped, capped at 100.
  - Joins `initiatives.title` to derive a label when `agent_runs.label` is null (callers don't all pass labels yet — PR 5 polish).
- `src/app/api/jobs/route.ts` — thin route, 400 on missing `workspace_id`.
- `src/app/(app)/jobs/page.tsx` — three stacked sections, polls every 2s, computes elapsed client-side every second, amber-tints live rows with elapsed >5min, paginates `recent` at 50/page, copyable scope_key chip.
- `src/components/shell/AppNav.tsx` — adds "Jobs" entry under Workspace.

## Test plan

- [x] `yarn tsc --noEmit` clean for new files (3 errors elsewhere are pre-existing on main).
- [x] `yarn test` — 782/783 pass; the 1 failure (`schedule-runner: produces a brief and advances run_count` at `src/lib/research/eval/schedule-runner.test.ts`) is pre-existing on main and called out in CLAUDE.md.
- [x] New unit tests in `src/lib/db/agent-runs.test.ts`:
  - `pm_chat` rows with same `scope_key` collapse into one entry with correct `group_count`.
  - Different-kind rows (`initiative_audit`) with same scope_key never collapse.
  - 24h `recent` window enforced; still-running rows excluded.
  - Paused recurring jobs and far-future (>24h) jobs excluded from `scheduled`.
  - Workspace isolation.
- [x] New route test in `src/app/api/jobs/route.test.ts` — empty buckets, missing-ws → 400, pm_chat collapse round-trip through HTTP.
- [x] End-to-end against running dev server (port 4010) returns real data:

```
$ curl -s -H "Authorization: Bearer ..." \
    "http://localhost:4010/api/jobs?workspace_id=default"
{
  "live": [{
    "id": "9c44e52a-…",
    "kind": "initiative_audit",
    "status": "running",
    "scope_key": "initiative-b60187b8-…:audit:1",
    "scope_type": "initiative_audit",
    "role": "researcher",
    "agent_id": "c76a437b-…",
    "initiative_id": "b60187b8-…",
    "label": null,
    "derived_label": "Audit: Add 'Hide offline gateway agents' toggle on /agents All tab",
    "started_at": "2026-05-07 04:57:52",
    "group_count": 1
  }],
  "scheduled": [],
  "recent": []
}
```

- [x] `GET /jobs` returns 200; nav link visible under Workspace.