### PR TITLE
feat(initiatives): note-presence indicator on list cards

### DIFF
--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -26,6 +26,7 @@ import {
   CalendarRange,
   ExternalLink,
   FolderInput,
+  StickyNote,
 } from 'lucide-react';
 import Drawer from '@/components/Drawer';
 import ActionMenu, { ActionMenuItem } from '@/components/ActionMenu';
@@ -53,6 +54,10 @@ export interface Initiative {
   sort_order: number;
   created_at: string;
   updated_at: string;
+  /** Non-archived agent_notes attached to this initiative. Surfaced by
+   *  the LEFT JOIN in `listInitiatives` (server side). Optional because
+   *  some upstream callers omit it. */
+  note_count?: number;
 }
 
 interface TreeNode extends Initiative {
@@ -903,6 +908,16 @@ function InitiativeRow({
                 title={`${counts.total} tasks: ${counts.draft} draft, ${counts.active} active, ${counts.done} done`}
               >
                 {counts.total} task{counts.total === 1 ? '' : 's'}
+              </span>
+            )}
+            {(node.note_count ?? 0) > 0 && (
+              <span
+                className="inline-flex items-center gap-0.5 text-[10px] text-mc-text-secondary"
+                title={`${node.note_count} agent note${node.note_count === 1 ? '' : 's'} attached`}
+                aria-label={`${node.note_count} agent note${node.note_count === 1 ? '' : 's'} attached`}
+              >
+                <StickyNote className="w-3 h-3" />
+                {node.note_count}
               </span>
             )}
           </div>

--- a/src/lib/db/initiatives.ts
+++ b/src/lib/db/initiatives.ts
@@ -45,6 +45,14 @@ export interface Initiative {
   source_idea_id: string | null;
   created_at: string;
   updated_at: string;
+  /**
+   * Count of non-archived agent_notes attached to this initiative.
+   * Populated by `listInitiatives` and `getInitiativeTree` (the list-card
+   * paths) via LEFT JOIN; left undefined by single-row reads
+   * (`getInitiative`, INSERT/UPDATE round-trips) since those callers
+   * don't render the indicator. Treat absence as 0.
+   */
+  note_count?: number;
 }
 
 export interface InitiativeDependency {
@@ -184,33 +192,50 @@ export interface ListInitiativesFilters {
 }
 
 export function listInitiatives(filters: ListInitiativesFilters = {}): Initiative[] {
+  // Build WHERE against the `i.` alias from the start so the JOIN below
+  // doesn't need post-hoc rewriting.
   const where: string[] = [];
   const params: unknown[] = [];
 
   if (filters.workspace_id) {
-    where.push('workspace_id = ?');
+    where.push('i.workspace_id = ?');
     params.push(filters.workspace_id);
   }
   if (filters.product_id) {
-    where.push('product_id = ?');
+    where.push('i.product_id = ?');
     params.push(filters.product_id);
   }
   if (filters.parent_id === null) {
-    where.push('parent_initiative_id IS NULL');
+    where.push('i.parent_initiative_id IS NULL');
   } else if (typeof filters.parent_id === 'string') {
-    where.push('parent_initiative_id = ?');
+    where.push('i.parent_initiative_id = ?');
     params.push(filters.parent_id);
   }
   if (filters.status) {
-    where.push('status = ?');
+    where.push('i.status = ?');
     params.push(filters.status);
   }
   if (filters.kind) {
-    where.push('kind = ?');
+    where.push('i.kind = ?');
     params.push(filters.kind);
   }
 
-  const sql = `SELECT * FROM initiatives ${where.length ? 'WHERE ' + where.join(' AND ') : ''} ORDER BY sort_order, created_at`;
+  // LEFT JOIN a COUNT-by-initiative_id subquery for the note-presence
+  // indicator on list cards. Excludes archived notes so the chip
+  // disappears when the operator empties the trash. Subquery uses the
+  // existing idx_agent_notes_initiative index.
+  const sql = `
+    SELECT i.*, COALESCE(n.note_count, 0) AS note_count
+      FROM initiatives i
+      LEFT JOIN (
+        SELECT initiative_id, COUNT(*) AS note_count
+          FROM agent_notes
+         WHERE initiative_id IS NOT NULL
+           AND archived_at IS NULL
+         GROUP BY initiative_id
+      ) n ON n.initiative_id = i.id
+      ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+     ORDER BY i.sort_order, i.created_at`;
   return queryAll<Initiative>(sql, params);
 }
 
@@ -224,8 +249,19 @@ export interface InitiativeTreeNode extends Initiative {
  * is flattened into a single array so callers can render a top-level list.
  */
 export function getInitiativeTree(workspace_id: string, root_id?: string): InitiativeTreeNode[] {
+  // Same JOIN as listInitiatives so tree-rendered cards also get note_count.
   const all = queryAll<Initiative>(
-    'SELECT * FROM initiatives WHERE workspace_id = ? ORDER BY sort_order, created_at',
+    `SELECT i.*, COALESCE(n.note_count, 0) AS note_count
+       FROM initiatives i
+       LEFT JOIN (
+         SELECT initiative_id, COUNT(*) AS note_count
+           FROM agent_notes
+          WHERE initiative_id IS NOT NULL
+            AND archived_at IS NULL
+          GROUP BY initiative_id
+       ) n ON n.initiative_id = i.id
+      WHERE i.workspace_id = ?
+      ORDER BY i.sort_order, i.created_at`,
     [workspace_id],
   );
 


### PR DESCRIPTION
## Summary

A small sticky-note icon + count appears on each initiative card when non-archived `agent_notes` are attached. Surfaces audit + observation activity from the list view so operators can find the initiatives that have something worth reading without clicking through.

## Changes

**DAO**
- `listInitiatives` + `getInitiativeTree` now LEFT JOIN a COUNT subquery on `agent_notes` filtered to `archived_at IS NULL`. Uses the existing `idx_agent_notes_initiative` index.
- `Initiative` interface gets optional `note_count?: number`. Single-row reads (`getInitiative`, INSERT/UPDATE round-trips) leave it undefined; callers treat absence as 0.

**UI**
- `InitiativeRow` renders `📝 N` next to the existing task count when `note_count > 0`. Title attribute + aria-label carry the full text for hover and screen-reader.
- Local `Initiative` type in `app/(app)/initiatives/page.tsx` mirrors the DB-layer addition.

## Test plan

- [x] `yarn test` — 814 pass, 1 pre-existing failure (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify** on `mission-control-dev`: 14 cards show indicators with counts ranging from 1 to 10. Hover tooltips read \"N agent note(s) attached\". Cards without notes show no indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)