### PR TITLE
feat(audit-actions): Ask-PM-from-notes handoff (PR 5/6)

### DIFF
--- a/src/app/api/initiatives/[id]/ask-pm-from-notes/route.test.ts
+++ b/src/app/api/initiatives/[id]/ask-pm-from-notes/route.test.ts
@@ -1,0 +1,114 @@
+/**
+ * POST /api/initiatives/:id/ask-pm-from-notes route tests.
+ *
+ * Validation behavior only — the dispatch path itself is exercised in
+ * pm-dispatch.test.ts. Here we verify that the route enforces note
+ * ownership, archived gating, and validation shape.
+ *
+ * See specs/audit-actions-and-tracking.md PR 5.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { run } from '@/lib/db';
+import { archiveNote, createNote } from '@/lib/db/agent-notes';
+
+function freshWorkspace(): string {
+  const id = `ws-ask-pm-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function freshInitiative(workspaceId: string): string {
+  const id = `init-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO initiatives (id, workspace_id, title, status, kind, created_at, updated_at)
+     VALUES (?, ?, ?, 'planned', 'epic', datetime('now'), datetime('now'))`,
+    [id, workspaceId, `seed ${id}`],
+  );
+  return id;
+}
+
+function makeNote(workspaceId: string, initiativeId: string | null) {
+  return createNote({
+    workspace_id: workspaceId,
+    agent_id: null,
+    initiative_id: initiativeId ?? null,
+    scope_key: `scope-${uuidv4()}`,
+    role: 'researcher',
+    run_group_id: `rg-${uuidv4()}`,
+    kind: 'observation',
+    body: 'audit noted X',
+  });
+}
+
+function postReq(
+  initId: string,
+  body: unknown,
+): { req: NextRequest; ctx: { params: Promise<{ id: string }> } } {
+  const url = new URL(`http://localhost/api/initiatives/${initId}/ask-pm-from-notes`);
+  return {
+    req: new NextRequest(url, {
+      method: 'POST',
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    }),
+    ctx: { params: Promise.resolve({ id: initId }) },
+  };
+}
+
+test('POST: missing initiative → 404', async () => {
+  const { req, ctx } = postReq('does-not-exist', { note_ids: ['x'] });
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 404);
+});
+
+test('POST: empty note_ids → 400', async () => {
+  const ws = freshWorkspace();
+  const init = freshInitiative(ws);
+  const { req, ctx } = postReq(init, { note_ids: [] });
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 400);
+});
+
+test('POST: missing note → 404', async () => {
+  const ws = freshWorkspace();
+  const init = freshInitiative(ws);
+  const { req, ctx } = postReq(init, { note_ids: ['nope'] });
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 404);
+});
+
+test('POST: note belongs to a different initiative → 400', async () => {
+  const ws = freshWorkspace();
+  const initA = freshInitiative(ws);
+  const initB = freshInitiative(ws);
+  const note = makeNote(ws, initB);
+  const { req, ctx } = postReq(initA, { note_ids: [note.id] });
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 400);
+});
+
+test('POST: archived note → 409', async () => {
+  const ws = freshWorkspace();
+  const init = freshInitiative(ws);
+  const note = makeNote(ws, init);
+  archiveNote(note.id, 'cleanup');
+  const { req, ctx } = postReq(init, { note_ids: [note.id] });
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 409);
+});
+
+test('POST: invalid JSON body → 400', async () => {
+  const ws = freshWorkspace();
+  const init = freshInitiative(ws);
+  const { req, ctx } = postReq(init, '{not json');
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 400);
+});

--- a/src/app/api/initiatives/[id]/ask-pm-from-notes/route.ts
+++ b/src/app/api/initiatives/[id]/ask-pm-from-notes/route.ts
@@ -1,0 +1,156 @@
+/**
+ * POST /api/initiatives/:id/ask-pm-from-notes
+ *
+ * Operator-facing handoff: hand the PM a specific subset of audit notes
+ * for this initiative and ask it to propose changes. The PM dispatch
+ * uses `trigger_kind='notes_intake'`, the same path the
+ * `propose_from_notes` MCP tool walks — the difference is that this
+ * route grounds the prompt in *specific* note ids rather than freeform
+ * paragraphs.
+ *
+ * Body:
+ *   { note_ids: string[] }   // 1..20 ids; must all belong to this initiative
+ *
+ * Response:
+ *   { proposal_id, awaiting_agent }
+ *
+ * After dispatch, each note is marked consumed by the `pm_proposal`
+ * stage so a second click doesn't re-hand the same note. Operators can
+ * still ask again — this is just a subtle "we've already done this"
+ * signal in the UI; it does not block.
+ *
+ * See specs/audit-actions-and-tracking.md PR 5.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  getNote,
+  markNoteConsumed,
+  type AgentNote,
+} from '@/lib/db/agent-notes';
+import { getInitiative } from '@/lib/db/initiatives';
+import { dispatchPm, PmDispatchGatewayUnavailableError } from '@/lib/agents/pm-dispatch';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  note_ids: z.array(z.string().min(1)).min(1).max(20),
+});
+
+const CONSUMED_STAGE = 'pm_proposal';
+
+function formatNoteAsTrigger(notes: AgentNote[], initiativeTitle: string): string {
+  const lines: string[] = [
+    `Please review the following audit note${notes.length === 1 ? '' : 's'} from initiative "${initiativeTitle}" and propose any changes you'd recommend.`,
+    '',
+    'Each note is one observation surfaced by an audit run; treat them as the primary input. Use the standard `propose_changes` flow with structured diffs (creates / updates on initiatives, draft tasks under them) — do not synthesize a free-text summary.',
+    '',
+    '---',
+    '',
+  ];
+  for (const n of notes) {
+    lines.push(`### Note ${n.id} (${n.kind}, importance ${n.importance})`);
+    if (n.role) lines.push(`*from role: ${n.role}*`);
+    lines.push('');
+    lines.push(n.body);
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+
+  const initiative = getInitiative(id);
+  if (!initiative) {
+    return NextResponse.json({ error: 'initiative not found' }, { status: 404 });
+  }
+
+  let body: z.infer<typeof Body>;
+  try {
+    const raw = await request.json();
+    const parsed = Body.safeParse(raw);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    body = parsed.data;
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  // Resolve every note id, validate ownership.
+  const notes: AgentNote[] = [];
+  for (const noteId of body.note_ids) {
+    const n = getNote(noteId);
+    if (!n) {
+      return NextResponse.json(
+        { error: `note ${noteId} not found` },
+        { status: 404 },
+      );
+    }
+    if (n.initiative_id !== id) {
+      return NextResponse.json(
+        {
+          error: `note ${noteId} does not belong to this initiative`,
+        },
+        { status: 400 },
+      );
+    }
+    if (n.archived_at) {
+      return NextResponse.json(
+        { error: `note ${noteId} is archived; restore it before handing to PM` },
+        { status: 409 },
+      );
+    }
+    notes.push(n);
+  }
+
+  const triggerText = formatNoteAsTrigger(notes, initiative.title);
+
+  try {
+    const result = dispatchPm({
+      workspace_id: initiative.workspace_id,
+      trigger_text: triggerText,
+      trigger_kind: 'notes_intake',
+      // Same as the MCP path — regex on freeform is worse than nothing.
+      allowFallback: false,
+    });
+
+    // Mark notes consumed so the UI can fade the "Ask PM" button on a
+    // re-render. Idempotent — re-clicking still works, just no new
+    // bookkeeping.
+    for (const n of notes) {
+      try {
+        markNoteConsumed(n.id, CONSUMED_STAGE);
+      } catch (err) {
+        // Best-effort; the dispatch already happened, this is housekeeping.
+        console.warn(
+          `[ask-pm-from-notes] markNoteConsumed failed for ${n.id}:`,
+          (err as Error).message,
+        );
+      }
+    }
+
+    return NextResponse.json({
+      proposal_id: result.proposal.id,
+      awaiting_agent: result.awaiting_agent,
+    });
+  } catch (err) {
+    if (err instanceof PmDispatchGatewayUnavailableError) {
+      return NextResponse.json(
+        { error: 'PM gateway unavailable. Try again when openclaw is reachable.' },
+        { status: 503 },
+      );
+    }
+    throw err;
+  }
+}

--- a/src/components/notes/NoteCard.tsx
+++ b/src/components/notes/NoteCard.tsx
@@ -11,7 +11,7 @@
  * actions until they opt in.
  */
 
-import { Archive, RotateCcw, Trash2 } from 'lucide-react';
+import { Archive, RotateCcw, Trash2, Sparkles } from 'lucide-react';
 import type { AgentNoteRecord, AgentNoteKind } from '@/hooks/useAgentNotes';
 
 const KIND_COLOR: Record<AgentNoteKind, string> = {
@@ -68,9 +68,16 @@ interface NoteCardProps {
    *  caller is expected to confirm via ConfirmDialog before issuing
    *  the destructive request. */
   onDelete?: (note: AgentNoteRecord) => void;
+  /**
+   * Called when the operator clicks "Ask PM" on an active note. Only
+   * rendered when the note is `kind='observation'` (the audit-derived
+   * subset, per the audit-actions tradeoff). The caller is responsible
+   * for the network round-trip; the button just emits intent.
+   */
+  onAskPm?: (note: AgentNoteRecord) => void;
 }
 
-export function NoteCard({ note, onArchive, onRestore, onDelete }: NoteCardProps) {
+export function NoteCard({ note, onArchive, onRestore, onDelete, onAskPm }: NoteCardProps) {
   const archived = !!note.archived_at;
   const kindClasses = `${KIND_COLOR[note.kind]} ${KIND_DARK[note.kind]}`;
   const importancePin =
@@ -80,7 +87,14 @@ export function NoteCard({ note, onArchive, onRestore, onDelete }: NoteCardProps
         ? '🔔 '
         : '';
 
-  const hasActions = !!(onArchive || onRestore || onDelete);
+  // "Ask PM" is gated to observation notes — that's where audit findings
+  // live. Other kinds (breadcrumb, decision, etc.) don't represent
+  // actionable findings the PM should triage.
+  const askPmEligible = !archived && note.kind === 'observation' && !!onAskPm;
+  const askPmAlreadyConsumed =
+    askPmEligible && (note.consumed_by_stages ?? []).includes('pm_proposal');
+
+  const hasActions = !!(onArchive || onRestore || onDelete || askPmEligible);
 
   return (
     <article
@@ -121,6 +135,24 @@ export function NoteCard({ note, onArchive, onRestore, onDelete }: NoteCardProps
       )}
       {hasActions && (
         <div className="flex flex-wrap items-center gap-1.5 pt-1.5 mt-1.5 border-t border-current/10">
+          {askPmEligible && (
+            <button
+              type="button"
+              onClick={() => onAskPm?.(note)}
+              className={`inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 ${
+                askPmAlreadyConsumed ? 'opacity-60' : ''
+              }`}
+              aria-label={askPmAlreadyConsumed ? 'Ask PM again' : 'Ask PM to propose changes'}
+              title={
+                askPmAlreadyConsumed
+                  ? 'Already handed to PM once — click to ask again'
+                  : 'Hand this note to the PM and ask for proposed changes'
+              }
+            >
+              <Sparkles className="w-3 h-3" />{' '}
+              {askPmAlreadyConsumed ? 'Ask PM again' : 'Ask PM'}
+            </button>
+          )}
           {!archived && onArchive && (
             <button
               type="button"

--- a/src/components/notes/NotesRail.tsx
+++ b/src/components/notes/NotesRail.tsx
@@ -133,6 +133,37 @@ export function NotesRail(props: NotesRailProps) {
     }
   };
 
+  const askPm = async (note: AgentNoteRecord) => {
+    if (!note.initiative_id) {
+      // Belt-and-braces — Ask PM only renders on observation notes which
+      // come from initiative audits, so they always carry initiative_id.
+      console.warn('[NotesRail] askPm called on note without initiative_id', note.id);
+      return;
+    }
+    try {
+      const res = await fetch(
+        `/api/initiatives/${encodeURIComponent(note.initiative_id)}/ask-pm-from-notes`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ note_ids: [note.id] }),
+        },
+      );
+      if (!res.ok) {
+        const detail = await res.json().catch(() => ({}));
+        throw new Error(
+          (detail as { error?: string }).error || `HTTP ${res.status}`,
+        );
+      }
+      // The route marks the note consumed; refresh so the button label
+      // flips to "Ask PM again". The proposal itself surfaces in the
+      // PM-chat UI; we don't need to navigate here.
+      refresh();
+    } catch (err) {
+      console.error('[NotesRail] askPm failed', err);
+    }
+  };
+
   const groups = useMemo(() => groupByRunGroup(activeNotes), [activeNotes]);
   const archivedGroups = useMemo(() => groupByRunGroup(archivedNotes), [archivedNotes]);
 
@@ -201,6 +232,7 @@ export function NotesRail(props: NotesRailProps) {
               key={n.id}
               note={n}
               onArchive={archive}
+              onAskPm={askPm}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

Fifth slice of audit-actions + run-tracking (spec: [`specs/audit-actions-and-tracking.md`](specs/audit-actions-and-tracking.md)). Closes the loop for audit notes: operator clicks **\"Ask PM\"** on an observation and the PM is dispatched with that note as the trigger, producing a `pm_proposals` row the operator reviews in the PM chat UI.

**Stacked on [PR 4](https://github.com/smb209/mission-control/pull/254).**

## Changes

**New route: `POST /api/initiatives/:id/ask-pm-from-notes`**
- Body: `{ note_ids: string[] }` (1–20 ids).
- Validates ownership: 400 if any note belongs to a different initiative.
- Gates archived: 409 if any note is archived (restore first).
- Formats notes into a `notes_intake` trigger_text with provenance (kind, importance, role, body) so the PM has structure rather than raw paragraphs.
- Dispatches via `dispatchPm({ trigger_kind: 'notes_intake', allowFallback: false })` — same path the `propose_from_notes` MCP tool walks. Returns `{ proposal_id, awaiting_agent }`.
- Marks each note `consumed_by_stages: ['pm_proposal']` so a follow-up click in the UI is gently de-emphasized.

**`NoteCard`**
- New optional `onAskPm` callback. Only renders the button when `kind='observation'` and the note is active (per the locked tradeoff — \"observation = audit-derived findings; other kinds aren't actionable to the PM\").
- Button label flips from \"Ask PM\" → \"Ask PM again\" once the note has been consumed by `pm_proposal`. Re-clicking still works; the label is just a hint.

**`NotesRail`**
- Wires the route call. SSE-driven `consumed_by_stages` updates flow into the rendered button label naturally.

## Test plan

- [x] 6 new route tests (validation: missing initiative 404, empty `note_ids` 400, missing note 404, ownership mismatch 400, archived 409, invalid JSON 400). All pass.
- [x] `yarn test` — 813 pass, 1 pre-existing failure (`schedule-runner`).
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify** on `mission-control-dev` (:4010):
  - Seeded an `observation` note → \"Ask PM\" button rendered.
  - Clicked → button flipped to \"Ask PM again\".
  - DB check: new `pm_proposals` row landed with `trigger_kind='notes_intake'`, `dispatch_state='pending_agent'`, and `trigger_text` containing the formatted note.

## Out of scope

- Editing the note before handing it off. The trigger_text is built server-side from the canonical note body.
- Bulk handoff (multiple notes at once via UI). The route accepts up to 20 ids; the UI sends one at a time today. A multi-select could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)