### PR TITLE
feat(audit-actions): note actions UI — archive, restore, delete (PR 4/6)

### DIFF
--- a/specs/audit-actions-and-tracking.md
+++ b/specs/audit-actions-and-tracking.md
@@ -1,0 +1,118 @@
+# Audit Actions & Per-Initiative Run Tracking
+
+Two pain points, one spec because they share surfaces (NoteCard, InvestigateModal, agent_runs):
+
+1. **Audits/notes have no clear next action.** They land in NotesRail and in PM-chat
+   context, both inert. Operator can't archive, correct, delete, or hand off to PM.
+2. **Investigate has no progress tracking.** Toast disappears in 8–10 s; on refresh
+   the operator can't recall what they queued or see where it'll land.
+
+## What we're not changing
+
+- `agent_runs` schema (the jobs spine — already has `initiative_id`, `scope_key`,
+  `kind`, `status`, lifecycle helpers; see `specs/jobs-in-progress.md`).
+- `agent_notes` schema (`archived_at`/`archived_reason` already present from
+  migration 065). We only add a hard-delete DAO and routes.
+- `/jobs` page (we link to it; we don't refactor it).
+- `propose_from_notes` MCP tool's existing call shape (we add an optional
+  `note_ids` arg, no breaking change).
+
+## Slices (stacked PRs against `smb209/mission-control:main`)
+
+### PR 1 — Note lifecycle DAO + HTTP routes
+**Scope:** add `restoreNote()` and `hardDeleteNote()` to `src/lib/db/agent-notes.ts`.
+Add HTTP surface that the UI can call:
+- `POST /api/agent-notes/:id/archive` (body: `{ reason?: string }`)
+- `POST /api/agent-notes/:id/restore`
+- `DELETE /api/agent-notes/:id` (hard delete; requires the note to be archived first
+  so destructive actions are gated by a two-step intent)
+
+**Why two-step:** mirrors the trash metaphor — archive first, then delete from trash.
+Prevents accidental loss when an audit is mid-review.
+
+**Tests:** unit tests in `agent-notes.test.ts` for the new DAO calls; route tests
+under `src/app/api/agent-notes/__tests__/` for the three HTTP verbs.
+
+### PR 2 — Per-initiative in-flight strip
+**Scope:** extend `listJobs()` and `GET /api/jobs` to accept optional
+`initiative_id` query param. When set, all three buckets filter to runs whose
+`initiative_id` matches (live + recent) or whose recurring job is scoped to that
+initiative (scheduled — best-effort; out-of-scope OK if it complicates).
+
+Build `<InitiativeRunsStrip>` (new component under `src/components/initiative/`)
+that polls `/api/jobs?workspace_id=…&initiative_id=…` every 2 s and renders a
+compact horizontal strip above NotesRail showing live + most-recent terminal
+runs. Each row: kind badge, label, elapsed (live) / completed-at (recent),
+status, link to `/jobs?run=<id>`.
+
+Mount on `InitiativeDetailView` between header and NotesRail.
+
+### PR 3 — Persistent Investigate confirmation
+**Scope:** `POST /api/initiatives/:id/investigate` already returns scope_key +
+timestamp; extend the JSON to also return `run_id` (or `run_ids` for subtree
+fanout) so the modal can navigate to specific rows in the strip.
+
+In `InvestigateModal`, replace the disappearing toast with an inline persistent
+result card under the Investigate button. Card shows: dispatch summary (1 narrow
+run / N subtree runs), elapsed time (live polled), "view in Jobs" link, and
+"dismiss" button. Card persists until dismissed or initiative is unmounted.
+
+Side effect: even after refresh, the strip from PR 2 already shows the dispatch.
+PR 3's card is the in-modal echo; PR 2 is the durable surface.
+
+### PR 4 — Note actions UI (archive, delete, trash view)
+**Scope:** add an action row to `NoteCard` with buttons:
+- **Archive** → `POST /api/agent-notes/:id/archive`. Optimistic update in hook.
+- **Restore** (only when archived) → `POST /api/agent-notes/:id/restore`.
+- **Delete** (only when archived) → `DELETE /api/agent-notes/:id`, behind
+  `ConfirmDialog` (per project rule: no native `window.confirm`). `destructive`
+  styling.
+
+`NotesRail` gets a "Show archived" toggle. When on, the rail fetches with
+`include_archived=true` and renders archived notes dimmed at the bottom of the
+list. This is the "trash can" view.
+
+Mirror these buttons in PM-chat-rendered notes (later PR; out of scope if PM chat
+doesn't render audit notes as cards today — leave a TODO).
+
+### PR 5 — Ask-PM handoff (note → PM proposal)
+**Scope:** extend the `propose_from_notes` MCP tool input schema to accept
+optional `note_ids: string[]` (defaults to current behavior of "all unconsumed
+notes" when absent). When provided, the PM intake prompt is grounded only in
+those notes.
+
+Add an "Ask PM to propose" button to `NoteCard` (only when `kind === 'observation'`
+per the locked tradeoff). Button calls a new
+`POST /api/initiatives/:id/ask-pm-from-notes` route which dispatches the PM with
+`trigger_kind='notes_intake'` and `note_ids=[noteId]`.
+
+The resulting PM run shows in the in-flight strip from PR 2 — closes the loop.
+
+### PR 6 — Note ↔ run linkage chip
+**Scope:** `agent_notes.scope_key` already joins to `agent_runs.scope_key`.
+Add a server-side join in the `/api/agent-notes` payload (or a sibling endpoint
+if join cost matters) that returns `originating_run_kind` + `originating_run_status`.
+Render a small chip on `NoteCard` ("from Audit · complete") that links to the
+`/jobs?run=<id>` drill-down.
+
+## Verification
+
+For each PR, follow the project verify pattern:
+1. `yarn typecheck` + `yarn test` (relevant slices) — inventory pre-existing
+   failures up-front per CLAUDE.md.
+2. For UI changes, `preview_eval` on `mission-control-dev` (running on :4010)
+   exercising the touched flow, then `preview_logs` for runtime errors.
+3. PR body uses `## Summary` / `## Changes` / `## Test plan`; target
+   `smb209/mission-control` with explicit `--repo` per project rules.
+
+## Out of scope (named so we don't drift)
+
+- Editing note bodies inline. The "Correct" button I'd originally proposed in
+  the plan turned into a fork: either edit-in-place (heavy: needs a new column /
+  audit log) or store an amendment as a child note (lightweight). Both are
+  valuable but neither is on the critical path for "no next action." Leave for a
+  follow-up; "Ask PM" + archive cover the immediate need.
+- PM-chat note rendering parity. PM chat surfaces note text inside the
+  conversation transcript, not as discrete cards; making chat-rendered notes
+  actionable is a separate UX problem.
+- SSE upgrade for the in-flight strip. 2 s polling matches `/jobs` page.

--- a/src/app/api/agent-notes/[id]/archive/route.test.ts
+++ b/src/app/api/agent-notes/[id]/archive/route.test.ts
@@ -1,0 +1,108 @@
+/**
+ * POST /api/agent-notes/:id/archive route tests.
+ *
+ * See specs/audit-actions-and-tracking.md PR 1.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { run } from '@/lib/db';
+import { createNote, getNote } from '@/lib/db/agent-notes';
+
+function freshWorkspace(): string {
+  const id = `ws-note-arc-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function makeNote(workspaceId: string) {
+  return createNote({
+    workspace_id: workspaceId,
+    agent_id: null,
+    scope_key: `scope-${uuidv4()}`,
+    role: 'researcher',
+    run_group_id: `rg-${uuidv4()}`,
+    kind: 'observation',
+    body: 'something audit-worthy',
+  });
+}
+
+function archiveReq(
+  id: string,
+  body?: unknown,
+): { req: NextRequest; ctx: { params: Promise<{ id: string }> } } {
+  const url = new URL(`http://localhost/api/agent-notes/${id}/archive`);
+  const bodyText =
+    body === undefined
+      ? undefined
+      : typeof body === 'string'
+        ? body
+        : JSON.stringify(body);
+  const init: { method: string; body?: string; headers?: Record<string, string> } = {
+    method: 'POST',
+  };
+  if (bodyText !== undefined) {
+    init.body = bodyText;
+    init.headers = { 'content-type': 'application/json' };
+  }
+  return {
+    req: new NextRequest(url, init),
+    ctx: { params: Promise.resolve({ id }) },
+  };
+}
+
+test('POST archive: missing note → 404', async () => {
+  const { req, ctx } = archiveReq('nope-' + uuidv4());
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 404);
+});
+
+test('POST archive: sets archived_at + archived_reason', async () => {
+  const ws = freshWorkspace();
+  const note = makeNote(ws);
+  const { req, ctx } = archiveReq(note.id, { reason: 'no longer relevant' });
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.ok(body.note.archived_at);
+  assert.equal(body.note.archived_reason, 'no longer relevant');
+});
+
+test('POST archive: empty body is tolerated', async () => {
+  const ws = freshWorkspace();
+  const note = makeNote(ws);
+  const { req, ctx } = archiveReq(note.id);
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.ok(body.note.archived_at);
+  assert.equal(body.note.archived_reason, null);
+});
+
+test('POST archive: idempotent on already-archived note', async () => {
+  const ws = freshWorkspace();
+  const note = makeNote(ws);
+  // First archive.
+  const r1 = archiveReq(note.id, { reason: 'first' });
+  await POST(r1.req, r1.ctx);
+  const firstReason = getNote(note.id)?.archived_reason;
+  // Second archive — DAO is idempotent (first reason wins).
+  const r2 = archiveReq(note.id, { reason: 'second' });
+  const res2 = await POST(r2.req, r2.ctx);
+  assert.equal(res2.status, 200);
+  assert.equal(getNote(note.id)?.archived_reason, firstReason);
+});
+
+test('POST archive: invalid JSON body → 400', async () => {
+  const ws = freshWorkspace();
+  const note = makeNote(ws);
+  const { req, ctx } = archiveReq(note.id, '{not json');
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 400);
+});

--- a/src/app/api/agent-notes/[id]/archive/route.ts
+++ b/src/app/api/agent-notes/[id]/archive/route.ts
@@ -1,0 +1,60 @@
+/**
+ * POST /api/agent-notes/:id/archive
+ *
+ * Soft-archive a note from the operator UI. Mirrors the MCP `archive_note`
+ * tool but without the agent-auth path — operator action over HTTP.
+ *
+ * Idempotent: archiving an already-archived note returns the existing row.
+ * Body (optional): `{ reason?: string }`.
+ *
+ * See specs/audit-actions-and-tracking.md PR 1.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { archiveNote, getNote } from '@/lib/db/agent-notes';
+import { broadcast } from '@/lib/events';
+
+export const dynamic = 'force-dynamic';
+
+interface ArchiveBody {
+  reason?: string | null;
+}
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+
+  const existing = getNote(id);
+  if (!existing) {
+    return NextResponse.json({ error: 'note not found' }, { status: 404 });
+  }
+
+  let body: ArchiveBody = {};
+  try {
+    // Body is optional; tolerate empty / non-JSON.
+    const text = await request.text();
+    if (text.trim()) body = JSON.parse(text) as ArchiveBody;
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  const reason = typeof body.reason === 'string' ? body.reason : null;
+  const updated = archiveNote(id, reason);
+  if (!updated) {
+    return NextResponse.json({ error: 'archive failed' }, { status: 500 });
+  }
+
+  broadcast({
+    type: 'agent_note_archived',
+    payload: {
+      note_id: updated.id,
+      workspace_id: updated.workspace_id,
+      reason: updated.archived_reason,
+      archived_at: updated.archived_at,
+    },
+  });
+
+  return NextResponse.json({ note: updated });
+}

--- a/src/app/api/agent-notes/[id]/restore/route.test.ts
+++ b/src/app/api/agent-notes/[id]/restore/route.test.ts
@@ -1,0 +1,71 @@
+/**
+ * POST /api/agent-notes/:id/restore route tests.
+ *
+ * See specs/audit-actions-and-tracking.md PR 1.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { run } from '@/lib/db';
+import { archiveNote, createNote } from '@/lib/db/agent-notes';
+
+function freshWorkspace(): string {
+  const id = `ws-note-res-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function makeNote(workspaceId: string) {
+  return createNote({
+    workspace_id: workspaceId,
+    agent_id: null,
+    scope_key: `scope-${uuidv4()}`,
+    role: 'researcher',
+    run_group_id: `rg-${uuidv4()}`,
+    kind: 'observation',
+    body: 'audit recap',
+  });
+}
+
+function restoreReq(id: string): { req: NextRequest; ctx: { params: Promise<{ id: string }> } } {
+  const url = new URL(`http://localhost/api/agent-notes/${id}/restore`);
+  return {
+    req: new NextRequest(url, { method: 'POST' }),
+    ctx: { params: Promise.resolve({ id }) },
+  };
+}
+
+test('POST restore: missing note → 404', async () => {
+  const { req, ctx } = restoreReq('nope-' + uuidv4());
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 404);
+});
+
+test('POST restore: clears archived_at and archived_reason', async () => {
+  const ws = freshWorkspace();
+  const note = makeNote(ws);
+  archiveNote(note.id, 'temporarily');
+
+  const { req, ctx } = restoreReq(note.id);
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.note.archived_at, null);
+  assert.equal(body.note.archived_reason, null);
+});
+
+test('POST restore: no-op on already-active note', async () => {
+  const ws = freshWorkspace();
+  const note = makeNote(ws);
+  const { req, ctx } = restoreReq(note.id);
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.note.archived_at, null);
+});

--- a/src/app/api/agent-notes/[id]/restore/route.ts
+++ b/src/app/api/agent-notes/[id]/restore/route.ts
@@ -1,0 +1,41 @@
+/**
+ * POST /api/agent-notes/:id/restore
+ *
+ * Un-archive a note. No-op if the note is already active. Returns 404
+ * if the note doesn't exist.
+ *
+ * See specs/audit-actions-and-tracking.md PR 1.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getNote, restoreNote } from '@/lib/db/agent-notes';
+import { broadcast } from '@/lib/events';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  _request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+
+  const existing = getNote(id);
+  if (!existing) {
+    return NextResponse.json({ error: 'note not found' }, { status: 404 });
+  }
+
+  const updated = restoreNote(id);
+  if (!updated) {
+    return NextResponse.json({ error: 'restore failed' }, { status: 500 });
+  }
+
+  broadcast({
+    type: 'agent_note_restored',
+    payload: {
+      note_id: updated.id,
+      workspace_id: updated.workspace_id,
+    },
+  });
+
+  return NextResponse.json({ note: updated });
+}

--- a/src/app/api/agent-notes/[id]/route.test.ts
+++ b/src/app/api/agent-notes/[id]/route.test.ts
@@ -1,0 +1,79 @@
+/**
+ * /api/agent-notes/[id] route tests — hard-delete (DELETE) only.
+ *
+ * Archive + restore live in sibling route.test.ts files because Next's
+ * route handler files are co-located one-per-verb-cluster.
+ *
+ * See specs/audit-actions-and-tracking.md PR 1.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { DELETE } from './route';
+import { run, queryOne } from '@/lib/db';
+import { archiveNote, createNote, getNote } from '@/lib/db/agent-notes';
+
+function freshWorkspace(): string {
+  const id = `ws-note-del-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function makeNote(workspaceId: string) {
+  return createNote({
+    workspace_id: workspaceId,
+    agent_id: null,
+    scope_key: `scope-${uuidv4()}`,
+    role: 'researcher',
+    run_group_id: `rg-${uuidv4()}`,
+    kind: 'observation',
+    body: 'audit said something',
+  });
+}
+
+function delReq(id: string): { req: NextRequest; ctx: { params: Promise<{ id: string }> } } {
+  const url = new URL(`http://localhost/api/agent-notes/${id}`);
+  return {
+    req: new NextRequest(url, { method: 'DELETE' }),
+    ctx: { params: Promise.resolve({ id }) },
+  };
+}
+
+test('DELETE: missing note → 404', async () => {
+  const { req, ctx } = delReq('nope-' + uuidv4());
+  const res = await DELETE(req, ctx);
+  assert.equal(res.status, 404);
+});
+
+test('DELETE: active note → 409 (archive-first gate)', async () => {
+  const ws = freshWorkspace();
+  const note = makeNote(ws);
+  const { req, ctx } = delReq(note.id);
+  const res = await DELETE(req, ctx);
+  assert.equal(res.status, 409);
+  // Row must still exist.
+  assert.ok(getNote(note.id), 'row should not be deleted');
+});
+
+test('DELETE: archived note → 200, row gone', async () => {
+  const ws = freshWorkspace();
+  const note = makeNote(ws);
+  archiveNote(note.id, 'cleanup');
+
+  const { req, ctx } = delReq(note.id);
+  const res = await DELETE(req, ctx);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+
+  const after = queryOne<{ n: number }>(
+    `SELECT COUNT(*) AS n FROM agent_notes WHERE id = ?`,
+    [note.id],
+  );
+  assert.equal(after?.n, 0);
+});

--- a/src/app/api/agent-notes/[id]/route.ts
+++ b/src/app/api/agent-notes/[id]/route.ts
@@ -1,0 +1,58 @@
+/**
+ * DELETE /api/agent-notes/:id
+ *
+ * Hard-delete a note. The note MUST be archived first (two-step intent —
+ * archive, then empty-the-trash). Returns 409 if the note is still active.
+ *
+ * UI must gate this behind `ConfirmDialog destructive` per project
+ * convention. See specs/audit-actions-and-tracking.md PR 1.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  AgentNoteNotArchivedError,
+  getNote,
+  hardDeleteNote,
+} from '@/lib/db/agent-notes';
+import { broadcast } from '@/lib/events';
+
+export const dynamic = 'force-dynamic';
+
+export async function DELETE(
+  _request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+
+  const existing = getNote(id);
+  if (!existing) {
+    return NextResponse.json({ error: 'note not found' }, { status: 404 });
+  }
+
+  try {
+    const ok = hardDeleteNote(id);
+    if (!ok) {
+      // Race: existed at the GET above, gone by the DELETE. Treat as
+      // already-deleted success rather than a 500.
+      return NextResponse.json({ ok: true, already_deleted: true });
+    }
+  } catch (err) {
+    if (err instanceof AgentNoteNotArchivedError) {
+      return NextResponse.json(
+        { error: 'note must be archived before delete' },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+
+  broadcast({
+    type: 'agent_note_deleted',
+    payload: {
+      note_id: id,
+      workspace_id: existing.workspace_id,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/notes/NoteCard.tsx
+++ b/src/components/notes/NoteCard.tsx
@@ -3,8 +3,15 @@
 /**
  * Single agent_notes record rendered as a card. Used by NotesRail and
  * the workspace /feed page. See specs/scope-keyed-sessions.md §3.6.
+ *
+ * Audit-actions PR 4 adds operator action buttons: archive (active →
+ * archived), restore (archived → active), delete (archived → gone).
+ * Buttons are gated by callbacks — when omitted, the card renders
+ * read-only as before, so /feed and other consumers don't surface
+ * actions until they opt in.
  */
 
+import { Archive, RotateCcw, Trash2 } from 'lucide-react';
 import type { AgentNoteRecord, AgentNoteKind } from '@/hooks/useAgentNotes';
 
 const KIND_COLOR: Record<AgentNoteKind, string> = {
@@ -53,9 +60,18 @@ function formatTime(iso: string): string {
 
 interface NoteCardProps {
   note: AgentNoteRecord;
+  /** Called when the operator clicks Archive on an active note. */
+  onArchive?: (note: AgentNoteRecord) => void;
+  /** Called when the operator clicks Restore on an archived note. */
+  onRestore?: (note: AgentNoteRecord) => void;
+  /** Called when the operator clicks Delete on an archived note. The
+   *  caller is expected to confirm via ConfirmDialog before issuing
+   *  the destructive request. */
+  onDelete?: (note: AgentNoteRecord) => void;
 }
 
-export function NoteCard({ note }: NoteCardProps) {
+export function NoteCard({ note, onArchive, onRestore, onDelete }: NoteCardProps) {
+  const archived = !!note.archived_at;
   const kindClasses = `${KIND_COLOR[note.kind]} ${KIND_DARK[note.kind]}`;
   const importancePin =
     note.importance === 2
@@ -64,16 +80,24 @@ export function NoteCard({ note }: NoteCardProps) {
         ? '🔔 '
         : '';
 
+  const hasActions = !!(onArchive || onRestore || onDelete);
+
   return (
     <article
-      className={`rounded-lg border ${kindClasses} px-3 py-2 text-sm space-y-1`}
+      className={`rounded-lg border ${kindClasses} ${archived ? 'opacity-60' : ''} px-3 py-2 text-sm space-y-1`}
       data-note-id={note.id}
       data-note-kind={note.kind}
+      data-note-archived={archived ? 'true' : 'false'}
     >
       <header className="flex items-center justify-between gap-2 text-xs opacity-80">
         <span className="font-medium">
           {importancePin}
           {KIND_LABEL[note.kind]} · {note.role}
+          {archived && (
+            <span className="ml-1.5 px-1 py-0.5 rounded bg-black/10 dark:bg-white/10 text-[10px] uppercase tracking-wide">
+              archived
+            </span>
+          )}
         </span>
         <time dateTime={note.created_at} title={note.created_at}>
           {formatTime(note.created_at)}
@@ -94,6 +118,43 @@ export function NoteCard({ note }: NoteCardProps) {
       )}
       {note.audience && (
         <p className="text-[11px] opacity-70">→ for {note.audience}</p>
+      )}
+      {hasActions && (
+        <div className="flex flex-wrap items-center gap-1.5 pt-1.5 mt-1.5 border-t border-current/10">
+          {!archived && onArchive && (
+            <button
+              type="button"
+              onClick={() => onArchive(note)}
+              className="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10"
+              aria-label="Archive note"
+              title="Archive — hides from default views; reversible"
+            >
+              <Archive className="w-3 h-3" /> Archive
+            </button>
+          )}
+          {archived && onRestore && (
+            <button
+              type="button"
+              onClick={() => onRestore(note)}
+              className="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10"
+              aria-label="Restore note"
+              title="Restore — return to active view"
+            >
+              <RotateCcw className="w-3 h-3" /> Restore
+            </button>
+          )}
+          {archived && onDelete && (
+            <button
+              type="button"
+              onClick={() => onDelete(note)}
+              className="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded text-rose-700 dark:text-rose-300 hover:bg-rose-100 dark:hover:bg-rose-950/40"
+              aria-label="Delete note permanently"
+              title="Delete — permanent; cannot be undone"
+            >
+              <Trash2 className="w-3 h-3" /> Delete
+            </button>
+          )}
+        </div>
       )}
     </article>
   );

--- a/src/components/notes/NotesRail.tsx
+++ b/src/components/notes/NotesRail.tsx
@@ -9,9 +9,16 @@
  * include_child_tasks rollup).
  *
  * Phase D of specs/scope-keyed-sessions.md §3.6.
+ *
+ * Audit-actions PR 4: archive / restore / delete actions on every card,
+ * "Show archived" toggle that re-fetches with include_archived=true so
+ * the trash view is just the same rail with archived rows un-hidden.
+ * Hard-delete is gated by a ConfirmDialog (no native window.confirm
+ * per project convention).
  */
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { Archive } from 'lucide-react';
 import {
   useAgentNotes,
   type AgentNoteKind,
@@ -19,6 +26,7 @@ import {
   type UseAgentNotesOptions,
 } from '@/hooks/useAgentNotes';
 import { NoteCard } from './NoteCard';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 
 interface NotesRailProps {
   /** When set, scope is "this task". */
@@ -49,6 +57,11 @@ function groupByRunGroup(notes: AgentNoteRecord[]): Map<string, AgentNoteRecord[
 }
 
 export function NotesRail(props: NotesRailProps) {
+  const [showArchived, setShowArchived] = useState(false);
+  // Note pending hard-delete confirmation. Two-step intent: archive
+  // first (reversible), then delete from the trash view.
+  const [pendingDelete, setPendingDelete] = useState<AgentNoteRecord | null>(null);
+
   const opts: UseAgentNotesOptions = useMemo(
     () => ({
       task_id: props.task_id,
@@ -57,6 +70,7 @@ export function NotesRail(props: NotesRailProps) {
       kinds: props.kinds,
       min_importance: props.min_importance,
       limit: props.limit ?? 100,
+      include_archived: showArchived,
     }),
     [
       props.task_id,
@@ -65,12 +79,62 @@ export function NotesRail(props: NotesRailProps) {
       props.kinds,
       props.min_importance,
       props.limit,
+      showArchived,
     ],
   );
 
   const { notes, loading, error, refresh } = useAgentNotes(opts);
 
-  const groups = useMemo(() => groupByRunGroup(notes), [notes]);
+  // Split active vs archived so we can render archived ones at the
+  // bottom of the list under their own header — keeps the active set
+  // clean for normal review.
+  const activeNotes = useMemo(() => notes.filter((n) => !n.archived_at), [notes]);
+  const archivedNotes = useMemo(() => notes.filter((n) => n.archived_at), [notes]);
+
+  const archivedCount = archivedNotes.length;
+
+  const archive = async (note: AgentNoteRecord) => {
+    try {
+      const res = await fetch(`/api/agent-notes/${encodeURIComponent(note.id)}/archive`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      // SSE will update the list via agent_note_archived; refetch as
+      // belt-and-braces in case the stream is dropped.
+      refresh();
+    } catch (err) {
+      console.error('[NotesRail] archive failed', err);
+    }
+  };
+
+  const restore = async (note: AgentNoteRecord) => {
+    try {
+      const res = await fetch(`/api/agent-notes/${encodeURIComponent(note.id)}/restore`, {
+        method: 'POST',
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      refresh();
+    } catch (err) {
+      console.error('[NotesRail] restore failed', err);
+    }
+  };
+
+  const hardDelete = async (note: AgentNoteRecord) => {
+    try {
+      const res = await fetch(`/api/agent-notes/${encodeURIComponent(note.id)}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      refresh();
+    } catch (err) {
+      console.error('[NotesRail] delete failed', err);
+    }
+  };
+
+  const groups = useMemo(() => groupByRunGroup(activeNotes), [activeNotes]);
+  const archivedGroups = useMemo(() => groupByRunGroup(archivedNotes), [archivedNotes]);
 
   return (
     <section
@@ -80,15 +144,35 @@ export function NotesRail(props: NotesRailProps) {
       data-scope-initiative={props.initiative_id ?? ''}
     >
       <header className="flex items-center justify-between gap-2 text-xs uppercase tracking-wide opacity-70">
-        <span>{props.title ?? 'Notes'} · {notes.length}</span>
-        <button
-          type="button"
-          onClick={refresh}
-          className="px-1.5 py-0.5 rounded hover:bg-black/5 dark:hover:bg-white/5"
-          aria-label="Refresh notes"
-        >
-          ↻
-        </button>
+        <span>{props.title ?? 'Notes'} · {activeNotes.length}</span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setShowArchived((v) => !v)}
+            className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded normal-case tracking-normal ${
+              showArchived
+                ? 'bg-black/10 dark:bg-white/10'
+                : 'hover:bg-black/5 dark:hover:bg-white/5'
+            }`}
+            aria-pressed={showArchived}
+            aria-label={showArchived ? 'Hide archived notes' : 'Show archived notes'}
+            title={showArchived ? 'Hide archived (trash)' : 'Show archived (trash)'}
+          >
+            <Archive className="w-3 h-3" />
+            {showArchived ? 'Hide archived' : 'Trash'}
+            {!showArchived && archivedCount > 0 && (
+              <span className="opacity-70">({archivedCount})</span>
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={refresh}
+            className="px-1.5 py-0.5 rounded hover:bg-black/5 dark:hover:bg-white/5"
+            aria-label="Refresh notes"
+          >
+            ↻
+          </button>
+        </div>
       </header>
 
       {error && (
@@ -101,7 +185,7 @@ export function NotesRail(props: NotesRailProps) {
       )}
       {!loading && notes.length === 0 && (
         <p className="text-xs opacity-60">
-          No notes yet. Agents leave notes as they work — they'll appear here live.
+          No notes yet. Agents leave notes as they work — they&apos;ll appear here live.
         </p>
       )}
 
@@ -113,10 +197,62 @@ export function NotesRail(props: NotesRailProps) {
             </p>
           )}
           {groupNotes.map((n) => (
-            <NoteCard key={n.id} note={n} />
+            <NoteCard
+              key={n.id}
+              note={n}
+              onArchive={archive}
+            />
           ))}
         </div>
       ))}
+
+      {showArchived && archivedNotes.length > 0 && (
+        <div className="mt-3 pt-3 border-t border-mc-border/60 flex flex-col gap-1.5">
+          <p className="text-[11px] uppercase tracking-wide opacity-60 flex items-center gap-1">
+            <Archive className="w-3 h-3" /> Archived · {archivedNotes.length}
+          </p>
+          {Array.from(archivedGroups.entries()).map(([runGroupId, groupNotes]) => (
+            <div key={runGroupId} className="flex flex-col gap-1.5" data-run-group={runGroupId}>
+              {groupNotes.map((n) => (
+                <NoteCard
+                  key={n.id}
+                  note={n}
+                  onRestore={restore}
+                  onDelete={(note) => setPendingDelete(note)}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete this note permanently?"
+        body={
+          <div className="space-y-2 text-sm text-mc-text">
+            <p>
+              This is the empty-the-trash step. The note will be removed from
+              the database — there is no undo.
+            </p>
+            {pendingDelete && (
+              <blockquote className="border-l-2 border-mc-border pl-2 italic opacity-80 text-xs">
+                {pendingDelete.body.slice(0, 240)}
+                {pendingDelete.body.length > 240 ? '…' : ''}
+              </blockquote>
+            )}
+          </div>
+        }
+        confirmLabel="Delete"
+        destructive
+        onConfirm={() => {
+          if (pendingDelete) {
+            void hardDelete(pendingDelete);
+          }
+          setPendingDelete(null);
+        }}
+        onCancel={() => setPendingDelete(null)}
+      />
     </section>
   );
 }

--- a/src/hooks/useAgentNotes.ts
+++ b/src/hooks/useAgentNotes.ts
@@ -200,6 +200,30 @@ export function useAgentNotes(opts: UseAgentNotesOptions): UseAgentNotesResult {
           }
           return prev.filter((n) => n.id !== payload.note_id);
         });
+      } else if (evt.type === 'agent_note_restored') {
+        // Note flipped back to active. If we're showing only-active and
+        // the note isn't in our list (because we hid it on archive), the
+        // simplest correct behavior is to refetch — the SSE payload doesn't
+        // carry the full note shape, and noteMatchesFilter needs all fields.
+        const payload = evt.payload as unknown as { note_id: string };
+        setNotes((prev) => {
+          const idx = prev.findIndex((n) => n.id === payload.note_id);
+          if (idx === -1) {
+            // Note isn't in our list — trigger a refetch on the next tick.
+            // (Cheap because /api/agent-notes is paginated and indexed.)
+            setRefreshTick((tick) => tick + 1);
+            return prev;
+          }
+          // We have it (filter.include_archived was true) — flip the flag.
+          return prev.map((n) =>
+            n.id === payload.note_id
+              ? { ...n, archived_at: null }
+              : n,
+          );
+        });
+      } else if (evt.type === 'agent_note_deleted') {
+        const payload = evt.payload as unknown as { note_id: string };
+        setNotes((prev) => prev.filter((n) => n.id !== payload.note_id));
       }
     };
 

--- a/src/lib/db/agent-notes.test.ts
+++ b/src/lib/db/agent-notes.test.ts
@@ -12,13 +12,16 @@ import { v4 as uuidv4 } from 'uuid';
 import { run, queryOne } from '@/lib/db';
 import {
   AgentNoteValidationError,
+  AgentNoteNotArchivedError,
   archiveNote,
   createNote,
   getNote,
+  hardDeleteNote,
   listNotes,
   markNoteConsumed,
   parseAttachedFiles,
   parseConsumedStages,
+  restoreNote,
   NOTE_BODY_MAX,
 } from './agent-notes';
 
@@ -228,6 +231,58 @@ test('archiveNote: idempotent', () => {
 
 test('archiveNote: returns null for missing note', () => {
   assert.equal(archiveNote('missing', 'irrelevant'), null);
+});
+
+test('restoreNote: clears archived_at + archived_reason', () => {
+  const ws = freshWorkspace();
+  const note = createNote(baseInput(ws, { body: 'maybe still relevant' }));
+  archiveNote(note.id, 'archived for now');
+  assert.ok(getNote(note.id)?.archived_at);
+
+  const restored = restoreNote(note.id);
+  assert.ok(restored);
+  assert.equal(restored.archived_at, null);
+  assert.equal(restored.archived_reason, null);
+
+  // Default listing now includes it again.
+  const visible = listNotes({ workspace_id: ws });
+  assert.equal(visible.length, 1);
+  assert.equal(visible[0].id, note.id);
+});
+
+test('restoreNote: no-op when note is already active', () => {
+  const ws = freshWorkspace();
+  const note = createNote(baseInput(ws));
+  const restored = restoreNote(note.id);
+  assert.ok(restored);
+  assert.equal(restored.archived_at, null);
+});
+
+test('restoreNote: returns null for missing note', () => {
+  assert.equal(restoreNote('missing'), null);
+});
+
+test('hardDeleteNote: requires archive first, then deletes the row', () => {
+  const ws = freshWorkspace();
+  const note = createNote(baseInput(ws, { body: 'will be purged' }));
+
+  // Trying to hard-delete an active note throws.
+  assert.throws(() => hardDeleteNote(note.id), AgentNoteNotArchivedError);
+  assert.ok(getNote(note.id), 'row should still exist after failed hard-delete');
+
+  // Archive first, then hard-delete succeeds.
+  archiveNote(note.id, 'no longer needed');
+  const deleted = hardDeleteNote(note.id);
+  assert.equal(deleted, true);
+  assert.equal(getNote(note.id), null);
+
+  // Even include_archived no longer surfaces it — the row is gone.
+  const all = listNotes({ workspace_id: ws, include_archived: true });
+  assert.equal(all.length, 0);
+});
+
+test('hardDeleteNote: returns false for missing note', () => {
+  assert.equal(hardDeleteNote('does-not-exist'), false);
 });
 
 test('listNotes: workspace deletion cascades agent_notes (FK)', () => {

--- a/src/lib/db/agent-notes.ts
+++ b/src/lib/db/agent-notes.ts
@@ -279,6 +279,53 @@ export function archiveNote(noteId: string, reason: string | null): AgentNote | 
   return getNote(noteId);
 }
 
+/**
+ * Un-archive a previously archived note. Clears `archived_at` and
+ * `archived_reason`. No-op if the note isn't archived. Returns null if
+ * the note doesn't exist.
+ */
+export function restoreNote(noteId: string): AgentNote | null {
+  const existing = getNote(noteId);
+  if (!existing) return null;
+  if (!existing.archived_at) return existing;
+
+  run(
+    `UPDATE agent_notes
+        SET archived_at = NULL,
+            archived_reason = NULL
+      WHERE id = ?`,
+    [noteId],
+  );
+  return getNote(noteId);
+}
+
+export class AgentNoteNotArchivedError extends Error {
+  constructor(public id: string) {
+    super(`agent_note ${id} must be archived before hard-delete`);
+    this.name = 'AgentNoteNotArchivedError';
+  }
+}
+
+/**
+ * Permanently delete a note. The note MUST be archived first — this is the
+ * "empty the trash" verb, not a one-shot delete. Throws
+ * `AgentNoteNotArchivedError` if the note isn't archived. Returns true
+ * if a row was deleted, false if the note didn't exist at all.
+ *
+ * The two-step intent (archive, then delete-from-trash) protects against
+ * accidental loss on agent-generated content. Project convention is to
+ * gate this behind ConfirmDialog at the UI layer too.
+ */
+export function hardDeleteNote(noteId: string): boolean {
+  const existing = getNote(noteId);
+  if (!existing) return false;
+  if (!existing.archived_at) {
+    throw new AgentNoteNotArchivedError(noteId);
+  }
+  run(`DELETE FROM agent_notes WHERE id = ?`, [noteId]);
+  return true;
+}
+
 // ─── Helpers ────────────────────────────────────────────────────────
 
 function safeParseStringArray(json: string): string[] {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1028,6 +1028,8 @@ export type SSEEventType =
   | 'agent_note_created'
   | 'agent_note_consumed'
   | 'agent_note_archived'
+  | 'agent_note_restored'
+  | 'agent_note_deleted'
   // Research Area phase 1 (specs/research-area-build-plan.md). Per-brief
   // execution lifecycle. brief_progress fires for streamed chunks /
   // status heartbeats while running so the hub's in-progress lane can


### PR DESCRIPTION
## Summary

Fourth slice of audit-actions + run-tracking (spec: [`specs/audit-actions-and-tracking.md`](specs/audit-actions-and-tracking.md)). Surfaces the lifecycle endpoints from [PR 1](https://github.com/smb209/mission-control/pull/251) on every note card plus a \"Trash\" toggle, so audits get a clear next action instead of accumulating as inert text.

**Stacked on [PR 1](https://github.com/smb209/mission-control/pull/251).**

## Changes

**`NoteCard`**
- Three optional callbacks: `onArchive`, `onRestore`, `onDelete`. When omitted, the card stays read-only — no behavior change for `/feed` or other consumers until they opt in.
- Active notes show \"Archive\". Archived notes render dimmed (60% opacity), get an `ARCHIVED` badge, and show \"Restore\" + \"Delete\" instead.

**`NotesRail`**
- New \"Trash\" toggle in the header. Pressed → flips `include_archived=true` on the listing query, button label becomes \"Hide archived\". Shows archived count `(N)` when collapsed.
- Active notes render at the top; archived notes render at the bottom under their own `ARCHIVED · N` header.
- Wires the three lifecycle endpoints from PR 1.
- Hard-delete is gated by `ConfirmDialog` (project convention — no native `window.confirm`). The dialog shows a 240-char excerpt of the note being deleted so the operator can verify intent.

## Test plan

- [x] `yarn test` — 813 tests, 812 pass, 1 pre-existing failure unrelated to this PR (`schedule-runner`).
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify** on `mission-control-dev` (:4010), full lifecycle:
  - Seeded an `observation` note → rendered with Archive button.
  - Clicked Archive → note disappeared from default view.
  - Clicked Trash → archived view showed dimmed note with `ARCHIVED` badge + Restore + Delete buttons.
  - Clicked Delete → ConfirmDialog appeared with body excerpt + destructive Delete button.
  - Confirmed → row deleted from DB (`SELECT id FROM agent_notes WHERE id = 'test-note-1'` returned empty).
  - No console errors.

## Out of scope (named so we don't drift)

- PM-chat note rendering parity. PM chat surfaces note text inside the conversation transcript, not as discrete cards; making chat-rendered notes actionable is a separate UX problem.
- Inline edit / amendments. Spec lists this as deferred — \"Ask PM\" (PR 5) + archive cover the immediate need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)