### PR TITLE
feat(workspace-conventions): repo_url + default_base_branch fields (PR 2/3)

### DIFF
--- a/src/app/(app)/workspace/[slug]/settings/page.tsx
+++ b/src/app/(app)/workspace/[slug]/settings/page.tsx
@@ -64,6 +64,11 @@ interface WorkspaceWithDefault {
   /** When true, the PATCH route runs `git init` in workspace_path on save.
    *  Idempotent. See specs/workspace-conventions-structured.md §5. */
   local_repo_init?: number | null;
+  /** Optional remote (e.g. https://github.com/owner/repo). Drives PR
+   *  targeting guidance in the conventions prompt and a UI chip. */
+  repo_url?: string | null;
+  /** Default base branch for PRs (e.g. main). */
+  default_base_branch?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -251,6 +256,8 @@ export default function WorkspaceSettingsPage({
     name: workspace.name,
     working_dir: effectiveWorkingDir,
     deliverables: effectiveWorkingDir,
+    repo_url: workspace.repo_url ?? null,
+    base_branch: workspace.default_base_branch ?? null,
   };
 
   // No top header here: the Identity section below already shows the
@@ -363,23 +370,46 @@ export default function WorkspaceSettingsPage({
           </Field>
         </Section>
 
-        {/* Source control — local-repo-init checkbox. The repo URL +
-            base-branch fields land in PR 2 of audit-actions structuring
-            (specs/workspace-conventions-structured.md). */}
+        {/* Source control — repo metadata + local-repo-init. Drives the
+            {{repo_url}} / {{base_branch}} variables and the "always
+            target this remote" rule in the dispatched prompt. See
+            specs/workspace-conventions-structured.md §2 / §5. */}
         <Section
           id="source-control"
           title="Source control"
           description={
             <>
-              Even non-code workspaces benefit from local git history — it lets
-              the orchestrator rewind if a thread goes off-track. Toggle
-              <strong className="text-mc-text"> &nbsp;Initialize local git repo&nbsp;</strong>
-              to have MC run <code className="text-mc-text">git init</code> in
-              the working tree on save (idempotent — no-op when{' '}
-              <code className="text-mc-text">.git/</code> is already there).
+              Optional repository metadata for <code className="text-mc-text">{`{{repo_url}}`}</code>
+              {' '}and <code className="text-mc-text">{`{{base_branch}}`}</code> in the conventions
+              text. Even folder-only workspaces benefit from local git history —
+              tick the checkbox below to <code className="text-mc-text">git init</code>{' '}
+              the working tree on save (idempotent).
             </>
           }
         >
+          <Field label="Repo URL">
+            <InlineText
+              value={workspace.repo_url ?? ''}
+              onSave={(next) => patch({ repo_url: next.trim() })}
+              placeholder="https://github.com/owner/repo (optional)"
+              label="Edit repo URL"
+            />
+            <p className="text-[11px] text-mc-text-secondary mt-1">
+              Used by <code className="text-mc-text">{`{{repo_url}}`}</code>. Leave
+              blank for folder-only workspaces.
+            </p>
+          </Field>
+          <Field label="Default base branch">
+            <InlineText
+              value={workspace.default_base_branch ?? ''}
+              onSave={(next) => patch({ default_base_branch: next.trim() })}
+              placeholder="main"
+              label="Edit default base branch"
+            />
+            <p className="text-[11px] text-mc-text-secondary mt-1">
+              Used by <code className="text-mc-text">{`{{base_branch}}`}</code>.
+            </p>
+          </Field>
           <Field label="Initialize local git repo">
             <label className="inline-flex items-center gap-2 text-sm text-mc-text cursor-pointer">
               <input
@@ -418,10 +448,9 @@ export default function WorkspaceSettingsPage({
               {' '}block. Use{' '}
               <code className="text-mc-text">{`{{name}}`}</code>,{' '}
               <code className="text-mc-text">{`{{working_dir}}`}</code>,{' '}
-              <code className="text-mc-text">{`{{deliverables}}`}</code>{' '}
-              (and once PR 2 lands,{' '}
+              <code className="text-mc-text">{`{{deliverables}}`}</code>,{' '}
               <code className="text-mc-text">{`{{repo_url}}`}</code>,{' '}
-              <code className="text-mc-text">{`{{base_branch}}`}</code>) — they
+              <code className="text-mc-text">{`{{base_branch}}`}</code> — they
               expand at dispatch time. Leave blank to skip the block entirely.
             </>
           }

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -904,8 +904,11 @@ ${criteria.length > 0 ? criteria.map(c => `  - ${c}`).join('\n') : '  - (none de
         name: string;
         context_md: string | null;
         workspace_path: string | null;
+        repo_url: string | null;
+        default_base_branch: string | null;
       }>(
-        `SELECT slug, name, context_md, workspace_path FROM workspaces WHERE id = ?`,
+        `SELECT slug, name, context_md, workspace_path, repo_url, default_base_branch
+           FROM workspaces WHERE id = ?`,
         [task.workspace_id],
       );
       const ctx = wsRow?.context_md;
@@ -920,6 +923,8 @@ ${criteria.length > 0 ? criteria.map(c => `  - ${c}`).join('\n') : '  - (none de
           name: wsRow.name,
           working_dir,
           deliverables: working_dir,
+          repo_url: wsRow.repo_url,
+          base_branch: wsRow.default_base_branch,
         };
         const resolved = resolveVariables(ctx.trim(), variableSrc);
         workspaceConventionsSection = `## Workspace conventions\n\n${resolved}\n\n---\n\n`;

--- a/src/app/api/workspaces/[id]/route.ts
+++ b/src/app/api/workspaces/[id]/route.ts
@@ -111,6 +111,8 @@ export async function PATCH(
       audit_per_node_timeout_ms,
       audit_subtree_concurrency,
       local_repo_init,
+      repo_url,
+      default_base_branch,
     } = body;
 
     const db = getDb();
@@ -176,6 +178,17 @@ export async function PATCH(
       // Boolean stored as INTEGER (0/1) per the migration.
       updates.push('local_repo_init = ?');
       values.push(local_repo_init ? 1 : 0);
+    }
+    if (repo_url !== undefined) {
+      // Empty string clears the field; any other value persists trimmed.
+      const trimmed = typeof repo_url === 'string' ? repo_url.trim() : null;
+      updates.push('repo_url = ?');
+      values.push(trimmed && trimmed.length > 0 ? trimmed : null);
+    }
+    if (default_base_branch !== undefined) {
+      const trimmed = typeof default_base_branch === 'string' ? default_base_branch.trim() : null;
+      updates.push('default_base_branch = ?');
+      values.push(trimmed && trimmed.length > 0 ? trimmed : null);
     }
     if (audit_subtree_concurrency !== undefined) {
       const n = Number(audit_subtree_concurrency);

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4455,6 +4455,25 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    id: '083',
+    name: 'workspaces_repo_fields',
+    up: (db) => {
+      // Workspace conventions structuring (PR 2): two nullable strings
+      // backing the {{repo_url}} and {{base_branch}} template variables.
+      // Drives PR-targeting guidance ("always pass --repo X --base Y")
+      // and a "fork → upstream" chip in the settings UI.
+      // See specs/workspace-conventions-structured.md §2.
+      const cols = db.prepare(`PRAGMA table_info(workspaces)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'repo_url')) {
+        db.exec(`ALTER TABLE workspaces ADD COLUMN repo_url TEXT`);
+      }
+      if (!cols.some((c) => c.name === 'default_base_branch')) {
+        db.exec(`ALTER TABLE workspaces ADD COLUMN default_base_branch TEXT`);
+      }
+      console.log('[Migration 083] workspaces.repo_url + default_base_branch added (nullable).');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/mcp/groups/core.ts
+++ b/src/lib/mcp/groups/core.ts
@@ -210,8 +210,11 @@ export function registerCoreTools(server: McpServer): void {
         name: string;
         context_md: string | null;
         workspace_path: string | null;
+        repo_url: string | null;
+        default_base_branch: string | null;
       }>(
-        `SELECT id, slug, name, context_md, workspace_path FROM workspaces WHERE id = ?`,
+        `SELECT id, slug, name, context_md, workspace_path, repo_url, default_base_branch
+           FROM workspaces WHERE id = ?`,
         [me.workspace_id],
       );
 
@@ -227,6 +230,8 @@ export function registerCoreTools(server: McpServer): void {
         name: ws?.name ?? '',
         working_dir,
         deliverables: working_dir,
+        repo_url: ws?.repo_url ?? null,
+        base_branch: ws?.default_base_branch ?? null,
       };
       const resolved_context_md = resolveVariables(ws?.context_md ?? null, variableSrc);
 
@@ -239,6 +244,8 @@ export function registerCoreTools(server: McpServer): void {
         // {{token}}-resolved variant — what agents should prefer.
         resolved_context_md: resolved_context_md || null,
         working_dir,
+        repo_url: ws?.repo_url ?? null,
+        base_branch: ws?.default_base_branch ?? null,
         present: typeof ws?.context_md === 'string' && ws.context_md.trim().length > 0,
       };
       return textResult(JSON.stringify(payload, null, 2), payload);


### PR DESCRIPTION
## Summary

Adds the two structured-repo fields the `{{repo_url}}` / `{{base_branch}}` template variables resolve from. Together with [PR 1](https://github.com/smb209/mission-control/pull/258) this completes the structured-fields layer; PR 3 layers an agent-driven refine flow on top.

**Stacked on [PR 1](https://github.com/smb209/mission-control/pull/258).**

## Changes

- **Migration 083**: `workspaces.repo_url` + `default_base_branch` (both nullable TEXT).
- `PATCH /api/workspaces/:id` accepts both fields; empty strings clear them.
- `get_workspace_context` MCP tool returns `repo_url` + `base_branch` alongside the existing fields and uses them when resolving `context_md`.
- Dispatch route propagates them into `VariableSource` so `{{repo_url}}` / `{{base_branch}}` expand in the agent prompt.
- Settings UI: \"Source control\" section gains **Repo URL** + **Default base branch** inputs above the existing init checkbox.
- Conventions section description drops the \"once PR 2 lands\" caveat now that both vars are real.

## Test plan

- [x] `yarn test` — 824 pass, 1 pre-existing failure (`schedule-runner`).
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify** on `mission-control-dev` (:4010):
  - `PATCH /api/workspaces/default { repo_url, default_base_branch }` round-trips ✓
  - Settings page renders both inputs with the correct values ✓
  - On a test workspace seeded with `repo_url=https://github.com/example/repo` + `default_base_branch=develop`, inserting the `code` template + viewing the prompt preview yields:
    > Repo: https://github.com/example/repo
    > Default base branch: develop
    > Always pass --base develop to gh pr create. If the repo is a fork, pass --repo https://github.com/example/repo explicitly...
    
    No `⚠️` warnings ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)