### PR TITLE
feat(audit-actions): per-initiative in-flight strip (PR 2/6)

### DIFF
--- a/src/app/api/jobs/route.test.ts
+++ b/src/app/api/jobs/route.test.ts
@@ -101,3 +101,49 @@ test('GET /api/jobs?count_only=true: missing workspace_id → 400', async () => 
   const res = await GET(jobsReq({ count_only: 'true' }));
   assert.equal(res.status, 400);
 });
+
+test('GET /api/jobs?initiative_id=…: filters live + recent, suppresses scheduled', async () => {
+  const ws = freshWorkspace();
+  // Seed two initiatives directly.
+  const iA = `init-A-${uuidv4().slice(0, 6)}`;
+  const iB = `init-B-${uuidv4().slice(0, 6)}`;
+  for (const id of [iA, iB]) {
+    run(
+      `INSERT OR IGNORE INTO initiatives (id, workspace_id, title, status, kind, created_at, updated_at)
+       VALUES (?, ?, ?, 'planned', 'epic', datetime('now'), datetime('now'))`,
+      [id, ws, `seed ${id}`],
+    );
+  }
+
+  // 1 live audit on A, 1 live audit on B.
+  startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: `audit-A-${uuidv4()}`,
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'r1',
+    initiative_id: iA,
+  });
+  startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: `audit-B-${uuidv4()}`,
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'r2',
+    initiative_id: iB,
+  });
+
+  // Filter to A — should see only that one in live, scheduled empty.
+  const resA = await GET(jobsReq({ workspace_id: ws, initiative_id: iA }));
+  const bodyA = await resA.json();
+  assert.equal(bodyA.live.length, 1);
+  assert.equal(bodyA.live[0].initiative_id, iA);
+  assert.deepEqual(bodyA.scheduled, []);
+
+  // No filter — should see both.
+  const resAll = await GET(jobsReq({ workspace_id: ws }));
+  const bodyAll = await resAll.json();
+  assert.equal(bodyAll.live.length, 2);
+});

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -28,7 +28,11 @@ export async function GET(request: NextRequest) {
     if (searchParams.get('count_only') === 'true') {
       return NextResponse.json({ live: countLiveJobs(workspaceId) });
     }
-    return NextResponse.json(listJobs(workspaceId));
+    // Optional per-initiative filter (audit-actions PR 2). Restricts
+    // live + recent to runs touching this initiative; suppresses
+    // scheduled bucket since recurring_jobs aren't initiative-scoped.
+    const initiativeId = searchParams.get('initiative_id') ?? undefined;
+    return NextResponse.json(listJobs(workspaceId, { initiative_id: initiativeId }));
   } catch (error) {
     if (error instanceof AgentRunValidationError) {
       return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -30,6 +30,7 @@ import {
   CornerUpLeft,
   Trash2,
   Search,
+  Activity,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -39,6 +40,7 @@ import { DecomposerAgentPicker, type DecomposerOption } from '@/components/inlin
 import { InvestigatePicker, type InvestigateOption } from '@/components/inline/InvestigatePicker';
 import InvestigateModal from '@/components/InvestigateModal';
 import { NotesRail } from '@/components/notes/NotesRail';
+import { InitiativeRunsStrip } from '@/components/initiative/InitiativeRunsStrip';
 import { useAgentNotes } from '@/hooks/useAgentNotes';
 import { countPriorAudits } from '@/components/inline/investigate-helpers';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -1096,6 +1098,17 @@ or "carve out the onboarding flow as its own story first"`}
               ))}
             </ul>
           )}
+        </Section>
+
+        {/* Activity — live + recent agent_runs touching this initiative.
+            Closes the "what did I just queue?" gap after page refresh and
+            gives investigations a durable surface beyond the dispatch
+            toast. See specs/audit-actions-and-tracking.md PR 2. */}
+        <Section title="Activity" icon={<Activity className="w-4 h-4" />}>
+          <InitiativeRunsStrip
+            workspaceId={initiative.workspace_id}
+            initiativeId={initiative.id}
+          />
         </Section>
 
         {/* Notes — agent-generated observations for this initiative.

--- a/src/components/initiative/InitiativeRunsStrip.tsx
+++ b/src/components/initiative/InitiativeRunsStrip.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+/**
+ * Per-initiative in-flight strip.
+ *
+ * Polls `/api/jobs?workspace_id=…&initiative_id=…` every 2s and renders
+ * a compact horizontal list of agent_runs touching this initiative —
+ * audit, plan, decompose, etc. Closes the "what did I just queue?" gap
+ * after a refresh, and the "where will the result land?" gap on dispatch.
+ *
+ * Shows:
+ *  - All live (queued + running) runs for this initiative.
+ *  - Up to 3 most-recent terminal runs from the last 24h.
+ *
+ * Each row links into `/jobs?run=<id>` for the existing drill-down panel.
+ *
+ * See specs/audit-actions-and-tracking.md PR 2.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  Activity,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  CircleDashed,
+} from 'lucide-react';
+
+const POLL_MS = 2000;
+const AMBER_ELAPSED_MS = 5 * 60 * 1000;
+const RECENT_LIMIT = 3;
+
+interface JobsItem {
+  id: string;
+  kind: string;
+  status: string;
+  derived_label: string;
+  started_at: string | null;
+  completed_at?: string | null;
+  parent_run_id: string | null;
+  group_count: number;
+}
+
+interface JobsResponse {
+  live: JobsItem[];
+  recent: JobsItem[];
+}
+
+interface Props {
+  workspaceId: string;
+  initiativeId: string;
+  /** When false, the strip stops polling (useful for tests / hidden tabs). */
+  poll?: boolean;
+}
+
+function formatElapsed(ms: number): string {
+  if (ms < 0) return '0s';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+function relativePast(iso: string | null, now: number): string {
+  if (!iso) return '—';
+  const dt = new Date(iso + (iso.includes('T') ? '' : 'Z')).getTime();
+  const diff = now - dt;
+  if (diff < 0) return 'just now';
+  if (diff < 60_000) return `${Math.round(diff / 1000)}s ago`;
+  if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.round(diff / 3_600_000)}h ago`;
+  return `${Math.round(diff / 86_400_000)}d ago`;
+}
+
+function statusIcon(status: string): React.ReactNode {
+  switch (status) {
+    case 'queued':
+      return <CircleDashed className="w-3.5 h-3.5 text-mc-text-secondary" />;
+    case 'running':
+      return <Activity className="w-3.5 h-3.5 text-blue-500 animate-pulse" />;
+    case 'complete':
+      return <CheckCircle2 className="w-3.5 h-3.5 text-emerald-600" />;
+    case 'failed':
+      return <XCircle className="w-3.5 h-3.5 text-rose-600" />;
+    case 'cancelled':
+      return <AlertTriangle className="w-3.5 h-3.5 text-amber-500" />;
+    default:
+      return <CircleDashed className="w-3.5 h-3.5" />;
+  }
+}
+
+function kindBadge(kind: string): string {
+  // Compact kind label for the chip prefix.
+  switch (kind) {
+    case 'initiative_audit':
+      return 'audit';
+    case 'pm_chat':
+      return 'PM';
+    case 'task_coord':
+      return 'coord';
+    case 'task_role':
+      return 'role';
+    default:
+      return kind;
+  }
+}
+
+export function InitiativeRunsStrip({ workspaceId, initiativeId, poll = true }: Props) {
+  const [data, setData] = useState<JobsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    if (!workspaceId || !initiativeId) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const tick = async () => {
+      try {
+        const url = `/api/jobs?workspace_id=${encodeURIComponent(workspaceId)}&initiative_id=${encodeURIComponent(initiativeId)}`;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = (await res.json()) as JobsResponse;
+        if (cancelled) return;
+        setData(json);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled && poll) {
+          timer = setTimeout(tick, POLL_MS);
+        }
+      }
+    };
+
+    tick();
+    const elapsedTimer = setInterval(() => setNow(Date.now()), 1000);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      clearInterval(elapsedTimer);
+    };
+  }, [workspaceId, initiativeId, poll]);
+
+  if (error) {
+    return (
+      <p className="text-xs text-rose-600">
+        Couldn’t load activity: {error}
+      </p>
+    );
+  }
+
+  if (!data) {
+    return <p className="text-xs text-mc-text-secondary">Loading activity…</p>;
+  }
+
+  const live = data.live;
+  const recent = data.recent.slice(0, RECENT_LIMIT);
+
+  if (live.length === 0 && recent.length === 0) {
+    return (
+      <p className="text-xs text-mc-text-secondary">
+        No agent activity for this initiative in the last 24h.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2" data-testid="initiative-runs-strip">
+      {live.length > 0 && (
+        <ul className="flex flex-wrap gap-2">
+          {live.map((row) => {
+            const startedMs = row.started_at
+              ? new Date(row.started_at + (row.started_at.includes('T') ? '' : 'Z')).getTime()
+              : 0;
+            const elapsed = startedMs ? now - startedMs : 0;
+            const amber = elapsed > AMBER_ELAPSED_MS;
+            return (
+              <li key={row.id}>
+                <Link
+                  href={`/jobs?run=${encodeURIComponent(row.id)}`}
+                  className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs hover:bg-mc-surface-hover transition-colors ${
+                    amber
+                      ? 'border-amber-300 bg-amber-50 text-amber-900 dark:bg-amber-950/30 dark:border-amber-800 dark:text-amber-200'
+                      : 'border-blue-200 bg-blue-50 text-blue-900 dark:bg-blue-950/30 dark:border-blue-800 dark:text-blue-200'
+                  }`}
+                  title={`${row.kind} · ${row.status} · started ${row.started_at ?? 'pending'}`}
+                >
+                  {statusIcon(row.status)}
+                  <span className="font-medium">{kindBadge(row.kind)}</span>
+                  <span className="opacity-90 truncate max-w-[18ch]">{row.derived_label}</span>
+                  {startedMs > 0 && (
+                    <span className="inline-flex items-center gap-0.5 opacity-75">
+                      <Clock className="w-3 h-3" />
+                      {formatElapsed(elapsed)}
+                    </span>
+                  )}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {recent.length > 0 && (
+        <ul className="flex flex-wrap gap-2 text-xs text-mc-text-secondary">
+          {recent.map((row) => (
+            <li key={row.id}>
+              <Link
+                href={`/jobs?run=${encodeURIComponent(row.id)}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-mc-border bg-mc-surface px-2.5 py-1 hover:bg-mc-surface-hover transition-colors"
+                title={`${row.kind} · ${row.status} · ${row.completed_at ?? '—'}`}
+              >
+                {statusIcon(row.status)}
+                <span className="font-medium">{kindBadge(row.kind)}</span>
+                <span className="opacity-90 truncate max-w-[18ch]">{row.derived_label}</span>
+                <span className="opacity-75">{relativePast(row.completed_at ?? null, now)}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/lib/db/agent-runs.ts
+++ b/src/lib/db/agent-runs.ts
@@ -518,10 +518,25 @@ function deriveLabel(row: { kind: AgentRunKind; label: string | null; initiative
   }
 }
 
-export function listJobs(workspaceId: string): JobsListResponse {
+export interface ListJobsOptions {
+  /**
+   * When set, restrict live + recent buckets to runs whose
+   * `initiative_id` matches. Scheduled bucket is excluded under this
+   * filter (recurring_jobs aren't initiative-scoped today; revisit if
+   * that changes). See specs/audit-actions-and-tracking.md PR 2.
+   */
+  initiative_id?: string;
+}
+
+export function listJobs(
+  workspaceId: string,
+  options: ListJobsOptions = {},
+): JobsListResponse {
   if (!workspaceId.trim()) {
     throw new AgentRunValidationError('workspace_id is required');
   }
+
+  const initiativeFilter = options.initiative_id?.trim() || undefined;
 
   // Live: queued + running. Join initiatives.title for derived_label fallback.
   const liveRows = queryAll<RawAgentRunRow>(
@@ -529,9 +544,10 @@ export function listJobs(workspaceId: string): JobsListResponse {
        FROM agent_runs ar
        LEFT JOIN initiatives i ON i.id = ar.initiative_id
       WHERE ar.workspace_id = ?
+        ${initiativeFilter ? 'AND ar.initiative_id = ?' : ''}
         AND ar.status IN ('queued','running')
       ORDER BY ar.started_at DESC, ar.created_at DESC, ar.rowid DESC`,
-    [workspaceId],
+    initiativeFilter ? [workspaceId, initiativeFilter] : [workspaceId],
   );
 
   // Collapse pm_chat by scope_key. Other kinds pass through.
@@ -589,15 +605,22 @@ export function listJobs(workspaceId: string): JobsListResponse {
   // Scheduled: recurring_jobs active in next 24h. For rows with a
   // failure streak, attach the most recent matching failed agent_runs
   // row's error_md as `last_failure_md` for the chip tooltip (PR 3).
-  const scheduledRaw = queryAll<Omit<JobsScheduledItem, 'last_failure_md'>>(
-    `SELECT id AS job_id, name, next_run_at, last_run_at, consecutive_failures, role
-       FROM recurring_jobs
-      WHERE workspace_id = ?
-        AND status = 'active'
-        AND next_run_at <= datetime('now', '+24 hours')
-      ORDER BY next_run_at ASC`,
-    [workspaceId],
-  );
+  //
+  // When filtering by initiative_id, scheduled is suppressed —
+  // recurring_jobs aren't initiative-scoped today, and showing all of a
+  // workspace's recurring jobs on every initiative page would be noisy.
+  // If recurring_jobs grow an initiative_id column later, revisit.
+  const scheduledRaw = initiativeFilter
+    ? []
+    : queryAll<Omit<JobsScheduledItem, 'last_failure_md'>>(
+        `SELECT id AS job_id, name, next_run_at, last_run_at, consecutive_failures, role
+           FROM recurring_jobs
+          WHERE workspace_id = ?
+            AND status = 'active'
+            AND next_run_at <= datetime('now', '+24 hours')
+          ORDER BY next_run_at ASC`,
+        [workspaceId],
+      );
   const scheduled: JobsScheduledItem[] = scheduledRaw.map((row) => {
     let last_failure_md: string | null = null;
     if (row.consecutive_failures > 0) {
@@ -622,11 +645,12 @@ export function listJobs(workspaceId: string): JobsListResponse {
        FROM agent_runs ar
        LEFT JOIN initiatives i ON i.id = ar.initiative_id
       WHERE ar.workspace_id = ?
+        ${initiativeFilter ? 'AND ar.initiative_id = ?' : ''}
         AND ar.status IN ('complete','failed','cancelled')
         AND ar.completed_at >= datetime('now', '-24 hours')
       ORDER BY ar.completed_at DESC, ar.rowid DESC
       LIMIT 100`,
-    [workspaceId],
+    initiativeFilter ? [workspaceId, initiativeFilter] : [workspaceId],
   );
   const recent: JobsRecentItem[] = recentRows.map(row => ({
     id: row.id,


### PR DESCRIPTION
## Summary

Second slice of the audit-actions + run-tracking work (spec: [`specs/audit-actions-and-tracking.md`](specs/audit-actions-and-tracking.md)). Renders a compact list of agent runs touching the current initiative — live (queued/running) and recent (last 24h) — directly on `InitiativeDetailView`. Closes the **\"what did I just queue?\"** gap after refresh and gives investigations a durable surface beyond the 8–10s dispatch toast.

Stacks **independently of PR 1** — this branch is off `main`.

## Changes

**API**
- `listJobs(workspaceId, { initiative_id })` filters live + recent buckets to runs whose `initiative_id` matches.
- `GET /api/jobs?initiative_id=…` plumbed through.
- Scheduled bucket is suppressed under the filter — `recurring_jobs` aren't initiative-scoped today and would just be noise on every initiative page. If they grow an `initiative_id` column later, revisit.

**UI**
- New `<InitiativeRunsStrip>` component (`src/components/initiative/`) polls `/api/jobs?workspace_id=…&initiative_id=…` every 2s.
- Live runs render as blue pills with a status icon, kind badge, label, and live-elapsed counter. Pills flip amber after 5 min.
- Up to 3 most-recent terminal runs render as grey pills with completed-at relative time.
- Each pill links to `/jobs?run=<id>` for the existing drill-down.
- Empty state: \"No agent activity for this initiative in the last 24h.\"
- Mounted as a new \"Activity\" section above \"Notes\" on `InitiativeDetailView`.

## Test plan

- [x] `yarn test` — 809 tests, 808 pass, 1 pre-existing failure (`schedule-runner: produces a brief and advances run_count` in `src/lib/research/eval/schedule-runner.test.ts`) unrelated to this PR.
- [x] New unit test in `src/app/api/jobs/route.test.ts`: `initiative_id` filter scopes live to that initiative and zeroes out scheduled.
- [x] `npx tsc --noEmit` — no new errors.
- [x] **Preview verify** on `mission-control-dev` (:4010): seeded one running + one complete agent_run row scoped to a real initiative; both render as expected (blue pulsing pill with elapsed counter; green-check pill with \"1m ago\"); chips are clickable and link to `/jobs?run=<id>`. No console errors. Empty state also verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)