### PR TITLE
fix(take-note): surface 3000-char cap + register_deliverable escape valve in schema

### DIFF
--- a/src/lib/mcp/groups/core-take-note.schema.test.ts
+++ b/src/lib/mcp/groups/core-take-note.schema.test.ts
@@ -1,0 +1,109 @@
+/**
+ * take_note MCP schema regression tests.
+ *
+ * Locks the JSON-schema export shape that agents see for take_note. The
+ * agent-facing description tells researchers what to do when their
+ * audit body overflows the 3000-char cap (= register a deliverable
+ * and keep the body to a summary). Without that hint, agents burn
+ * retries trying to trim a structured report under the cap and
+ * eventually drop the audit entirely.
+ *
+ * See chat-mc-runner-1778192581039.md for the failure mode this
+ * regression locks.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { z } from 'zod';
+import * as z4mini from 'zod/v4-mini';
+
+import { agentIdArg, noteKindArg, noteImportanceArg } from '../shared';
+import { NOTE_BODY_MAX } from '@/lib/db/agent-notes';
+
+// Re-declare the take_note input schema from core.ts so we can lift
+// it into a JSON schema without standing up the whole MCP server.
+// Keep this in sync with core.ts; the tests assert the contract
+// agents have come to depend on.
+const TakeNoteInput = z.object({
+  agent_id: agentIdArg,
+  kind: noteKindArg,
+  body: z
+    .string()
+    .min(1)
+    .max(NOTE_BODY_MAX)
+    .describe(
+      `REQUIRED. Concrete > aspirational. One thought per note. Hard limit ${NOTE_BODY_MAX} characters. If your finding doesn't fit (e.g. a multi-section audit report), attach the full report as a deliverable via register_deliverable and use this body for a tight summary + verdict + link only. Reference file paths in attached_files.`,
+    ),
+  scope_key: z.string().min(1).describe('REQUIRED.'),
+  role: z.string().min(1).describe('REQUIRED.'),
+  run_group_id: z.string().min(1).describe('REQUIRED.'),
+  task_id: z.string().optional().describe('Optional.'),
+  initiative_id: z.string().optional().describe('Optional.'),
+  audience: z.string().optional().describe('Optional.'),
+  attached_files: z.array(z.string()).optional().describe('Optional.'),
+  importance: noteImportanceArg.optional(),
+});
+
+interface JsonSchema {
+  properties?: Record<string, { description?: string; maxLength?: number }>;
+  required?: string[];
+}
+
+function lift(schema: z.ZodTypeAny): JsonSchema {
+  return z4mini.toJSONSchema(schema as unknown as Parameters<typeof z4mini.toJSONSchema>[0], {
+    target: 'draft-7',
+    io: 'input',
+  }) as JsonSchema;
+}
+
+test('take_note: body, scope_key, role, run_group_id are required', () => {
+  const required = new Set(lift(TakeNoteInput).required ?? []);
+  for (const f of ['body', 'scope_key', 'role', 'run_group_id']) {
+    assert.ok(required.has(f), `expected ${f} required, got [${[...required].join(', ')}]`);
+  }
+});
+
+test('take_note: body description states the char cap explicitly (regression for audit retry loop)', () => {
+  const desc = lift(TakeNoteInput).properties?.body?.description ?? '';
+  assert.match(
+    desc,
+    new RegExp(`${NOTE_BODY_MAX}\\s*character`),
+    `body description must mention the ${NOTE_BODY_MAX}-char cap so agents stop retry-looping on overflow. Got: ${desc}`,
+  );
+});
+
+test('take_note: body description points at register_deliverable as the escape valve', () => {
+  const desc = lift(TakeNoteInput).properties?.body?.description ?? '';
+  assert.match(
+    desc,
+    /register_deliverable/,
+    `body description must mention register_deliverable so agents know what to do when a finding exceeds the cap. Got: ${desc}`,
+  );
+});
+
+test('take_note: every required field description begins with REQUIRED.', () => {
+  const props = lift(TakeNoteInput).properties ?? {};
+  for (const f of ['body', 'scope_key', 'role', 'run_group_id']) {
+    assert.match(
+      props[f]?.description ?? '',
+      /^REQUIRED\./,
+      `${f} description should lead with REQUIRED. so agents see the requirement at a glance. Got: ${props[f]?.description}`,
+    );
+  }
+});
+
+test('take_note: optional fields lead with Optional.', () => {
+  const props = lift(TakeNoteInput).properties ?? {};
+  for (const f of ['task_id', 'initiative_id', 'audience', 'attached_files']) {
+    assert.match(
+      props[f]?.description ?? '',
+      /^Optional\./,
+      `${f} description should lead with Optional. Got: ${props[f]?.description}`,
+    );
+  }
+});
+
+test('take_note: maxLength on body matches NOTE_BODY_MAX', () => {
+  const props = lift(TakeNoteInput).properties ?? {};
+  assert.equal(props.body?.maxLength, NOTE_BODY_MAX);
+});

--- a/src/lib/mcp/groups/core.ts
+++ b/src/lib/mcp/groups/core.ts
@@ -356,32 +356,49 @@ export function registerCoreTools(server: McpServer): void {
           .string()
           .min(1)
           .max(NOTE_BODY_MAX)
-          .describe('Concrete > aspirational. One thought per note. Reference file paths in attached_files.'),
+          .describe(
+            `REQUIRED. Concrete > aspirational. One thought per note. Hard limit ${NOTE_BODY_MAX} characters. If your finding doesn't fit (e.g. a multi-section audit report), attach the full report as a deliverable via register_deliverable and use this body for a tight summary + verdict + link only. Reference file paths in attached_files.`,
+          ),
         scope_key: z
           .string()
           .min(1)
-          .describe('The openclaw sessionKey you are running under. Take this verbatim from your dispatch briefing.'),
+          .describe(
+            'REQUIRED. The openclaw sessionKey you are running under. Take this verbatim from your dispatch briefing.',
+          ),
         role: z
           .string()
           .min(1)
-          .describe("Your role-of-the-moment ('builder', 'tester', 'pm', 'researcher', etc.). From the briefing."),
+          .describe(
+            "REQUIRED. Your role-of-the-moment ('builder', 'tester', 'pm', 'researcher', etc.). From the briefing.",
+          ),
         run_group_id: z
           .string()
           .min(1)
-          .describe('UUID minted at session start that groups all notes from one run/stage. From the briefing.'),
-        task_id: z.string().optional().describe('Set when the note relates to a specific task.'),
+          .describe(
+            'REQUIRED. UUID minted at session start that groups all notes from one run/stage. From the briefing.',
+          ),
+        task_id: z
+          .string()
+          .optional()
+          .describe('Optional. Set when the note relates to a specific task.'),
         initiative_id: z
           .string()
           .optional()
-          .describe('Set when the note relates to an initiative directly (no task scope).'),
+          .describe(
+            'Optional. Set when the note relates to an initiative directly (no task scope).',
+          ),
         audience: z
           .string()
           .optional()
-          .describe("Who this note is for: 'pm', 'reviewer', 'next-stage', 'tester', etc. Omit for anyone."),
+          .describe(
+            "Optional. Who this note is for: 'pm', 'reviewer', 'next-stage', 'tester', etc. Omit for anyone.",
+          ),
         attached_files: z
           .array(z.string())
           .optional()
-          .describe('File paths the note references. Helps the next session navigate without re-reading.'),
+          .describe(
+            'Optional. File paths the note references. Helps the next session navigate without re-reading.',
+          ),
         importance: noteImportanceArg.optional(),
       },
       annotations: { destructiveHint: false, openWorldHint: false },


### PR DESCRIPTION
## Summary

Operator transcript [chat-mc-runner-...md](.) showed the researcher agent burning 6 retries on an audit observation that overflowed `NOTE_BODY_MAX` (3000), trying to trim a 3893-char structured report under the cap. After the 5th failure it started writing the body to `/tmp/audit6_body.txt` — an orphaned file MC never sees. Net waste: ~6 minutes, audit lost.

Same pattern as PR #263 (PM `propose_changes` clarity).

## Diagnosis

Two schema-clarity issues in `take_note`:

1. **Missing `role` on first call.** The `role` description was substantive but didn't flag itself as required. Agents miss it when composing the call.
2. **Body too long.** The schema enforces `body.max(3000)` but the description never mentions the cap. The agent learned about it the hard way (validator error) and burned 6 retries trying to trim a structured audit under the limit. Eventually gave up on `take_note` and tried disk.

The 3000-char limit is reasonable for *most* notes but inherently tight for structured audit observations. Audits #1–5 (which stored successfully) ran just under the cap; #6 added jobs/-feature drift entries and overflowed. The escape valve already exists — `register_deliverable` for the long report + `take_note` for the summary — but the schema didn't tell the agent.

## Fix

- **`body` description** now states the cap explicitly AND points at `register_deliverable` as the escape: \"Hard limit 3000 characters. If your finding doesn't fit (e.g. a multi-section audit report), attach the full report as a deliverable via register_deliverable and use this body for a tight summary + verdict + link only.\"
- **Required fields** (`body`, `scope_key`, `role`, `run_group_id`) lead with `REQUIRED.` — agents see the requirement at a glance.
- **Optional fields** (`task_id`, `initiative_id`, `audience`, `attached_files`) lead with `Optional.` for symmetry.

**Not raising the cap.** The 3000 limit forces good behavior — observations should be summaries, not multi-page reports. Operators want a browseable rail; long audits belong in `/deliverables` as real artifacts.

## Test plan

- [x] `yarn test` — 849 pass (+6 new), 1 pre-existing (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.
- [x] 6 new regression tests against the actual zod-v4 → JSON-schema converter the MCP SDK uses, asserting:
  - `body`, `scope_key`, `role`, `run_group_id` are in `required[]`
  - `body` description mentions the `3000 characters` cap
  - `body` description mentions `register_deliverable`
  - All required descriptions lead with `REQUIRED.`
  - All optional descriptions lead with `Optional.`
  - `body.maxLength` matches `NOTE_BODY_MAX`

🤖 Generated with [Claude Code](https://claude.com/claude-code)