### PR TITLE
feat(jobs): per-run artifacts panel + shareable ?run=<id> deep link

### DIFF
--- a/src/app/(app)/jobs/JobDetailDrawer.tsx
+++ b/src/app/(app)/jobs/JobDetailDrawer.tsx
@@ -15,7 +15,14 @@ import { useEffect, useState } from 'react';
 import Drawer from '@/components/Drawer';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import Link from 'next/link';
-import { Copy, Check, AlertTriangle, ExternalLink } from 'lucide-react';
+import {
+  Copy,
+  Check,
+  AlertTriangle,
+  ExternalLink,
+  FileText,
+  StickyNote,
+} from 'lucide-react';
 
 interface JobDetail {
   id: string;
@@ -92,6 +99,65 @@ function statusChipClass(status: string): string {
   }
 }
 
+interface ArtifactNote {
+  id: string;
+  task_id: string | null;
+  initiative_id: string | null;
+  kind: string;
+  audience: string | null;
+  body: string;
+  importance: number;
+  attached_files: string[];
+  archived_at: string | null;
+  created_at: string;
+}
+
+interface ArtifactDeliverable {
+  id: string;
+  task_id: string;
+  deliverable_type: string;
+  title: string;
+  path: string | null;
+  description: string | null;
+  size_bytes: number | null;
+  role: string;
+  created_at: string;
+}
+
+interface ArtifactsPayload {
+  run_id: string;
+  notes: ArtifactNote[];
+  deliverables: ArtifactDeliverable[];
+}
+
+const ARTIFACTS_POLL_MS = 2000;
+const NOTE_PREVIEW_MAX = 240;
+
+function notePreview(body: string): string {
+  if (!body) return '';
+  // Strip leading markdown leaders so headings don't dominate.
+  const firstNonEmpty = body
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  const stripped = (firstNonEmpty ?? '')
+    .replace(/^#+\s+/, '')
+    .replace(/^[-*+]\s+/, '')
+    .replace(/^\d+\.\s+/, '')
+    .replace(/^>\s+/, '')
+    .trim();
+  return stripped.length > NOTE_PREVIEW_MAX
+    ? `${stripped.slice(0, NOTE_PREVIEW_MAX - 1)}…`
+    : stripped;
+}
+
+function formatBytes(n: number | null): string {
+  if (n == null) return '';
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
 interface JobDetailDrawerProps {
   jobId: string | null;
   onClose: () => void;
@@ -105,6 +171,8 @@ export default function JobDetailDrawer({ jobId, onClose, onReset }: JobDetailDr
   const [error, setError] = useState<string | null>(null);
   const [resetPending, setResetPending] = useState(false);
   const [resetting, setResetting] = useState(false);
+  const [artifacts, setArtifacts] = useState<ArtifactsPayload | null>(null);
+  const [artifactsError, setArtifactsError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!jobId) {
@@ -136,6 +204,54 @@ export default function JobDetailDrawer({ jobId, onClose, onReset }: JobDetailDr
       cancelled = true;
     };
   }, [jobId]);
+
+  // Live artifacts feed. Polls every 2s while the run is queued/running
+  // so operators watch notes + deliverables land in real time. Stops as
+  // soon as we see a terminal status — no point polling a finished run.
+  useEffect(() => {
+    if (!jobId) {
+      setArtifacts(null);
+      setArtifactsError(null);
+      return;
+    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const tick = async () => {
+      try {
+        const res = await fetch(
+          `/api/jobs/${encodeURIComponent(jobId)}/artifacts`,
+        );
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || `HTTP ${res.status}`);
+        }
+        const data = (await res.json()) as ArtifactsPayload;
+        if (cancelled) return;
+        setArtifacts(data);
+        setArtifactsError(null);
+      } catch (err) {
+        if (!cancelled) {
+          setArtifactsError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (cancelled) return;
+        const terminal =
+          job?.status === 'complete' ||
+          job?.status === 'failed' ||
+          job?.status === 'cancelled';
+        if (!terminal) {
+          timer = setTimeout(tick, ARTIFACTS_POLL_MS);
+        }
+      }
+    };
+    tick();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+    // job?.status is intentionally a dep — we want the loop to restart
+    // when the run flips terminal so polling stops cleanly.
+  }, [jobId, job?.status]);
 
   const doReset = async () => {
     if (!job || !job.agent_id || !job.scope_key) return;
@@ -270,6 +386,133 @@ export default function JobDetailDrawer({ jobId, onClose, onReset }: JobDetailDr
                 )}
               </section>
             )}
+
+            <section className="space-y-2">
+              <header className="flex items-center justify-between gap-2">
+                <h4 className="text-[10px] uppercase tracking-wider text-mc-text-secondary opacity-70">
+                  Artifacts produced
+                </h4>
+                {artifacts && (
+                  <span className="text-[11px] text-mc-text-secondary">
+                    {artifacts.notes.length} note{artifacts.notes.length === 1 ? '' : 's'} ·{' '}
+                    {artifacts.deliverables.length} deliverable{artifacts.deliverables.length === 1 ? '' : 's'}
+                  </span>
+                )}
+              </header>
+              {artifactsError && (
+                <p className="text-[12px] text-amber-300/90">
+                  Couldn&apos;t load artifacts: {artifactsError}
+                </p>
+              )}
+              {!artifacts && !artifactsError && (
+                <p className="text-[12px] text-mc-text-secondary italic">
+                  Loading artifacts…
+                </p>
+              )}
+              {artifacts &&
+                artifacts.notes.length === 0 &&
+                artifacts.deliverables.length === 0 && (
+                  <p className="text-[12px] text-mc-text-secondary italic">
+                    No artifacts yet.{' '}
+                    {job.status === 'running' || job.status === 'queued'
+                      ? 'Notes and deliverables will appear here as the run produces them.'
+                      : 'This run finished without registering any notes or deliverables.'}
+                  </p>
+                )}
+
+              {artifacts && artifacts.deliverables.length > 0 && (
+                <ul className="space-y-1.5">
+                  {artifacts.deliverables.map((d) => (
+                    <li
+                      key={d.id}
+                      className="rounded border border-mc-border bg-mc-bg/50 px-2.5 py-1.5 text-[12px]"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-1.5">
+                            <FileText className="w-3 h-3 shrink-0 text-mc-text-secondary" />
+                            <span className="font-medium text-mc-text truncate">
+                              {d.title}
+                            </span>
+                            <span className="text-[10px] uppercase tracking-wide px-1 py-0.5 rounded bg-mc-bg-tertiary text-mc-text-secondary shrink-0">
+                              {d.deliverable_type}
+                            </span>
+                          </div>
+                          {d.path && (
+                            <p className="mt-0.5 text-[11px] font-mono text-mc-text-secondary truncate">
+                              {d.path}
+                            </p>
+                          )}
+                          {d.description && (
+                            <p className="mt-0.5 text-[11px] text-mc-text-secondary">
+                              {d.description}
+                            </p>
+                          )}
+                        </div>
+                        <span className="text-[11px] text-mc-text-secondary shrink-0">
+                          {formatBytes(d.size_bytes)}
+                        </span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {artifacts && artifacts.notes.length > 0 && (
+                <ul className="space-y-1.5">
+                  {artifacts.notes.map((n) => {
+                    const importancePin =
+                      n.importance === 2 ? '🚩 ' : n.importance === 1 ? '🔔 ' : '';
+                    const linkHref = n.initiative_id
+                      ? `/initiatives/${encodeURIComponent(n.initiative_id)}`
+                      : null;
+                    return (
+                      <li
+                        key={n.id}
+                        className={`rounded border border-mc-border bg-mc-bg/50 px-2.5 py-1.5 text-[12px] ${
+                          n.archived_at ? 'opacity-60' : ''
+                        }`}
+                      >
+                        <div className="flex items-center gap-1.5 text-[11px] text-mc-text-secondary">
+                          <StickyNote className="w-3 h-3 shrink-0" />
+                          <span className="font-medium text-mc-text">
+                            {importancePin}
+                            {n.kind}
+                          </span>
+                          {n.audience && (
+                            <span className="opacity-80">→ {n.audience}</span>
+                          )}
+                          {n.archived_at && (
+                            <span className="ml-auto text-[10px] uppercase tracking-wide px-1 rounded bg-black/10 dark:bg-white/10">
+                              archived
+                            </span>
+                          )}
+                        </div>
+                        <p className="mt-0.5 text-mc-text">
+                          {notePreview(n.body)}
+                        </p>
+                        {n.attached_files.length > 0 && (
+                          <p className="mt-0.5 text-[10px] font-mono text-mc-text-secondary truncate">
+                            {n.attached_files.join(', ')}
+                          </p>
+                        )}
+                        {linkHref && (
+                          <p className="mt-1">
+                            <Link
+                              href={linkHref}
+                              className="inline-flex items-center gap-1 text-[11px] text-mc-accent hover:underline"
+                            >
+                              Open in initiative
+                              <ExternalLink className="w-3 h-3" />
+                            </Link>
+                          </p>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </section>
 
             {job.error_md && (
               <section className="space-y-1">

--- a/src/app/(app)/jobs/page.tsx
+++ b/src/app/(app)/jobs/page.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useEffect, useState, useMemo } from 'react';
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import { Activity, Clock, Calendar, History, AlertTriangle, Copy, Check } from 'lucide-react';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -177,7 +178,21 @@ export default function JobsPage() {
   const [cancelling, setCancelling] = useState(false);
   // PR 5: drill-down drawer state. Holds the agent_runs.id of the row
   // the operator clicked. Drawer fetches /api/jobs/:id on open.
-  const [detailJobId, setDetailJobId] = useState<string | null>(null);
+  // Driven by the `?run=<id>` query param so the URL is shareable —
+  // the artifacts panel inside the drawer is what makes a deep link
+  // useful (operators want to point each other at "this audit's
+  // notes" without re-clicking through the table).
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const detailJobId = searchParams.get('run');
+  const setDetailJobId = (next: string | null) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next) params.set('run', next);
+    else params.delete('run');
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  };
 
   // Children-of-pending counter for the dialog body — only count
   // non-terminal direct children since those are what the cascade

--- a/src/app/api/jobs/[id]/artifacts/route.ts
+++ b/src/app/api/jobs/[id]/artifacts/route.ts
@@ -1,0 +1,117 @@
+/**
+ * GET /api/jobs/:id/artifacts
+ *
+ * Backs the JobDetailDrawer's "Artifacts" panel — what did this run
+ * actually produce? Two sources, joined by what we can prove:
+ *
+ *   - notes: agent_notes where scope_key = run.scope_key. (Notes are
+ *     scope-keyed by design; the same scope_key the run wrote against
+ *     is the one any take_note calls during the run will carry.)
+ *
+ *   - deliverables: task_deliverables where task_id = run.task_id AND
+ *     created_at >= run.started_at. (task_deliverables predates the
+ *     run model so there's no run_id column. Filtering by
+ *     created_at >= started_at is the best signal for "produced by
+ *     this run" without a schema migration. Initiative-scoped runs
+ *     have no task_id and so return [] for deliverables.)
+ *
+ * The endpoint is meant to be polled while the run is in-flight so
+ * operators can watch artifacts land in real time.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { queryAll } from '@/lib/db';
+import { getAgentRun } from '@/lib/db/agent-runs';
+
+export const dynamic = 'force-dynamic';
+
+interface NoteRow {
+  id: string;
+  task_id: string | null;
+  initiative_id: string | null;
+  kind: string;
+  audience: string | null;
+  body: string;
+  importance: number;
+  attached_files: string | null;
+  archived_at: string | null;
+  created_at: string;
+}
+
+interface DeliverableRow {
+  id: string;
+  task_id: string;
+  deliverable_type: string;
+  title: string;
+  path: string | null;
+  description: string | null;
+  size_bytes: number | null;
+  role: string;
+  created_at: string;
+}
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  if (!id) {
+    return NextResponse.json({ error: 'job id required' }, { status: 400 });
+  }
+  const run = getAgentRun(id);
+  if (!run) {
+    return NextResponse.json({ error: 'job not found' }, { status: 404 });
+  }
+
+  // Notes by scope_key. Skip when the run never claimed a scope_key
+  // (legacy rows from before scope-keyed dispatch).
+  const notes: NoteRow[] = run.scope_key
+    ? queryAll<NoteRow>(
+        `SELECT id, task_id, initiative_id, kind, audience, body, importance,
+                attached_files, archived_at, created_at
+           FROM agent_notes
+          WHERE scope_key = ?
+          ORDER BY importance DESC, created_at ASC`,
+        [run.scope_key],
+      )
+    : [];
+
+  // Deliverables: only meaningful when the run was task-scoped, and
+  // only after started_at so we don't misattribute pre-existing rows.
+  const deliverables: DeliverableRow[] =
+    run.task_id && run.started_at
+      ? queryAll<DeliverableRow>(
+          `SELECT id, task_id, deliverable_type, title, path, description,
+                  size_bytes, role, created_at
+             FROM task_deliverables
+            WHERE task_id = ?
+              AND role = 'output'
+              AND created_at >= ?
+            ORDER BY created_at ASC`,
+          [run.task_id, run.started_at],
+        )
+      : [];
+
+  return NextResponse.json({
+    run_id: run.id,
+    notes: notes.map((n) => ({
+      ...n,
+      attached_files: n.attached_files
+        ? safeParseStringArray(n.attached_files)
+        : [],
+    })),
+    deliverables,
+  });
+}
+
+function safeParseStringArray(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((x) => typeof x === 'string')) {
+      return parsed;
+    }
+  } catch {
+    /* fall through */
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary

The `/jobs` drill-down drawer now surfaces what each run **actually produced** — notes (joined by `scope_key`) and deliverables (joined by `task_id` + `created_at`). Polled every 2s while the run is queued/running, falls quiet once terminal.

Triggered by an audit run (`5de05d1d-d3bb-4574-bae5-2f5837b62cb6`) that self-reported `complete` but where the operator couldn't find any notes on the initiative — turns out the agent's final `take_note` had dropped `initiative_id` while trimming args under the 3000-char cap, so the note landed in the DB but was invisible from the initiative page. The new panel joins by `scope_key` (always set on `take_note`) so it surfaces the artifact regardless of which fields the agent dropped.

## Changes

- **New `GET /api/jobs/:id/artifacts`.** Returns `{ run_id, notes, deliverables }`.
  - Notes by `scope_key` — sorted by importance DESC, created_at ASC. Includes archived state, attached_files, audience.
  - Deliverables by `task_id` + `created_at >= started_at` (best-effort \"produced by this run\" without a schema migration). Initiative-scoped runs return `[]` (no `task_id` available — out of scope for this slice).
- **New Artifacts section in `JobDetailDrawer`.** Renders deliverables and notes inline. Notes show importance pin + kind + audience + 240-char preview + attached files + an \"Open in initiative\" link when `initiative_id` is set. Empty state distinguishes in-flight (\"will appear here as the run produces them\") from terminal (\"finished without registering any\").
- **`/jobs` page now reads `?run=<id>`** from the URL into the drawer state. `router.replace` keeps the URL in sync as the operator opens / closes the drawer. Makes deep links from initiative Activity strips and from artifact references shareable.

## Test plan

- [x] `yarn test` — 843 pass, 1 pre-existing (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify** end-to-end on `mission-control-dev`:
  - Hit `/jobs?run=5de05d1d-d3bb-4574-bae5-2f5837b62cb6` (the audit run from the operator's transcript). Drawer auto-opened, surfaced the orphaned note that wasn't visible on the initiative page (note had `initiative_id=NULL` because the agent dropped it during retry).
  - Header shows `1 note · 0 deliverables` summary.
  - Note row renders: importance pin (🚩), kind (`observation`), audience (`pm`), 240-char preview (\"Audit #6: Refactor native alert() calls (RE-AUDIT) ...\").
  - Polling stops cleanly once `status='complete'`.
  - Trigger body section still renders below — no layout regression.

## Next-step ideas (deliberately out of scope)

- Gate `update_task_status: complete` on at least one artifact existing for the run. Would prevent the \"self-reports complete but nothing landed\" failure mode at the source. Bigger change touching dispatch flow.
- `agent_runs.task_id` for `initiative_audit` runs (today they are initiative-scoped only, so `register_deliverable` can't be called from inside the audit). Would let initiative-scoped audits register deliverables too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)