### PR TITLE
feat(jobs): cancel button + POST /api/jobs/:id/cancel (PR 4/5)

### DIFF
--- a/src/app/(app)/jobs/page.tsx
+++ b/src/app/(app)/jobs/page.tsx
@@ -16,6 +16,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { Activity, Clock, Calendar, History, AlertTriangle, Copy, Check } from 'lucide-react';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 
 const POLL_MS = 2000;
 const AMBER_ELAPSED_MS = 5 * 60 * 1000;
@@ -170,6 +171,40 @@ export default function JobsPage() {
   const [error, setError] = useState<string | null>(null);
   const [now, setNow] = useState(() => Date.now());
   const [recentPage, setRecentPage] = useState(0);
+  const [pendingCancel, setPendingCancel] = useState<JobsLiveItem | null>(null);
+  const [cancelling, setCancelling] = useState(false);
+
+  // Children-of-pending counter for the dialog body — only count
+  // non-terminal direct children since those are what the cascade
+  // hits on the server.
+  const pendingChildCount = useMemo(() => {
+    if (!pendingCancel || !data) return 0;
+    return data.live.filter(r => r.parent_run_id === pendingCancel.id).length;
+  }, [pendingCancel, data]);
+
+  const doCancel = async () => {
+    if (!pendingCancel) return;
+    setCancelling(true);
+    try {
+      const res = await fetch(`/api/jobs/${encodeURIComponent(pendingCancel.id)}/cancel`, {
+        method: 'POST',
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        // Route through the global alert shim — same affordance as the
+        // rest of the app per UI conventions in CLAUDE.md.
+        window.alert(
+          `Cancel failed: ${body.error || `HTTP ${res.status}`}`,
+        );
+      }
+      // 200 path: the 2s poll picks up the cancelled status; no manual mutation needed.
+    } catch (err) {
+      window.alert(`Cancel failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setCancelling(false);
+      setPendingCancel(null);
+    }
+  };
 
   // Tick `now` every second so live elapsed columns refresh without
   // waiting on the 2s poll.
@@ -289,7 +324,15 @@ export default function JobsPage() {
                     <Td className={amber ? 'text-amber-300 font-medium' : 'text-mc-text-secondary'}>
                       {startedMs ? formatDuration(elapsedMs) : '—'}
                     </Td>
-                    <Td className="text-mc-text-secondary text-xs">—</Td>
+                    <Td className="text-xs">
+                      <button
+                        type="button"
+                        onClick={() => setPendingCancel(row)}
+                        className="px-2 py-0.5 rounded border border-red-500/40 text-red-300 hover:bg-red-500/10"
+                      >
+                        Cancel
+                      </button>
+                    </Td>
                   </tr>
                 );
               })}
@@ -416,6 +459,40 @@ export default function JobsPage() {
           </>
         )}
       </Section>
+
+      <ConfirmDialog
+        open={pendingCancel !== null}
+        title="Cancel job?"
+        body={
+          pendingCancel ? (
+            <div className="space-y-2">
+              <p>
+                <span className="font-mono text-[11px]">{pendingCancel.kind}</span>
+                {' · '}
+                <span>{pendingCancel.derived_label}</span>
+              </p>
+              {pendingCancel.scope_key && (
+                <p className="font-mono text-[11px] text-mc-text-secondary break-all">
+                  {pendingCancel.scope_key}
+                </p>
+              )}
+              {pendingChildCount > 0 && (
+                <p className="text-amber-300">
+                  This will also cancel {pendingChildCount} in-flight {pendingChildCount === 1 ? 'child' : 'children'}.
+                </p>
+              )}
+              <p className="text-mc-text-secondary">
+                The agent may continue running briefly while shutdown propagates — gateway abort is best-effort.
+              </p>
+            </div>
+          ) : null
+        }
+        confirmLabel={cancelling ? 'Cancelling…' : 'Cancel job'}
+        cancelLabel="Keep running"
+        destructive
+        onConfirm={doCancel}
+        onCancel={() => setPendingCancel(null)}
+      />
     </div>
   );
 }

--- a/src/app/api/jobs/[id]/cancel/route.test.ts
+++ b/src/app/api/jobs/[id]/cancel/route.test.ts
@@ -1,0 +1,103 @@
+/**
+ * /api/jobs/:id/cancel route tests.
+ *
+ * Verifies the 404 / 409 / 200 paths and that the response body
+ * surfaces children_cancelled. The DAO-level cascade + transaction
+ * behavior is covered in src/lib/db/agent-runs.test.ts.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { run } from '@/lib/db';
+import {
+  createAgentRun,
+  startAgentRun,
+  markComplete,
+  markRunning,
+  getAgentRun,
+} from '@/lib/db/agent-runs';
+
+function freshWorkspace(): string {
+  const id = `ws-cancel-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function cancelReq(id: string): NextRequest {
+  return new NextRequest(`http://localhost/api/jobs/${id}/cancel`, { method: 'POST' });
+}
+
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+test('POST /api/jobs/:id/cancel: 404 when row does not exist', async () => {
+  const res = await POST(cancelReq('nope'), ctx('nope'));
+  assert.equal(res.status, 404);
+});
+
+test('POST /api/jobs/:id/cancel: 409 when row is already terminal', async () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'pm_chat' });
+  markRunning(r.id);
+  markComplete(r.id);
+  const res = await POST(cancelReq(r.id), ctx(r.id));
+  assert.equal(res.status, 409);
+  const body = await res.json();
+  assert.equal(body.status, 'complete');
+});
+
+test('POST /api/jobs/:id/cancel: 200 marks queued row cancelled', async () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'pm_chat' });
+  const res = await POST(cancelReq(r.id), ctx(r.id));
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.id, r.id);
+  assert.equal(body.status, 'cancelled');
+  assert.equal(body.children_cancelled, 0);
+  assert.equal(getAgentRun(r.id)!.status, 'cancelled');
+});
+
+test('POST /api/jobs/:id/cancel: cascades to running children', async () => {
+  const ws = freshWorkspace();
+  const parentId = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'audit:r',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'a',
+  });
+  const c1 = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'audit:r:1',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'a1',
+    parent_run_id: parentId,
+  });
+  const c2 = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'audit:r:2',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'a2',
+    parent_run_id: parentId,
+  });
+
+  const res = await POST(cancelReq(parentId), ctx(parentId));
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.children_cancelled, 2);
+  assert.equal(getAgentRun(c1)!.status, 'cancelled');
+  assert.equal(getAgentRun(c2)!.status, 'cancelled');
+});

--- a/src/app/api/jobs/[id]/cancel/route.ts
+++ b/src/app/api/jobs/[id]/cancel/route.ts
@@ -1,0 +1,86 @@
+/**
+ * POST /api/jobs/:id/cancel
+ *
+ * Operator cancel for an in-flight agent_runs row, surfaced as the
+ * Cancel button on /jobs live rows. Behavior:
+ *   - 404 if the row doesn't exist.
+ *   - 409 if the row is already terminal (complete/failed/cancelled).
+ *   - 200 → flip the row to `cancelled` with `error_md='Cancelled by
+ *     operator'` and cascade to any non-terminal direct children
+ *     (parent_run_id = id) with `'Parent cancelled by operator'`.
+ *
+ * Gateway abort is fire-and-forget: if the row had an openclaw
+ * session id we kick `sessions.abort` with a 2s timeout but don't
+ * block the cancel response on its result. The DB write IS the
+ * cancel; the gateway call is just a courtesy nudge so the underlying
+ * agent shuts down sooner. See specs/jobs-in-progress.md PR 4.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  cancelAgentRun,
+  AgentRunNotFoundError,
+  AgentRunNotCancellableError,
+} from '@/lib/db/agent-runs';
+import { getOpenClawClient } from '@/lib/openclaw/client';
+
+export const dynamic = 'force-dynamic';
+
+const GATEWAY_ABORT_TIMEOUT_MS = 2000;
+
+/** Best-effort gateway session abort. Never throws; never blocks > 2s. */
+async function fireAndForgetAbort(sessionKey: string): Promise<void> {
+  try {
+    const client = getOpenClawClient();
+    if (!client.isConnected()) {
+      console.warn(`[jobs.cancel] gateway not connected; skipping abort for ${sessionKey}`);
+      return;
+    }
+    await Promise.race([
+      client.abortSession(sessionKey),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('gateway abort timeout')), GATEWAY_ABORT_TIMEOUT_MS),
+      ),
+    ]);
+  } catch (err) {
+    console.warn(
+      `[jobs.cancel] gateway abort failed for ${sessionKey}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+export async function POST(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  if (!id) {
+    return NextResponse.json({ error: 'job id required' }, { status: 400 });
+  }
+
+  try {
+    const result = cancelAgentRun(id);
+    if (result.openclaw_session_id) {
+      // Fire-and-forget — don't await. Errors are swallowed inside.
+      void fireAndForgetAbort(result.openclaw_session_id);
+    }
+    return NextResponse.json({
+      id: result.id,
+      status: result.status,
+      children_cancelled: result.children_cancelled,
+    });
+  } catch (err) {
+    if (err instanceof AgentRunNotFoundError) {
+      return NextResponse.json({ error: err.message }, { status: 404 });
+    }
+    if (err instanceof AgentRunNotCancellableError) {
+      return NextResponse.json(
+        { error: err.message, status: err.status },
+        { status: 409 },
+      );
+    }
+    console.error('Failed to cancel job:', err);
+    return NextResponse.json({ error: 'Failed to cancel job' }, { status: 500 });
+  }
+}

--- a/src/lib/db/agent-runs.test.ts
+++ b/src/lib/db/agent-runs.test.ts
@@ -16,6 +16,9 @@ import {
   getAgentRun,
   listAgentRuns,
   markCancelled,
+  cancelAgentRun,
+  AgentRunNotFoundError,
+  AgentRunNotCancellableError,
   markComplete,
   markFailed,
   markRunning,
@@ -585,4 +588,138 @@ test('listJobs: scheduled.last_failure_md attaches most-recent failed recurring 
   const r = listJobs(ws);
   const sched = r.scheduled.find(x => x.job_id === jobId)!;
   assert.equal(sched.last_failure_md, 'LATEST: gateway 502');
+});
+
+// ─── cancelAgentRun (PR 4) ──────────────────────────────────────────
+
+test('cancelAgentRun: queued → cancelled stamps timestamp + error_md', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'pm_chat' });
+  assert.equal(r.status, 'queued');
+  const result = cancelAgentRun(r.id);
+  assert.equal(result.status, 'cancelled');
+  assert.equal(result.children_cancelled, 0);
+  const after = getAgentRun(r.id)!;
+  assert.equal(after.status, 'cancelled');
+  assert.equal(after.error_md, 'Cancelled by operator');
+  assert.ok(after.completed_at, 'completed_at stamped');
+});
+
+test('cancelAgentRun: running → cancelled', () => {
+  const ws = freshWorkspace();
+  const id = startAgentRun({
+    workspace_id: ws,
+    kind: 'plan',
+    scope_key: 's',
+    scope_type: 'plan',
+    role: 'planner',
+    agent_id: 'a',
+  });
+  const result = cancelAgentRun(id);
+  assert.equal(result.status, 'cancelled');
+  const row = getAgentRun(id)!;
+  assert.equal(row.status, 'cancelled');
+});
+
+test('cancelAgentRun: missing id throws AgentRunNotFoundError', () => {
+  assert.throws(() => cancelAgentRun('does-not-exist'), AgentRunNotFoundError);
+});
+
+test('cancelAgentRun: already-complete row throws AgentRunNotCancellableError', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'pm_chat' });
+  markRunning(r.id);
+  markComplete(r.id);
+  assert.throws(() => cancelAgentRun(r.id), AgentRunNotCancellableError);
+});
+
+test('cancelAgentRun: already-cancelled row throws AgentRunNotCancellableError', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'pm_chat' });
+  markCancelled(r.id);
+  assert.throws(() => cancelAgentRun(r.id), AgentRunNotCancellableError);
+});
+
+test('cancelAgentRun: parent + 2 running children all flip to cancelled', () => {
+  const ws = freshWorkspace();
+  const parentId = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'audit:1',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'a-parent',
+  });
+  const childA = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'audit:1:a',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'a-child-a',
+    parent_run_id: parentId,
+  });
+  const childB = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'audit:1:b',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'a-child-b',
+    parent_run_id: parentId,
+  });
+
+  const result = cancelAgentRun(parentId);
+  assert.equal(result.children_cancelled, 2);
+  assert.equal(getAgentRun(parentId)!.status, 'cancelled');
+  const a = getAgentRun(childA)!;
+  const b = getAgentRun(childB)!;
+  assert.equal(a.status, 'cancelled');
+  assert.equal(b.status, 'cancelled');
+  assert.equal(a.error_md, 'Parent cancelled by operator');
+  assert.equal(b.error_md, 'Parent cancelled by operator');
+});
+
+test('cancelAgentRun: child already complete is left alone', () => {
+  const ws = freshWorkspace();
+  const parentId = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'audit:2',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'a-parent',
+  });
+  const childDone = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'audit:2:done',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'a-done',
+    parent_run_id: parentId,
+  });
+  completeAgentRun(childDone);
+  const childRunning = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'audit:2:run',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'a-run',
+    parent_run_id: parentId,
+  });
+
+  const result = cancelAgentRun(parentId);
+  assert.equal(result.children_cancelled, 1, 'only running child cancelled');
+  assert.equal(getAgentRun(childDone)!.status, 'complete', 'finished child untouched');
+  assert.equal(getAgentRun(childRunning)!.status, 'cancelled');
+});
+
+test('cancelAgentRun: returns openclaw_session_id from the row', () => {
+  const ws = freshWorkspace();
+  const r = createAgentRun({ workspace_id: ws, kind: 'pm_chat' });
+  markRunning(r.id, { openclaw_session_id: 'agent:mc-pm-default:dispatch-main' });
+  const result = cancelAgentRun(r.id);
+  assert.equal(result.openclaw_session_id, 'agent:mc-pm-default:dispatch-main');
 });

--- a/src/lib/db/agent-runs.ts
+++ b/src/lib/db/agent-runs.ts
@@ -13,7 +13,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { queryAll, queryOne, run } from '@/lib/db';
+import { queryAll, queryOne, run, transaction } from '@/lib/db';
 
 export type AgentRunKind =
   | 'brief'
@@ -602,6 +602,82 @@ export function listJobs(workspaceId: string): JobsListResponse {
   }));
 
   return { live, scheduled, recent };
+}
+
+// ─── Jobs-in-Progress: cancel (PR 4) ───────────────────────────────
+//
+// cancelAgentRun flips a queued/running row → cancelled and cascades
+// to any non-terminal direct children (parent_run_id = id). Used by
+// POST /api/jobs/:id/cancel. Gateway session-close is best-effort and
+// happens in the route, not here — DAO stays pure.
+
+export class AgentRunNotFoundError extends Error {
+  constructor(id: string) {
+    super(`agent_run ${id} not found`);
+    this.name = 'AgentRunNotFoundError';
+  }
+}
+
+export class AgentRunNotCancellableError extends Error {
+  constructor(public id: string, public status: AgentRunStatus) {
+    super(`agent_run ${id} is ${status}, not cancellable`);
+    this.name = 'AgentRunNotCancellableError';
+  }
+}
+
+export interface CancelAgentRunResult {
+  id: string;
+  status: 'cancelled';
+  children_cancelled: number;
+  /** The openclaw_session_id the row had at cancel time, if any.
+   *  Returned so the route can fire a best-effort gateway abort. */
+  openclaw_session_id: string | null;
+}
+
+/**
+ * Cancel an agent_runs row and any non-terminal direct children.
+ *
+ * Throws AgentRunNotFoundError if the id doesn't exist.
+ * Throws AgentRunNotCancellableError if the row is already terminal
+ * (complete/failed/cancelled) — caller maps to 409.
+ *
+ * Children are matched by `parent_run_id = id` and cancelled with
+ * 'Parent cancelled by operator'. The whole thing runs in one
+ * transaction so a partial cascade can't strand children.
+ */
+export function cancelAgentRun(id: string): CancelAgentRunResult {
+  return transaction(() => {
+    const row = getAgentRun(id);
+    if (!row) throw new AgentRunNotFoundError(id);
+    if (row.status !== 'queued' && row.status !== 'running') {
+      throw new AgentRunNotCancellableError(id, row.status);
+    }
+    run(
+      `UPDATE agent_runs SET
+         status = 'cancelled',
+         error_md = COALESCE(error_md, ?),
+         completed_at = datetime('now'),
+         updated_at = datetime('now')
+       WHERE id = ?`,
+      ['Cancelled by operator', id],
+    );
+    const result = run(
+      `UPDATE agent_runs SET
+         status = 'cancelled',
+         error_md = COALESCE(error_md, ?),
+         completed_at = datetime('now'),
+         updated_at = datetime('now')
+       WHERE parent_run_id = ?
+         AND status IN ('queued','running')`,
+      ['Parent cancelled by operator', id],
+    );
+    return {
+      id,
+      status: 'cancelled' as const,
+      children_cancelled: result.changes,
+      openclaw_session_id: row.openclaw_session_id,
+    };
+  });
 }
 
 export function reapStaleRunning(staleSeconds: number, errorMd: string): number {


### PR DESCRIPTION
## Summary

PR 4 of 5 in the jobs-in-progress feature ([spec](specs/jobs-in-progress.md)). Operators currently have no way to stop a misbehaving in-flight dispatch — the only remediation is restarting the dev server or waiting on the stale-running reaper. This PR adds a Cancel button to every `/jobs` live row, backed by `POST /api/jobs/:id/cancel` and a one-transaction DAO that cascades to non-terminal subtree-audit children.

## Changes

- **`cancelAgentRun(id)`** in `src/lib/db/agent-runs.ts` — single transaction, flips queued/running rows to `cancelled` with `error_md='Cancelled by operator'` and cascades to non-terminal direct children with `'Parent cancelled by operator'`. Throws typed errors (`AgentRunNotFoundError`, `AgentRunNotCancellableError`) the route maps to 404 / 409.
- **`POST /api/jobs/:id/cancel`** at `src/app/api/jobs/[id]/cancel/route.ts` — thin wrapper around the DAO. Best-effort gateway abort (`sessions.abort`) with a 2s timeout, never blocks the cancel response. Matches the no-auth pattern of `GET /api/jobs`.
- **/jobs UI** — Cancel button on every live row (parent and child), opens the existing `ConfirmDialog` with destructive styling. Dialog body counts in-flight children for parent rows and warns that gateway shutdown propagates asynchronously. The 2s poll picks up the new status — no manual mutation.

## Notes / deferrals

- **PM chat `synth_only` fallback wiring deferred to PR 5.** There's no clean FK from `agent_runs` to `pm_proposals` today, and the spec was explicit not to invent one here. The existing `pm-dispatch.ts` fallback still fires when the gateway never replies; cancelling a `pm_chat` row leaves the proposal in `pending_agent` until a follow-up threads the link.
- Sidebar pip / drill-down ship in PR 5 per spec.

## Test plan

- [x] `yarn test`: 798 pass / 1 pre-existing fail (`schedule-runner: produces a brief and advances run_count` — known, unrelated).
- [x] New DAO tests in `src/lib/db/agent-runs.test.ts` cover: queued→cancelled, running→cancelled, missing id, already-complete, already-cancelled, parent + 2 running children cascade, complete-child preserved when parent cancelled, openclaw_session_id passthrough.
- [x] Route tests added at `src/app/api/jobs/[id]/cancel/route.test.ts`. Note: the existing `find … -print0 | xargs tsx --test` runner doesn't pick up files under bracketed `[id]` dirs — this is a pre-existing pattern that also affects `api/briefs/[id]/`, `api/topics/[id]/`, etc. Tracked separately; the DAO-level tests cover the cancellation logic comprehensively.
- [ ] Manual e2e against `:4010` blocked by externally-held dev server (operator was warned about a stale SQLite "disk I/O error"); DAO + route tests are the primary evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)