### PR TITLE
feat(audit-actions): persistent investigate confirmation panel (PR 3/6)

### DIFF
--- a/src/app/api/jobs/route.test.ts
+++ b/src/app/api/jobs/route.test.ts
@@ -101,3 +101,49 @@ test('GET /api/jobs?count_only=true: missing workspace_id → 400', async () => 
   const res = await GET(jobsReq({ count_only: 'true' }));
   assert.equal(res.status, 400);
 });
+
+test('GET /api/jobs?initiative_id=…: filters live + recent, suppresses scheduled', async () => {
+  const ws = freshWorkspace();
+  // Seed two initiatives directly.
+  const iA = `init-A-${uuidv4().slice(0, 6)}`;
+  const iB = `init-B-${uuidv4().slice(0, 6)}`;
+  for (const id of [iA, iB]) {
+    run(
+      `INSERT OR IGNORE INTO initiatives (id, workspace_id, title, status, kind, created_at, updated_at)
+       VALUES (?, ?, ?, 'planned', 'epic', datetime('now'), datetime('now'))`,
+      [id, ws, `seed ${id}`],
+    );
+  }
+
+  // 1 live audit on A, 1 live audit on B.
+  startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: `audit-A-${uuidv4()}`,
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'r1',
+    initiative_id: iA,
+  });
+  startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: `audit-B-${uuidv4()}`,
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'r2',
+    initiative_id: iB,
+  });
+
+  // Filter to A — should see only that one in live, scheduled empty.
+  const resA = await GET(jobsReq({ workspace_id: ws, initiative_id: iA }));
+  const bodyA = await resA.json();
+  assert.equal(bodyA.live.length, 1);
+  assert.equal(bodyA.live[0].initiative_id, iA);
+  assert.deepEqual(bodyA.scheduled, []);
+
+  // No filter — should see both.
+  const resAll = await GET(jobsReq({ workspace_id: ws }));
+  const bodyAll = await resAll.json();
+  assert.equal(bodyAll.live.length, 2);
+});

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -28,7 +28,11 @@ export async function GET(request: NextRequest) {
     if (searchParams.get('count_only') === 'true') {
       return NextResponse.json({ live: countLiveJobs(workspaceId) });
     }
-    return NextResponse.json(listJobs(workspaceId));
+    // Optional per-initiative filter (audit-actions PR 2). Restricts
+    // live + recent to runs touching this initiative; suppresses
+    // scheduled bucket since recurring_jobs aren't initiative-scoped.
+    const initiativeId = searchParams.get('initiative_id') ?? undefined;
+    return NextResponse.json(listJobs(workspaceId, { initiative_id: initiativeId }));
   } catch (error) {
     if (error instanceof AgentRunValidationError) {
       return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -30,6 +30,7 @@ import {
   CornerUpLeft,
   Trash2,
   Search,
+  Activity,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -39,6 +40,7 @@ import { DecomposerAgentPicker, type DecomposerOption } from '@/components/inlin
 import { InvestigatePicker, type InvestigateOption } from '@/components/inline/InvestigatePicker';
 import InvestigateModal from '@/components/InvestigateModal';
 import { NotesRail } from '@/components/notes/NotesRail';
+import { InitiativeRunsStrip } from '@/components/initiative/InitiativeRunsStrip';
 import { useAgentNotes } from '@/hooks/useAgentNotes';
 import { countPriorAudits } from '@/components/inline/investigate-helpers';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -1096,6 +1098,17 @@ or "carve out the onboarding flow as its own story first"`}
               ))}
             </ul>
           )}
+        </Section>
+
+        {/* Activity — live + recent agent_runs touching this initiative.
+            Closes the "what did I just queue?" gap after page refresh and
+            gives investigations a durable surface beyond the dispatch
+            toast. See specs/audit-actions-and-tracking.md PR 2. */}
+        <Section title="Activity" icon={<Activity className="w-4 h-4" />}>
+          <InitiativeRunsStrip
+            workspaceId={initiative.workspace_id}
+            initiativeId={initiative.id}
+          />
         </Section>
 
         {/* Notes — agent-generated observations for this initiative.

--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -1237,12 +1237,22 @@ or "carve out the onboarding flow as its own story first"`}
           mode={investigateMode}
           onClose={() => setShowInvestigateModal(false)}
           onDispatched={() => {
-            // Route is fire-and-forget; close immediately so the
-            // operator returns to the detail view and watches the
-            // NotesRail for the take_note row that lands when the
-            // researcher finishes (1–15 min). The toast inside the
-            // modal communicates dispatch success.
+            // Modal swaps to a persistent confirmation panel — DO NOT
+            // close here (audit-actions PR 3). The operator dismisses
+            // via "Done" or jumps to the Activity strip via "View
+            // activity" (handled by onViewActivity below).
+          }}
+          onViewActivity={() => {
             setShowInvestigateModal(false);
+            // Defer one frame so the modal's unmount completes before
+            // we scroll, otherwise the modal's overflow:hidden parent
+            // wins and the scroll is a no-op.
+            requestAnimationFrame(() => {
+              const heading = Array.from(
+                document.querySelectorAll('h2, h3'),
+              ).find((el) => el.textContent?.trim() === 'Activity');
+              heading?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            });
           }}
         />
       )}

--- a/src/components/InvestigateModal.tsx
+++ b/src/components/InvestigateModal.tsx
@@ -16,8 +16,14 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
-import { Search, X, Loader2 } from 'lucide-react';
-import { useToast } from '@/components/Toast';
+import {
+  Search,
+  X,
+  Loader2,
+  Activity,
+  CheckCircle2,
+  ExternalLink,
+} from 'lucide-react';
 import { buildInvestigateBody } from '@/components/inline/investigate-helpers';
 
 interface InitiativeLite {
@@ -37,6 +43,12 @@ export interface InvestigateModalProps {
   /** Audit scope. Drives radio visibility + endpoint mode. */
   mode?: 'narrow' | 'subtree';
   onClose: () => void;
+  /**
+   * Called after a successful dispatch. The modal stays open and shows
+   * a confirmation panel — the parent should NOT close the modal in
+   * response (closing happens when the operator clicks Done or
+   * View Activity).
+   */
   onDispatched: (result: {
     mode: 'narrow' | 'subtree';
     scope_key?: string;
@@ -46,6 +58,13 @@ export interface InvestigateModalProps {
     planned_layers?: number;
     concurrency?: number;
   }) => void;
+  /**
+   * Called when the operator clicks "View activity" on the confirmation
+   * panel. Parent should close the modal AND scroll the Activity strip
+   * into view (audit-actions PR 2 mounts the strip on InitiativeDetailView).
+   * If omitted, the button falls back to plain `onClose`.
+   */
+  onViewActivity?: () => void;
 }
 
 interface SubtreePlan {
@@ -55,9 +74,157 @@ interface SubtreePlan {
   per_node_timeout_ms: number;
 }
 
+/**
+ * Persistent confirmation panel shown after a successful dispatch.
+ *
+ * Polls /api/jobs filtered to this initiative every 2s and renders a
+ * compact live-status line so the operator can watch the dispatch
+ * progress without leaving the modal. The same data backs the Activity
+ * strip on InitiativeDetailView (audit-actions PR 2) — this is just an
+ * in-modal echo so the dispatch confirmation isn't a vanishing toast.
+ */
+function DispatchedPanel({
+  initiative,
+  result,
+  onRunAnother,
+}: {
+  initiative: InitiativeLite;
+  result: DispatchResult;
+  onRunAnother: () => void;
+}) {
+  interface JobsRow {
+    id: string;
+    kind: string;
+    status: string;
+    started_at: string | null;
+    completed_at?: string | null;
+    derived_label: string;
+    parent_run_id: string | null;
+  }
+  const [live, setLive] = useState<JobsRow[]>([]);
+  const [recent, setRecent] = useState<JobsRow[]>([]);
+  const [now, setNow] = useState<number>(Date.now());
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const tick = async () => {
+      try {
+        const url = `/api/jobs?workspace_id=${encodeURIComponent(initiative.workspace_id)}&initiative_id=${encodeURIComponent(initiative.id)}`;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = (await res.json()) as { live: JobsRow[]; recent: JobsRow[] };
+        if (cancelled) return;
+        setLive(json.live ?? []);
+        setRecent(json.recent ?? []);
+      } catch {
+        /* swallow — the strip on the page handles surfacing errors. */
+      } finally {
+        if (!cancelled) timer = setTimeout(tick, 2000);
+      }
+    };
+    tick();
+    const elapsedTimer = setInterval(() => setNow(Date.now()), 1000);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      clearInterval(elapsedTimer);
+    };
+  }, [initiative.id, initiative.workspace_id]);
+
+  // Filter to runs started at-or-after the dispatch we just kicked off.
+  // Belt-and-braces: scope_key alone would match too, but a parent
+  // running in subtree fanout doesn't carry the per-node scope.
+  const dispatchedAtMs = new Date(result.dispatched_at).getTime();
+  const inFlight = live.filter((r) => {
+    if (!r.started_at) return true;
+    const t = new Date(r.started_at + (r.started_at.includes('T') ? '' : 'Z')).getTime();
+    // Tolerate clock skew: include rows started up to 5s before dispatch.
+    return t >= dispatchedAtMs - 5_000;
+  });
+  const justCompleted = recent.filter((r) => {
+    if (!r.completed_at) return false;
+    const t = new Date(r.completed_at + (r.completed_at.includes('T') ? '' : 'Z')).getTime();
+    return t >= dispatchedAtMs - 5_000;
+  });
+
+  const runningCount = inFlight.filter((r) => r.status === 'running' || r.status === 'queued').length;
+  const completeCount = justCompleted.filter((r) => r.status === 'complete').length;
+  const failedCount = justCompleted.filter((r) => r.status === 'failed' || r.status === 'cancelled').length;
+
+  const summary =
+    result.mode === 'subtree'
+      ? `${result.planned_nodes} initiative${result.planned_nodes === 1 ? '' : 's'} across ${result.planned_layers} layer${result.planned_layers === 1 ? '' : 's'} (up to ${result.concurrency} parallel)`
+      : `Narrow audit, attempt ${result.attempt}`;
+
+  function elapsedSec(iso: string | null): number {
+    if (!iso) return 0;
+    const t = new Date(iso + (iso.includes('T') ? '' : 'Z')).getTime();
+    return Math.max(0, Math.round((now - t) / 1000));
+  }
+
+  return (
+    <div className="px-5 py-4 flex flex-col gap-3">
+      <div className="text-sm text-mc-text">
+        <p className="leading-snug">
+          {summary}. Activity is now visible on the initiative&apos;s detail page,
+          so a refresh won&apos;t lose it.
+        </p>
+      </div>
+
+      <div className="rounded border border-mc-border/60 bg-mc-bg/40 px-3 py-2 text-xs text-mc-text-secondary leading-relaxed">
+        {runningCount === 0 && completeCount === 0 && failedCount === 0 ? (
+          <span className="opacity-70">Waiting for the run to register…</span>
+        ) : (
+          <ul className="space-y-1">
+            <li>
+              <strong className="text-mc-text">{runningCount}</strong> running
+              {runningCount > 0 && inFlight[0]?.started_at && (
+                <span className="opacity-70">
+                  {' '}
+                  · oldest {elapsedSec(inFlight[0].started_at)}s
+                </span>
+              )}
+            </li>
+            {completeCount > 0 && (
+              <li className="text-emerald-600 dark:text-emerald-400">
+                <strong>{completeCount}</strong> complete
+              </li>
+            )}
+            {failedCount > 0 && (
+              <li className="text-rose-600 dark:text-rose-400">
+                <strong>{failedCount}</strong> failed/cancelled
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+
+      <button
+        onClick={onRunAnother}
+        className="self-start text-xs underline text-mc-text-secondary hover:text-mc-text inline-flex items-center gap-1"
+      >
+        <ExternalLink className="w-3 h-3" />
+        Run another audit
+      </button>
+    </div>
+  );
+}
+
 type Reaudit = 'fresh' | 'build_on';
 
 const GUIDANCE_MAX = 2000;
+
+interface DispatchResult {
+  mode: 'narrow' | 'subtree';
+  scope_key?: string;
+  root_scope_key?: string;
+  attempt?: number;
+  planned_nodes?: number;
+  planned_layers?: number;
+  concurrency?: number;
+  dispatched_at: string;
+}
 
 export default function InvestigateModal({
   initiative,
@@ -65,6 +232,7 @@ export default function InvestigateModal({
   mode = 'narrow',
   onClose,
   onDispatched,
+  onViewActivity,
 }: InvestigateModalProps) {
   const [reaudit, setReaudit] = useState<Reaudit>('fresh');
   const [guidance, setGuidance] = useState('');
@@ -72,7 +240,10 @@ export default function InvestigateModal({
   const [err, setErr] = useState<string | null>(null);
   const [plan, setPlan] = useState<SubtreePlan | null>(null);
   const [planErr, setPlanErr] = useState<string | null>(null);
-  const { addToast } = useToast();
+  // After a successful dispatch, the modal swaps to a persistent
+  // confirmation panel instead of closing. Operator dismisses via
+  // "Done" or jumps to the Activity strip via "View activity".
+  const [dispatched, setDispatched] = useState<DispatchResult | null>(null);
 
   // Pre-flight: when opened in subtree mode, fetch the planned-nodes /
   // planned-layers / concurrency from the dryrun endpoint so we can
@@ -150,6 +321,7 @@ export default function InvestigateModal({
           (body as { error?: string }).error || `Investigate failed (${res.status})`,
         );
       }
+      const dispatchedAt = new Date().toISOString();
       if (mode === 'subtree') {
         const { root_scope_key, planned_nodes, planned_layers, concurrency } =
           body as {
@@ -158,32 +330,29 @@ export default function InvestigateModal({
             planned_layers: number;
             concurrency: number;
           };
-        addToast({
-          type: 'success',
-          title: 'Subtree audit dispatched',
-          message: `${planned_nodes} initiative${planned_nodes === 1 ? '' : 's'} across ${planned_layers} layer${planned_layers === 1 ? '' : 's'} (up to ${concurrency} parallel). Each node’s note will appear in its own initiative’s notes panel as it lands.`,
-          duration: 10000,
-        });
-        onDispatched({
+        const result: DispatchResult = {
           mode: 'subtree',
           root_scope_key,
           planned_nodes,
           planned_layers,
           concurrency,
-        });
+          dispatched_at: dispatchedAt,
+        };
+        setDispatched(result);
+        onDispatched(result);
       } else {
         const { scope_key, attempt } = body as {
           scope_key: string;
           attempt: number;
         };
-        addToast({
-          type: 'success',
-          title: 'Audit dispatched to researcher',
-          message:
-            'Note will appear in this initiative’s notes panel when the researcher finishes (typically 1–15 min).',
-          duration: 8000,
-        });
-        onDispatched({ mode: 'narrow', scope_key, attempt });
+        const result: DispatchResult = {
+          mode: 'narrow',
+          scope_key,
+          attempt,
+          dispatched_at: dispatchedAt,
+        };
+        setDispatched(result);
+        onDispatched(result);
       }
     } catch (e) {
       setErr(e instanceof Error ? e.message : 'Investigate failed');
@@ -207,12 +376,20 @@ export default function InvestigateModal({
       >
         <header className="flex items-start justify-between gap-2 px-5 py-3 border-b border-mc-border">
           <div className="flex items-start gap-2">
-            <Search className="w-4 h-4 mt-0.5 text-mc-accent shrink-0" />
+            {dispatched ? (
+              <CheckCircle2 className="w-4 h-4 mt-0.5 text-emerald-500 shrink-0" />
+            ) : (
+              <Search className="w-4 h-4 mt-0.5 text-mc-accent shrink-0" />
+            )}
             <div className="min-w-0">
               <h2 className="text-base font-semibold leading-tight">
-                {mode === 'subtree'
-                  ? 'Investigate subtree (bottom-up)'
-                  : 'Investigate initiative'}
+                {dispatched
+                  ? mode === 'subtree'
+                    ? 'Subtree audit dispatched'
+                    : 'Audit dispatched'
+                  : mode === 'subtree'
+                    ? 'Investigate subtree (bottom-up)'
+                    : 'Investigate initiative'}
               </h2>
               <p className="text-xs text-mc-text-secondary mt-0.5 truncate" title={initiative.title}>
                 {initiative.title}
@@ -229,6 +406,16 @@ export default function InvestigateModal({
           </button>
         </header>
 
+        {dispatched ? (
+          <DispatchedPanel
+            initiative={initiative}
+            result={dispatched}
+            onRunAnother={() => {
+              setDispatched(null);
+              setErr(null);
+            }}
+          />
+        ) : (
         <div className="px-5 py-4 flex flex-col gap-4">
           {err && (
             <div
@@ -333,30 +520,53 @@ export default function InvestigateModal({
             </p>
           )}
         </div>
+        )}
 
         <footer className="border-t border-mc-border px-5 py-3 flex justify-end gap-2">
-          <button
-            onClick={onClose}
-            disabled={submitting}
-            className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm disabled:opacity-50"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={submit}
-            disabled={submitting}
-            className="inline-flex items-center gap-1.5 px-3 py-2 rounded bg-mc-accent text-white text-sm disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {submitting ? (
-              <>
-                <Loader2 className="w-3.5 h-3.5 animate-spin" /> Dispatching…
-              </>
-            ) : (
-              <>
-                <Search className="w-3.5 h-3.5" /> Investigate
-              </>
-            )}
-          </button>
+          {dispatched ? (
+            <>
+              <button
+                onClick={onClose}
+                className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm"
+              >
+                Done
+              </button>
+              <button
+                onClick={() => {
+                  if (onViewActivity) onViewActivity();
+                  else onClose();
+                }}
+                className="inline-flex items-center gap-1.5 px-3 py-2 rounded bg-mc-accent text-white text-sm"
+              >
+                <Activity className="w-3.5 h-3.5" /> View activity
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={onClose}
+                disabled={submitting}
+                className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={submit}
+                disabled={submitting}
+                className="inline-flex items-center gap-1.5 px-3 py-2 rounded bg-mc-accent text-white text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {submitting ? (
+                  <>
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" /> Dispatching…
+                  </>
+                ) : (
+                  <>
+                    <Search className="w-3.5 h-3.5" /> Investigate
+                  </>
+                )}
+              </button>
+            </>
+          )}
         </footer>
       </div>
     </div>

--- a/src/components/initiative/InitiativeRunsStrip.tsx
+++ b/src/components/initiative/InitiativeRunsStrip.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+/**
+ * Per-initiative in-flight strip.
+ *
+ * Polls `/api/jobs?workspace_id=…&initiative_id=…` every 2s and renders
+ * a compact horizontal list of agent_runs touching this initiative —
+ * audit, plan, decompose, etc. Closes the "what did I just queue?" gap
+ * after a refresh, and the "where will the result land?" gap on dispatch.
+ *
+ * Shows:
+ *  - All live (queued + running) runs for this initiative.
+ *  - Up to 3 most-recent terminal runs from the last 24h.
+ *
+ * Each row links into `/jobs?run=<id>` for the existing drill-down panel.
+ *
+ * See specs/audit-actions-and-tracking.md PR 2.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  Activity,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  CircleDashed,
+} from 'lucide-react';
+
+const POLL_MS = 2000;
+const AMBER_ELAPSED_MS = 5 * 60 * 1000;
+const RECENT_LIMIT = 3;
+
+interface JobsItem {
+  id: string;
+  kind: string;
+  status: string;
+  derived_label: string;
+  started_at: string | null;
+  completed_at?: string | null;
+  parent_run_id: string | null;
+  group_count: number;
+}
+
+interface JobsResponse {
+  live: JobsItem[];
+  recent: JobsItem[];
+}
+
+interface Props {
+  workspaceId: string;
+  initiativeId: string;
+  /** When false, the strip stops polling (useful for tests / hidden tabs). */
+  poll?: boolean;
+}
+
+function formatElapsed(ms: number): string {
+  if (ms < 0) return '0s';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+function relativePast(iso: string | null, now: number): string {
+  if (!iso) return '—';
+  const dt = new Date(iso + (iso.includes('T') ? '' : 'Z')).getTime();
+  const diff = now - dt;
+  if (diff < 0) return 'just now';
+  if (diff < 60_000) return `${Math.round(diff / 1000)}s ago`;
+  if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.round(diff / 3_600_000)}h ago`;
+  return `${Math.round(diff / 86_400_000)}d ago`;
+}
+
+function statusIcon(status: string): React.ReactNode {
+  switch (status) {
+    case 'queued':
+      return <CircleDashed className="w-3.5 h-3.5 text-mc-text-secondary" />;
+    case 'running':
+      return <Activity className="w-3.5 h-3.5 text-blue-500 animate-pulse" />;
+    case 'complete':
+      return <CheckCircle2 className="w-3.5 h-3.5 text-emerald-600" />;
+    case 'failed':
+      return <XCircle className="w-3.5 h-3.5 text-rose-600" />;
+    case 'cancelled':
+      return <AlertTriangle className="w-3.5 h-3.5 text-amber-500" />;
+    default:
+      return <CircleDashed className="w-3.5 h-3.5" />;
+  }
+}
+
+function kindBadge(kind: string): string {
+  // Compact kind label for the chip prefix.
+  switch (kind) {
+    case 'initiative_audit':
+      return 'audit';
+    case 'pm_chat':
+      return 'PM';
+    case 'task_coord':
+      return 'coord';
+    case 'task_role':
+      return 'role';
+    default:
+      return kind;
+  }
+}
+
+export function InitiativeRunsStrip({ workspaceId, initiativeId, poll = true }: Props) {
+  const [data, setData] = useState<JobsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    if (!workspaceId || !initiativeId) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const tick = async () => {
+      try {
+        const url = `/api/jobs?workspace_id=${encodeURIComponent(workspaceId)}&initiative_id=${encodeURIComponent(initiativeId)}`;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = (await res.json()) as JobsResponse;
+        if (cancelled) return;
+        setData(json);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled && poll) {
+          timer = setTimeout(tick, POLL_MS);
+        }
+      }
+    };
+
+    tick();
+    const elapsedTimer = setInterval(() => setNow(Date.now()), 1000);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      clearInterval(elapsedTimer);
+    };
+  }, [workspaceId, initiativeId, poll]);
+
+  if (error) {
+    return (
+      <p className="text-xs text-rose-600">
+        Couldn’t load activity: {error}
+      </p>
+    );
+  }
+
+  if (!data) {
+    return <p className="text-xs text-mc-text-secondary">Loading activity…</p>;
+  }
+
+  const live = data.live;
+  const recent = data.recent.slice(0, RECENT_LIMIT);
+
+  if (live.length === 0 && recent.length === 0) {
+    return (
+      <p className="text-xs text-mc-text-secondary">
+        No agent activity for this initiative in the last 24h.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2" data-testid="initiative-runs-strip">
+      {live.length > 0 && (
+        <ul className="flex flex-wrap gap-2">
+          {live.map((row) => {
+            const startedMs = row.started_at
+              ? new Date(row.started_at + (row.started_at.includes('T') ? '' : 'Z')).getTime()
+              : 0;
+            const elapsed = startedMs ? now - startedMs : 0;
+            const amber = elapsed > AMBER_ELAPSED_MS;
+            return (
+              <li key={row.id}>
+                <Link
+                  href={`/jobs?run=${encodeURIComponent(row.id)}`}
+                  className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs hover:bg-mc-surface-hover transition-colors ${
+                    amber
+                      ? 'border-amber-300 bg-amber-50 text-amber-900 dark:bg-amber-950/30 dark:border-amber-800 dark:text-amber-200'
+                      : 'border-blue-200 bg-blue-50 text-blue-900 dark:bg-blue-950/30 dark:border-blue-800 dark:text-blue-200'
+                  }`}
+                  title={`${row.kind} · ${row.status} · started ${row.started_at ?? 'pending'}`}
+                >
+                  {statusIcon(row.status)}
+                  <span className="font-medium">{kindBadge(row.kind)}</span>
+                  <span className="opacity-90 truncate max-w-[18ch]">{row.derived_label}</span>
+                  {startedMs > 0 && (
+                    <span className="inline-flex items-center gap-0.5 opacity-75">
+                      <Clock className="w-3 h-3" />
+                      {formatElapsed(elapsed)}
+                    </span>
+                  )}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {recent.length > 0 && (
+        <ul className="flex flex-wrap gap-2 text-xs text-mc-text-secondary">
+          {recent.map((row) => (
+            <li key={row.id}>
+              <Link
+                href={`/jobs?run=${encodeURIComponent(row.id)}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-mc-border bg-mc-surface px-2.5 py-1 hover:bg-mc-surface-hover transition-colors"
+                title={`${row.kind} · ${row.status} · ${row.completed_at ?? '—'}`}
+              >
+                {statusIcon(row.status)}
+                <span className="font-medium">{kindBadge(row.kind)}</span>
+                <span className="opacity-90 truncate max-w-[18ch]">{row.derived_label}</span>
+                <span className="opacity-75">{relativePast(row.completed_at ?? null, now)}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/lib/db/agent-runs.ts
+++ b/src/lib/db/agent-runs.ts
@@ -518,10 +518,25 @@ function deriveLabel(row: { kind: AgentRunKind; label: string | null; initiative
   }
 }
 
-export function listJobs(workspaceId: string): JobsListResponse {
+export interface ListJobsOptions {
+  /**
+   * When set, restrict live + recent buckets to runs whose
+   * `initiative_id` matches. Scheduled bucket is excluded under this
+   * filter (recurring_jobs aren't initiative-scoped today; revisit if
+   * that changes). See specs/audit-actions-and-tracking.md PR 2.
+   */
+  initiative_id?: string;
+}
+
+export function listJobs(
+  workspaceId: string,
+  options: ListJobsOptions = {},
+): JobsListResponse {
   if (!workspaceId.trim()) {
     throw new AgentRunValidationError('workspace_id is required');
   }
+
+  const initiativeFilter = options.initiative_id?.trim() || undefined;
 
   // Live: queued + running. Join initiatives.title for derived_label fallback.
   const liveRows = queryAll<RawAgentRunRow>(
@@ -529,9 +544,10 @@ export function listJobs(workspaceId: string): JobsListResponse {
        FROM agent_runs ar
        LEFT JOIN initiatives i ON i.id = ar.initiative_id
       WHERE ar.workspace_id = ?
+        ${initiativeFilter ? 'AND ar.initiative_id = ?' : ''}
         AND ar.status IN ('queued','running')
       ORDER BY ar.started_at DESC, ar.created_at DESC, ar.rowid DESC`,
-    [workspaceId],
+    initiativeFilter ? [workspaceId, initiativeFilter] : [workspaceId],
   );
 
   // Collapse pm_chat by scope_key. Other kinds pass through.
@@ -589,15 +605,22 @@ export function listJobs(workspaceId: string): JobsListResponse {
   // Scheduled: recurring_jobs active in next 24h. For rows with a
   // failure streak, attach the most recent matching failed agent_runs
   // row's error_md as `last_failure_md` for the chip tooltip (PR 3).
-  const scheduledRaw = queryAll<Omit<JobsScheduledItem, 'last_failure_md'>>(
-    `SELECT id AS job_id, name, next_run_at, last_run_at, consecutive_failures, role
-       FROM recurring_jobs
-      WHERE workspace_id = ?
-        AND status = 'active'
-        AND next_run_at <= datetime('now', '+24 hours')
-      ORDER BY next_run_at ASC`,
-    [workspaceId],
-  );
+  //
+  // When filtering by initiative_id, scheduled is suppressed —
+  // recurring_jobs aren't initiative-scoped today, and showing all of a
+  // workspace's recurring jobs on every initiative page would be noisy.
+  // If recurring_jobs grow an initiative_id column later, revisit.
+  const scheduledRaw = initiativeFilter
+    ? []
+    : queryAll<Omit<JobsScheduledItem, 'last_failure_md'>>(
+        `SELECT id AS job_id, name, next_run_at, last_run_at, consecutive_failures, role
+           FROM recurring_jobs
+          WHERE workspace_id = ?
+            AND status = 'active'
+            AND next_run_at <= datetime('now', '+24 hours')
+          ORDER BY next_run_at ASC`,
+        [workspaceId],
+      );
   const scheduled: JobsScheduledItem[] = scheduledRaw.map((row) => {
     let last_failure_md: string | null = null;
     if (row.consecutive_failures > 0) {
@@ -622,11 +645,12 @@ export function listJobs(workspaceId: string): JobsListResponse {
        FROM agent_runs ar
        LEFT JOIN initiatives i ON i.id = ar.initiative_id
       WHERE ar.workspace_id = ?
+        ${initiativeFilter ? 'AND ar.initiative_id = ?' : ''}
         AND ar.status IN ('complete','failed','cancelled')
         AND ar.completed_at >= datetime('now', '-24 hours')
       ORDER BY ar.completed_at DESC, ar.rowid DESC
       LIMIT 100`,
-    [workspaceId],
+    initiativeFilter ? [workspaceId, initiativeFilter] : [workspaceId],
   );
   const recent: JobsRecentItem[] = recentRows.map(row => ({
     id: row.id,


### PR DESCRIPTION
## Summary

Third slice of the audit-actions + run-tracking work (spec: [`specs/audit-actions-and-tracking.md`](specs/audit-actions-and-tracking.md)). Replaces the disappearing 8-10s dispatch toast with an in-modal confirmation panel that sticks until the operator dismisses it, with live dispatch status updating in place.

**Stacked on [PR 2](https://github.com/smb209/mission-control/pull/252)** — needs the Activity strip to scroll to.

## Changes

**InvestigateModal**
- After a successful dispatch, the form is replaced by a `<DispatchedPanel>` showing:
  - "Audit dispatched" header (green check)
  - Mode summary: `Narrow audit, attempt 3` / `5 initiatives across 3 layers (up to 3 parallel)`
  - Live status, polled every 2s from `/api/jobs?initiative_id=…`: running count + oldest elapsed, complete count, failed count.
  - "Run another audit" link that resets the form.
- Footer buttons swap from `Cancel / Investigate` to `Done / View activity` after dispatch.
- Drops the in-modal toast — it was redundant with the persistent panel.

**InitiativeDetailView**
- Adds `onViewActivity` callback that closes the modal and smooth-scrolls the Activity strip (PR 2) into view.
- The `onDispatched` callback no longer auto-closes the modal — closing is now intentional, via Done or View activity.

## Test plan

- [x] `yarn test` — 809/810 pass; only pre-existing `schedule-runner` failure unrelated to this PR.
- [x] `npx tsc --noEmit` — no new errors.
- [x] **Preview verify** on `mission-control-dev` (:4010):
  - Opened Investigate modal on a real initiative → form rendered.
  - Clicked Investigate → form swapped to confirmation panel showing \"Narrow audit, attempt 1. Activity is now visible … so a refresh won't lose it.\" and \"1 running · oldest 8s\".
  - Clicked View activity → modal closed and the page smooth-scrolled to the Activity section, showing the live audit pill.
  - No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)