### PR TITLE
feat(workspace-conventions): docker host↔container path translation for git init (PR 4/3)

### DIFF
--- a/specs/workspace-conventions-structured.md
+++ b/specs/workspace-conventions-structured.md
@@ -85,6 +85,12 @@ Switching templates after the textarea has content prompts the operator via `Con
 
 ### 5. Local-repo init checkbox
 
+**Path translation note (PR 4).** The `workspace_path` column stores the **host** path so host-side gateway agents can find the working tree. When MC itself runs in Docker (prod at `:4001`), that host path isn't valid inside the container. The `git init` runner therefore translates host → container via the existing `hostPathToContainerPath` helper, which uses the bind mount declared by `MC_DELIVERABLES_HOST_PATH` / `MC_DELIVERABLES_CONTAINER_PATH`. When MC runs natively (`yarn dev` at `:4010`) the translator is a no-op (host root === container root). Paths outside the bind mount surface a clear error ("translated to X inside MC ... is the bind mount configured?") rather than silently failing.
+
+**Original §5 below.**
+
+
+
 In the Repo section of the settings page (PR 1 lands the checkbox even though `repo_url` itself ships in PR 2 — the use case is "I have a folder, no remote yet, just init git for me"):
 
 - Single boolean field `local_repo_init` (column added in PR 2; pre-PR-2 the checkbox writes to a transient state and only takes effect on PR-2 save).

--- a/src/app/(app)/workspace/[slug]/settings/page.tsx
+++ b/src/app/(app)/workspace/[slug]/settings/page.tsx
@@ -171,11 +171,22 @@ export default function WorkspaceSettingsPage({
       try {
         const data = await res.json();
         if (data?.local_repo_init_result) {
-          const r = data.local_repo_init_result as { status: string; message?: string };
+          const r = data.local_repo_init_result as {
+            status: string;
+            message?: string;
+            effective_cwd?: string;
+          };
+          // When MC is dockerized, effective_cwd is the container path
+          // (the host path is bind-mounted in). Mention it in the
+          // notice so operators can sanity-check the mapping.
+          const cwdSuffix =
+            r.effective_cwd && r.effective_cwd !== (workspace?.workspace_path ?? '')
+              ? ` (mapped to ${r.effective_cwd} inside MC)`
+              : '';
           if (r.status === 'initialized') {
-            setLocalRepoInitNotice('Initialized a local git repo in the working tree.');
+            setLocalRepoInitNotice(`Initialized a local git repo in the working tree${cwdSuffix}.`);
           } else if (r.status === 'noop') {
-            setLocalRepoInitNotice('Working tree already has a git repo — no init needed.');
+            setLocalRepoInitNotice(`Working tree already has a git repo — no init needed${cwdSuffix}.`);
           } else {
             setLocalRepoInitNotice(`git init skipped: ${r.message ?? 'unknown error'}`);
           }

--- a/src/app/api/workspaces/[id]/route.ts
+++ b/src/app/api/workspaces/[id]/route.ts
@@ -13,12 +13,22 @@ import {
   AUDIT_SUBTREE_CONCURRENCY_MAX,
 } from '@/lib/db/workspaces';
 import { resolveWorkspacePath } from '@/lib/config';
+import { hostPathToContainerPath } from '@/lib/deliverables/storage';
 
 const execFileAsync = promisify(execFile);
 
 /**
  * Initialize a git repo at `workspacePath` if one isn't already there.
  * Idempotent — when `.git/` already exists this is a silent no-op.
+ *
+ * Path resolution: `workspacePath` is stored as the **host** path
+ * (that's what host-side gateway agents use to find the working tree).
+ * When MC runs in Docker, the host path isn't valid inside the
+ * container, so we translate via `hostPathToContainerPath` (which uses
+ * the bind mount declared via `MC_DELIVERABLES_HOST_PATH` /
+ * `MC_DELIVERABLES_CONTAINER_PATH`). When MC runs natively (dev), the
+ * translator returns the input unchanged. The resulting `.git/` is
+ * visible on the host because the directory is bind-mounted in.
  *
  * Returns a structured result so the route can surface non-blocking
  * warnings; failure does NOT abort the workspace save (the operator's
@@ -28,26 +38,41 @@ const execFileAsync = promisify(execFile);
  */
 async function ensureLocalRepo(
   workspacePath: string,
-): Promise<{ status: 'noop' | 'initialized' | 'error'; message?: string }> {
+): Promise<{
+  status: 'noop' | 'initialized' | 'error';
+  message?: string;
+  /** When the path was translated (host → container), the value MC
+   *  actually executed against. Surfaced for operator sanity-check. */
+  effective_cwd?: string;
+}> {
   if (!workspacePath || !workspacePath.trim()) {
     return { status: 'error', message: 'workspace_path is empty; cannot init git here' };
   }
-  if (!existsSync(workspacePath)) {
+  // Translate host → container if MC is dockerized AND the path is
+  // under the declared bind mount. When MC runs natively this is a
+  // no-op (host root === container root).
+  const effectivePath = hostPathToContainerPath(workspacePath);
+  if (!existsSync(effectivePath)) {
     return {
       status: 'error',
-      message: `workspace_path '${workspacePath}' does not exist on disk`,
+      message:
+        effectivePath === workspacePath
+          ? `workspace_path '${workspacePath}' does not exist on disk`
+          : `workspace_path '${workspacePath}' (translated to '${effectivePath}' inside MC) does not exist on disk — is the bind mount configured?`,
+      effective_cwd: effectivePath,
     };
   }
-  if (existsSync(join(workspacePath, '.git'))) {
-    return { status: 'noop' };
+  if (existsSync(join(effectivePath, '.git'))) {
+    return { status: 'noop', effective_cwd: effectivePath };
   }
   try {
-    await execFileAsync('git', ['init', '-b', 'main'], { cwd: workspacePath });
-    return { status: 'initialized' };
+    await execFileAsync('git', ['init', '-b', 'main'], { cwd: effectivePath });
+    return { status: 'initialized', effective_cwd: effectivePath };
   } catch (err) {
     return {
       status: 'error',
       message: err instanceof Error ? err.message : String(err),
+      effective_cwd: effectivePath,
     };
   }
 }

--- a/src/lib/workspace-conventions/host-container-path.test.ts
+++ b/src/lib/workspace-conventions/host-container-path.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Verify the host→container translation we lean on for the
+ * `local_repo_init` git-init runner. The translator itself lives in
+ * src/lib/deliverables/storage.ts; this suite locks the contract in
+ * relative to the workspace-conventions use case so a future change
+ * to the deliverables module won't silently break the dockerized
+ * git-init flow.
+ *
+ * See specs/workspace-conventions-structured.md §5 + the route
+ * implementation in src/app/api/workspaces/[id]/route.ts.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { hostPathToContainerPath } from '@/lib/deliverables/storage';
+
+function withEnv<T>(
+  patch: Record<string, string | undefined>,
+  fn: () => T,
+): T {
+  const prev: Record<string, string | undefined> = {};
+  for (const k of Object.keys(patch)) prev[k] = process.env[k];
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+test('host→container: no-op when host root equals container root', () => {
+  withEnv(
+    {
+      MC_DELIVERABLES_HOST_PATH: '/Users/op/projects',
+      MC_DELIVERABLES_CONTAINER_PATH: '/Users/op/projects',
+    },
+    () => {
+      assert.equal(
+        hostPathToContainerPath('/Users/op/projects/foo'),
+        '/Users/op/projects/foo',
+      );
+    },
+  );
+});
+
+test('host→container: dockerized — host path under bind root translates', () => {
+  withEnv(
+    {
+      MC_DELIVERABLES_HOST_PATH: '/Users/op/projects',
+      MC_DELIVERABLES_CONTAINER_PATH: '/app/data/projects',
+    },
+    () => {
+      assert.equal(
+        hostPathToContainerPath('/Users/op/projects/foo'),
+        '/app/data/projects/foo',
+      );
+      // Direct match on the root is also handled.
+      assert.equal(
+        hostPathToContainerPath('/Users/op/projects'),
+        '/app/data/projects',
+      );
+    },
+  );
+});
+
+test('host→container: path outside the bind root passes through', () => {
+  // The translator returns the input as-is when it can't translate.
+  // The git-init runner relies on existsSync() to then catch the miss
+  // and surface a clear error — see ensureLocalRepo.
+  withEnv(
+    {
+      MC_DELIVERABLES_HOST_PATH: '/Users/op/projects',
+      MC_DELIVERABLES_CONTAINER_PATH: '/app/data/projects',
+    },
+    () => {
+      assert.equal(
+        hostPathToContainerPath('/somewhere/else/foo'),
+        '/somewhere/else/foo',
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Followup to [PR 1](https://github.com/smb209/mission-control/pull/258)'s local-repo-init checkbox. The `workspace_path` column stores the **host** path because that's what host-side gateway agents need to locate the working tree. When MC itself runs in Docker (prod at `:4001`), that host path isn't valid inside the container — `git init` would fail because `/Users/op/...` doesn't exist on the container's filesystem.

**Stacked on [PR 3](https://github.com/smb209/mission-control/pull/260).**

## Changes

- `ensureLocalRepo` now translates host → container via the existing `hostPathToContainerPath` helper (`src/lib/deliverables/storage.ts`) before `existsSync` checks and the `execFile` cwd. Native dev (host root === container root) is a no-op.
- Failure messages distinguish translated paths so operators can see the bind-mount mapping is wrong:
  > workspace_path '/Users/op/foo' (translated to '/app/data/foo' inside MC) does not exist on disk — is the bind mount configured?
- PATCH response gains `effective_cwd`. The settings UI surfaces it in the success notice when it differs from the host path so operators can sanity-check the mapping (\"Initialized a local git repo in the working tree (mapped to /app/data/projects/foo inside MC).\").
- 3 new unit tests around `hostPathToContainerPath` locking the contract for the workspace-conventions use case (so a future deliverables refactor can't silently break the dockerized git-init flow).
- Spec updated with the path-translation note.

## Test plan

- [x] `yarn test` — 837 pass (3 new), 1 pre-existing (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify** on `mission-control-dev`: native init still works on `/tmp/pr4-test-ws` (no translation suffix in the notice — correct, since dev's HOST and CONTAINER env vars point to the same path). The dockerized-translation path is unit-tested rather than verified live since the dev server can't be configured for both branches simultaneously without restarting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)