### PR TITLE
feat(audit-actions): note ↔ run linkage chip (PR 6/6)

### DIFF
--- a/src/app/api/agent-notes/route.ts
+++ b/src/app/api/agent-notes/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { queryAll } from '@/lib/db';
+import { queryAll, queryOne } from '@/lib/db';
 import {
   listNotes,
   parseAttachedFiles,
@@ -19,6 +19,7 @@ import {
   type NoteImportance,
   type NoteKind,
 } from '@/lib/db/agent-notes';
+import type { AgentRunKind, AgentRunStatus } from '@/lib/db/agent-runs';
 
 const VALID_KINDS: ReadonlyArray<NoteKind> = [
   'discovery',
@@ -30,7 +31,42 @@ const VALID_KINDS: ReadonlyArray<NoteKind> = [
   'breadcrumb',
 ];
 
-function notePayload(note: AgentNote): Record<string, unknown> {
+interface OriginatingRun {
+  id: string;
+  kind: AgentRunKind;
+  status: AgentRunStatus;
+  completed_at: string | null;
+}
+
+/**
+ * Look up the most-recent agent_runs row sharing this note's scope_key.
+ *
+ * agent_notes were introduced before the agent_runs migration (065 vs
+ * 075/080), so older notes may have no matching run. PM chats reuse a
+ * scope_key across many runs, so "most recent" is the only sensible
+ * choice for a single chip — if the operator wants the full run history
+ * they can click through to /jobs.
+ *
+ * Two-pass: a single batched query keyed by scope_key would be cheaper,
+ * but listings cap at 200 and SQLite handles 200 keyed lookups in < 1ms
+ * locally. Revisit if /api/agent-notes shows up in slow logs.
+ */
+function fetchOriginatingRun(scopeKey: string): OriginatingRun | null {
+  const row = queryOne<OriginatingRun>(
+    `SELECT id, kind, status, completed_at
+       FROM agent_runs
+      WHERE scope_key = ?
+      ORDER BY started_at DESC, created_at DESC, rowid DESC
+      LIMIT 1`,
+    [scopeKey],
+  );
+  return row ?? null;
+}
+
+function notePayload(
+  note: AgentNote,
+  originatingRun: OriginatingRun | null,
+): Record<string, unknown> {
   return {
     id: note.id,
     workspace_id: note.workspace_id,
@@ -48,6 +84,13 @@ function notePayload(note: AgentNote): Record<string, unknown> {
     consumed_by_stages: parseConsumedStages(note),
     archived_at: note.archived_at,
     created_at: note.created_at,
+    /**
+     * The agent_runs row that produced this note (most recent run for
+     * the scope_key). Null when no agent_runs row matches — typically
+     * pre-migration-075 notes. UI uses this to render a "from <kind> ·
+     * <status>" chip linking into /jobs?run=<id>.
+     */
+    originating_run: originatingRun,
   };
 }
 
@@ -156,8 +199,19 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     });
   }
 
+  // Hydrate originating_run per note. We cache by scope_key so the
+  // common case (subtree audit dispatching N notes that share scope)
+  // collapses to a single lookup.
+  const runCache = new Map<string, OriginatingRun | null>();
+  const lookup = (sk: string): OriginatingRun | null => {
+    if (runCache.has(sk)) return runCache.get(sk)!;
+    const row = fetchOriginatingRun(sk);
+    runCache.set(sk, row);
+    return row;
+  };
+
   return NextResponse.json({
     count: notes.length,
-    notes: notes.map(notePayload),
+    notes: notes.map((n) => notePayload(n, lookup(n.scope_key))),
   });
 }

--- a/src/components/notes/NoteCard.tsx
+++ b/src/components/notes/NoteCard.tsx
@@ -11,7 +11,14 @@
  * actions until they opt in.
  */
 
-import { Archive, RotateCcw, Trash2, Sparkles } from 'lucide-react';
+import Link from 'next/link';
+import {
+  Archive,
+  RotateCcw,
+  Trash2,
+  Sparkles,
+  ExternalLink,
+} from 'lucide-react';
 import type { AgentNoteRecord, AgentNoteKind } from '@/hooks/useAgentNotes';
 
 const KIND_COLOR: Record<AgentNoteKind, string> = {
@@ -43,6 +50,29 @@ const KIND_LABEL: Record<AgentNoteKind, string> = {
   question: '💬 question',
   breadcrumb: '🍞 breadcrumb',
 };
+
+function runKindLabel(kind: string): string {
+  switch (kind) {
+    case 'initiative_audit':
+      return 'audit';
+    case 'pm_chat':
+      return 'PM';
+    case 'plan':
+      return 'plan';
+    case 'decompose':
+      return 'decompose';
+    case 'task_coord':
+      return 'coord';
+    case 'task_role':
+      return 'role';
+    case 'recurring':
+      return 'recurring';
+    case 'brief':
+      return 'brief';
+    default:
+      return kind;
+  }
+}
 
 function formatTime(iso: string): string {
   try {
@@ -118,6 +148,19 @@ export function NoteCard({ note, onArchive, onRestore, onDelete, onAskPm }: Note
         </time>
       </header>
       <p className="whitespace-pre-wrap leading-relaxed">{note.body}</p>
+      {note.originating_run && (
+        <p className="text-[11px] opacity-70">
+          <Link
+            href={`/jobs?run=${encodeURIComponent(note.originating_run.id)}`}
+            className="inline-flex items-center gap-1 underline-offset-2 hover:underline"
+            title={`Originating run · ${note.originating_run.kind} · ${note.originating_run.status}`}
+          >
+            <ExternalLink className="w-3 h-3" />
+            from {runKindLabel(note.originating_run.kind)} ·{' '}
+            {note.originating_run.status}
+          </Link>
+        </p>
+      )}
       {note.attached_files.length > 0 && (
         <ul className="mt-1 flex flex-wrap gap-1">
           {note.attached_files.map((f) => (

--- a/src/hooks/useAgentNotes.ts
+++ b/src/hooks/useAgentNotes.ts
@@ -33,6 +33,23 @@ export type AgentNoteKind =
   | 'question'
   | 'breadcrumb';
 
+/**
+ * Most-recent `agent_runs` row sharing this note's scope_key. Hydrated
+ * server-side by /api/agent-notes (audit-actions PR 6). Null when no
+ * agent_runs row matches — typically notes from before migration 075.
+ *
+ * Note: SSE-delivered note events (`agent_note_created`) don't carry
+ * this field; the run is hydrated only on initial fetch + refresh().
+ * For most flows that's fine — the note's run is freshly created at
+ * dispatch time, so a refresh shortly after surfaces the link.
+ */
+export interface OriginatingRunRef {
+  id: string;
+  kind: string;
+  status: string;
+  completed_at: string | null;
+}
+
 export interface AgentNoteRecord {
   id: string;
   workspace_id: string;
@@ -50,6 +67,8 @@ export interface AgentNoteRecord {
   consumed_by_stages?: string[];
   archived_at: string | null;
   created_at: string;
+  /** Hydrated by /api/agent-notes; null on SSE-pushed notes. */
+  originating_run?: OriginatingRunRef | null;
 }
 
 export interface UseAgentNotesOptions {


### PR DESCRIPTION
## Summary

Final slice of audit-actions + run-tracking (spec: [`specs/audit-actions-and-tracking.md`](specs/audit-actions-and-tracking.md)). Renders a small chip on every `NoteCard` that links to the `agent_runs` row that produced the note — closes the audit-trail loop, so the operator can jump from a note to its originating dispatch in `/jobs`.

**Stacked on [PR 5](https://github.com/smb209/mission-control/pull/255).**

## Changes

**API**
- `/api/agent-notes` payload gains `originating_run: { id, kind, status, completed_at } | null`.
- Server-side lookup by `scope_key`, picking the most-recent run. (PM chats reuse scope_keys across many turns — \"most recent\" is what fits in a single chip; full history is a click away in `/jobs`.)
- Per-request scope_key cache so a subtree audit fan-out producing N notes that share scope_key collapses to a single DB lookup.

**Hook**
- `AgentNoteRecord` type gains the optional `originating_run`. Notes arriving via SSE (`agent_note_created`) don't carry the field — the broadcast payload predates this work. That's acceptable: refresh() hydrates it, and the chip is most useful a beat after the run starts anyway.

**`NoteCard`**
- New chip `↗ from <kind> · <status>` linking to `/jobs?run=<id>`.
- `<kind>` is mapped to a short label (audit / PM / plan / decompose / coord / role / recurring / brief).
- Notes without a matching run (pre-migration-075) simply don't render the chip — graceful fallback.

## Test plan

- [x] `yarn test` — 813 pass, 1 pre-existing failure (`schedule-runner`).
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify** on `mission-control-dev` (:4010): seeded an `agent_runs` row + `agent_notes` row sharing a scope_key. Note rendered \"↗ from audit · complete\" pointing to `/jobs?run=test-run-pr6`. Pre-existing notes with no matching run continue to render without the chip.

## Out of scope

- Showing the *full* run history when scope_key is reused (PM chats). Requires either inline expansion or a small drawer; not worth the complexity for the MVP. Click-through to `/jobs` is sufficient.
- SSE-pushed `agent_note_created` payload extension to include `originating_run`. Would avoid the refetch on SSE, but it's a cross-cutting change to the broadcast site and not a critical-path UX gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)