### PR TITLE
feat(notes): collapsible NoteCard + Expand all / Collapse all in NotesRail

### DIFF
--- a/src/components/notes/NoteCard.tsx
+++ b/src/components/notes/NoteCard.tsx
@@ -9,15 +9,24 @@
  * Buttons are gated by callbacks — when omitted, the card renders
  * read-only as before, so /feed and other consumers don't surface
  * actions until they opt in.
+ *
+ * Collapse: when the caller owns `expanded` state and provides
+ * `onToggleExpanded`, the card renders a one-line preview while
+ * collapsed and the full body + actions when expanded. Used by
+ * NotesRail (which exposes Expand all / Collapse all) so initiative
+ * detail panels stay scannable. Without these props the card is
+ * always-expanded, preserving the /feed page's full-body display.
  */
 
 import Link from 'next/link';
 import {
   Archive,
-  RotateCcw,
-  Trash2,
-  Sparkles,
+  ChevronDown,
+  ChevronRight,
   ExternalLink,
+  RotateCcw,
+  Sparkles,
+  Trash2,
 } from 'lucide-react';
 import type { AgentNoteRecord, AgentNoteKind } from '@/hooks/useAgentNotes';
 
@@ -74,6 +83,33 @@ function runKindLabel(kind: string): string {
   }
 }
 
+/**
+ * One-line preview of a note body, used when the card is collapsed.
+ *
+ * Strategy: take the first non-blank line, strip leading markdown noise
+ * (heading hashes, bullet markers, numbered-list prefix) so audit notes
+ * that lead with `## Audit: Foo` collapse to just `Audit: Foo`. Cap at
+ * 100 chars with an ellipsis. Returns the empty string for an empty
+ * body — caller decides whether to render at all.
+ */
+function bodyPreview(body: string): string {
+  if (!body) return '';
+  for (const raw of body.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    // Strip markdown leaders: `## `, `### `, `- `, `* `, `1. `, `> `.
+    const stripped = line
+      .replace(/^#+\s+/, '')
+      .replace(/^[-*+]\s+/, '')
+      .replace(/^\d+\.\s+/, '')
+      .replace(/^>\s+/, '')
+      .trim();
+    if (!stripped) continue;
+    return stripped.length > 100 ? `${stripped.slice(0, 99)}…` : stripped;
+  }
+  return '';
+}
+
 function formatTime(iso: string): string {
   try {
     const d = new Date(iso);
@@ -105,9 +141,27 @@ interface NoteCardProps {
    * for the network round-trip; the button just emits intent.
    */
   onAskPm?: (note: AgentNoteRecord) => void;
+  /**
+   * Caller-controlled collapse state. When `onToggleExpanded` is
+   * provided, the card renders a chevron + one-line preview while
+   * `expanded` is false and the full body + actions when true.
+   * When omitted, the card behaves as it did pre-collapse — always
+   * expanded, no chevron — which keeps /feed and any other always-on
+   * consumers unchanged.
+   */
+  expanded?: boolean;
+  onToggleExpanded?: (note: AgentNoteRecord) => void;
 }
 
-export function NoteCard({ note, onArchive, onRestore, onDelete, onAskPm }: NoteCardProps) {
+export function NoteCard({
+  note,
+  onArchive,
+  onRestore,
+  onDelete,
+  onAskPm,
+  expanded,
+  onToggleExpanded,
+}: NoteCardProps) {
   const archived = !!note.archived_at;
   const kindClasses = `${KIND_COLOR[note.kind]} ${KIND_DARK[note.kind]}`;
   const importancePin =
@@ -125,6 +179,11 @@ export function NoteCard({ note, onArchive, onRestore, onDelete, onAskPm }: Note
     askPmEligible && (note.consumed_by_stages ?? []).includes('pm_proposal');
 
   const hasActions = !!(onArchive || onRestore || onDelete || askPmEligible);
+  // Collapse is opt-in: only when the caller provides both the state
+  // and a toggle. Default (always expanded) preserves /feed behavior.
+  const collapsible = !!onToggleExpanded;
+  const isExpanded = !collapsible || expanded === true;
+  const preview = collapsible ? bodyPreview(note.body) : '';
 
   return (
     <article
@@ -132,23 +191,56 @@ export function NoteCard({ note, onArchive, onRestore, onDelete, onAskPm }: Note
       data-note-id={note.id}
       data-note-kind={note.kind}
       data-note-archived={archived ? 'true' : 'false'}
+      data-note-expanded={isExpanded ? 'true' : 'false'}
     >
       <header className="flex items-center justify-between gap-2 text-xs opacity-80">
-        <span className="font-medium">
-          {importancePin}
-          {KIND_LABEL[note.kind]} · {note.role}
-          {archived && (
-            <span className="ml-1.5 px-1 py-0.5 rounded bg-black/10 dark:bg-white/10 text-[10px] uppercase tracking-wide">
-              archived
+        {collapsible ? (
+          <button
+            type="button"
+            onClick={() => onToggleExpanded?.(note)}
+            className="flex items-center gap-1.5 font-medium text-left hover:opacity-100 opacity-90 min-w-0 flex-1"
+            aria-expanded={isExpanded}
+            aria-label={isExpanded ? 'Collapse note' : 'Expand note'}
+          >
+            {isExpanded ? (
+              <ChevronDown className="w-3 h-3 shrink-0" />
+            ) : (
+              <ChevronRight className="w-3 h-3 shrink-0" />
+            )}
+            <span className="shrink-0">
+              {importancePin}
+              {KIND_LABEL[note.kind]} · {note.role}
             </span>
-          )}
-        </span>
-        <time dateTime={note.created_at} title={note.created_at}>
+            {archived && (
+              <span className="ml-1 px-1 py-0.5 rounded bg-black/10 dark:bg-white/10 text-[10px] uppercase tracking-wide shrink-0">
+                archived
+              </span>
+            )}
+            {!isExpanded && preview && (
+              <span className="ml-2 truncate opacity-75 font-normal">
+                {preview}
+              </span>
+            )}
+          </button>
+        ) : (
+          <span className="font-medium">
+            {importancePin}
+            {KIND_LABEL[note.kind]} · {note.role}
+            {archived && (
+              <span className="ml-1.5 px-1 py-0.5 rounded bg-black/10 dark:bg-white/10 text-[10px] uppercase tracking-wide">
+                archived
+              </span>
+            )}
+          </span>
+        )}
+        <time dateTime={note.created_at} title={note.created_at} className="shrink-0">
           {formatTime(note.created_at)}
         </time>
       </header>
-      <p className="whitespace-pre-wrap leading-relaxed">{note.body}</p>
-      {note.originating_run && (
+      {isExpanded && (
+        <p className="whitespace-pre-wrap leading-relaxed">{note.body}</p>
+      )}
+      {isExpanded && note.originating_run && (
         <p className="text-[11px] opacity-70">
           <Link
             href={`/jobs?run=${encodeURIComponent(note.originating_run.id)}`}
@@ -161,7 +253,7 @@ export function NoteCard({ note, onArchive, onRestore, onDelete, onAskPm }: Note
           </Link>
         </p>
       )}
-      {note.attached_files.length > 0 && (
+      {isExpanded && note.attached_files.length > 0 && (
         <ul className="mt-1 flex flex-wrap gap-1">
           {note.attached_files.map((f) => (
             <li
@@ -173,10 +265,10 @@ export function NoteCard({ note, onArchive, onRestore, onDelete, onAskPm }: Note
           ))}
         </ul>
       )}
-      {note.audience && (
+      {isExpanded && note.audience && (
         <p className="text-[11px] opacity-70">→ for {note.audience}</p>
       )}
-      {hasActions && (
+      {isExpanded && hasActions && (
         <div className="flex flex-wrap items-center gap-1.5 pt-1.5 mt-1.5 border-t border-current/10">
           {askPmEligible && (
             <button

--- a/src/components/notes/NotesRail.tsx
+++ b/src/components/notes/NotesRail.tsx
@@ -17,8 +17,8 @@
  * per project convention).
  */
 
-import { useMemo, useState } from 'react';
-import { Archive } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { Archive, ChevronsDownUp, ChevronsUpDown } from 'lucide-react';
 import {
   useAgentNotes,
   type AgentNoteKind,
@@ -58,6 +58,19 @@ function groupByRunGroup(notes: AgentNoteRecord[]): Map<string, AgentNoteRecord[
 
 export function NotesRail(props: NotesRailProps) {
   const [showArchived, setShowArchived] = useState(false);
+  // Per-note collapse state. Default = collapsed (Set is empty). Operator
+  // expands one at a time, OR clicks "Expand all" in the header. New
+  // notes arriving via SSE land collapsed for free since their id isn't
+  // in the set yet.
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+  const toggleExpanded = useCallback((note: AgentNoteRecord) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(note.id)) next.delete(note.id);
+      else next.add(note.id);
+      return next;
+    });
+  }, []);
   // Note pending hard-delete confirmation. Two-step intent: archive
   // first (reversible), then delete from the trash view.
   const [pendingDelete, setPendingDelete] = useState<AgentNoteRecord | null>(null);
@@ -176,7 +189,33 @@ export function NotesRail(props: NotesRailProps) {
     >
       <header className="flex items-center justify-between gap-2 text-xs uppercase tracking-wide opacity-70">
         <span>{props.title ?? 'Notes'} · {activeNotes.length}</span>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
+          {notes.length > 0 && (
+            <>
+              <button
+                type="button"
+                onClick={() =>
+                  setExpandedIds(new Set(notes.map((n) => n.id)))
+                }
+                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded normal-case tracking-normal hover:bg-black/5 dark:hover:bg-white/5"
+                aria-label="Expand all notes"
+                title="Expand every note in this list"
+              >
+                <ChevronsUpDown className="w-3 h-3" />
+                Expand all
+              </button>
+              <button
+                type="button"
+                onClick={() => setExpandedIds(new Set())}
+                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded normal-case tracking-normal hover:bg-black/5 dark:hover:bg-white/5"
+                aria-label="Collapse all notes"
+                title="Collapse every note"
+              >
+                <ChevronsDownUp className="w-3 h-3" />
+                Collapse all
+              </button>
+            </>
+          )}
           <button
             type="button"
             onClick={() => setShowArchived((v) => !v)}
@@ -233,6 +272,8 @@ export function NotesRail(props: NotesRailProps) {
               note={n}
               onArchive={archive}
               onAskPm={askPm}
+              expanded={expandedIds.has(n.id)}
+              onToggleExpanded={toggleExpanded}
             />
           ))}
         </div>
@@ -251,6 +292,8 @@ export function NotesRail(props: NotesRailProps) {
                   note={n}
                   onRestore={restore}
                   onDelete={(note) => setPendingDelete(note)}
+                  expanded={expandedIds.has(n.id)}
+                  onToggleExpanded={toggleExpanded}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary

Initiative detail panels were rendering every note's full body — typically 1–3K chars of audit markdown each — eating the whole side rail on initiatives with active research. Now every note starts **collapsed** showing just kind/role/timestamp + a one-line preview from the first non-blank body line, and the operator expands what they want. Header gains **Expand all** / **Collapse all** buttons.

## Changes

**`NoteCard`**
- New optional `expanded` + `onToggleExpanded` props. When provided, the card renders a chevron + preview while collapsed and the full body + actions when expanded. When omitted, the card stays always-expanded — preserves the `/feed` page's behavior unchanged.
- `bodyPreview()` strips heading hashes, bullet markers, blockquote prefixes, and numbered-list prefixes so audit notes that lead with `## Audit: Foo` preview as just `Audit: Foo`. Capped at 100 chars.
- Action buttons (Archive / Restore / Delete / Ask PM) are only rendered while expanded — keeps the collapsed surface to one line.

**`NotesRail`**
- `expandedIds: Set<string>` in component state, default empty (everything collapsed). New notes arriving via SSE land collapsed automatically — their id isn't in the set yet.
- **Expand all** / **Collapse all** buttons in the header (only when there are notes to act on). Operate on every visible note across both the active and archived/trash sections.
- Same wiring on the archived rendering path; collapse state is shared so trash-toggling doesn't reset what the operator just expanded.

## Test plan

- [x] `yarn test` — 843 pass, 1 pre-existing (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify** on `mission-control-dev`: opened the dogfood theme initiative — Notes section shows 1 note in a single collapsed row with kind/role + first-line preview (`Audit: Ground agents in durable workspace context (c7a9b7d7)`) + timestamp. \"Expand all\" reveals the full markdown body. \"Collapse all\" returns to single-row state. Individual chevron toggle on the card flips the row in isolation. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)