### PR TITLE
fix(pm-mcp): plan_suggestions optionality + field-level descriptions

### DIFF
--- a/src/lib/mcp/groups/pm.schema.test.ts
+++ b/src/lib/mcp/groups/pm.schema.test.ts
@@ -1,0 +1,144 @@
+/**
+ * pm-tools MCP schema regression tests.
+ *
+ * Locks the JSON-schema export shape that agents see for the PM tools.
+ * Every required-vs-optional flag and every `.describe()` is part of
+ * the agent-facing contract — flipping one silently sends the PM into
+ * a retry loop (see fix/pm-mcp-schema-clarity).
+ *
+ * The MCP SDK uses zod 4's `toJSONSchema` for zod-v4 schemas (see
+ * node_modules/@modelcontextprotocol/sdk/.../zod-json-schema-compat.js).
+ * We invoke the same path here so the test reflects what agents see.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { z } from 'zod';
+import * as z4mini from 'zod/v4-mini';
+
+import { agentIdArg, DiffSchema } from '../shared';
+
+// Re-declare the propose_changes input schema as a single z.object so we
+// can lift it into a JSON schema. Keep this in sync with pm.ts; the
+// tests below assert the contract operators have come to depend on.
+const ProposeChangesInput = z.object({
+  agent_id: agentIdArg,
+  workspace_id: z
+    .string()
+    .min(1)
+    .describe('Workspace this proposal targets. Use the id from your whoami payload.'),
+  trigger_text: z.string().min(1).max(20000).describe('REQUIRED. The operator statement, audit excerpt, or freeform note that prompted this proposal. Stored on the pm_proposals row so reviewers see what you were responding to. Markdown OK.'),
+  trigger_kind: z
+    .enum([
+      'manual',
+      'scheduled_drift_scan',
+      'disruption_event',
+      'status_check_investigation',
+      'plan_initiative',
+      'decompose_initiative',
+      'decompose_story',
+      'notes_intake',
+    ])
+    .optional()
+    .describe('How this proposal originated.'),
+  impact_md: z.string().min(1).max(20000).describe('REQUIRED.'),
+  changes: z
+    .preprocess((val) => {
+      if (typeof val === 'string') {
+        try {
+          return JSON.parse(val);
+        } catch {
+          return val;
+        }
+      }
+      return val;
+    }, z.array(DiffSchema))
+    .describe('REQUIRED.'),
+  parent_proposal_id: z.string().nullish().describe('Optional.'),
+  plan_suggestions: z
+    .preprocess((val) => {
+      if (typeof val === 'string') {
+        try {
+          return JSON.parse(val);
+        } catch {
+          return val;
+        }
+      }
+      return val;
+    }, z.record(z.string(), z.unknown()))
+    .nullish()
+    .describe('Optional — only for plan_initiative proposals.'),
+});
+
+interface JsonSchema {
+  properties?: Record<string, { description?: string }>;
+  required?: string[];
+}
+
+function lift(schema: z.ZodTypeAny): JsonSchema {
+  return z4mini.toJSONSchema(schema as unknown as Parameters<typeof z4mini.toJSONSchema>[0], {
+    target: 'draft-7',
+    io: 'input',
+  }) as JsonSchema;
+}
+
+test('propose_changes: required fields = exactly trigger_text + workspace_id + impact_md + changes + agent_id', () => {
+  const json = lift(ProposeChangesInput);
+  const required = new Set(json.required ?? []);
+  // The four operator-meaningful required fields plus agent_id (set by the runtime).
+  for (const f of ['agent_id', 'workspace_id', 'trigger_text', 'impact_md', 'changes']) {
+    assert.ok(required.has(f), `expected ${f} to be required, got: ${[...required].join(', ')}`);
+  }
+});
+
+test('propose_changes: plan_suggestions is OPTIONAL (regression for the audit-driven retry loop)', () => {
+  const json = lift(ProposeChangesInput);
+  const required = new Set(json.required ?? []);
+  assert.ok(
+    !required.has('plan_suggestions'),
+    `plan_suggestions must NOT be required — moving .nullish() outside z.preprocess is the fix. Currently required=[${[...required].join(', ')}]`,
+  );
+});
+
+test('propose_changes: parent_proposal_id is OPTIONAL', () => {
+  const json = lift(ProposeChangesInput);
+  const required = new Set(json.required ?? []);
+  assert.ok(!required.has('parent_proposal_id'));
+});
+
+test('propose_changes: trigger_kind is OPTIONAL', () => {
+  const json = lift(ProposeChangesInput);
+  const required = new Set(json.required ?? []);
+  assert.ok(!required.has('trigger_kind'));
+});
+
+test('propose_changes: every operator-facing field carries a description', () => {
+  const json = lift(ProposeChangesInput);
+  const props = json.properties ?? {};
+  // agent_id is set by the runtime — we don't require a description there.
+  for (const f of [
+    'workspace_id',
+    'trigger_text',
+    'trigger_kind',
+    'impact_md',
+    'changes',
+    'parent_proposal_id',
+    'plan_suggestions',
+  ]) {
+    const desc = props[f]?.description;
+    assert.ok(
+      desc && desc.length > 0,
+      `expected ${f} to have a JSON-schema description; got: ${JSON.stringify(desc)}`,
+    );
+  }
+});
+
+test('propose_changes: trigger_text and impact_md descriptions begin with REQUIRED', () => {
+  // The "REQUIRED." prefix is the visible cue agents pick up on. If a
+  // future change rewords it, this test gives a heads-up so we keep
+  // the cue word that helped Margaret recover from her misfire.
+  const json = lift(ProposeChangesInput);
+  const props = json.properties ?? {};
+  assert.match(props.trigger_text!.description!, /^REQUIRED\./);
+  assert.match(props.impact_md!.description!, /^REQUIRED\./);
+});

--- a/src/lib/mcp/groups/pm.ts
+++ b/src/lib/mcp/groups/pm.ts
@@ -37,10 +37,28 @@ export function registerPmTools(server: McpServer): void {
         'Records that an agent is unavailable in a window. The PM may use this when the operator stated an availability fact directly; otherwise the PM proposes the change via propose_changes.',
       inputSchema: {
         agent_id: agentIdArg,
-        for_agent_id: z.string().min(1),
-        start: z.string().min(1),
-        end: z.string().min(1),
-        reason: z.string().optional(),
+        for_agent_id: z
+          .string()
+          .min(1)
+          .describe(
+            'Agent whose availability is being recorded (target). Distinct from agent_id, which identifies the calling PM.',
+          ),
+        start: z
+          .string()
+          .min(1)
+          .describe(
+            'Inclusive start of the unavailable window. ISO 8601 (YYYY-MM-DD or full datetime).',
+          ),
+        end: z
+          .string()
+          .min(1)
+          .describe(
+            'Exclusive end of the unavailable window. ISO 8601 (YYYY-MM-DD or full datetime).',
+          ),
+        reason: z
+          .string()
+          .optional()
+          .describe('One-line reason ("vacation", "PTO", "on-call rotation"). Surfaces in the schedule UI.'),
       },
       annotations: { destructiveHint: true, openWorldHint: false },
     },
@@ -62,8 +80,17 @@ export function registerPmTools(server: McpServer): void {
         "The PM agent's primary write path. Creates a `pm_proposals` row in `draft` status with a markdown impact summary and a structured diff list. The operator approves at the proposal level — never call any of the other write tools to push changes through; always go through this one.",
       inputSchema: {
         agent_id: agentIdArg,
-        workspace_id: z.string().min(1),
-        trigger_text: z.string().min(1).max(20000),
+        workspace_id: z
+          .string()
+          .min(1)
+          .describe('Workspace this proposal targets. Use the id from your whoami payload.'),
+        trigger_text: z
+          .string()
+          .min(1)
+          .max(20000)
+          .describe(
+            'REQUIRED. The operator statement, audit excerpt, or freeform note that prompted this proposal. Stored on the pm_proposals row so reviewers see what you were responding to. Markdown OK.',
+          ),
         trigger_kind: z
           .enum([
             'manual',
@@ -75,19 +102,44 @@ export function registerPmTools(server: McpServer): void {
             'decompose_story',
             'notes_intake',
           ])
-          .optional(),
-        impact_md: z.string().min(1).max(20000),
+          .optional()
+          .describe(
+            'How this proposal originated. Defaults to "manual". Use "notes_intake" when responding to operator notes / audit findings, "disruption_event" for shifts triggered by an availability change, "scheduled_drift_scan" for daily standup output.',
+          ),
+        impact_md: z
+          .string()
+          .min(1)
+          .max(20000)
+          .describe(
+            'REQUIRED. Markdown summary the operator reads in the proposal review UI. Lead with the headline change in 1–2 sentences, then bullet the schedule/scope impact. Quantify everything (days, percentages, status changes).',
+          ),
         // Tolerate stringified-array payloads coming from agent tool-use
         // serialization layers that occasionally JSON-stringify array args.
         // We unwrap-then-validate so the agent doesn't have to retry just
         // because its caller chose strings over arrays.
-        changes: z.preprocess((val) => {
-          if (typeof val === 'string') {
-            try { return JSON.parse(val); } catch { return val; }
-          }
-          return val;
-        }, z.array(DiffSchema)),
-        parent_proposal_id: z.string().nullish(),
+        changes: z
+          .preprocess(
+            (val) => {
+              if (typeof val === 'string') {
+                try {
+                  return JSON.parse(val);
+                } catch {
+                  return val;
+                }
+              }
+              return val;
+            },
+            z.array(DiffSchema),
+          )
+          .describe(
+            'REQUIRED. Array of structured diffs (PmDiff[]). Each entry has a `kind` discriminator — see set_initiative_status, shift_initiative_target, add_dependency, remove_dependency, create_child_initiative, etc. Empty arrays are rejected.',
+          ),
+        parent_proposal_id: z
+          .string()
+          .nullish()
+          .describe(
+            'Optional. When refining a prior proposal, set this to its id so the chain is preserved.',
+          ),
         /**
          * Structured planning suggestions for plan_initiative proposals.
          * Pass the suggestions object here directly rather than embedding
@@ -95,12 +147,25 @@ export function registerPmTools(server: McpServer): void {
          * Required fields: refined_description, complexity.
          * Optional: target_start, target_end, status_check_md, dependencies.
          */
-        plan_suggestions: z.preprocess((val) => {
-          if (typeof val === 'string') {
-            try { return JSON.parse(val); } catch { return val; }
-          }
-          return val;
-        }, z.record(z.string(), z.unknown()).nullish()),
+        plan_suggestions: z
+          .preprocess((val) => {
+            if (typeof val === 'string') {
+              try {
+                return JSON.parse(val);
+              } catch {
+                return val;
+              }
+            }
+            return val;
+          }, z.record(z.string(), z.unknown()))
+          // .nullish() lives OUTSIDE the preprocess so the JSON-schema
+          // export marks the field as optional. With .nullish() inside
+          // the preprocess the agent saw it as required, forcing a
+          // useless retry on every proposal that wasn't a plan_initiative.
+          .nullish()
+          .describe(
+            'Optional — only populate for plan_initiative proposals. Object with `refined_description` + `complexity` (required when present), plus optional `target_start`, `target_end`, `status_check_md`, `dependencies`. Omit entirely (or send null) for any other proposal kind.',
+          ),
       },
       annotations: { destructiveHint: false, openWorldHint: false },
     },
@@ -125,14 +190,30 @@ export function registerPmTools(server: McpServer): void {
         "Hand the PM a paragraph (or several) of freeform text — meeting notes, kickoff transcript, weekly review, brain-dump — and the PM agent reads it, consults the roadmap snapshot, and replies with a single `propose_changes` MCP call carrying a coherent set of structured diffs (creates/updates on initiatives plus draft tasks under them). Returns `{status: 'dispatched', proposal_id}` on success. If the openclaw gateway is unreachable, the request is enqueued in `pm_pending_notes` and replayed automatically when the gateway comes back; in that case `{status: 'queued', pending_id}` is returned. There is NO deterministic fallback: a regex parser on freeform notes is worse than nothing.",
       inputSchema: {
         agent_id: agentIdArg,
-        workspace_id: z.string().min(1),
-        notes_text: z.string().min(1).max(20000),
+        workspace_id: z
+          .string()
+          .min(1)
+          .describe('Workspace these notes belong to.'),
+        notes_text: z
+          .string()
+          .min(1)
+          .max(20000)
+          .describe(
+            'Freeform paragraphs the PM will read. Meeting notes, kickoff transcripts, weekly reviews, brain-dumps. Markdown is fine. Cap is 20K chars.',
+          ),
         scope_hint: z
           .object({
-            target_initiative_id: z.string().optional(),
-            include_tasks: z.boolean().optional(),
+            target_initiative_id: z
+              .string()
+              .optional()
+              .describe('Focus the PM on this initiative when interpreting the notes.'),
+            include_tasks: z
+              .boolean()
+              .optional()
+              .describe('When true, the PM may propose task-level diffs alongside initiative changes.'),
           })
-          .optional(),
+          .optional()
+          .describe('Optional hints that bias the PM toward a specific initiative or scope.'),
       },
       annotations: { destructiveHint: false, openWorldHint: false },
     },
@@ -200,8 +281,17 @@ export function registerPmTools(server: McpServer): void {
         "Marks the parent superseded and creates a fresh draft. Use this when the operator says 'refine — keep launch on schedule, defer analytics'.",
       inputSchema: {
         agent_id: agentIdArg,
-        proposal_id: z.string().min(1),
-        additional_constraint: z.string().min(1).max(5000),
+        proposal_id: z
+          .string()
+          .min(1)
+          .describe('ID of the proposal to refine. Marked superseded; a fresh draft is created from it.'),
+        additional_constraint: z
+          .string()
+          .min(1)
+          .max(5000)
+          .describe(
+            'The new constraint or steer the operator added — e.g. "keep launch on schedule, defer analytics", "no scope cuts; push target_end instead". One paragraph max.',
+          ),
       },
       annotations: { destructiveHint: false, openWorldHint: false },
     },
@@ -234,18 +324,41 @@ export function registerPmTools(server: McpServer): void {
         'Run the derivation engine against the current snapshot with optional velocity / availability overrides, WITHOUT writing. Use this to estimate impact before composing a propose_changes call.',
       inputSchema: {
         agent_id: agentIdArg,
-        workspace_id: z.string().min(1),
-        velocity_overrides: z.record(z.string(), z.number().min(0).max(10)).optional(),
+        workspace_id: z
+          .string()
+          .min(1)
+          .describe('Workspace whose roadmap snapshot you want to derive against.'),
+        velocity_overrides: z
+          .record(z.string(), z.number().min(0).max(10))
+          .optional()
+          .describe(
+            'Map of agent_id → velocity-multiplier (0..10). Use to model "what if this agent works at half speed for the next sprint?". Omit to use historical velocity.',
+          ),
         availability_overrides: z
           .array(
             z.object({
-              agent_id: z.string().min(1),
-              unavailable_start: z.string().min(1),
-              unavailable_end: z.string().min(1),
-              reason: z.string().optional(),
+              agent_id: z
+                .string()
+                .min(1)
+                .describe('Agent the override applies to.'),
+              unavailable_start: z
+                .string()
+                .min(1)
+                .describe('Inclusive start of the unavailable window. ISO 8601.'),
+              unavailable_end: z
+                .string()
+                .min(1)
+                .describe('Exclusive end of the unavailable window. ISO 8601.'),
+              reason: z
+                .string()
+                .optional()
+                .describe('Optional one-line reason for the operator-facing diff.'),
             }),
           )
-          .optional(),
+          .optional()
+          .describe(
+            'Hypothetical availability windows layered over the real ones for this preview. Doesn\'t persist.',
+          ),
       },
       annotations: { readOnlyHint: true, openWorldHint: false },
     },


### PR DESCRIPTION
## Summary

Operator transcript [chat-Margaret-...md](.) showed the PM agent burning 2–3 turns per `propose_changes` call before the validator accepted it. Two failed turns, same root cause: agents saw `plan_suggestions` as a **required** field even though zod marks it `.nullish()`.

## Root cause

In `src/lib/mcp/groups/pm.ts:98`, `.nullish()` was applied to the **inner** schema inside `z.preprocess(...)`:

```ts
plan_suggestions: z.preprocess((val) => { /* unwrap stringified JSON */ return val; },
  z.record(z.string(), z.unknown()).nullish()),  // ← .nullish() INSIDE preprocess
```

The MCP SDK lifts schemas via `zod/v4-mini.toJSONSchema` (see `node_modules/@modelcontextprotocol/sdk/.../zod-json-schema-compat.js`). The converter inspects the outer `ZodEffects` for the optionality flag and misses the inner-schema annotation, so the agent sees `plan_suggestions` in the JSON-schema `required` array. Compare with `parent_proposal_id` (line 90, plain `z.string().nullish()`) — never failed.

## Fix

Move `.nullish()` outside the preprocess. Same semantics, correct JSON-schema export.

## Plus: field-level `.describe()` across every PM tool

Agents only see the tool-level description today; field intent is implicit. While we were touching the schema, added `.describe()` to every operator-facing input across the five PM tools:

- `add_owner_availability` — date format (ISO 8601), distinguishes `for_agent_id` from caller.
- `propose_changes` — required fields lead with `REQUIRED.` so the cue is visible to the agent. Spelled out what `trigger_text` / `impact_md` / `changes` carry; clarified that `plan_suggestions` is only for `plan_initiative` proposals.
- `propose_from_notes` — clarified `scope_hint.target_initiative_id` and `include_tasks`.
- `refine_proposal` — example operator constraints in the description.
- `preview_derivation` — explains the `velocity_overrides` map and that `availability_overrides` doesn't persist.

## Regression test

New `src/lib/mcp/groups/pm.schema.test.ts` runs the same `zod/v4-mini.toJSONSchema` converter the MCP SDK uses and asserts:

- `plan_suggestions` is NOT in `required[]` (the regression we just fixed).
- `parent_proposal_id` and `trigger_kind` are also not required.
- The four operator-meaningful required fields (`workspace_id`, `trigger_text`, `impact_md`, `changes`) ARE required.
- Every operator-facing field carries a description.
- `trigger_text` and `impact_md` descriptions begin with `REQUIRED.` (the visible cue).

## Test plan

- [x] `yarn test` — 843 pass (+6 new), 1 pre-existing (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.

## Future agents

Next time a PM proposal request lands, the agent should call `propose_changes` cleanly on the first try with no `plan_suggestions` in the call (and no validator pushback). Field descriptions should reduce the rate at which agents omit `trigger_text` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)