### PR TITLE
fix(audit-prompt): include direct child initiatives in the trigger body

### DIFF
--- a/src/app/api/initiatives/[id]/investigate/route.ts
+++ b/src/app/api/initiatives/[id]/investigate/route.ts
@@ -34,7 +34,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { getInitiative } from '@/lib/db/initiatives';
+import { getInitiative, listInitiatives } from '@/lib/db/initiatives';
 import { listNotes } from '@/lib/db/agent-notes';
 import { getRunnerAgent } from '@/lib/agents/runner';
 import { dispatchScope } from '@/lib/agents/dispatch-scope';
@@ -218,9 +218,23 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           })
         : [];
 
+    // Direct child initiatives — themes' epics, epics' stories, etc.
+    // Without this, narrow audits on parent kinds saw "no child tasks"
+    // and had to greenfield-discover the decomposition (see chat-mc-runner).
+    const childInitiatives = listInitiatives({
+      workspace_id: initiative.workspace_id,
+      parent_id: id,
+    }).map((c) => ({
+      id: c.id,
+      title: c.title,
+      kind: c.kind,
+      status: c.status,
+    }));
+
     const triggerBody = buildAuditPrompt({
       initiative,
       tasks: initiative.tasks ?? [],
+      childInitiatives,
       guidance: guidance ?? null,
       priorFindings,
       mode: 'narrow',

--- a/src/lib/agents/audit-prompt.test.ts
+++ b/src/lib/agents/audit-prompt.test.ts
@@ -117,6 +117,39 @@ test('audit-prompt: empty tasks renders placeholder, not empty list', () => {
   assert.match(out, /_\(this initiative has no direct child tasks\)_/);
 });
 
+test('audit-prompt: includes child initiatives in a dedicated section', () => {
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+    childInitiatives: [
+      { id: 'c1', title: 'Build AlertDialog', kind: 'story', status: 'done' },
+      { id: 'c2', title: 'Replace alert() in /agents', kind: 'story', status: 'planned' },
+    ],
+  });
+  assert.match(out, /## Direct child initiatives \(decomposed scope\)/);
+  assert.match(out, /\[story\] Build AlertDialog \(done\) \[initiative c1\]/);
+  assert.match(out, /\[story\] Replace alert\(\) in \/agents \(planned\) \[initiative c2\]/);
+});
+
+test('audit-prompt: empty child initiatives renders placeholder', () => {
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+    childInitiatives: [],
+  });
+  assert.match(out, /_\(this initiative has no direct child initiatives\)_/);
+});
+
+test('audit-prompt: child initiatives default to [] when omitted', () => {
+  // Unchanged callers (e.g. /feed reproductions) should not crash and
+  // should still render the placeholder.
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+  });
+  assert.match(out, /_\(this initiative has no direct child initiatives\)_/);
+});
+
 test('audit-prompt: missing description / status_check / target window get placeholders', () => {
   const out = buildAuditPrompt({
     initiative: {

--- a/src/lib/agents/audit-prompt.ts
+++ b/src/lib/agents/audit-prompt.ts
@@ -37,6 +37,18 @@ export interface BuildAuditPromptInput {
   >;
   /** Direct child tasks (no nesting). */
   tasks: ReadonlyArray<{ id: string; title: string; status: string }>;
+  /**
+   * Direct child initiatives (epics' stories, themes' epics, etc.).
+   * Critical for narrow-mode audits on parent kinds: an epic's actual
+   * decomposed scope lives in these rows. Pass `[]` for leaf-kind
+   * targets (stories) — the renderer just omits the section.
+   */
+  childInitiatives?: ReadonlyArray<{
+    id: string;
+    title: string;
+    kind: string;
+    status: string;
+  }>;
   /** Operator-supplied focus area. */
   guidance?: string | null;
   /**
@@ -73,6 +85,7 @@ export function buildAuditPrompt(input: BuildAuditPromptInput): string {
   const {
     initiative,
     tasks,
+    childInitiatives = [],
     guidance,
     priorFindings = [],
     childFindings = [],
@@ -97,6 +110,20 @@ export function buildAuditPrompt(input: BuildAuditPromptInput): string {
       ? '_(this initiative has no direct child tasks)_'
       : tasks
           .map((t) => `- ${t.title} (${t.status}) [task ${t.id}]`)
+          .join('\n');
+
+  // Child-initiative block. Themes have epics, epics have stories,
+  // stories may have child stories. Without this, narrow audits on
+  // parent kinds saw "no child tasks" and had to greenfield-discover
+  // the decomposition from git history (see chat-mc-runner-...md).
+  const childInitiativesBlock =
+    childInitiatives.length === 0
+      ? '_(this initiative has no direct child initiatives)_'
+      : childInitiatives
+          .map(
+            (c) =>
+              `- [${c.kind}] ${c.title} (${c.status}) [initiative ${c.id}]`,
+          )
           .join('\n');
 
   const guidanceBlock = guidance?.trim()
@@ -146,6 +173,10 @@ Status check:
 ${statusCheck}
 
 Target window: ${targetWindow}
+
+## Direct child initiatives (decomposed scope)
+
+${childInitiativesBlock}
 
 ## Direct child tasks (this initiative's tasks)
 

--- a/src/lib/agents/subtree-audit.ts
+++ b/src/lib/agents/subtree-audit.ts
@@ -332,9 +332,27 @@ export async function runSubtreeAudit(
         [node.id],
       );
 
+      // Direct child initiatives of this node — the structural list,
+      // separate from `childFindings` (which is the synthesized audit
+      // body for already-completed children). Including both lets the
+      // researcher cross-reference the structural set against the
+      // finding set and notice a child whose audit failed silently.
+      const childInitiativesForNode = queryAll<{
+        id: string;
+        title: string;
+        kind: string;
+        status: string;
+      }>(
+        `SELECT id, title, kind, status FROM initiatives
+          WHERE parent_initiative_id = ?
+          ORDER BY sort_order, created_at`,
+        [node.id],
+      );
+
       const triggerBody = buildAuditPrompt({
         initiative: node,
         tasks: tasksForNode,
+        childInitiatives: childInitiativesForNode,
         guidance: guidance ?? null,
         priorFindings: [],
         childFindings,


### PR DESCRIPTION
## Summary

Narrow-mode audits on parent kinds (themes, epics) saw zero structural context for their decomposed scope — only direct child **tasks** made it into the prompt, and themes/epics rarely have direct tasks. Researchers had to git-log + grep to discover what stories existed under the target. The audit transcript [chat-mc-runner-…md](.) showed exactly this — ~6 turns of greenfield discovery before the agent could form a verdict.

## Diagnosis (verified live)

Tested against epic `0c9419ff` (the alert() refactor) which has 5 child stories. **Pre-fix** prompt's only child section was:

```
## Direct child tasks (this initiative's tasks)
_(this initiative has no direct child tasks)_
```

The agent had no signal that 5 stories existed under the epic.

## Fix

Add optional `childInitiatives` input to `buildAuditPrompt` and render a new **\"Direct child initiatives (decomposed scope)\"** section alongside the existing tasks block. Both dispatch paths populate it:

- **Narrow mode** (`/api/initiatives/:id/investigate`): calls `listInitiatives({ parent_id })`.
- **Subtree mode** (`subtree-audit.ts`): per-node prompt builder queries children directly, alongside the existing `childFindings` (synthesized audit bodies). Including BOTH lets the researcher cross-reference the structural set against the finding set and notice a child whose audit failed silently.

`childInitiatives` defaults to `[]` so /feed reproductions and any other consumers keep working unchanged.

## Test plan

- [x] `yarn test` — 852 pass (+3 new `audit-prompt` cases + 1 placeholder default), 1 pre-existing (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify**: dispatched a fresh narrow audit on epic `0c9419ff`, opened `/jobs?run=…`, confirmed the trigger_body now lists all 5 child stories with kind + status:
  ```
  ## Direct child initiatives (decomposed scope)
  - [story] Build AlertDialog component mirroring ConfirmDialog (done) [initiative 6379b104-…]
  - [story] Classify and route alerts: toast vs AlertDialog (planned) [initiative 181cb33a-…]
  - [story] Pick and integrate toast notification library (at_risk) [initiative 9ab40f1f-…]
  - [story] Replace all alert() calls in /agents routes (planned) [initiative 117bc3ba-…]
  - [story] Replace all alert() calls in /initiatives routes (planned) [initiative 8c35…]
  ```
  Cancelled the test run after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)