### PR TITLE
feat(workspace-conventions): variable resolver + templates + local-repo init (PR 1/3)

### DIFF
--- a/specs/workspace-conventions-structured.md
+++ b/specs/workspace-conventions-structured.md
@@ -1,0 +1,181 @@
+# Workspace Conventions: Structured Fields + Templates + Refine
+
+The workspace `conventions` text on `/workspace/<slug>/settings` is one freeform markdown blob. Operators end up rewriting the same boilerplate per project (paths, repo URL, base branch, package manager, port reservations). The blob also gets duplicated visually inside `<AgentPromptPreview>` on the same page, eating vertical space in narrow viewports.
+
+This spec replaces "one big textarea + a memory-prone copy each time" with **a tiny set of structured fields + templates + variable substitution + an optional agent-driven refine step.** Existing workspaces are unchanged until the operator opts in.
+
+## What stays the same
+
+- `workspaces.context_md` is still the canonical narrative store. Templates write into it; the dispatch route still reads it.
+- `get_workspace_context` MCP tool keeps its current shape — agents see the same structure.
+- The settings page keeps its layout; we add controls *above* the conventions textarea.
+
+## What's new
+
+### 1. Required structured fields (already exist on the table)
+
+| Field | Existing column | Notes |
+|-------|-----------------|-------|
+| `name` | `workspaces.name` | unchanged |
+| `workspace_path` | `workspaces.workspace_path` | unchanged |
+| `deliverables_path` | `workspaces.deliverables_path` | unchanged; defaults to `workspace_path` if blank (existing behavior) |
+
+No schema migration needed for the required-fields slice. Bare-minimum-functional ships in PR 1.
+
+### 2. Optional structured fields (new columns)
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `repo_url` | TEXT | drives `gh pr create --repo` enforcement guidance, UI chip ("fork → upstream") |
+| `default_base_branch` | TEXT | drives `--base` enforcement guidance |
+| `local_repo_init` | INTEGER (0/1) | when true, server-side `git init` runs at save time inside `workspace_path` (idempotent — no-op if `.git/` already exists) |
+
+All nullable. Migration: PR 2.
+
+### 3. Variable substitution (`{{...}}`)
+
+Postman / standard-template syntax. The resolver replaces these tokens at render time:
+
+| Token | Source |
+|-------|--------|
+| `{{name}}` | `workspaces.name` |
+| `{{working_dir}}` | `workspaces.workspace_path` |
+| `{{deliverables}}` | `workspaces.deliverables_path` (falls back to `workspace_path`) |
+| `{{repo_url}}` | `workspaces.repo_url` (PR 2; before PR 2 lands, expands to empty + warning) |
+| `{{base_branch}}` | `workspaces.default_base_branch` (PR 2; same fallback) |
+
+Behavior:
+- Unknown tokens render as literal `{{whatever}}` with a `⚠️` chip in the preview pane so typos are visible.
+- Empty values render as the empty string but emit a `⚠️ {{repo_url}} (empty)` chip in the preview pane only — the dispatched agent prompt swallows the warning silently (we don't want noisy `⚠️` lines mid-prompt).
+- Resolver is one regex pass; no template engine.
+
+Resolver lives at `src/lib/workspace-conventions/resolve-variables.ts`. Wired into:
+- `<AgentPromptPreview>` (settings page)
+- `get_workspace_context` MCP tool
+- Dispatch route (`src/app/api/tasks/[id]/dispatch/route.ts`)
+
+### 4. Templates
+
+Pre-written `.md` files with frontmatter under `src/lib/workspace-templates/`. Each file:
+
+```md
+---
+slug: code
+title: Code project
+description: Repository-backed codebase with tests, PRs, and a build pipeline.
+intended_for: developers / coding agents
+---
+
+## Repos
+- Working tree: {{working_dir}}
+- Repo: {{repo_url}} (default base: {{base_branch}})
+...
+```
+
+Initial set:
+- `blank.md` — empty body; minimal frontmatter.
+- `code.md` — repo / language-agnostic version of today's mission-control conventions.
+- `research.md` — sources / output format / style guide / review path.
+- `writing.md` — tone / voice / draft locations / review path.
+- `ops.md` — runbook locations / on-call rules / change windows.
+
+Templates are read at request time (no bundling step). A small server-side function `listTemplates()` parses frontmatter via gray-matter (already a transitive dep via Next? — check; otherwise add). UI shows a `<select>` of templates by `title`; selecting one inserts the body into the conventions textarea.
+
+Switching templates after the textarea has content prompts the operator via `ConfirmDialog` ("replace existing conventions?") — same project rule, no native `confirm`.
+
+### 5. Local-repo init checkbox
+
+In the Repo section of the settings page (PR 1 lands the checkbox even though `repo_url` itself ships in PR 2 — the use case is "I have a folder, no remote yet, just init git for me"):
+
+- Single boolean field `local_repo_init` (column added in PR 2; pre-PR-2 the checkbox writes to a transient state and only takes effect on PR-2 save).
+- Wait — to avoid this footgun, **PR 1 ships the column too** (one-line schema migration alongside the resolver work). Actual use of `repo_url` etc. waits for PR 2.
+- On save, server runs:
+  ```js
+  if (settings.local_repo_init && !existsSync(join(workspace_path, '.git'))) {
+    await execFile('git', ['init', '-b', settings.default_base_branch ?? 'main'], { cwd: workspace_path });
+  }
+  ```
+- Failure surfaces as a non-blocking warning toast — the workspace save still succeeds.
+
+### 6. Refine button (PR 3)
+
+Operator clicks **"Refine with agent"** under the conventions textarea. Flow:
+
+1. Modal opens: shows the current conventions body and a one-line operator note ("optional — what would you like the agent to focus on?").
+2. On submit: `POST /api/workspaces/:id/refine-conventions` with `{ current_conventions, operator_note }`.
+3. Route dispatches a writer/coder agent in a fresh session via `dispatchScope` with `scope_type='conventions_refine'`. New agent role; uses any available code/writer agent in the roster.
+4. Agent receives:
+   - The current conventions text
+   - Workspace facts (name, paths, repo_url, base_branch)
+   - Available `{{...}}` variables list
+   - System prompt: "Review the conventions for clarity, completeness, and consistency. Either propose a fully-rewritten replacement (markdown) OR ask up to 5 clarifying questions. Return JSON `{ kind: 'replacement' | 'questions', body: string, questions?: string[] }`."
+5. Agent's reply is parsed and returned to the operator as a proposal — modal swaps to a review pane:
+   - **Replacement**: shows side-by-side diff (or "swap" button if diff lib is heavy); operator clicks Accept (writes body to `context_md`) or Discard.
+   - **Questions**: shows the questions; operator types answers inline; clicking "Send answers" re-dispatches with the answers appended to operator_note.
+6. Persistence: a transient `pm_proposals`-shaped row? **No** — too much overlap with PM. Use a new lightweight table `workspace_conventions_proposals` with columns `id`, `workspace_id`, `kind`, `body`, `questions_json`, `status`, `created_at`. Default status `'open'`; `'accepted'` on apply; `'discarded'` on close.
+
+### 7. Settings UI cleanup (in PR 1)
+
+While we're touching the page:
+- `<AgentPromptPreview>` collapses by default in narrow viewports (under ~900px). Operator clicks "Show prompt preview" to expand. Above the threshold, current side-by-side layout is preserved.
+
+## Schema (PR 2 migration)
+
+```sql
+-- migration 082_workspace_repo_fields.ts
+ALTER TABLE workspaces ADD COLUMN repo_url TEXT;
+ALTER TABLE workspaces ADD COLUMN default_base_branch TEXT;
+ALTER TABLE workspaces ADD COLUMN local_repo_init INTEGER NOT NULL DEFAULT 0;
+```
+
+Optional follow-up index if `repo_url` ends up filtered (unlikely): skip.
+
+## API surface
+
+- `GET /api/workspace-templates` — returns `[{ slug, title, description, intended_for, body }]`. Static read of the templates dir.
+- Existing `PATCH /api/workspaces/:id/settings` route grows fields for `repo_url`, `default_base_branch`, `local_repo_init` (PR 2). Server-side `git init` runs on save when `local_repo_init` flips true.
+- `POST /api/workspaces/:id/refine-conventions` (PR 3).
+
+## MCP tool changes
+
+- `get_workspace_context` (PR 1) extends its return shape: `{ workspace_id, workspace_name, context_md, present, working_dir, deliverables, repo_url?, base_branch?, resolved_context_md }`. The new `resolved_context_md` is `context_md` with `{{...}}` expanded — agents prefer this; existing fields preserved for back-compat.
+- Existing dispatch route already prepends `## Workspace conventions`; switch to `resolved_context_md` so agents stop seeing `{{working_dir}}` literally.
+
+## Non-goals (named so we don't drift)
+
+- No multi-template stacking. One template at a time. Operator can hand-merge multiple if desired.
+- No template versioning. Updates to templates ship in the repo; operators re-pick if they want updates.
+- No live re-render of `{{...}}` mid-keystroke in the textarea — only in the preview pane and at dispatch time. Keeps the editor predictable.
+- No template editing UI. Templates are repo-shipped only; if an operator wants a custom template they edit the file directly (or refine inline).
+
+## Verification gates
+
+Per the project's spec-first rule, each PR has a preview-verify gate before opening:
+
+**PR 1**
+1. Settings page renders the template dropdown + checkbox.
+2. Picking a template inserts text into the textarea.
+3. `<AgentPromptPreview>` shows resolved `{{working_dir}}` etc.
+4. Save with `local_repo_init` checked on a path without `.git` runs `git init`; second save no-ops.
+5. `get_workspace_context` returns `resolved_context_md`.
+6. Existing dispatch flow still works (no regressions on a real Investigate or PM-chat dispatch).
+
+**PR 2**
+1. Migration applies cleanly on dogfood DB.
+2. Settings page shows the Repo subsection; values save and round-trip.
+3. Templates referencing `{{repo_url}}` / `{{base_branch}}` resolve correctly.
+4. Existing workspace dispatches unchanged when fields are blank.
+
+**PR 3**
+1. Refine button opens the modal.
+2. Submit dispatches an agent (verify with a real run; capture proposal output).
+3. Replacement-kind reply: accept replaces `context_md`; discard leaves it.
+4. Question-kind reply: operator can answer + re-dispatch; second reply settles.
+5. `workspace_conventions_proposals` rows lifecycle (open → accepted/discarded).
+
+## Out of scope (followups)
+
+- Variable substitution in template *frontmatter* (only body is resolved).
+- Bulk re-template across many workspaces.
+- "Default workspace" presets stored at user level.
+- A composer for the AI-fill-from-blank flow (the user's earlier idea — the refine flow covers iteration but not from-zero generation).

--- a/src/app/(app)/workspace/[slug]/settings/page.tsx
+++ b/src/app/(app)/workspace/[slug]/settings/page.tsx
@@ -23,9 +23,17 @@ import {
   AlertTriangle,
   Download,
   Folder,
+  GitBranch,
   Loader,
   Trash2,
+  FilePlus,
 } from 'lucide-react';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import {
+  resolveVariables,
+  inventoryVariables,
+  type VariableSource,
+} from '@/lib/workspace-conventions/resolve-variables';
 import {
   InlineText,
   InlineTextarea,
@@ -53,8 +61,19 @@ interface WorkspaceWithDefault {
   audit_subtree_concurrency?: number | null;
   /** Server-resolved default the override falls back to. */
   default_workspace_path: string;
+  /** When true, the PATCH route runs `git init` in workspace_path on save.
+   *  Idempotent. See specs/workspace-conventions-structured.md §5. */
+  local_repo_init?: number | null;
   created_at: string;
   updated_at: string;
+}
+
+interface WorkspaceTemplate {
+  slug: string;
+  title: string;
+  description: string;
+  intended_for: string;
+  body: string;
 }
 
 export default function WorkspaceSettingsPage({
@@ -77,6 +96,9 @@ export default function WorkspaceSettingsPage({
   // Live keystroke draft for the conventions textarea so the right-rail
   // preview updates as the operator types — `null` means "use saved value".
   const [conventionsDraft, setConventionsDraft] = useState<string | null>(null);
+  const [templates, setTemplates] = useState<WorkspaceTemplate[]>([]);
+  const [pendingTemplate, setPendingTemplate] = useState<WorkspaceTemplate | null>(null);
+  const [localRepoInitNotice, setLocalRepoInitNotice] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -104,6 +126,24 @@ export default function WorkspaceSettingsPage({
     refresh();
   }, [refresh]);
 
+  // One-shot fetch of starter templates so the dropdown isn't empty on
+  // first paint. The list is small and rarely-changes; no re-fetch.
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/workspace-templates')
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        setTemplates(data.templates ?? []);
+      })
+      .catch((err) => {
+        console.warn('[settings] template list failed', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const patch = useCallback(
     async (body: Record<string, unknown>) => {
       if (!workspace) return;
@@ -115,6 +155,24 @@ export default function WorkspaceSettingsPage({
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         throw new Error(data.error || `Update failed (${res.status})`);
+      }
+      // The PATCH route returns a `local_repo_init_result` envelope when
+      // a `git init` was attempted on save. Surface it as an inline
+      // notice — non-blocking; the field has already saved.
+      try {
+        const data = await res.json();
+        if (data?.local_repo_init_result) {
+          const r = data.local_repo_init_result as { status: string; message?: string };
+          if (r.status === 'initialized') {
+            setLocalRepoInitNotice('Initialized a local git repo in the working tree.');
+          } else if (r.status === 'noop') {
+            setLocalRepoInitNotice('Working tree already has a git repo — no init needed.');
+          } else {
+            setLocalRepoInitNotice(`git init skipped: ${r.message ?? 'unknown error'}`);
+          }
+        }
+      } catch {
+        /* response wasn't JSON — fine; field still saved */
       }
       await refresh();
     },
@@ -177,11 +235,23 @@ export default function WorkspaceSettingsPage({
   const sections = [
     { id: 'identity', label: 'Identity' },
     { id: 'project-root', label: 'Project root' },
+    { id: 'source-control', label: 'Source control' },
     { id: 'conventions', label: 'Workspace conventions' },
     { id: 'audit-defaults', label: 'Audit defaults' },
     { id: 'export', label: 'Export' },
     { id: 'danger-zone', label: 'Danger zone' },
   ];
+
+  // Effective working dir for variable substitution previews — same
+  // resolution the PATCH route uses on save.
+  const effectiveWorkingDir =
+    (workspace.workspace_path && workspace.workspace_path.trim()) ||
+    workspace.default_workspace_path;
+  const variableSrc: VariableSource = {
+    name: workspace.name,
+    working_dir: effectiveWorkingDir,
+    deliverables: effectiveWorkingDir,
+  };
 
   // No top header here: the Identity section below already shows the
   // workspace's name + icon + description, and the global left nav
@@ -202,6 +272,7 @@ export default function WorkspaceSettingsPage({
         <AgentPromptPreview
           contextMd={conventionsDraft ?? workspace.context_md ?? ''}
           dirty={conventionsDraft !== null && conventionsDraft !== (workspace.context_md ?? '')}
+          variableSrc={variableSrc}
         />
       }
       rightRailTitle="Agent prompt preview"
@@ -292,6 +363,45 @@ export default function WorkspaceSettingsPage({
           </Field>
         </Section>
 
+        {/* Source control — local-repo-init checkbox. The repo URL +
+            base-branch fields land in PR 2 of audit-actions structuring
+            (specs/workspace-conventions-structured.md). */}
+        <Section
+          id="source-control"
+          title="Source control"
+          description={
+            <>
+              Even non-code workspaces benefit from local git history — it lets
+              the orchestrator rewind if a thread goes off-track. Toggle
+              <strong className="text-mc-text"> &nbsp;Initialize local git repo&nbsp;</strong>
+              to have MC run <code className="text-mc-text">git init</code> in
+              the working tree on save (idempotent — no-op when{' '}
+              <code className="text-mc-text">.git/</code> is already there).
+            </>
+          }
+        >
+          <Field label="Initialize local git repo">
+            <label className="inline-flex items-center gap-2 text-sm text-mc-text cursor-pointer">
+              <input
+                type="checkbox"
+                checked={!!workspace.local_repo_init}
+                onChange={(e) => patch({ local_repo_init: e.target.checked })}
+                aria-label="Initialize local git repo"
+              />
+              <span>
+                <GitBranch className="w-3.5 h-3.5 inline-block mr-1 align-text-bottom" />
+                Run <code className="text-mc-text">git init</code> in{' '}
+                <code className="text-mc-text">{effectiveWorkingDir}</code> on save
+              </span>
+            </label>
+            {localRepoInitNotice && (
+              <p className="text-[11px] text-mc-text-secondary mt-1">
+                {localRepoInitNotice}
+              </p>
+            )}
+          </Field>
+        </Section>
+
         {/* Workspace conventions — rules-of-the-road prepended to every
             dispatched agent's task prompt. v0 of org-scope memory
             grounding (precursor to the memory-layer epic). Operator
@@ -305,25 +415,91 @@ export default function WorkspaceSettingsPage({
             <>
               Markdown that gets prepended to every dispatched task&apos;s
               prompt as a <code className="text-mc-text">## Workspace conventions</code>
-              {' '}block. Use this for repo URLs, testing patterns, push/PR rules,
-              package manager — whatever a fresh agent needs to ground its
-              work. Leave blank to skip the block entirely.
+              {' '}block. Use{' '}
+              <code className="text-mc-text">{`{{name}}`}</code>,{' '}
+              <code className="text-mc-text">{`{{working_dir}}`}</code>,{' '}
+              <code className="text-mc-text">{`{{deliverables}}`}</code>{' '}
+              (and once PR 2 lands,{' '}
+              <code className="text-mc-text">{`{{repo_url}}`}</code>,{' '}
+              <code className="text-mc-text">{`{{base_branch}}`}</code>) — they
+              expand at dispatch time. Leave blank to skip the block entirely.
             </>
           }
         >
+          {templates.length > 0 && (
+            <Field label="Start from a template">
+              <div className="flex flex-wrap items-center gap-2">
+                <select
+                  className="px-2 py-1 rounded border border-mc-border bg-mc-bg text-sm text-mc-text"
+                  defaultValue=""
+                  onChange={(e) => {
+                    const slug = e.target.value;
+                    if (!slug) return;
+                    const tpl = templates.find((t) => t.slug === slug);
+                    if (!tpl) return;
+                    const current = (conventionsDraft ?? workspace.context_md ?? '').trim();
+                    if (current.length > 0) {
+                      // Confirm before overwriting hand-written content.
+                      setPendingTemplate(tpl);
+                    } else {
+                      patch({ context_md: tpl.body.length > 0 ? tpl.body : null });
+                      setConventionsDraft(tpl.body);
+                    }
+                    e.target.value = '';
+                  }}
+                  aria-label="Insert a starter template"
+                >
+                  <option value="" disabled>
+                    Choose a template…
+                  </option>
+                  {templates.map((tpl) => (
+                    <option key={tpl.slug} value={tpl.slug}>
+                      {tpl.title}
+                    </option>
+                  ))}
+                </select>
+                <span className="text-[11px] text-mc-text-secondary">
+                  <FilePlus className="w-3 h-3 inline-block mr-1 align-text-bottom" />
+                  Templates are starter markdown — edit freely after inserting.
+                </span>
+              </div>
+            </Field>
+          )}
           <Field label="Conventions (markdown)">
             <InlineTextarea
               value={workspace.context_md ?? ''}
               onSave={next =>
                 patch({ context_md: next.length > 0 ? next : null })
               }
-              placeholder={`# Repos\n- ...\n\n# Testing\n- yarn test\n\n# Git rules\n- Never push to main\n- ...`}
+              placeholder={`## Repos\n- Working tree: {{working_dir}}\n\n## Testing\n- ...\n\n## Git rules\n- Never push to main\n`}
               minRows={8}
               label="Edit workspace conventions"
               onDraftChange={setConventionsDraft}
             />
           </Field>
         </Section>
+
+        <ConfirmDialog
+          open={pendingTemplate !== null}
+          title="Replace existing conventions?"
+          body={
+            <p className="text-sm text-mc-text">
+              Inserting <strong>{pendingTemplate?.title ?? 'this template'}</strong>{' '}
+              will replace the conventions you have written so far. The current
+              text isn&apos;t saved anywhere; it will be lost.
+            </p>
+          }
+          confirmLabel="Replace"
+          destructive
+          onConfirm={() => {
+            const tpl = pendingTemplate;
+            setPendingTemplate(null);
+            if (!tpl) return;
+            patch({ context_md: tpl.body.length > 0 ? tpl.body : null });
+            setConventionsDraft(tpl.body);
+          }}
+          onCancel={() => setPendingTemplate(null)}
+        />
 
         {/* Audit defaults — workspace-scoped knobs for the initiative
             Investigate flow's subtree mode. See
@@ -501,9 +677,11 @@ export default function WorkspaceSettingsPage({
 function AgentPromptPreview({
   contextMd,
   dirty = false,
+  variableSrc,
 }: {
   contextMd: string;
   dirty?: boolean;
+  variableSrc: VariableSource;
 }) {
   const trimmed = contextMd.trim();
   if (!trimmed) {
@@ -519,6 +697,10 @@ function AgentPromptPreview({
       </div>
     );
   }
+  // Expand `{{...}}` so the preview shows what the agent actually sees.
+  const resolved = resolveVariables(trimmed, variableSrc);
+  const variableUsage = inventoryVariables(trimmed, variableSrc);
+  const warnings = variableUsage.filter((v) => !v.known || v.empty);
   return (
     <div className="rounded-lg border border-mc-border/60 bg-mc-bg-secondary">
       <header className="px-4 py-2 border-b border-mc-border/60 flex items-center justify-between gap-2">
@@ -533,9 +715,26 @@ function AgentPromptPreview({
           </span>
         )}
       </header>
+      {warnings.length > 0 && (
+        <div className="px-4 py-2 border-b border-mc-border/60 text-[10px] flex flex-wrap gap-1.5 bg-amber-500/5">
+          {warnings.map((v) => (
+            <span
+              key={v.variable}
+              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-amber-500/10 border border-amber-500/30 text-amber-200"
+              title={
+                v.known
+                  ? `{{${v.variable}}} resolves to an empty value — set the field above to populate it.`
+                  : `{{${v.variable}}} is not a known variable — likely a typo.`
+              }
+            >
+              ⚠️ {`{{${v.variable}}}`} {v.known ? '(empty)' : '(unknown)'}
+            </span>
+          ))}
+        </div>
+      )}
       <div className="p-4 mc-md text-xs text-mc-text break-words">
         <ReactMarkdown remarkPlugins={[remarkGfm]}>
-          {`## Workspace conventions\n\n${trimmed}\n\n---`}
+          {`## Workspace conventions\n\n${resolved}\n\n---`}
         </ReactMarkdown>
       </div>
     </div>

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -4,7 +4,11 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { sendChatToAgent } from '@/lib/openclaw/send-chat';
 import { broadcast } from '@/lib/events';
-import { getProjectsPath, getMissionControlUrl } from '@/lib/config';
+import { getProjectsPath, getMissionControlUrl, resolveWorkspacePath } from '@/lib/config';
+import {
+  resolveVariables,
+  type VariableSource,
+} from '@/lib/workspace-conventions/resolve-variables';
 import { getTaskDeliverableDir } from '@/lib/deliverables/storage';
 import { getRelevantKnowledge, formatKnowledgeForDispatch } from '@/lib/learner';
 import { getTaskWorkflow } from '@/lib/workflow-engine';
@@ -895,14 +899,30 @@ ${criteria.length > 0 ? criteria.map(c => `  - ${c}`).join('\n') : '  - (none de
     // no block at all so we don't render an empty placeholder.
     let workspaceConventionsSection = '';
     try {
-      const wsRow = queryOne<{ context_md: string | null }>(
-        `SELECT context_md FROM workspaces WHERE id = ?`,
+      const wsRow = queryOne<{
+        slug: string;
+        name: string;
+        context_md: string | null;
+        workspace_path: string | null;
+      }>(
+        `SELECT slug, name, context_md, workspace_path FROM workspaces WHERE id = ?`,
         [task.workspace_id],
       );
       const ctx = wsRow?.context_md;
-      if (typeof ctx === 'string' && ctx.trim().length > 0) {
-        workspaceConventionsSection =
-          `## Workspace conventions\n\n${ctx.trim()}\n\n---\n\n`;
+      if (wsRow && typeof ctx === 'string' && ctx.trim().length > 0) {
+        // Resolve {{...}} tokens against the workspace's structured
+        // fields so agents see real paths / urls, not literal template
+        // variables. Spec §3.
+        const working_dir =
+          (wsRow.workspace_path && wsRow.workspace_path.trim()) ||
+          resolveWorkspacePath(wsRow.slug, null);
+        const variableSrc: VariableSource = {
+          name: wsRow.name,
+          working_dir,
+          deliverables: working_dir,
+        };
+        const resolved = resolveVariables(ctx.trim(), variableSrc);
+        workspaceConventionsSection = `## Workspace conventions\n\n${resolved}\n\n---\n\n`;
       }
     } catch (err) {
       console.warn('[Dispatch] workspace context lookup failed:', (err as Error).message);

--- a/src/app/api/workspace-templates/route.ts
+++ b/src/app/api/workspace-templates/route.ts
@@ -1,0 +1,24 @@
+/**
+ * GET /api/workspace-templates
+ *
+ * Returns the operator-pickable starter templates for the workspace
+ * conventions textarea. See specs/workspace-conventions-structured.md §4.
+ */
+
+import { NextResponse } from 'next/server';
+import { listTemplates } from '@/lib/workspace-templates';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const templates = await listTemplates();
+    return NextResponse.json({ templates });
+  } catch (err) {
+    console.error('[workspace-templates] list failed', err);
+    return NextResponse.json(
+      { error: 'failed to list templates' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/workspaces/[id]/route.ts
+++ b/src/app/api/workspaces/[id]/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { getDb } from '@/lib/db';
 import {
   deleteWorkspaceCascade,
@@ -9,6 +13,44 @@ import {
   AUDIT_SUBTREE_CONCURRENCY_MAX,
 } from '@/lib/db/workspaces';
 import { resolveWorkspacePath } from '@/lib/config';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Initialize a git repo at `workspacePath` if one isn't already there.
+ * Idempotent — when `.git/` already exists this is a silent no-op.
+ *
+ * Returns a structured result so the route can surface non-blocking
+ * warnings; failure does NOT abort the workspace save (the operator's
+ * primary intent — setting fields — has already succeeded by this point).
+ *
+ * See specs/workspace-conventions-structured.md §5.
+ */
+async function ensureLocalRepo(
+  workspacePath: string,
+): Promise<{ status: 'noop' | 'initialized' | 'error'; message?: string }> {
+  if (!workspacePath || !workspacePath.trim()) {
+    return { status: 'error', message: 'workspace_path is empty; cannot init git here' };
+  }
+  if (!existsSync(workspacePath)) {
+    return {
+      status: 'error',
+      message: `workspace_path '${workspacePath}' does not exist on disk`,
+    };
+  }
+  if (existsSync(join(workspacePath, '.git'))) {
+    return { status: 'noop' };
+  }
+  try {
+    await execFileAsync('git', ['init', '-b', 'main'], { cwd: workspacePath });
+    return { status: 'initialized' };
+  } catch (err) {
+    return {
+      status: 'error',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
 
 export const dynamic = 'force-dynamic';
 // GET /api/workspaces/[id] - Get a single workspace
@@ -68,6 +110,7 @@ export async function PATCH(
       context_md,
       audit_per_node_timeout_ms,
       audit_subtree_concurrency,
+      local_repo_init,
     } = body;
 
     const db = getDb();
@@ -129,6 +172,11 @@ export async function PATCH(
       updates.push('audit_per_node_timeout_ms = ?');
       values.push(n);
     }
+    if (local_repo_init !== undefined) {
+      // Boolean stored as INTEGER (0/1) per the migration.
+      updates.push('local_repo_init = ?');
+      values.push(local_repo_init ? 1 : 0);
+    }
     if (audit_subtree_concurrency !== undefined) {
       const n = Number(audit_subtree_concurrency);
       if (!Number.isFinite(n) || !Number.isInteger(n)) {
@@ -160,8 +208,29 @@ export async function PATCH(
       UPDATE workspaces SET ${updates.join(', ')} WHERE id = ?
     `).run(...values);
 
-    const workspace = db.prepare('SELECT * FROM workspaces WHERE id = ?').get(id);
-    return NextResponse.json(workspace);
+    const workspace = db.prepare('SELECT * FROM workspaces WHERE id = ?').get(id) as
+      | { workspace_path?: string | null; slug: string; local_repo_init?: number }
+      | undefined;
+
+    // Local-repo init: when the operator just flipped the checkbox on
+    // (or had it on already and is re-saving), ensure the working tree
+    // has a git repo. Idempotent. Failures surface as a non-blocking
+    // warning — the workspace save itself has already succeeded.
+    let localRepoInit: { status: string; message?: string } | undefined;
+    if (
+      local_repo_init !== undefined &&
+      local_repo_init &&
+      workspace
+    ) {
+      const effectivePath =
+        (workspace.workspace_path && workspace.workspace_path.trim()) ||
+        resolveWorkspacePath(workspace.slug, null);
+      localRepoInit = await ensureLocalRepo(effectivePath);
+    }
+
+    return NextResponse.json(
+      localRepoInit ? { ...workspace, local_repo_init_result: localRepoInit } : workspace,
+    );
   } catch (error) {
     console.error('Failed to update workspace:', error);
     return NextResponse.json({ error: 'Failed to update workspace' }, { status: 500 });

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4436,6 +4436,25 @@ const migrations: Migration[] = [
       console.log('[Migration 081] agent_runs.trigger_body + pm_proposal_id columns added.');
     },
   },
+  {
+    id: '082',
+    name: 'workspaces_local_repo_init',
+    up: (db) => {
+      // Workspace conventions structuring (PR 1): one boolean — when
+      // true, the PATCH /api/workspaces/:id route runs `git init` in
+      // the workspace_path on save (idempotent — no-op if `.git/` is
+      // already there). Lets operators wire up a folder-only workspace
+      // for local commit history without leaving the settings page.
+      // See specs/workspace-conventions-structured.md §5.
+      const cols = db.prepare(`PRAGMA table_info(workspaces)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'local_repo_init')) {
+        db.exec(`ALTER TABLE workspaces ADD COLUMN local_repo_init INTEGER NOT NULL DEFAULT 0`);
+        console.log('[Migration 082] workspaces.local_repo_init added.');
+      } else {
+        console.log('[Migration 082] workspaces.local_repo_init already present; skipping.');
+      }
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/mcp/groups/core.ts
+++ b/src/lib/mcp/groups/core.ts
@@ -13,6 +13,11 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { queryAll, queryOne } from '@/lib/db';
+import { resolveWorkspacePath } from '@/lib/config';
+import {
+  resolveVariables,
+  type VariableSource,
+} from '@/lib/workspace-conventions/resolve-variables';
 import { logActivity } from '@/lib/services/task-activities';
 import { postPmChatMessage } from '@/lib/agents/pm-dispatch';
 import {
@@ -199,14 +204,41 @@ export function registerCoreTools(server: McpServer): void {
           structuredContent: { error: 'agent_not_found', agent_id },
         };
       }
-      const ws = queryOne<{ id: string; name: string; context_md: string | null }>(
-        `SELECT id, name, context_md FROM workspaces WHERE id = ?`,
+      const ws = queryOne<{
+        id: string;
+        slug: string;
+        name: string;
+        context_md: string | null;
+        workspace_path: string | null;
+      }>(
+        `SELECT id, slug, name, context_md, workspace_path FROM workspaces WHERE id = ?`,
         [me.workspace_id],
       );
+
+      const working_dir = ws
+        ? (ws.workspace_path && ws.workspace_path.trim()) ||
+          resolveWorkspacePath(ws.slug, null)
+        : '';
+
+      // Resolve {{...}} tokens in the conventions text so agents see
+      // working_dir / repo_url etc. expanded rather than the literal
+      // template variables. Spec §3.
+      const variableSrc: VariableSource = {
+        name: ws?.name ?? '',
+        working_dir,
+        deliverables: working_dir,
+      };
+      const resolved_context_md = resolveVariables(ws?.context_md ?? null, variableSrc);
+
       const payload = {
         workspace_id: me.workspace_id,
         workspace_name: ws?.name ?? null,
+        // Raw markdown — what's stored in the DB. Kept for back-compat
+        // with callers that already round-trip this exact field.
         context_md: ws?.context_md ?? null,
+        // {{token}}-resolved variant — what agents should prefer.
+        resolved_context_md: resolved_context_md || null,
+        working_dir,
         present: typeof ws?.context_md === 'string' && ws.context_md.trim().length > 0,
       };
       return textResult(JSON.stringify(payload, null, 2), payload);

--- a/src/lib/workspace-conventions/resolve-variables.test.ts
+++ b/src/lib/workspace-conventions/resolve-variables.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Variable resolver — unit tests.
+ *
+ * See specs/workspace-conventions-structured.md §3.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  KNOWN_VARIABLES,
+  inventoryVariables,
+  resolveVariables,
+} from './resolve-variables';
+
+const SRC = {
+  name: 'Test Workspace',
+  working_dir: '/Users/op/projects/x',
+  deliverables: '/Users/op/Deliverables',
+  repo_url: 'https://github.com/op/x',
+  base_branch: 'main',
+};
+
+test('resolveVariables: known tokens expand', () => {
+  const text = 'cwd: {{working_dir}}; repo: {{repo_url}}; base: {{base_branch}}';
+  assert.equal(
+    resolveVariables(text, SRC),
+    'cwd: /Users/op/projects/x; repo: https://github.com/op/x; base: main',
+  );
+});
+
+test('resolveVariables: name + deliverables resolve', () => {
+  assert.equal(
+    resolveVariables('Hi from {{name}} → {{deliverables}}', SRC),
+    'Hi from Test Workspace → /Users/op/Deliverables',
+  );
+});
+
+test('resolveVariables: deliverables falls back to working_dir when blank', () => {
+  const fallback = { ...SRC, deliverables: null };
+  assert.equal(
+    resolveVariables('{{deliverables}}', fallback),
+    '/Users/op/projects/x',
+  );
+});
+
+test('resolveVariables: empty optional value renders empty silently', () => {
+  const blankRepo = { ...SRC, repo_url: null };
+  // Note: we don't insert ⚠️ here — that's the preview pane's job.
+  assert.equal(resolveVariables('see {{repo_url}} for source', blankRepo), 'see  for source');
+});
+
+test('resolveVariables: unknown token preserved verbatim', () => {
+  assert.equal(resolveVariables('{{not_a_token}} stays', SRC), '{{not_a_token}} stays');
+});
+
+test('resolveVariables: tolerates whitespace inside the braces', () => {
+  assert.equal(resolveVariables('{{ working_dir }}', SRC), '/Users/op/projects/x');
+});
+
+test('resolveVariables: null/undefined input returns empty string', () => {
+  assert.equal(resolveVariables(null, SRC), '');
+  assert.equal(resolveVariables(undefined, SRC), '');
+});
+
+test('resolveVariables: multiple occurrences all replaced', () => {
+  const text = '{{name}} :: {{name}} :: {{name}}';
+  assert.equal(resolveVariables(text, SRC), 'Test Workspace :: Test Workspace :: Test Workspace');
+});
+
+test('inventoryVariables: classifies known/unknown/empty', () => {
+  const blankRepo = { ...SRC, repo_url: '' };
+  const text = '{{name}} {{repo_url}} {{garbage}} {{name}}';
+  const usage = inventoryVariables(text, blankRepo);
+  assert.deepEqual(usage, [
+    { variable: 'name', known: true, empty: false },
+    { variable: 'repo_url', known: true, empty: true },
+    { variable: 'garbage', known: false },
+  ]);
+});
+
+test('KNOWN_VARIABLES export matches resolver coverage', () => {
+  // Belt-and-braces: every advertised variable resolves to a non-null
+  // value (i.e. the lookup() switch knows it).
+  for (const v of KNOWN_VARIABLES) {
+    const resolved = resolveVariables(`{{${v}}}`, SRC);
+    assert.notStrictEqual(resolved, `{{${v}}}`, `Expected ${v} to be a known variable`);
+  }
+});

--- a/src/lib/workspace-conventions/resolve-variables.ts
+++ b/src/lib/workspace-conventions/resolve-variables.ts
@@ -1,0 +1,124 @@
+/**
+ * Workspace conventions variable substitution.
+ *
+ * Postman-style `{{token}}` syntax replaces declared tokens with values
+ * pulled from the workspace row. Used by:
+ *   - <AgentPromptPreview> on the settings page
+ *   - get_workspace_context MCP tool
+ *   - dispatch route (src/app/api/tasks/[id]/dispatch/route.ts)
+ *
+ * Behavior:
+ *   - Known token, value present → expanded.
+ *   - Known token, value missing/empty → expanded to '' silently.
+ *     (Settings preview separately decorates these as ⚠️ chips.)
+ *   - Unknown token → left as the literal `{{whatever}}` so typos are
+ *     visible at render time.
+ *
+ * See specs/workspace-conventions-structured.md §3.
+ */
+
+/** Tokens the resolver knows about. Keep sorted; add new ones explicitly. */
+export const KNOWN_VARIABLES = [
+  'base_branch',
+  'deliverables',
+  'name',
+  'repo_url',
+  'working_dir',
+] as const;
+
+export type KnownVariable = (typeof KNOWN_VARIABLES)[number];
+
+export interface VariableSource {
+  /** Workspace display name (workspaces.name). */
+  name: string;
+  /** Resolved working tree path (workspaces.workspace_path or env default). */
+  working_dir: string;
+  /** Deliverables path. Falls back to working_dir when not set. */
+  deliverables?: string | null;
+  /** Repo URL. Optional — null/empty ⇒ '' substitution + preview warning. */
+  repo_url?: string | null;
+  /** Default base branch. Optional. */
+  base_branch?: string | null;
+}
+
+const TOKEN_RE = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
+
+function lookup(varName: string, src: VariableSource): string | null {
+  switch (varName) {
+    case 'name':
+      return src.name ?? '';
+    case 'working_dir':
+      return src.working_dir ?? '';
+    case 'deliverables':
+      // deliverables falls back to working_dir per spec §1.
+      return (src.deliverables && src.deliverables.trim()) || src.working_dir || '';
+    case 'repo_url':
+      return src.repo_url ?? '';
+    case 'base_branch':
+      return src.base_branch ?? '';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolve all `{{token}}` occurrences in `text`.
+ *
+ * `text` may be null/undefined → returns ''.
+ *
+ * Unknown tokens are preserved verbatim (a regex lookup miss returns
+ * null, and we slot back the original match).
+ */
+export function resolveVariables(
+  text: string | null | undefined,
+  src: VariableSource,
+): string {
+  if (!text) return '';
+  return text.replace(TOKEN_RE, (match, varName: string) => {
+    const value = lookup(varName, src);
+    if (value === null) return match;
+    return value;
+  });
+}
+
+export interface VariableUsage {
+  variable: string;
+  /** Whether the resolver knows this token. */
+  known: boolean;
+  /**
+   * Whether the resolved value is empty (only meaningful when known).
+   * The settings preview pane uses this to render `⚠️ {{x}} (empty)`
+   * chips so operators can see what won't expand at dispatch time.
+   */
+  empty?: boolean;
+}
+
+/**
+ * Inventory the `{{...}}` tokens in `text`. Used by the settings page
+ * to render warning chips for unknown / empty variables alongside the
+ * preview pane. Order matches first appearance; duplicates collapsed.
+ */
+export function inventoryVariables(
+  text: string | null | undefined,
+  src: VariableSource,
+): VariableUsage[] {
+  if (!text) return [];
+  const out: VariableUsage[] = [];
+  const seen = new Set<string>();
+  for (const m of text.matchAll(TOKEN_RE)) {
+    const varName = m[1];
+    if (seen.has(varName)) continue;
+    seen.add(varName);
+    const value = lookup(varName, src);
+    if (value === null) {
+      out.push({ variable: varName, known: false });
+    } else {
+      out.push({
+        variable: varName,
+        known: true,
+        empty: value.trim().length === 0,
+      });
+    }
+  }
+  return out;
+}

--- a/src/lib/workspace-templates/blank.md
+++ b/src/lib/workspace-templates/blank.md
@@ -1,0 +1,5 @@
+---
+title: Blank
+description: Empty conventions — start from scratch.
+intended_for: any workspace
+---

--- a/src/lib/workspace-templates/code.md
+++ b/src/lib/workspace-templates/code.md
@@ -1,0 +1,57 @@
+---
+title: Code project
+description: Repository-backed codebase with tests, PRs, and a build pipeline.
+intended_for: software engineering / coding agents
+---
+## Repos
+
+- Working tree: `{{working_dir}}`
+- Repo: {{repo_url}}
+- Default base branch: `{{base_branch}}`
+- Always pass `--base {{base_branch}}` to `gh pr create`. If the repo is a fork, pass `--repo {{repo_url}}` explicitly so PRs don't auto-resolve to upstream.
+
+## Source control
+
+- Never push directly to `{{base_branch}}`.
+- Never force-push to `{{base_branch}}`.
+- Never skip commit hooks (`--no-verify`) unless the operator explicitly approves.
+- New commits, not amends — if a pre-commit hook fails, fix and re-commit instead of `--amend`.
+
+## Branch naming
+
+When you pick a branch yourself (non-dispatched flow):
+
+- `feat/<slug>` — new features
+- `fix/<slug>` — bug fixes
+- `docs/<slug>` — doc-only changes
+- `perf/<slug>` — performance work
+
+When MC dispatches a task you're already on the right branch (typically `task/<id>` or `autopilot/<slug>`). Don't rename it.
+
+## Stacked PRs
+
+Retarget child PRs to `{{base_branch}}` **before** merging the parent with `--delete-branch`. Otherwise GitHub auto-closes the children when the parent branch is deleted.
+
+## Testing
+
+Before declaring a change done, run the full suite once and inventory all failures up front. Don't iteratively add `--skip` flags to silence individual failures — that hides pre-existing breakage.
+
+- _(replace with this project's test commands — e.g. `yarn test`, `pytest`, `go test ./...`)_
+
+## Verification
+
+Type-check + tests verify code correctness, not feature correctness. **Exercise the change against a running system before reporting it done.** If you can't actually exercise it, say so explicitly — don't substitute an irrelevant smoke test.
+
+## Spec-first for non-trivial refactors
+
+For multi-layer changes (DB migration + service + UI), follow audit → spec → implement → verify:
+
+1. **Audit**: list current behavior and gaps.
+2. **Spec**: short design doc citing specific files / lines.
+3. **Implement**: commit per logical slice.
+4. **Verify**: tests + smoke before opening the PR.
+
+## Communication
+
+- Keep updates tight: 1–3 sentences. Substance lives in the artifacts you produce, not in chat prose.
+- End-of-turn summary: ≤ 2 sentences. What changed, what's next.

--- a/src/lib/workspace-templates/index.ts
+++ b/src/lib/workspace-templates/index.ts
@@ -1,0 +1,125 @@
+/**
+ * Workspace conventions templates.
+ *
+ * Operator-pickable starter markdown for the conventions textarea. Each
+ * template is a `.md` file in this directory with simple `--- key: value
+ * ---` frontmatter. The body uses `{{...}}` variables that get resolved
+ * at preview / dispatch time (see resolve-variables.ts).
+ *
+ * Templates are read at request time — no bundling step. Adding a new
+ * template means dropping a `.md` file in this directory; nothing else
+ * to wire.
+ *
+ * See specs/workspace-conventions-structured.md §4.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export interface WorkspaceTemplate {
+  slug: string;
+  title: string;
+  description: string;
+  intended_for: string;
+  body: string;
+}
+
+const TEMPLATES_DIR = path.join(process.cwd(), 'src/lib/workspace-templates');
+
+/**
+ * Tiny frontmatter parser. We don't need a full YAML engine — every
+ * template uses a stable subset (string-only top-level keys). Matches:
+ *
+ *     ---
+ *     title: Code project
+ *     description: Some text with: colons inside is fine
+ *     ---
+ *     <body>
+ *
+ * The body picks up everything after the closing fence. Leading newline
+ * trimmed.
+ */
+function parseFrontmatter(raw: string): { fm: Record<string, string>; body: string } {
+  const fm: Record<string, string> = {};
+  if (!raw.startsWith('---')) {
+    return { fm, body: raw };
+  }
+  // Find the closing fence on its own line.
+  const lines = raw.split('\n');
+  if (lines[0]?.trim() !== '---') return { fm, body: raw };
+  let endIdx = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      endIdx = i;
+      break;
+    }
+  }
+  if (endIdx === -1) {
+    // No closing fence; treat as no frontmatter to avoid swallowing the body.
+    return { fm, body: raw };
+  }
+  for (let i = 1; i < endIdx; i++) {
+    const line = lines[i];
+    const m = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.*)$/);
+    if (!m) continue;
+    fm[m[1]] = m[2].trim();
+  }
+  // Trim a single leading newline after the closing fence so templates
+  // can have a blank line after frontmatter without the body leading
+  // with whitespace.
+  let bodyStart = endIdx + 1;
+  if (lines[bodyStart] === '') bodyStart += 1;
+  return { fm, body: lines.slice(bodyStart).join('\n') };
+}
+
+/**
+ * Read every `.md` file in the templates dir and parse frontmatter.
+ * Files lacking required keys (title, description) are skipped with a
+ * warning — never crash the request.
+ */
+export async function listTemplates(): Promise<WorkspaceTemplate[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(TEMPLATES_DIR);
+  } catch (err) {
+    console.error('[workspace-templates] cannot read templates dir', err);
+    return [];
+  }
+  const out: WorkspaceTemplate[] = [];
+  for (const fname of entries) {
+    if (!fname.endsWith('.md')) continue;
+    const slug = fname.replace(/\.md$/, '');
+    const full = path.join(TEMPLATES_DIR, fname);
+    let raw: string;
+    try {
+      raw = await fs.readFile(full, 'utf8');
+    } catch (err) {
+      console.warn(`[workspace-templates] failed to read ${fname}`, err);
+      continue;
+    }
+    const { fm, body } = parseFrontmatter(raw);
+    if (!fm.title || !fm.description) {
+      console.warn(`[workspace-templates] ${fname} is missing title/description in frontmatter`);
+      continue;
+    }
+    out.push({
+      slug,
+      title: fm.title,
+      description: fm.description,
+      intended_for: fm.intended_for ?? '',
+      body: body.replace(/^\n+/, ''),
+    });
+  }
+  // Stable ordering: blank first, then alphabetical by title for the rest.
+  out.sort((a, b) => {
+    if (a.slug === 'blank') return -1;
+    if (b.slug === 'blank') return 1;
+    return a.title.localeCompare(b.title);
+  });
+  return out;
+}
+
+export async function getTemplate(slug: string): Promise<WorkspaceTemplate | null> {
+  const all = await listTemplates();
+  return all.find((t) => t.slug === slug) ?? null;
+}

--- a/src/lib/workspace-templates/ops.md
+++ b/src/lib/workspace-templates/ops.md
@@ -1,0 +1,37 @@
+---
+title: Ops / runbook
+description: Operational work — incident response, scheduled maintenance, system tending.
+intended_for: ops / on-call agents
+---
+## Working area
+
+- Working tree: `{{working_dir}}`
+- Runbook outputs (post-mortems, change records, incident notes) go in `{{deliverables}}`.
+
+## Source control
+
+Operational logs benefit from being version-controlled — they form an auditable trail. Commit each significant action in its own commit (one action ↔ one commit) so the timeline is legible. If `{{repo_url}}` is set, push branches there.
+
+## On-call rules
+
+- _(operator: describe escalation contacts and pager / Slack channels.)_
+- Never make changes during a freeze window without explicit operator approval.
+- Read-only investigation is always safe. Mutations require operator sign-off unless the runbook explicitly pre-authorizes them.
+
+## Change windows
+
+- _(operator: list approved windows — e.g. "weekdays 10:00–16:00 PT, no Fridays".)_
+
+## Verification
+
+After every change, confirm it landed in the *running* system — not just in the local config. Curl the endpoint, exec into the container, query the DB. A clean local edit is not proof.
+
+## Incident response
+
+- Don't paper over a failure with a retry loop or an `--ignore` flag.
+- If the root cause isn't clear, surface what you saw, what you tried, and what you'd try next — let the operator decide before mutations.
+
+## Communication
+
+- Tight updates at decision points. Long narratives belong in the post-mortem deliverable, not in chat.
+- End-of-turn: ≤ 2 sentences (what changed, what's next / what's blocked).

--- a/src/lib/workspace-templates/research.md
+++ b/src/lib/workspace-templates/research.md
@@ -1,0 +1,35 @@
+---
+title: Research
+description: Gather, synthesize, and write up findings — sources are first-class.
+intended_for: research / analyst agents
+---
+## Working area
+
+- Working tree: `{{working_dir}}`
+- Final artifacts go in `{{deliverables}}` so MC serves them as web-downloadable.
+- Drafts and source notes can stay inside the working tree.
+
+## Source control
+
+Even non-code work benefits from version control. Commit drafts in logical chunks so the orchestrator can rewind if a thread goes off-track. If `{{repo_url}}` is set, push branches there; otherwise local commits are sufficient.
+
+## Sources
+
+- Cite every external source by title + stable URL. Treat archive.org / wayback links as a fallback only if the live URL is gone.
+- For paywalled content, capture a short excerpt in the report and cite the source — don't re-host the body.
+- When a fact comes from the operator's own working knowledge (not a discoverable source), say so explicitly: "(operator-provided)".
+
+## Output format
+
+- Prefer markdown for the body. Tables for comparison. Inline citations as `[label](url)` rather than footnote syntax.
+- Lead with a 3–5-sentence executive summary.
+- End with an "Open questions" section listing what couldn't be settled.
+
+## Review
+
+- Drafts land in `{{deliverables}}` for the operator to read.
+- Don't act on findings (e.g. propose initiative changes) without operator confirmation. Surface a recommendation; let the operator pull the trigger.
+
+## Communication
+
+- 1–3 sentence updates at decision points. End-of-turn: ≤ 2 sentences (what's settled, what's next).

--- a/src/lib/workspace-templates/writing.md
+++ b/src/lib/workspace-templates/writing.md
@@ -1,0 +1,36 @@
+---
+title: Writing
+description: Long-form drafting — memos, briefs, proposals — with a clear voice and review path.
+intended_for: writers / editorial agents
+---
+## Working area
+
+- Working tree: `{{working_dir}}`
+- Final drafts go in `{{deliverables}}`.
+- Source notes, outlines, and abandoned drafts stay inside the working tree.
+
+## Source control
+
+Commit drafts in logical chunks ("v1 outline", "v2 with operator feedback") so the operator can rewind. If `{{repo_url}}` is set, push to that remote; otherwise local commits.
+
+## Voice & tone
+
+- _(operator: describe the desired voice — formal / conversational / clinical, etc.)_
+- Avoid hype words ("revolutionary", "game-changing", "seamless"). Show, don't claim.
+- Active voice by default. Passive only when the actor is genuinely unknown.
+
+## Structure
+
+- Lead with a 1–2 sentence summary.
+- Headings for each section so the operator can skim.
+- Short paragraphs (≤ 5 sentences). Lists where structure helps; prose where rhythm matters.
+
+## Review
+
+- Don't publish, send, or post on the operator's behalf.
+- Final drafts land in `{{deliverables}}` for the operator to review.
+- Surface alternates as separate files (`-v1.md`, `-v2.md`) rather than overwriting.
+
+## Communication
+
+- 1–3 sentence updates at decision points. Substance lives in the draft itself, not in chat narration.


### PR DESCRIPTION
## Summary

First slice of the [workspace-conventions structuring](specs/workspace-conventions-structured.md) work. Replaces \"one big freeform textarea is the only source of workspace agent guidance\" with **starter templates**, **`{{...}}` variable expansion**, and a **one-click local git-init checkbox** — all additive; existing workspaces are unchanged until the operator opts in.

## Changes

**Variable resolver** (`src/lib/workspace-conventions/resolve-variables.ts`)
- `{{name}}` / `{{working_dir}}` / `{{deliverables}}` resolve at preview + dispatch + `get_workspace_context`.
- `{{repo_url}}` / `{{base_branch}}` are recognized but resolve to empty until [PR 2](specs/workspace-conventions-structured.md#schema-pr-2-migration) ships the columns.
- Unknown tokens preserved literally (`{{whatever}}`) so typos are visible.
- Empty known-token values render silently in the agent prompt; the **preview** decorates them with a ⚠️ chip.
- 10 unit tests.

**Templates** (`src/lib/workspace-templates/*.md`)
- Five `.md` files with frontmatter (`title`, `description`, `intended_for`): `blank`, `code`, `research`, `writing`, `ops`.
- New `GET /api/workspace-templates` serves them.

**Settings UI**
- New \"Use template\" dropdown above the conventions textarea. Replacing non-empty content is gated by `ConfirmDialog`.
- Description text mentions the available `{{...}}` variables.
- `<AgentPromptPreview>` now resolves variables and renders ⚠️ chips for unknown / empty tokens.

**Source control section**
- New section above conventions with an \"Initialize local git repo\" checkbox.
- On save, server runs `git init -b main` in the working tree. **Idempotent** — no-op when `.git/` already exists.
- Migration 082 adds `workspaces.local_repo_init INTEGER DEFAULT 0`.
- Failure surfaces as a non-blocking inline notice; the workspace save itself still succeeds.

**Dispatch + MCP**
- `src/app/api/tasks/[id]/dispatch/route.ts` now resolves `{{...}}` before prepending the conventions block.
- `get_workspace_context` MCP tool returns a new `resolved_context_md` field alongside the raw `context_md` for back-compat.

## Test plan

- [x] `yarn test` — 824 pass, 1 pre-existing failure (`schedule-runner`).
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify** on `mission-control-dev` (:4010):
  - `GET /api/workspace-templates` returns 5 entries with parsed frontmatter ✓
  - Settings page shows the new \"Source control\" section, the template dropdown, and the variable-syntax callout ✓
  - Inserting `code` template into an empty workspace populates the textarea; preview renders with `{{working_dir}}` resolved to the real path and `{{repo_url}}` flagged as ⚠️ empty (correct — PR 2 ships that field) ✓
  - Trying to insert a different template over existing text → ConfirmDialog gates the overwrite ✓
  - Toggling \"Initialize local git repo\" on a path without `.git/` writes the directory; second toggle reports \"already has a git repo — no init needed\" ✓
  - Workspace conventions for the dogfood workspace remain intact (length 9721, starts with `## Repos`) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)