### PR TITLE
feat(jobs): nav pip + drill-down detail panel (PR 5/5)

### DIFF
--- a/src/app/(app)/jobs/JobDetailDrawer.tsx
+++ b/src/app/(app)/jobs/JobDetailDrawer.tsx
@@ -1,0 +1,361 @@
+'use client';
+
+/**
+ * /jobs drill-down side panel (PR 5 of jobs-in-progress).
+ *
+ * Opened when the operator clicks any live or recent row. Surfaces
+ * what /api/jobs/:id returns plus a "Reset session" button that wipes
+ * the openclaw session for `scope_key` via the existing per-agent
+ * reset endpoint. The trigger_body and error_md are rendered as <pre>
+ * blocks with a max-height + overflow scroll so the drawer doesn't
+ * become unbounded for large briefings.
+ */
+
+import { useEffect, useState } from 'react';
+import Drawer from '@/components/Drawer';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import Link from 'next/link';
+import { Copy, Check, AlertTriangle, ExternalLink } from 'lucide-react';
+
+interface JobDetail {
+  id: string;
+  workspace_id: string;
+  kind: string;
+  status: string;
+  source_kind: string;
+  source_ref: string | null;
+  scope_key: string | null;
+  scope_type: string | null;
+  role: string | null;
+  agent_id: string | null;
+  initiative_id: string | null;
+  task_id: string | null;
+  parent_run_id: string | null;
+  label: string | null;
+  openclaw_session_id: string | null;
+  model_used: string | null;
+  cost_cents: number | null;
+  cost_ceiling_cents: number | null;
+  error_md: string | null;
+  trigger_body: string | null;
+  pm_proposal_id: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+  initiative_title: string | null;
+}
+
+function formatElapsed(startedAt: string | null, completedAt: string | null): string {
+  if (!startedAt) return '—';
+  const start = new Date(startedAt + (startedAt.includes('T') ? '' : 'Z')).getTime();
+  const end = completedAt
+    ? new Date(completedAt + (completedAt.includes('T') ? '' : 'Z')).getTime()
+    : Date.now();
+  const ms = Math.max(0, end - start);
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  if (m < 60) return `${m}m ${rem}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard?.writeText(text).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        });
+      }}
+      className="inline-flex items-center gap-1 text-mc-text-secondary hover:text-mc-text"
+      title="Copy"
+    >
+      {copied ? <Check className="w-3 h-3 text-emerald-400" /> : <Copy className="w-3 h-3" />}
+    </button>
+  );
+}
+
+function statusChipClass(status: string): string {
+  switch (status) {
+    case 'complete': return 'bg-emerald-500/20 text-emerald-300';
+    case 'failed': return 'bg-red-500/20 text-red-300';
+    case 'cancelled': return 'bg-zinc-500/20 text-zinc-300';
+    case 'running': return 'bg-cyan-500/20 text-cyan-300';
+    case 'queued': return 'bg-amber-500/20 text-amber-300';
+    default: return 'bg-zinc-500/20 text-zinc-300';
+  }
+}
+
+interface JobDetailDrawerProps {
+  jobId: string | null;
+  onClose: () => void;
+  /** Called after a successful reset so the parent can re-poll. */
+  onReset?: () => void;
+}
+
+export default function JobDetailDrawer({ jobId, onClose, onReset }: JobDetailDrawerProps) {
+  const [job, setJob] = useState<JobDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [resetPending, setResetPending] = useState(false);
+  const [resetting, setResetting] = useState(false);
+
+  useEffect(() => {
+    if (!jobId) {
+      setJob(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/jobs/${encodeURIComponent(jobId)}`)
+      .then(async r => {
+        if (!r.ok) {
+          const body = await r.json().catch(() => ({}));
+          throw new Error(body.error || `HTTP ${r.status}`);
+        }
+        return r.json() as Promise<JobDetail>;
+      })
+      .then(body => {
+        if (!cancelled) setJob(body);
+      })
+      .catch(e => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [jobId]);
+
+  const doReset = async () => {
+    if (!job || !job.agent_id || !job.scope_key) return;
+    setResetting(true);
+    // Derive the session_suffix from scope_key. scope_key is shaped
+    // <session_key_prefix>:<suffix> — strip the prefix off so the
+    // reset endpoint targets just this session, not all of the
+    // agent's sessions. Best-effort: if the key doesn't have a colon
+    // we pass the whole thing.
+    const idx = job.scope_key.lastIndexOf(':');
+    const suffix = idx >= 0 ? job.scope_key.slice(idx + 1) : job.scope_key;
+    try {
+      const res = await fetch(
+        `/api/agents/${encodeURIComponent(job.agent_id)}/reset?session_suffix=${encodeURIComponent(suffix)}`,
+        { method: 'POST' },
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        window.alert(`Reset failed: ${body.error || `HTTP ${res.status}`}`);
+      } else {
+        onReset?.();
+      }
+    } catch (err) {
+      window.alert(`Reset failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setResetting(false);
+      setResetPending(false);
+    }
+  };
+
+  return (
+    <>
+      <Drawer
+        open={jobId !== null}
+        title={(job ? deriveLabel(job) : 'Job detail')}
+        onClose={onClose}
+      >
+        {loading && (
+          <p className="text-sm text-mc-text-secondary">Loading…</p>
+        )}
+        {error && (
+          <p className="text-sm text-red-300">Failed to load: {error}</p>
+        )}
+        {job && (
+          <div className="space-y-5 text-sm">
+            <section className="space-y-1">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="px-1.5 py-0.5 rounded bg-mc-bg-tertiary text-mc-text-secondary text-[11px] font-mono">
+                  {job.kind}
+                </span>
+                <span className={`px-1.5 py-0.5 rounded text-[11px] ${statusChipClass(job.status)}`}>
+                  {job.status}
+                </span>
+                {job.source_kind !== 'manual' && (
+                  <span className="px-1.5 py-0.5 rounded bg-mc-bg-tertiary text-mc-text-secondary text-[11px] font-mono">
+                    {job.source_kind}
+                  </span>
+                )}
+              </div>
+              <h3 className="text-base font-medium text-mc-text">
+                {job.label ?? deriveLabel(job)}
+              </h3>
+              {job.scope_key && (
+                <p className="text-[11px] font-mono text-mc-text-secondary break-all">
+                  {job.scope_key} <CopyButton text={job.scope_key} />
+                </p>
+              )}
+            </section>
+
+            <section className="grid grid-cols-2 gap-x-4 gap-y-1 text-mc-text-secondary text-[12px]">
+              <div>
+                <span className="block text-[10px] uppercase tracking-wider opacity-70">Started</span>
+                <span className="text-mc-text">{job.started_at ?? '—'}</span>
+              </div>
+              <div>
+                <span className="block text-[10px] uppercase tracking-wider opacity-70">Completed</span>
+                <span className="text-mc-text">{job.completed_at ?? '—'}</span>
+              </div>
+              <div>
+                <span className="block text-[10px] uppercase tracking-wider opacity-70">Elapsed</span>
+                <span className="text-mc-text">{formatElapsed(job.started_at, job.completed_at)}</span>
+              </div>
+              <div>
+                <span className="block text-[10px] uppercase tracking-wider opacity-70">Cost</span>
+                <span className="text-mc-text">
+                  {job.cost_cents != null ? `${(job.cost_cents / 100).toFixed(2)}¢` : '—'}
+                </span>
+              </div>
+              <div>
+                <span className="block text-[10px] uppercase tracking-wider opacity-70">Role</span>
+                <span className="text-mc-text">{job.role ?? '—'}</span>
+              </div>
+              <div>
+                <span className="block text-[10px] uppercase tracking-wider opacity-70">Agent</span>
+                <span className="text-mc-text font-mono text-[11px] break-all">
+                  {job.agent_id ? (
+                    <Link href={`/agents/${encodeURIComponent(job.agent_id)}`} className="hover:underline inline-flex items-center gap-1">
+                      {job.agent_id}
+                      <ExternalLink className="w-3 h-3" />
+                    </Link>
+                  ) : '—'}
+                </span>
+              </div>
+              {job.model_used && (
+                <div className="col-span-2">
+                  <span className="block text-[10px] uppercase tracking-wider opacity-70">Model</span>
+                  <span className="text-mc-text font-mono text-[11px]">{job.model_used}</span>
+                </div>
+              )}
+            </section>
+
+            {(job.initiative_id || job.task_id) && (
+              <section className="space-y-1">
+                <h4 className="text-[10px] uppercase tracking-wider text-mc-text-secondary opacity-70">
+                  Targets
+                </h4>
+                {job.initiative_id && (
+                  <p className="text-[12px]">
+                    <Link
+                      href={`/initiatives/${encodeURIComponent(job.initiative_id)}`}
+                      className="text-mc-accent hover:underline inline-flex items-center gap-1"
+                    >
+                      Initiative: {job.initiative_title ?? job.initiative_id}
+                      <ExternalLink className="w-3 h-3" />
+                    </Link>
+                  </p>
+                )}
+                {job.task_id && (
+                  <p className="text-[12px] font-mono">
+                    Task: {job.task_id}
+                  </p>
+                )}
+              </section>
+            )}
+
+            {job.error_md && (
+              <section className="space-y-1">
+                <h4 className="text-[10px] uppercase tracking-wider text-red-300 flex items-center gap-1">
+                  <AlertTriangle className="w-3 h-3" /> Error
+                </h4>
+                <pre className="text-[12px] text-red-200 bg-red-500/10 border border-red-500/30 rounded p-2 overflow-auto max-h-[40vh] whitespace-pre-wrap break-words">
+                  {job.error_md}
+                </pre>
+              </section>
+            )}
+
+            <section className="space-y-1">
+              <h4 className="text-[10px] uppercase tracking-wider text-mc-text-secondary opacity-70">
+                Trigger body
+              </h4>
+              {job.trigger_body ? (
+                <pre className="text-[11px] text-mc-text-secondary bg-mc-bg border border-mc-border rounded p-2 overflow-auto max-h-[50vh] whitespace-pre-wrap break-words">
+                  {job.trigger_body}
+                </pre>
+              ) : (
+                <p className="text-[12px] text-mc-text-secondary italic">
+                  Trigger body not captured for this run.
+                </p>
+              )}
+            </section>
+
+            {job.agent_id && job.scope_key && (
+              <section className="space-y-2 pt-2 border-t border-mc-border">
+                <h4 className="text-[10px] uppercase tracking-wider text-mc-text-secondary opacity-70">
+                  Session
+                </h4>
+                <p className="text-[12px] text-mc-text-secondary">
+                  Reset wipes the openclaw history for this scope. Useful when
+                  the conversation is stuck on a stale model state.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setResetPending(true)}
+                  className="px-2 py-1 rounded border border-red-500/40 text-red-300 hover:bg-red-500/10 text-xs"
+                >
+                  Reset session
+                </button>
+              </section>
+            )}
+          </div>
+        )}
+      </Drawer>
+
+      <ConfirmDialog
+        open={resetPending}
+        title="Reset session?"
+        body={
+          job?.scope_key ? (
+            <div className="space-y-2">
+              <p>
+                This will wipe the openclaw conversation history for this scope.
+                The next dispatch starts cold.
+              </p>
+              <p className="font-mono text-[11px] text-mc-text-secondary break-all">
+                {job.scope_key}
+              </p>
+            </div>
+          ) : null
+        }
+        confirmLabel={resetting ? 'Resetting…' : 'Reset session'}
+        cancelLabel="Keep history"
+        destructive
+        onConfirm={doReset}
+        onCancel={() => setResetPending(false)}
+      />
+    </>
+  );
+}
+
+function deriveLabel(job: JobDetail): string {
+  if (job.label && job.label.trim()) return job.label;
+  switch (job.kind) {
+    case 'pm_chat': return 'PM chat';
+    case 'plan': return job.initiative_title ? `Plan: ${job.initiative_title}` : 'Plan';
+    case 'decompose': return job.initiative_title ? `Decompose: ${job.initiative_title}` : 'Decompose';
+    case 'initiative_audit': return job.initiative_title ? `Audit: ${job.initiative_title}` : 'Audit';
+    case 'recurring': return 'Recurring tick';
+    case 'task_coord': return 'Task coordinator';
+    case 'task_role': return 'Task role';
+    case 'brief': return 'Brief';
+    default: return job.kind;
+  }
+}

--- a/src/app/(app)/jobs/page.tsx
+++ b/src/app/(app)/jobs/page.tsx
@@ -17,6 +17,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { Activity, Clock, Calendar, History, AlertTriangle, Copy, Check } from 'lucide-react';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
+import JobDetailDrawer from './JobDetailDrawer';
 
 const POLL_MS = 2000;
 const AMBER_ELAPSED_MS = 5 * 60 * 1000;
@@ -150,7 +151,8 @@ function CopyableScope({ scopeKey }: { scopeKey: string | null }) {
   return (
     <button
       type="button"
-      onClick={() => {
+      onClick={e => {
+        e.stopPropagation();
         navigator.clipboard?.writeText(scopeKey).then(() => {
           setCopied(true);
           setTimeout(() => setCopied(false), 1200);
@@ -173,6 +175,9 @@ export default function JobsPage() {
   const [recentPage, setRecentPage] = useState(0);
   const [pendingCancel, setPendingCancel] = useState<JobsLiveItem | null>(null);
   const [cancelling, setCancelling] = useState(false);
+  // PR 5: drill-down drawer state. Holds the agent_runs.id of the row
+  // the operator clicked. Drawer fetches /api/jobs/:id on open.
+  const [detailJobId, setDetailJobId] = useState<string | null>(null);
 
   // Children-of-pending counter for the dialog body — only count
   // non-terminal direct children since those are what the cascade
@@ -308,7 +313,11 @@ export default function JobsPage() {
                     ? `${(row.scope_key ?? '').split(':').pop() ?? row.scope_key} · ${row.group_count} turns in last hour`
                     : row.derived_label;
                 return (
-                  <tr key={row.id} className={`border-t border-mc-border ${amber ? 'bg-amber-500/10' : ''}`}>
+                  <tr
+                    key={row.id}
+                    onClick={() => setDetailJobId(row.id)}
+                    className={`border-t border-mc-border cursor-pointer hover:bg-mc-bg-tertiary/50 ${amber ? 'bg-amber-500/10' : ''}`}
+                  >
                     <Td><KindBadge kind={row.kind} /></Td>
                     <Td className="text-mc-text">
                       {depth > 0 ? (
@@ -327,7 +336,10 @@ export default function JobsPage() {
                     <Td className="text-xs">
                       <button
                         type="button"
-                        onClick={() => setPendingCancel(row)}
+                        onClick={e => {
+                          e.stopPropagation();
+                          setPendingCancel(row);
+                        }}
                         className="px-2 py-0.5 rounded border border-red-500/40 text-red-300 hover:bg-red-500/10"
                       >
                         Cancel
@@ -408,7 +420,11 @@ export default function JobsPage() {
               </thead>
               <tbody>
                 {recentSlice.map(row => (
-                  <tr key={row.id} className="border-t border-mc-border">
+                  <tr
+                    key={row.id}
+                    onClick={() => setDetailJobId(row.id)}
+                    className="border-t border-mc-border cursor-pointer hover:bg-mc-bg-tertiary/50"
+                  >
                     <Td><KindBadge kind={row.kind} /></Td>
                     <Td className="text-mc-text">{row.derived_label}</Td>
                     <Td className="text-mc-text-secondary">
@@ -492,6 +508,11 @@ export default function JobsPage() {
         destructive
         onConfirm={doCancel}
         onCancel={() => setPendingCancel(null)}
+      />
+
+      <JobDetailDrawer
+        jobId={detailJobId}
+        onClose={() => setDetailJobId(null)}
       />
     </div>
   );

--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -1,0 +1,41 @@
+/**
+ * GET /api/jobs/:id
+ *
+ * Backs the /jobs drill-down side panel (PR 5). Returns the full
+ * agent_runs row for one id — same shape as the AgentRun DAO type
+ * plus a derived label and the linked initiative title (best-effort
+ * join) for headers. trigger_body and error_md ride through verbatim
+ * so the side panel can render them without a second fetch.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getAgentRun } from '@/lib/db/agent-runs';
+import { queryOne } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  if (!id) {
+    return NextResponse.json({ error: 'job id required' }, { status: 400 });
+  }
+  const row = getAgentRun(id);
+  if (!row) {
+    return NextResponse.json({ error: 'job not found' }, { status: 404 });
+  }
+  // Best-effort initiative title for the header. Cheap single-row
+  // lookup; null if the row doesn't reference an initiative or the
+  // initiative was deleted.
+  let initiative_title: string | null = null;
+  if (row.initiative_id) {
+    const init = queryOne<{ title: string }>(
+      `SELECT title FROM initiatives WHERE id = ?`,
+      [row.initiative_id],
+    );
+    initiative_title = init?.title ?? null;
+  }
+  return NextResponse.json({ ...row, initiative_title });
+}

--- a/src/app/api/jobs/route.test.ts
+++ b/src/app/api/jobs/route.test.ts
@@ -67,3 +67,37 @@ test('GET /api/jobs: live bucket reflects running pm_chat collapse', async () =>
   assert.equal(body.live[0].kind, 'pm_chat');
   assert.equal(typeof body.live[0].derived_label, 'string');
 });
+
+test('GET /api/jobs?count_only=true: returns just { live: N } with collapse', async () => {
+  const ws = freshWorkspace();
+  const scope = `scope-${uuidv4()}`;
+  for (let i = 0; i < 3; i++) {
+    startAgentRun({
+      workspace_id: ws,
+      kind: 'pm_chat',
+      scope_key: scope,
+      scope_type: 'pm_chat',
+      role: 'pm',
+      agent_id: `a${i}`,
+    });
+  }
+  startAgentRun({
+    workspace_id: ws,
+    kind: 'plan',
+    scope_key: 'plan-x',
+    scope_type: 'plan',
+    role: 'pm',
+    agent_id: 'plan-a',
+  });
+  const res = await GET(jobsReq({ workspace_id: ws, count_only: 'true' }));
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(Object.keys(body), ['live']);
+  // 3 collapsed pm_chat → 1 group + 1 plan row = 2.
+  assert.equal(body.live, 2);
+});
+
+test('GET /api/jobs?count_only=true: missing workspace_id → 400', async () => {
+  const res = await GET(jobsReq({ count_only: 'true' }));
+  assert.equal(res.status, 400);
+});

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -11,7 +11,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { listJobs, AgentRunValidationError } from '@/lib/db/agent-runs';
+import { listJobs, countLiveJobs, AgentRunValidationError } from '@/lib/db/agent-runs';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,6 +21,12 @@ export async function GET(request: NextRequest) {
     const workspaceId = searchParams.get('workspace_id');
     if (!workspaceId) {
       return NextResponse.json({ error: 'workspace_id is required' }, { status: 400 });
+    }
+    // PR 5: lightweight count endpoint for the AppNav live-count badge.
+    // Same collapse rules as the full payload but skips the recent /
+    // scheduled queries entirely.
+    if (searchParams.get('count_only') === 'true') {
+      return NextResponse.json({ live: countLiveJobs(workspaceId) });
     }
     return NextResponse.json(listJobs(workspaceId));
   } catch (error) {

--- a/src/components/shell/AppNav.tsx
+++ b/src/components/shell/AppNav.tsx
@@ -371,6 +371,11 @@ function NavSectionView({
                     <ResearchPreflightDot />
                   </span>
                 )}
+                {item.href === '/jobs' && (
+                  <span className={collapsed ? 'md:hidden' : ''}>
+                    <JobsLivePip />
+                  </span>
+                )}
               </Link>
             </li>
           );
@@ -403,6 +408,59 @@ function ResearchPreflightDot() {
   return (
     <span title={reason} aria-label={reason} className="ml-1 shrink-0">
       <AlertCircle className="w-3.5 h-3.5 text-amber-400" />
+    </span>
+  );
+}
+
+/**
+ * Live-count pip on the Jobs nav entry. Polls /api/jobs?count_only=true
+ * every 5s — slower than the /jobs page's 2s poll because the badge
+ * doesn't need to be live-as-fast. Hides at 0; shows "9+" beyond 9.
+ *
+ * Lives in AppNav (not the page) so it stays visible regardless of
+ * which route the operator is on — the whole point is "you don't have
+ * to navigate to /jobs to notice activity."
+ */
+function JobsLivePip() {
+  const workspaceId = useCurrentWorkspaceId();
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    if (!workspaceId) {
+      setCount(0);
+      return;
+    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const tick = async () => {
+      try {
+        const res = await fetch(
+          `/api/jobs?workspace_id=${encodeURIComponent(workspaceId)}&count_only=true`,
+        );
+        if (res.ok) {
+          const body = (await res.json()) as { live?: number };
+          if (!cancelled) setCount(typeof body.live === 'number' ? body.live : 0);
+        }
+      } catch {
+        /* keep last value on transient failure */
+      } finally {
+        if (!cancelled) timer = setTimeout(tick, 5000);
+      }
+    };
+    tick();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [workspaceId]);
+  if (count <= 0) return null;
+  const label = count > 9 ? '9+' : String(count);
+  return (
+    <span
+      title={`${count} live ${count === 1 ? 'job' : 'jobs'}`}
+      aria-label={`${count} live jobs`}
+      className="ml-1 shrink-0 min-w-[18px] h-[18px] px-1 rounded-full bg-mc-accent-red text-white text-[10px] font-bold flex items-center justify-center"
+    >
+      {label}
     </span>
   );
 }

--- a/src/lib/agents/dispatch-scope.ts
+++ b/src/lib/agents/dispatch-scope.ts
@@ -118,6 +118,10 @@ export interface DispatchScopeInput {
   source_ref?: string | null;
   /** Display label snapshot at dispatch time (rendered in /jobs UI). */
   label?: string | null;
+  /** Optional pm_proposals.id for pm_chat dispatches — recorded on
+   *  agent_runs so the cancel cascade can flip the linked proposal to
+   *  `synth_only` (PR 5 of jobs-in-progress). */
+  pm_proposal_id?: string | null;
   /**
    * Skip the agent_runs lifecycle bookkeeping. Used by callers (today:
    * brief dispatch via run-brief.ts) that already manage their own
@@ -230,6 +234,11 @@ export async function dispatchScope(input: DispatchScopeInput): Promise<Dispatch
         source_kind: input.source_kind ?? 'manual',
         source_ref: input.source_ref ?? null,
         label: input.label ?? null,
+        // PR 5: capture the briefing as-sent so the /jobs drill-down
+        // can replay what the agent saw. Composed briefing (not just
+        // trigger_body) so the operator sees the full system context.
+        trigger_body: briefing,
+        pm_proposal_id: input.pm_proposal_id ?? null,
       });
     } catch (err) {
       // Don't let an agent_runs write failure break dispatch. Log and

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -485,6 +485,9 @@ async function runDisruptionDispatchInBackground(
       timeoutMs: namedAgentTimeoutMs(),
       onEvent,
       onAgentEvent,
+      // PR 5 jobs-in-progress: link this run to the placeholder so a
+      // mid-flight cancel can flip dispatch_state → synth_only.
+      pm_proposal_id: placeholder.id,
     });
     result = dispatch.reply;
   } catch (err) {
@@ -938,6 +941,8 @@ async function runNamedAgentDispatchInBackground(
       initiative_id: input.target_initiative_id ?? null,
       idempotencyKey: `pm-${input.trigger_kind}-${correlationId}`,
       timeoutMs,
+      // PR 5: thread placeholder so cancel can flip to synth_only.
+      pm_proposal_id: placeholder.id,
     });
     result = dispatch.reply;
   } catch (err) {

--- a/src/lib/db/agent-runs.test.ts
+++ b/src/lib/db/agent-runs.test.ts
@@ -723,3 +723,144 @@ test('cancelAgentRun: returns openclaw_session_id from the row', () => {
   const result = cancelAgentRun(r.id);
   assert.equal(result.openclaw_session_id, 'agent:mc-pm-default:dispatch-main');
 });
+
+// ─── PR 5: trigger_body, pm_proposal_id, drill-down ─────────────────
+
+test('startAgentRun: persists trigger_body + pm_proposal_id', () => {
+  const ws = freshWorkspace();
+  const id = startAgentRun({
+    workspace_id: ws,
+    kind: 'pm_chat',
+    scope_key: 'scope:t1',
+    scope_type: 'pm_chat',
+    role: 'pm',
+    agent_id: 'a1',
+    trigger_body: '# briefing\n\nDo the thing.',
+    pm_proposal_id: 'pp-123',
+  });
+  const row = getAgentRun(id)!;
+  assert.equal(row.trigger_body, '# briefing\n\nDo the thing.');
+  assert.equal(row.pm_proposal_id, 'pp-123');
+});
+
+test('startAgentRun: trigger_body / pm_proposal_id default to null', () => {
+  const ws = freshWorkspace();
+  const id = startAgentRun({
+    workspace_id: ws,
+    kind: 'pm_chat',
+    scope_key: 'scope:t2',
+    scope_type: 'pm_chat',
+    role: 'pm',
+    agent_id: 'a2',
+  });
+  const row = getAgentRun(id)!;
+  assert.equal(row.trigger_body, null);
+  assert.equal(row.pm_proposal_id, null);
+});
+
+test('cancelAgentRun: linked pm_proposal in pending_agent flips to synth_only', async () => {
+  const { createProposal } = await import('./pm-proposals');
+  const ws = freshWorkspace();
+  const proposal = createProposal({
+    workspace_id: ws,
+    trigger_text: 'unit test',
+    trigger_kind: 'manual',
+    impact_md: 'placeholder',
+    proposed_changes: [],
+    dispatch_state: 'pending_agent',
+  });
+  const id = startAgentRun({
+    workspace_id: ws,
+    kind: 'pm_chat',
+    scope_key: `scope:${proposal.id}`,
+    scope_type: 'pm_chat',
+    role: 'pm',
+    agent_id: 'a-pm',
+    pm_proposal_id: proposal.id,
+  });
+  cancelAgentRun(id);
+  // Re-read the proposal row directly so we don't depend on the
+  // listProposals projection.
+  const after = (await import('./pm-proposals')).getProposal(proposal.id)!;
+  assert.equal(after.dispatch_state, 'synth_only');
+});
+
+test('cancelAgentRun: no linked proposal — still cancels cleanly', () => {
+  const ws = freshWorkspace();
+  const id = startAgentRun({
+    workspace_id: ws,
+    kind: 'pm_chat',
+    scope_key: 'scope:lonely',
+    scope_type: 'pm_chat',
+    role: 'pm',
+    agent_id: 'a-lonely',
+  });
+  const result = cancelAgentRun(id);
+  assert.equal(result.status, 'cancelled');
+  assert.equal(getAgentRun(id)!.status, 'cancelled');
+});
+
+test('cancelAgentRun: linked proposal already agent_complete is left alone', async () => {
+  const { createProposal, getProposal } = await import('./pm-proposals');
+  const ws = freshWorkspace();
+  const proposal = createProposal({
+    workspace_id: ws,
+    trigger_text: 'unit test',
+    impact_md: 'something',
+    proposed_changes: [],
+    dispatch_state: 'agent_complete',
+  });
+  const id = startAgentRun({
+    workspace_id: ws,
+    kind: 'pm_chat',
+    scope_key: `scope:${proposal.id}`,
+    scope_type: 'pm_chat',
+    role: 'pm',
+    agent_id: 'a-pm',
+    pm_proposal_id: proposal.id,
+  });
+  cancelAgentRun(id);
+  // Cancel must not regress an already-settled proposal back to synth_only.
+  assert.equal(getProposal(proposal.id)!.dispatch_state, 'agent_complete');
+});
+
+test('countLiveJobs: collapses pm_chat by scope_key', async () => {
+  const { countLiveJobs } = await import('./agent-runs');
+  const ws = freshWorkspace();
+  const scope = `count-scope-${uuidv4()}`;
+  for (let i = 0; i < 3; i++) {
+    startAgentRun({
+      workspace_id: ws,
+      kind: 'pm_chat',
+      scope_key: scope,
+      scope_type: 'pm_chat',
+      role: 'pm',
+      agent_id: `a${i}`,
+    });
+  }
+  startAgentRun({
+    workspace_id: ws,
+    kind: 'plan',
+    scope_key: 'plan-1',
+    scope_type: 'plan',
+    role: 'pm',
+    agent_id: 'plan-a',
+  });
+  // 3 pm_chat rows → 1 group; 1 plan row → 1; total 2.
+  assert.equal(countLiveJobs(ws), 2);
+});
+
+test('countLiveJobs: ignores terminal rows', async () => {
+  const { countLiveJobs } = await import('./agent-runs');
+  const ws = freshWorkspace();
+  const id = startAgentRun({
+    workspace_id: ws,
+    kind: 'plan',
+    scope_key: 'p-done',
+    scope_type: 'plan',
+    role: 'pm',
+    agent_id: 'a',
+  });
+  completeAgentRun(id);
+  assert.equal(countLiveJobs(ws), 0);
+});

--- a/src/lib/db/agent-runs.ts
+++ b/src/lib/db/agent-runs.ts
@@ -49,6 +49,13 @@ export interface AgentRun {
   cost_cents: number | null;
   cost_ceiling_cents: number | null;
   error_md: string | null;
+  /** Briefing/trigger body sent to the agent at dispatch (PR 5).
+   *  Nullable because rows pre-migration-081 don't have it. */
+  trigger_body: string | null;
+  /** When kind='pm_chat' AND the dispatch was kicked by a pm_proposals
+   *  row, this points at that proposal so the cancel cascade can flip
+   *  it to `synth_only` (PR 5). */
+  pm_proposal_id: string | null;
   started_at: string | null;
   completed_at: string | null;
   created_at: string;
@@ -277,6 +284,13 @@ export interface StartAgentRunInput {
   source_ref?: string | null;
   cost_ceiling_cents?: number | null;
   label?: string | null;
+  /** Briefing/trigger body sent to the agent (PR 5 — surfaced in the
+   *  /jobs drill-down). Optional; existing callers don't set it. */
+  trigger_body?: string | null;
+  /** Optional pm_proposals.id this dispatch is wired up to. Used by
+   *  the cancel cascade to flip `pending_agent` → `synth_only` when
+   *  an in-flight PM chat is killed before the agent replies. */
+  pm_proposal_id?: string | null;
 }
 
 /**
@@ -295,8 +309,9 @@ export function startAgentRun(input: StartAgentRunInput): string {
        id, workspace_id, kind, status, source_kind, source_ref,
        scope_key, scope_type, role, agent_id,
        initiative_id, task_id, parent_run_id, label,
+       trigger_body, pm_proposal_id,
        cost_ceiling_cents, started_at, created_at, updated_at
-     ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), datetime('now'))`,
+     ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), datetime('now'))`,
     [
       id,
       input.workspace_id,
@@ -311,6 +326,8 @@ export function startAgentRun(input: StartAgentRunInput): string {
       input.task_id ?? null,
       input.parent_run_id ?? null,
       input.label ?? null,
+      input.trigger_body ?? null,
+      input.pm_proposal_id ?? null,
       input.cost_ceiling_cents ?? null,
     ],
   );
@@ -449,6 +466,37 @@ export interface JobsListResponse {
   live: JobsLiveItem[];
   scheduled: JobsScheduledItem[];
   recent: JobsRecentItem[];
+}
+
+/**
+ * Lightweight live count using the same collapse rules as listJobs:
+ * pm_chat collapsed by scope_key (one entry per session), every other
+ * kind one-per-row. Backs the AppNav badge — polled at a slower rate
+ * than the page so we keep this query cheap.
+ */
+export function countLiveJobs(workspaceId: string): number {
+  if (!workspaceId.trim()) {
+    throw new AgentRunValidationError('workspace_id is required');
+  }
+  const row = queryOne<{ live: number }>(
+    `SELECT
+       (SELECT COUNT(*) FROM agent_runs
+          WHERE workspace_id = ?
+            AND status IN ('queued','running')
+            AND (kind != 'pm_chat' OR scope_key IS NULL))
+       +
+       (SELECT COUNT(*) FROM (
+          SELECT 1 FROM agent_runs
+           WHERE workspace_id = ?
+             AND status IN ('queued','running')
+             AND kind = 'pm_chat'
+             AND scope_key IS NOT NULL
+           GROUP BY scope_key
+        ))
+       AS live`,
+    [workspaceId, workspaceId],
+  );
+  return row?.live ?? 0;
 }
 
 interface RawAgentRunRow extends AgentRun {
@@ -671,6 +719,27 @@ export function cancelAgentRun(id: string): CancelAgentRunResult {
          AND status IN ('queued','running')`,
       ['Parent cancelled by operator', id],
     );
+    // PR 5: if this was a PM-chat dispatch tied to a still-pending
+    // pm_proposals row, flip that proposal to `synth_only` so the
+    // existing fallback fires instead of leaving operators staring at
+    // a placeholder card forever. Best-effort — don't unwind the
+    // cancel if this throws.
+    if (row.pm_proposal_id) {
+      try {
+        run(
+          `UPDATE pm_proposals
+              SET dispatch_state = 'synth_only'
+            WHERE id = ?
+              AND dispatch_state = 'pending_agent'`,
+          [row.pm_proposal_id],
+        );
+      } catch (err) {
+        console.warn(
+          '[cancelAgentRun] pm_proposal flip to synth_only failed:',
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
     return {
       id,
       status: 'cancelled' as const,

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4402,6 +4402,40 @@ const migrations: Migration[] = [
       console.log('[Migration 080] agent_runs extended with scope/role/agent/parent attribution; kind enum relaxed.');
     },
   },
+  {
+    id: '081',
+    name: 'agent_runs_trigger_body_and_proposal_link',
+    up: (db) => {
+      // Jobs-in-Progress (PR 5): add `trigger_body` (the briefing text
+      // sent to the agent at dispatch time, surfaced in the /jobs
+      // drill-down) and `pm_proposal_id` (FK linking pm_chat dispatches
+      // to the pm_proposals row they were spawned for, used by the
+      // cancel cascade to flip pending_agent → synth_only). Both
+      // nullable; existing rows stay NULL.
+      const tableRow = db
+        .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='agent_runs'")
+        .get() as { sql: string } | undefined;
+      if (!tableRow) {
+        console.log('[Migration 081] agent_runs missing; skipping.');
+        return;
+      }
+      const cols = db.prepare(`PRAGMA table_info(agent_runs)`).all() as Array<{ name: string }>;
+      const hasTriggerBody = cols.some((c) => c.name === 'trigger_body');
+      const hasProposalId = cols.some((c) => c.name === 'pm_proposal_id');
+      if (hasTriggerBody && hasProposalId) {
+        console.log('[Migration 081] agent_runs already has trigger_body + pm_proposal_id; skipping.');
+        return;
+      }
+      if (!hasTriggerBody) {
+        db.exec(`ALTER TABLE agent_runs ADD COLUMN trigger_body TEXT`);
+      }
+      if (!hasProposalId) {
+        db.exec(`ALTER TABLE agent_runs ADD COLUMN pm_proposal_id TEXT`);
+      }
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_runs_pm_proposal ON agent_runs(pm_proposal_id) WHERE pm_proposal_id IS NOT NULL`);
+      console.log('[Migration 081] agent_runs.trigger_body + pm_proposal_id columns added.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */


### PR DESCRIPTION
## Summary

Final PR (5 of 5) of the Jobs-in-Progress stack — see `specs/jobs-in-progress.md`. Adds the live-count pip on the AppNav Jobs entry and a drill-down side drawer for any row on `/jobs`.

- **Nav pip** — polls `/api/jobs?count_only=true` every 5s (slower than the page's 2s). Hides at 0, shows `9+` past 9. Same `bg-mc-accent-red` styling as the chat unread badge.
- **Drill-down drawer** — clicking any live or recent row opens a slide-over with kind/status, started/completed/elapsed, agent + role + model, initiative/task links, error_md (red block), and the trigger body as a scrollable `<pre>`. Reset Session button reuses the existing per-agent reset endpoint and is wrapped in `ConfirmDialog` (destructive).
- **Migration 081** — two nullable columns on `agent_runs`:
  - `trigger_body` — captured by `dispatchScope` from the composed briefing so the drawer can replay what the agent saw.
  - `pm_proposal_id` — set by pm-dispatch on both disruption + synthesized paths. `cancelAgentRun` reads it and flips a still-`pending_agent` proposal to `synth_only` so the existing fallback fires instead of stranding the placeholder card.

## Changes

- `src/lib/db/migrations.ts` — migration 081, idempotent on cols + index.
- `src/lib/db/agent-runs.ts` — `trigger_body` / `pm_proposal_id` on type + insert; `cancelAgentRun` cascades to `pm_proposals`; new `countLiveJobs()` for the badge.
- `src/lib/agents/dispatch-scope.ts` — threads `pm_proposal_id` through and persists the composed briefing as `trigger_body`.
- `src/lib/agents/pm-dispatch.ts` — both `runDisruptionDispatchInBackground` + `runNamedAgentDispatchInBackground` pass the placeholder id.
- `src/app/api/jobs/route.ts` — `?count_only=true` short-circuit.
- `src/app/api/jobs/[id]/route.ts` (new) — single-row fetch for the drawer; joins `initiatives.title` for the header.
- `src/components/shell/AppNav.tsx` — `JobsLivePip` component on the Jobs nav entry.
- `src/app/(app)/jobs/JobDetailDrawer.tsx` (new) + `page.tsx` — clickable rows + Drawer mount.

## Test plan

- [x] `yarn test` — 807/808 pass; only pre-existing failure is `schedule-runner` (per project CLAUDE.md inventory).
- [x] New unit coverage:
  - `startAgentRun` persists/defaults `trigger_body` + `pm_proposal_id`.
  - `cancelAgentRun` flips linked `pending_agent` proposal → `synth_only`; leaves `agent_complete` proposals alone; still cancels cleanly when no proposal is linked.
  - `countLiveJobs` collapses pm_chat by `scope_key`, ignores terminal rows.
  - Route test for `?count_only=true` (3 collapsed pm_chat + 1 plan = 2) + missing-workspace 400.
- [x] `yarn tsc --noEmit` — no new errors in any of the touched files; the three pre-existing TS errors in unrelated files (`pm/proposals/[id]/route.ts`, `pm-decompose.test.ts`) are unchanged from `main`.
- [ ] Live e2e — operator reported the running dev server's better-sqlite3 connection was stale; if a bounce restores `/api/jobs`, confirm the cancel→synth_only flip via `sqlite3` shell (`SELECT id, dispatch_state FROM pm_proposals ORDER BY created_at DESC LIMIT 5;`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)