### PR TITLE
feat(notes): persistent note → PM proposal link via pm_proposal_ids

### DIFF
--- a/src/app/api/agent-notes/route.ts
+++ b/src/app/api/agent-notes/route.ts
@@ -15,6 +15,7 @@ import {
   listNotes,
   parseAttachedFiles,
   parseConsumedStages,
+  parsePmProposalIds,
   type AgentNote,
   type NoteImportance,
   type NoteKind,
@@ -82,6 +83,7 @@ function notePayload(
     attached_files: parseAttachedFiles(note),
     importance: note.importance,
     consumed_by_stages: parseConsumedStages(note),
+    pm_proposal_ids: parsePmProposalIds(note),
     archived_at: note.archived_at,
     created_at: note.created_at,
     /**

--- a/src/app/api/initiatives/[id]/ask-pm-from-notes/route.ts
+++ b/src/app/api/initiatives/[id]/ask-pm-from-notes/route.ts
@@ -25,6 +25,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
+  appendNoteProposalId,
   getNote,
   markNoteConsumed,
   type AgentNote,
@@ -125,16 +126,18 @@ export async function POST(
       allowFallback: false,
     });
 
-    // Mark notes consumed so the UI can fade the "Ask PM" button on a
-    // re-render. Idempotent — re-clicking still works, just no new
-    // bookkeeping.
+    // Mark notes consumed so the UI can fade the "Ask PM" button on
+    // a re-render. Also remember the resulting proposal id on each
+    // note so the UI can offer a persistent "View proposal" link
+    // (survives page reloads). Both operations are idempotent.
     for (const n of notes) {
       try {
         markNoteConsumed(n.id, CONSUMED_STAGE);
+        appendNoteProposalId(n.id, result.proposal.id);
       } catch (err) {
         // Best-effort; the dispatch already happened, this is housekeeping.
         console.warn(
-          `[ask-pm-from-notes] markNoteConsumed failed for ${n.id}:`,
+          `[ask-pm-from-notes] note bookkeeping failed for ${n.id}:`,
           (err as Error).message,
         );
       }

--- a/src/components/notes/NoteCard.tsx
+++ b/src/components/notes/NoteCard.tsx
@@ -301,6 +301,24 @@ export function NoteCard({
           </Link>
         </p>
       )}
+      {isExpanded && (note.pm_proposal_ids?.length ?? 0) > 0 && (
+        <p className="text-[11px] opacity-80">
+          <Link
+            href={`/pm?proposal=${encodeURIComponent((note.pm_proposal_ids ?? []).at(-1)!)}`}
+            className="inline-flex items-center gap-1 underline-offset-2 hover:underline"
+            title="Open the most recent PM proposal created from this note"
+          >
+            <Sparkles className="w-3 h-3" />
+            View proposal in PM chat
+            {note.pm_proposal_ids!.length > 1 && (
+              <span className="opacity-70">
+                {' '}
+                (latest of {note.pm_proposal_ids!.length})
+              </span>
+            )}
+          </Link>
+        </p>
+      )}
       {isExpanded && note.attached_files.length > 0 && (
         <ul className="mt-1 flex flex-wrap gap-1">
           {note.attached_files.map((f) => (

--- a/src/hooks/useAgentNotes.ts
+++ b/src/hooks/useAgentNotes.ts
@@ -65,6 +65,10 @@ export interface AgentNoteRecord {
   attached_files: string[];
   importance: 0 | 1 | 2;
   consumed_by_stages?: string[];
+  /** pm_proposals.id values created from this note via Ask-PM-from-notes.
+   *  Hydrated server-side; SSE-pushed `agent_note_created` events
+   *  initialize empty until refresh. */
+  pm_proposal_ids?: string[];
   archived_at: string | null;
   created_at: string;
   /** Hydrated by /api/agent-notes; null on SSE-pushed notes. */

--- a/src/lib/db/agent-notes.ts
+++ b/src/lib/db/agent-notes.ts
@@ -57,6 +57,10 @@ export interface AgentNote {
   archived_at: string | null;
   archived_reason: string | null;
   created_at: string;
+  /** Stored as JSON string array. Holds pm_proposals.id values created
+   *  from this note via the Ask-PM-from-notes flow. Multiple ids are
+   *  possible because the operator can re-ask on the same note. */
+  pm_proposal_ids: string | null;
 }
 
 /** Maximum body length per note (matches the role-soul guidance). */
@@ -354,4 +358,39 @@ export function parseAttachedFiles(note: Pick<AgentNote, 'attached_files'>): str
 export function parseConsumedStages(note: Pick<AgentNote, 'consumed_by_stages'>): string[] {
   if (!note.consumed_by_stages) return [];
   return safeParseStringArray(note.consumed_by_stages);
+}
+
+/**
+ * Convenience: parse the JSON `pm_proposal_ids` field into a string[].
+ * Returns [] for null/invalid.
+ */
+export function parsePmProposalIds(
+  note: Pick<AgentNote, 'pm_proposal_ids'>,
+): string[] {
+  if (!note.pm_proposal_ids) return [];
+  return safeParseStringArray(note.pm_proposal_ids);
+}
+
+/**
+ * Append a `pm_proposals.id` to the note's `pm_proposal_ids` JSON
+ * array. Idempotent — already-present ids aren't duplicated. Returns
+ * the updated note, or null if the note doesn't exist.
+ *
+ * Used by the Ask-PM-from-notes route after a successful PM dispatch
+ * so the UI can render a persistent "View proposal" link.
+ */
+export function appendNoteProposalId(
+  noteId: string,
+  proposalId: string,
+): AgentNote | null {
+  const existing = getNote(noteId);
+  if (!existing) return null;
+  const current = parsePmProposalIds(existing);
+  if (current.includes(proposalId)) return existing;
+  current.push(proposalId);
+  run(
+    `UPDATE agent_notes SET pm_proposal_ids = ? WHERE id = ?`,
+    [JSON.stringify(current), noteId],
+  );
+  return getNote(noteId);
 }

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4474,6 +4474,25 @@ const migrations: Migration[] = [
       console.log('[Migration 083] workspaces.repo_url + default_base_branch added (nullable).');
     },
   },
+  {
+    id: '084',
+    name: 'agent_notes_pm_proposal_ids',
+    up: (db) => {
+      // Persistent note → proposal association. When the operator
+      // clicks "Ask PM" on a note, the route dispatches the PM and
+      // gets back a pm_proposals.id. We need to remember that mapping
+      // so the UI can offer a "View proposal" link that survives
+      // reload. Stored as a JSON array because re-asking on the same
+      // note creates additional proposals over time.
+      const cols = db.prepare(`PRAGMA table_info(agent_notes)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'pm_proposal_ids')) {
+        db.exec(`ALTER TABLE agent_notes ADD COLUMN pm_proposal_ids TEXT`);
+        console.log('[Migration 084] agent_notes.pm_proposal_ids added (nullable JSON array).');
+      } else {
+        console.log('[Migration 084] agent_notes.pm_proposal_ids already present; skipping.');
+      }
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/mcp/shared.ts
+++ b/src/lib/mcp/shared.ts
@@ -14,7 +14,11 @@ import { AuthzError } from '@/lib/authz/agent-task';
 import { authzErrorToToolResult, internalErrorToToolResult } from './errors';
 import { logMcpToolCall } from './debug';
 import { PmProposalValidationError } from '@/lib/db/pm-proposals';
-import { parseAttachedFiles, type AgentNote } from '@/lib/db/agent-notes';
+import {
+  parseAttachedFiles,
+  parsePmProposalIds,
+  type AgentNote,
+} from '@/lib/db/agent-notes';
 
 // ─── shared zod fragments ────────────────────────────────────────────
 
@@ -186,6 +190,7 @@ export function noteToPayload(note: AgentNote): Record<string, unknown> {
     body: note.body,
     attached_files: parseAttachedFiles(note),
     importance: note.importance,
+    pm_proposal_ids: parsePmProposalIds(note),
     created_at: note.created_at,
   };
 }


### PR DESCRIPTION
## Summary

Answers \"after I click Ask PM on a note, it should link to the created PM chat — are the associations already in place?\". They weren't: the route returned `proposal_id` but the UI threw it away, and there was no DB column to remember the mapping past the single network call. Now persistent and survives reload.

## Changes

**Schema**
- **Migration 084**: `agent_notes.pm_proposal_ids TEXT` (nullable JSON array). Many-to-one — operator can re-ask on the same note and build up an audit trail of every proposal it spawned.

**DAO** (`src/lib/db/agent-notes.ts`)
- `parsePmProposalIds()` helper (mirrors `parseConsumedStages`).
- `appendNoteProposalId()` — idempotent JSON-array append.

**API**
- `POST /api/initiatives/:id/ask-pm-from-notes` calls `appendNoteProposalId` alongside the existing `markNoteConsumed`. Both wrapped in the same best-effort try/catch.
- `GET /api/agent-notes` payload returns parsed `pm_proposal_ids`.
- `noteToPayload` (used by SSE broadcast) includes the field so freshly-created notes carry the right shape.

**UI**
- `AgentNoteRecord` type gains `pm_proposal_ids?: string[]`.
- `NoteCard` renders a **\"✨ View proposal in PM chat\"** link in the expanded card body when the array is non-empty. Links to `/pm?proposal=<id>` (existing deep-link feature scrolls + highlights the card on the PM page). Multiple proposals → points at the latest with `(latest of N)` suffix.

## Test plan

- [x] `yarn test` — 852 pass, 1 pre-existing (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.
- [x] Migration 084 runs on dev-server restart; `agent_notes.pm_proposal_ids` column present, all existing rows initialize empty as expected.
- [x] **Preview verify** end-to-end:
  - `POST /api/initiatives/:id/ask-pm-from-notes` returns `proposal_id`; the note's `pm_proposal_ids` array is now `[<that id>]` and `consumed_by_stages` is `['pm_proposal']`.
  - Expanded NoteCard shows `✨ View proposal in PM chat` linking to `/pm?proposal=<id>`. Verified the link's `href` matches the persisted id.
  - State survives reload (the column persists across browser refresh).

## Pre-existing issue (unrelated)

The `/pm` page itself renders empty in this dev session even with a valid `?proposal=<id>` URL — `/api/mcp/pm` responds 200 but no proposal cards render. The link's job is to point at the right URL with the right id; what `/pm` does with that URL is the existing deep-link feature (`useSearchParams` + scrollIntoView at `pm/page.tsx:141–146`). The blank-render symptom predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)