### PR TITLE
feat(workspace-conventions): agent-driven refine flow (PR 3/3)

### DIFF
--- a/src/app/(app)/workspace/[slug]/settings/page.tsx
+++ b/src/app/(app)/workspace/[slug]/settings/page.tsx
@@ -25,8 +25,11 @@ import {
   Folder,
   GitBranch,
   Loader,
+  Loader2,
+  Sparkles,
   Trash2,
   FilePlus,
+  X,
 } from 'lucide-react';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import {
@@ -104,6 +107,7 @@ export default function WorkspaceSettingsPage({
   const [templates, setTemplates] = useState<WorkspaceTemplate[]>([]);
   const [pendingTemplate, setPendingTemplate] = useState<WorkspaceTemplate | null>(null);
   const [localRepoInitNotice, setLocalRepoInitNotice] = useState<string | null>(null);
+  const [refineModalOpen, setRefineModalOpen] = useState(false);
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -505,6 +509,21 @@ export default function WorkspaceSettingsPage({
               label="Edit workspace conventions"
               onDraftChange={setConventionsDraft}
             />
+            <div className="mt-2">
+              <button
+                type="button"
+                onClick={() => setRefineModalOpen(true)}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-xs border border-mc-border hover:bg-mc-surface-hover text-mc-text"
+                aria-label="Refine conventions with an agent"
+              >
+                <Sparkles className="w-3 h-3" />
+                Refine with agent
+              </button>
+              <span className="ml-2 text-[11px] text-mc-text-secondary">
+                Hand the current text to a writer agent and get a proposed
+                rewrite or follow-up questions.
+              </span>
+            </div>
           </Field>
         </Section>
 
@@ -529,6 +548,19 @@ export default function WorkspaceSettingsPage({
           }}
           onCancel={() => setPendingTemplate(null)}
         />
+
+        {refineModalOpen && (
+          <RefineModal
+            workspaceId={workspace.id}
+            currentConventions={conventionsDraft ?? workspace.context_md ?? ''}
+            onClose={() => setRefineModalOpen(false)}
+            onAccept={(replacement) => {
+              setRefineModalOpen(false);
+              patch({ context_md: replacement.length > 0 ? replacement : null });
+              setConventionsDraft(replacement);
+            }}
+          />
+        )}
 
         {/* Audit defaults — workspace-scoped knobs for the initiative
             Investigate flow's subtree mode. See
@@ -765,6 +797,271 @@ function AgentPromptPreview({
         <ReactMarkdown remarkPlugins={[remarkGfm]}>
           {`## Workspace conventions\n\n${resolved}\n\n---`}
         </ReactMarkdown>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Refine modal — POSTs the current conventions text to the runner agent
+ * and renders the structured proposal (replacement or questions) for
+ * the operator to review.
+ *
+ * v1 keeps the flow synchronous: submit → spinner → result. Failure is
+ * surfaced inline; the modal stays open so the operator can edit + retry.
+ *
+ * Spec: specs/workspace-conventions-structured.md §6.
+ */
+interface RefineModalProps {
+  workspaceId: string;
+  currentConventions: string;
+  onClose: () => void;
+  onAccept: (replacement: string) => void;
+}
+
+interface RefineProposal {
+  kind: 'replacement' | 'questions';
+  body?: string;
+  questions?: string[];
+  rationale?: string;
+}
+
+function RefineModal({
+  workspaceId,
+  currentConventions,
+  onClose,
+  onAccept,
+}: RefineModalProps) {
+  const [operatorNote, setOperatorNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [proposal, setProposal] = useState<RefineProposal | null>(null);
+  // When agent returned questions, the operator answers inline → next
+  // submit appends them to operator_note for the second turn.
+  const [answers, setAnswers] = useState<string[]>([]);
+
+  const submit = async (extraNote?: string) => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const composed = [operatorNote, extraNote ?? ''].filter(Boolean).join('\n\n').trim();
+      const res = await fetch(
+        `/api/workspaces/${encodeURIComponent(workspaceId)}/refine-conventions`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            current_conventions: currentConventions,
+            operator_note: composed || null,
+          }),
+        },
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error((data as { error?: string }).error || `HTTP ${res.status}`);
+      }
+      const p = (data as { proposal: RefineProposal }).proposal;
+      setProposal(p);
+      if (p.kind === 'questions') {
+        setAnswers(new Array(p.questions?.length ?? 0).fill(''));
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Refine failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const sendAnswers = async () => {
+    if (!proposal || proposal.kind !== 'questions') return;
+    const composed = (proposal.questions ?? [])
+      .map((q, i) => `Q: ${q}\nA: ${answers[i] ?? '(no answer)'}`)
+      .join('\n\n');
+    await submit(`Operator answers to your follow-up questions:\n\n${composed}`);
+    setAnswers([]);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Refine workspace conventions"
+      onClick={onClose}
+    >
+      <div
+        className="bg-mc-bg-secondary border border-mc-border rounded-lg w-full max-w-2xl flex flex-col text-mc-text max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-start justify-between gap-2 px-5 py-3 border-b border-mc-border shrink-0">
+          <div className="flex items-start gap-2">
+            <Sparkles className="w-4 h-4 mt-0.5 text-mc-accent shrink-0" />
+            <div>
+              <h2 className="text-base font-semibold leading-tight">
+                Refine conventions with an agent
+              </h2>
+              <p className="text-xs text-mc-text-secondary mt-0.5">
+                The runner agent will review the current text and either propose
+                a rewrite or ask up to 5 clarifying questions.
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text shrink-0"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </header>
+
+        <div className="px-5 py-4 flex flex-col gap-4 overflow-y-auto">
+          {error && (
+            <div
+              className="p-3 rounded bg-red-500/10 border border-red-500/30 text-red-300 text-sm"
+              role="alert"
+            >
+              {error}
+            </div>
+          )}
+
+          {!proposal && (
+            <>
+              <label className="flex flex-col gap-1">
+                <span className="text-xs uppercase tracking-wide text-mc-text-secondary/80">
+                  Operator note <span className="normal-case opacity-70">(optional)</span>
+                </span>
+                <textarea
+                  value={operatorNote}
+                  onChange={(e) => setOperatorNote(e.target.value.slice(0, 2000))}
+                  rows={4}
+                  placeholder="What would you like the agent to focus on? e.g. 'tighten the testing section', 'add a deliverables policy'."
+                  className="w-full px-2 py-1.5 rounded bg-mc-bg border border-mc-border text-sm text-mc-text outline-none focus:border-mc-accent/60 resize-y leading-relaxed"
+                  maxLength={2000}
+                />
+                <span className="text-[10px] text-mc-text-secondary/70 self-end">
+                  {operatorNote.length}/2000
+                </span>
+              </label>
+            </>
+          )}
+
+          {proposal?.kind === 'replacement' && (
+            <>
+              {proposal.rationale && (
+                <p className="text-xs text-mc-text-secondary italic">
+                  {proposal.rationale}
+                </p>
+              )}
+              <div>
+                <span className="text-xs uppercase tracking-wide text-mc-text-secondary/80">
+                  Proposed replacement
+                </span>
+                <pre className="mt-1 p-3 rounded bg-mc-bg border border-mc-border text-xs leading-relaxed whitespace-pre-wrap break-words text-mc-text max-h-[40vh] overflow-y-auto">
+                  {proposal.body}
+                </pre>
+              </div>
+            </>
+          )}
+
+          {proposal?.kind === 'questions' && (
+            <>
+              {proposal.rationale && (
+                <p className="text-xs text-mc-text-secondary italic">
+                  {proposal.rationale}
+                </p>
+              )}
+              <div className="flex flex-col gap-3">
+                <span className="text-xs uppercase tracking-wide text-mc-text-secondary/80">
+                  Clarifying questions
+                </span>
+                {(proposal.questions ?? []).map((q, i) => (
+                  <label key={i} className="flex flex-col gap-1">
+                    <span className="text-sm text-mc-text">{q}</span>
+                    <textarea
+                      value={answers[i] ?? ''}
+                      onChange={(e) =>
+                        setAnswers((prev) => {
+                          const next = [...prev];
+                          next[i] = e.target.value;
+                          return next;
+                        })
+                      }
+                      rows={2}
+                      className="w-full px-2 py-1.5 rounded bg-mc-bg border border-mc-border text-sm text-mc-text outline-none focus:border-mc-accent/60 resize-y leading-relaxed"
+                    />
+                  </label>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+
+        <footer className="border-t border-mc-border px-5 py-3 flex justify-end gap-2 shrink-0">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          {!proposal && (
+            <button
+              onClick={() => submit()}
+              disabled={submitting}
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded bg-mc-accent text-white text-sm disabled:opacity-50"
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  Refining…
+                </>
+              ) : (
+                <>
+                  <Sparkles className="w-3.5 h-3.5" />
+                  Refine
+                </>
+              )}
+            </button>
+          )}
+          {proposal?.kind === 'replacement' && (
+            <>
+              <button
+                onClick={() => {
+                  setProposal(null);
+                  setAnswers([]);
+                }}
+                disabled={submitting}
+                className="px-3 py-2 rounded border border-mc-border text-mc-text-secondary text-sm disabled:opacity-50"
+              >
+                Refine again
+              </button>
+              <button
+                onClick={() => proposal.body && onAccept(proposal.body)}
+                className="inline-flex items-center gap-1.5 px-3 py-2 rounded bg-mc-accent text-white text-sm"
+              >
+                Accept replacement
+              </button>
+            </>
+          )}
+          {proposal?.kind === 'questions' && (
+            <button
+              onClick={sendAnswers}
+              disabled={submitting}
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded bg-mc-accent text-white text-sm disabled:opacity-50"
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  Sending…
+                </>
+              ) : (
+                <>Send answers</>
+              )}
+            </button>
+          )}
+        </footer>
       </div>
     </div>
   );

--- a/src/app/api/workspaces/[id]/refine-conventions/route.ts
+++ b/src/app/api/workspaces/[id]/refine-conventions/route.ts
@@ -1,0 +1,88 @@
+/**
+ * POST /api/workspaces/:id/refine-conventions
+ *
+ * Agent-driven refine: hand the workspace's current conventions text to
+ * the runner agent in a fresh session, ask it to either propose a
+ * replacement or ask clarifying questions, return the structured result
+ * for the operator to review.
+ *
+ * Spec: specs/workspace-conventions-structured.md §6.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { queryOne } from '@/lib/db';
+import {
+  RefineDispatchError,
+  refineConventions,
+} from '@/lib/workspace-conventions/refine';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  current_conventions: z.string().max(20000),
+  operator_note: z.string().max(2000).nullish(),
+});
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+
+  const ws = queryOne<{
+    id: string;
+    name: string;
+    workspace_path: string | null;
+    repo_url: string | null;
+    default_base_branch: string | null;
+  }>(
+    `SELECT id, name, workspace_path, repo_url, default_base_branch
+       FROM workspaces WHERE id = ?`,
+    [id],
+  );
+  if (!ws) {
+    return NextResponse.json({ error: 'workspace not found' }, { status: 404 });
+  }
+
+  let body: z.infer<typeof Body>;
+  try {
+    const raw = await request.json();
+    const parsed = Body.safeParse(raw);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    body = parsed.data;
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  try {
+    const proposal = await refineConventions({
+      workspace: ws,
+      current_conventions: body.current_conventions,
+      operator_note: body.operator_note ?? null,
+    });
+    return NextResponse.json({ proposal });
+  } catch (err) {
+    if (err instanceof RefineDispatchError) {
+      const status =
+        err.reason === 'no_runner' || err.reason === 'no_session' ? 503
+        : err.reason === 'timeout' ? 504
+        : err.reason === 'parse_failed' ? 502
+        : 500;
+      return NextResponse.json(
+        { error: err.message, reason: err.reason },
+        { status },
+      );
+    }
+    console.error('[refine-conventions] unexpected', err);
+    return NextResponse.json(
+      { error: (err as Error).message ?? 'unexpected error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/workspace-conventions/refine.test.ts
+++ b/src/lib/workspace-conventions/refine.test.ts
@@ -1,0 +1,108 @@
+/**
+ * refine.ts — parser unit tests.
+ *
+ * The dispatch path is exercised by hand via the Refine modal in
+ * settings; these tests cover the JSON parser so a rogue agent reply
+ * doesn't crash the route.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RefineDispatchError, parseRefineReply, buildRefineTrigger } from './refine';
+
+test('parseRefineReply: replacement reply round-trips', () => {
+  const raw = JSON.stringify({
+    kind: 'replacement',
+    body: '## Repos\n- working tree: {{working_dir}}',
+    rationale: 'Streamlines the section headings.',
+  });
+  const parsed = parseRefineReply(raw);
+  assert.equal(parsed.kind, 'replacement');
+  assert.match(parsed.body!, /working tree/);
+  assert.equal(parsed.rationale, 'Streamlines the section headings.');
+});
+
+test('parseRefineReply: questions reply caps at 5', () => {
+  const raw = JSON.stringify({
+    kind: 'questions',
+    questions: ['q1', 'q2', 'q3', 'q4', 'q5', 'q6'],
+  });
+  const parsed = parseRefineReply(raw);
+  assert.equal(parsed.kind, 'questions');
+  assert.equal(parsed.questions!.length, 5);
+});
+
+test('parseRefineReply: tolerates leading prose before JSON', () => {
+  const raw = `Sure, here is my proposed refinement:\n\n${JSON.stringify({
+    kind: 'replacement',
+    body: 'X',
+  })}`;
+  const parsed = parseRefineReply(raw);
+  assert.equal(parsed.kind, 'replacement');
+  assert.equal(parsed.body, 'X');
+});
+
+test('parseRefineReply: tolerates ```json fences', () => {
+  const raw = '```json\n' + JSON.stringify({ kind: 'replacement', body: 'X' }) + '\n```';
+  const parsed = parseRefineReply(raw);
+  assert.equal(parsed.kind, 'replacement');
+});
+
+test('parseRefineReply: rejects missing kind', () => {
+  assert.throws(
+    () => parseRefineReply(JSON.stringify({ body: 'no kind' })),
+    RefineDispatchError,
+  );
+});
+
+test('parseRefineReply: rejects replacement with empty body', () => {
+  assert.throws(
+    () => parseRefineReply(JSON.stringify({ kind: 'replacement', body: '' })),
+    RefineDispatchError,
+  );
+});
+
+test('parseRefineReply: rejects questions with no strings', () => {
+  assert.throws(
+    () => parseRefineReply(JSON.stringify({ kind: 'questions', questions: [123, null] })),
+    RefineDispatchError,
+  );
+});
+
+test('parseRefineReply: rejects raw without JSON', () => {
+  assert.throws(() => parseRefineReply('not json at all'), RefineDispatchError);
+});
+
+test('buildRefineTrigger: includes workspace facts + operator note', () => {
+  const trigger = buildRefineTrigger({
+    workspace: {
+      id: 'ws1',
+      name: 'My WS',
+      workspace_path: '/Users/a/b',
+      repo_url: 'https://github.com/a/b',
+      default_base_branch: 'main',
+    },
+    current_conventions: '## hello',
+    operator_note: 'tighten the testing section',
+  });
+  assert.match(trigger, /Working tree: \/Users\/a\/b/);
+  assert.match(trigger, /Repo URL: https:\/\/github\.com\/a\/b/);
+  assert.match(trigger, /tighten the testing section/);
+  assert.match(trigger, /## Current conventions/);
+});
+
+test('buildRefineTrigger: omits operator-note section when blank', () => {
+  const trigger = buildRefineTrigger({
+    workspace: {
+      id: 'ws1',
+      name: 'My WS',
+      workspace_path: null,
+      repo_url: null,
+      default_base_branch: null,
+    },
+    current_conventions: '',
+    operator_note: null,
+  });
+  assert.doesNotMatch(trigger, /## Operator note/);
+  assert.match(trigger, /\(empty\)/);
+});

--- a/src/lib/workspace-conventions/refine.ts
+++ b/src/lib/workspace-conventions/refine.ts
@@ -1,0 +1,232 @@
+/**
+ * Workspace conventions — agent-driven refine flow.
+ *
+ * Hands the operator's current conventions text to a writer/coder
+ * agent in a fresh session. The agent reviews and replies with either
+ * a structured `replacement` (full markdown swap) or a list of
+ * clarifying `questions`. The operator reviews + accepts in the UI.
+ *
+ * Spec: specs/workspace-conventions-structured.md §6.
+ *
+ * v1 keeps the dispatch synchronous (operator sees a spinner, then
+ * a result). The refine doesn't write to mc_sessions / agent_runs —
+ * it's a transient one-shot, not a tracked job. If we add a tracked
+ * variant later (e.g. so refines show in /jobs) we'll route through
+ * `dispatchScope` with a new scope_type and a matching CHECK migration.
+ */
+
+import { sendChatAndAwaitReply } from '@/lib/openclaw/send-chat';
+import { getRunnerAgent } from '@/lib/agents/runner';
+import { KNOWN_VARIABLES } from './resolve-variables';
+
+export interface RefineInput {
+  workspace: {
+    id: string;
+    name: string;
+    workspace_path: string | null;
+    repo_url: string | null;
+    default_base_branch: string | null;
+  };
+  current_conventions: string;
+  operator_note: string | null;
+}
+
+export interface RefineProposal {
+  /** 'replacement' = full markdown swap; 'questions' = clarifying turn. */
+  kind: 'replacement' | 'questions';
+  /** Replacement markdown (when kind='replacement'). */
+  body?: string;
+  /** Clarifying questions (when kind='questions'); ≤ 5 entries. */
+  questions?: string[];
+  /** Brief explanation the agent surfaces alongside its proposal. */
+  rationale?: string;
+}
+
+export class RefineDispatchError extends Error {
+  constructor(public reason: 'no_runner' | 'no_session' | 'timeout' | 'parse_failed' | 'send_failed', message: string) {
+    super(message);
+    this.name = 'RefineDispatchError';
+  }
+}
+
+const SYSTEM_PROMPT = `You are reviewing a workspace's conventions document for a software / project-management platform.
+
+The conventions are markdown that gets prepended to every dispatched agent's prompt. Your job is to either:
+  - Propose a fully-rewritten replacement that's clearer, more complete, or better-structured;
+  - OR ask up to 5 clarifying questions if the existing text is ambiguous or missing essential facts.
+
+Use \`{{token}}\` placeholders where appropriate so the variable resolver expands them at dispatch time. Available tokens: ${KNOWN_VARIABLES.map((v) => `{{${v}}}`).join(', ')}.
+
+Reply with a SINGLE JSON object, no preamble or trailing prose:
+  { "kind": "replacement", "body": "<full markdown>", "rationale": "<one paragraph why>" }
+or
+  { "kind": "questions", "questions": ["q1", "q2", ...], "rationale": "<one paragraph why>" }
+
+Do NOT wrap the JSON in code fences. Do NOT add commentary outside the JSON.`;
+
+export function buildRefineTrigger(input: RefineInput): string {
+  const lines: string[] = [];
+  lines.push(SYSTEM_PROMPT);
+  lines.push('');
+  lines.push('## Workspace facts');
+  lines.push(`- Name: ${input.workspace.name}`);
+  lines.push(`- Working tree: ${input.workspace.workspace_path ?? '(not set)'}`);
+  lines.push(`- Repo URL: ${input.workspace.repo_url ?? '(not set)'}`);
+  lines.push(`- Default base branch: ${input.workspace.default_base_branch ?? '(not set)'}`);
+  lines.push('');
+  if (input.operator_note && input.operator_note.trim()) {
+    lines.push('## Operator note');
+    lines.push(input.operator_note.trim());
+    lines.push('');
+  }
+  lines.push('## Current conventions (markdown)');
+  lines.push('```md');
+  lines.push(input.current_conventions || '(empty)');
+  lines.push('```');
+  return lines.join('\n');
+}
+
+/**
+ * Extract the chat content from the agent's final reply.
+ * Mirrors `extractAgentReplyText` in pm-dispatch.ts — agents send their
+ * payload as either a plain string, `{content: string}`, or
+ * `{content: [{text}]}` depending on provider. The doneEvent's message
+ * carries the final answer; intermediate events may carry chunks.
+ */
+function flattenReply(
+  result: Awaited<ReturnType<typeof sendChatAndAwaitReply>>,
+): string {
+  const readMessage = (m: unknown): string => {
+    if (!m) return '';
+    if (typeof m === 'string') return m;
+    if (typeof m === 'object' && 'content' in m) {
+      const c = (m as { content: unknown }).content;
+      if (typeof c === 'string') return c;
+      if (Array.isArray(c)) {
+        return c
+          .map((part) =>
+            typeof part === 'string'
+              ? part
+              : typeof part === 'object' && part && 'text' in part && typeof (part as { text: unknown }).text === 'string'
+                ? (part as { text: string }).text
+                : '',
+          )
+          .filter(Boolean)
+          .join('');
+      }
+    }
+    return '';
+  };
+  const fromDone = readMessage(result.doneEvent?.message).trim();
+  if (fromDone) return fromDone;
+  return (result.reply ?? []).map((e) => readMessage(e.message)).join('').trim();
+}
+
+/**
+ * Pull the first JSON object out of a string, tolerating leading /
+ * trailing prose or accidental code fences. We keep parse strict: the
+ * agent's reply is rejected if it doesn't yield a JSON object with a
+ * recognized `kind`.
+ */
+export function parseRefineReply(raw: string): RefineProposal {
+  const trimmed = raw.trim();
+  // Strip ```json / ``` fences if the agent ignored the "no fences" rule.
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  const candidate = fenced ? fenced[1].trim() : trimmed;
+  // Find the first { ... } block — agents sometimes prepend a sentence.
+  const firstBrace = candidate.indexOf('{');
+  const lastBrace = candidate.lastIndexOf('}');
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+    throw new RefineDispatchError('parse_failed', `agent reply lacked a JSON object: ${candidate.slice(0, 200)}`);
+  }
+  const jsonSlice = candidate.slice(firstBrace, lastBrace + 1);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonSlice);
+  } catch (err) {
+    throw new RefineDispatchError(
+      'parse_failed',
+      `agent reply JSON didn't parse: ${(err as Error).message}`,
+    );
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new RefineDispatchError('parse_failed', 'agent reply was not a JSON object');
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.kind === 'replacement') {
+    if (typeof obj.body !== 'string' || !obj.body.trim()) {
+      throw new RefineDispatchError('parse_failed', 'replacement reply missing body');
+    }
+    return {
+      kind: 'replacement',
+      body: obj.body,
+      rationale: typeof obj.rationale === 'string' ? obj.rationale : undefined,
+    };
+  }
+  if (obj.kind === 'questions') {
+    if (!Array.isArray(obj.questions) || obj.questions.length === 0) {
+      throw new RefineDispatchError('parse_failed', 'questions reply missing questions[]');
+    }
+    const questions = obj.questions
+      .filter((q): q is string => typeof q === 'string' && q.trim().length > 0)
+      .slice(0, 5);
+    if (questions.length === 0) {
+      throw new RefineDispatchError('parse_failed', 'questions reply had no usable strings');
+    }
+    return {
+      kind: 'questions',
+      questions,
+      rationale: typeof obj.rationale === 'string' ? obj.rationale : undefined,
+    };
+  }
+  throw new RefineDispatchError(
+    'parse_failed',
+    `unrecognized kind: ${JSON.stringify(obj.kind)}`,
+  );
+}
+
+/**
+ * Run the refine round-trip. Throws RefineDispatchError on dispatch /
+ * timeout / parse failures so the route can map to the right HTTP code.
+ */
+export async function refineConventions(input: RefineInput): Promise<RefineProposal> {
+  const runner = getRunnerAgent();
+  if (!runner) {
+    throw new RefineDispatchError(
+      'no_runner',
+      'No runner agent registered (mc-runner / mc-runner-dev).',
+    );
+  }
+  const triggerBody = buildRefineTrigger(input);
+  const sessionSuffix = `conventions-refine-${input.workspace.id}-${Date.now()}`;
+  const result = await sendChatAndAwaitReply({
+    agent: runner,
+    sessionSuffix,
+    message: triggerBody,
+    timeoutMs: 90_000,
+  });
+
+  if (!result.sent) {
+    if (result.reason === 'no_session') {
+      throw new RefineDispatchError(
+        'no_session',
+        'OpenClaw gateway is not connected; try again when it comes back.',
+      );
+    }
+    throw new RefineDispatchError(
+      'send_failed',
+      `gateway dispatch failed (${result.reason ?? 'unknown'}): ${result.error?.message ?? ''}`,
+    );
+  }
+  if (result.timedOut) {
+    throw new RefineDispatchError(
+      'timeout',
+      'Agent did not respond within 90s. Try again or simplify your operator note.',
+    );
+  }
+  const replyText = flattenReply(result);
+  if (!replyText) {
+    throw new RefineDispatchError('parse_failed', 'agent reply was empty');
+  }
+  return parseRefineReply(replyText);
+}


### PR DESCRIPTION
## Summary

Final slice. A **\"Refine with agent\"** button under the conventions textarea hands the current text to the runner agent in a fresh session. The agent reviews and replies with either a proposed rewrite or up to 5 clarifying questions. The operator reviews + accepts in a modal, with answer-and-resubmit for the question case.

**Stacked on [PR 2](https://github.com/smb209/mission-control/pull/259).**

## Changes

**New endpoint** `POST /api/workspaces/:id/refine-conventions`
- Body: `{ current_conventions: string, operator_note?: string }`
- Calls the runner agent via `sendChatAndAwaitReply` with a fresh session suffix.
- Reply is parsed as JSON: `{ kind: 'replacement' | 'questions', body?, questions?, rationale? }`.
- Maps dispatch failures to the right HTTP code: 503 for missing runner / disconnected gateway, 504 for timeout, 502 for parse failure.

**`src/lib/workspace-conventions/refine.ts`**
- Prompt builder includes workspace facts (name, paths, repo, base branch) + operator note + the available `{{...}}` tokens, with strict instructions to reply with a single JSON object.
- Reply parser tolerates code-fence wrappers, leading prose, and JSON-only output.
- Reply extractor mirrors `extractAgentReplyText` in `pm-dispatch.ts` so we handle string, `{content: string}`, and `{content: [{text}]}` payload shapes.
- 10 unit tests for the parser.

**Settings UI**
- \"Refine with agent\" button under the conventions textarea opens a modal.
- Operator types an optional 2k-char note → submit → spinner → result.
- **Replacement kind**: proposed markdown rendered in a `<pre>` block + rationale; \"Accept replacement\" writes to `context_md`, \"Refine again\" resets the form for another pass.
- **Questions kind**: each question gets an inline answer textarea; \"Send answers\" re-dispatches with the answers appended to the operator note.
- Errors (timeout, gateway down, parse failure) render inline; modal stays open for retry.

## Test plan

- [x] `yarn test` — 834 pass, 1 pre-existing failure (`schedule-runner`).
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify** end-to-end on `mission-control-dev` (:4010):
  - Created a tiny test workspace with conventions \"## Tests\n- run yarn test before declaring done\".
  - Clicked Refine → modal opened → submitted → ~30s wait → returned a structured replacement (3.7K chars) with rationale (\"existing conventions are dangerously minimal…\") and preserved `{{name}}` / `{{working_dir}}` / `{{repo_url}}` / `{{base_branch}}` tokens ✓
  - \"Accept replacement\" closed the modal and persisted the new text to `workspaces.context_md` ✓
  - Also exercised the **timeout path** with a much larger conventions input (90s budget exceeded) — modal showed \"Agent did not respond within 90s. Try again or simplify your operator note.\" and stayed open for retry ✓

## Out of scope (named so we don't drift)

- Tracked refine runs in `agent_runs` / `/jobs`. v1 is operator-driven and synchronous — fits in a modal. If we want refine history later, we'll route through `dispatchScope` with a new scope_type and a CHECK migration on `mc_sessions`.
- Side-by-side diff view. The `<pre>` block is the v1 review surface; a real diff is a polish item.
- Per-workspace `workspace_conventions_proposals` table the spec mentioned. The synchronous flow doesn't need it; deferred until/unless the refine becomes async.

🤖 Generated with [Claude Code](https://claude.com/claude-code)