### PR TITLE
fix(initiatives): live-refresh note_count chip on agent_note_* SSE events

### DIFF
--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -288,6 +288,34 @@ export default function InitiativesPage() {
     refresh();
   }, [refresh]);
 
+  // Note-count chips on each card come from a SQL JOIN on agent_notes
+  // (active rows only). Without an SSE listener the chip stayed stale
+  // until navigation — operator archives a note in NotesRail, that
+  // rail's own count drops, but the list card still showed the old
+  // count. Subscribe to the four agent_note_* events that affect
+  // active counts and re-fetch.
+  useEffect(() => {
+    const source = new EventSource('/api/events/stream');
+    source.onmessage = (e) => {
+      if (!e.data || e.data.startsWith(':')) return;
+      let evt: { type?: string };
+      try {
+        evt = JSON.parse(e.data) as { type?: string };
+      } catch {
+        return;
+      }
+      if (
+        evt.type === 'agent_note_created' ||
+        evt.type === 'agent_note_archived' ||
+        evt.type === 'agent_note_restored' ||
+        evt.type === 'agent_note_deleted'
+      ) {
+        refresh();
+      }
+    };
+    return () => source.close();
+  }, [refresh]);
+
   // Tree + picker list derive from flat + the cancelled-filter toggle.
   // Cancelled rows are spliced out and their non-cancelled children
   // re-parent to the cancelled row's effective parent so the subtree


### PR DESCRIPTION
## Summary

The note-count chip on initiative list cards comes from a SQL JOIN that **already excludes archived notes** (PR #257) — `WHERE archived_at IS NULL`. But the page only fetches once on mount, so when an operator archives a note in NotesRail (or anywhere else), the rail's own count drops while the list card's chip stays at the old number. From the operator's perspective the chip looked like it included archived notes; really it was just stale.

## Fix

Subscribe the initiatives list page to the `agent_note_*` SSE channel and re-fetch on the four events that can change an initiative's active note count:

- `agent_note_created`
- `agent_note_archived`
- `agent_note_restored`
- `agent_note_deleted`

Same SSE channel `useAgentNotes` already uses; matches NotesRail's incremental-update pattern.

## Test plan

- [x] `yarn test` — 849 pass, 1 pre-existing (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify**: opened `/initiatives` (chip count = 4 across 2 cards × tree-expansion), archived a real note via the existing `/archive` endpoint while the page was loaded. Chip dropped to 2 inside 1.5s without navigation. Restored the note after for dogfood-DB hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)