### PR TITLE
feat(notes): icon-only archive/restore/delete shortcut on collapsed NoteCard

### DIFF
--- a/src/components/notes/NoteCard.tsx
+++ b/src/components/notes/NoteCard.tsx
@@ -233,9 +233,57 @@ export function NoteCard({
             )}
           </span>
         )}
-        <time dateTime={note.created_at} title={note.created_at} className="shrink-0">
-          {formatTime(note.created_at)}
-        </time>
+        <span className="flex items-center gap-1.5 shrink-0">
+          <time dateTime={note.created_at} title={note.created_at}>
+            {formatTime(note.created_at)}
+          </time>
+          {/* Compact icon-only action shortcuts — shown ONLY while
+              collapsed so operators can sweep-archive without expanding
+              every card. When expanded the labelled button row under
+              the body provides the same affordances; we don't double up. */}
+          {!isExpanded && !archived && onArchive && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onArchive(note);
+              }}
+              className="p-1 rounded hover:bg-black/10 dark:hover:bg-white/10"
+              aria-label="Archive note"
+              title="Archive — hides from default views; reversible"
+            >
+              <Archive className="w-3 h-3" />
+            </button>
+          )}
+          {!isExpanded && archived && onRestore && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRestore(note);
+              }}
+              className="p-1 rounded hover:bg-black/10 dark:hover:bg-white/10"
+              aria-label="Restore note"
+              title="Restore — return to active view"
+            >
+              <RotateCcw className="w-3 h-3" />
+            </button>
+          )}
+          {!isExpanded && archived && onDelete && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(note);
+              }}
+              className="p-1 rounded text-rose-700 dark:text-rose-300 hover:bg-rose-100 dark:hover:bg-rose-950/40"
+              aria-label="Delete note permanently"
+              title="Delete — permanent; cannot be undone"
+            >
+              <Trash2 className="w-3 h-3" />
+            </button>
+          )}
+        </span>
       </header>
       {isExpanded && (
         <p className="whitespace-pre-wrap leading-relaxed">{note.body}</p>


### PR DESCRIPTION
## Summary

Operators reviewing audit notes wanted to sweep-archive without expanding every card. The labelled action row (Archive / Restore / Delete / Ask PM) only renders while expanded; archiving a 20-note rail meant 20 expand-click-archive-collapse cycles.

Adds a compact icon-only Archive shortcut (or Restore + Delete when archived) to the card header — same actions, tucked next to the timestamp. Renders **only while collapsed**; the expanded state still shows the labelled buttons in the action row, so we don't double up.

## Changes

- **`NoteCard` header** gains an icon-only action area on the right of the timestamp.
- Active notes show 📦 Archive. Archived notes show 🔄 Restore + 🗑 Delete (destructive styled).
- Conditional on `!isExpanded` — vanishes when the operator expands the card, since the labelled action row covers it there.
- Click handlers `stopPropagation()` so an archive click can't bubble to the chevron toggle.
- \"Ask PM\" stays expanded-only (it's a more verbose action; the icon shortcut is for the destructive housekeeping path).

## Test plan

- [x] `yarn test` — 849 pass, 1 pre-existing (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify**: opened an initiative with one note, observed the new 📦 archive icon on the collapsed card. One click → note dropped from the active list, header count went 1 → 0, card stayed collapsed (no expansion side-effect). Restored after for dogfood-DB hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)