### PR TITLE
fix(pm): unbreak /pm?proposal=<id> deep-link rendering

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -11,8 +11,7 @@
  * proposals" sidebar on the right with proposal status chips.
  */
 
-import { useEffect, useState, useCallback, useMemo, useRef, Suspense } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import Link from 'next/link';
 import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox, Sunrise, Pin, ArrowDown, MessageSquarePlus, Trash2, RotateCcw, Info, Sparkles } from 'lucide-react';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -88,16 +87,6 @@ const STATUS_BADGE: Record<PmProposal['status'], string> = {
 // missing plan/decompose/notes — all three rendered as blue "manual").
 
 export default function PmChatPage() {
-  // useSearchParams() requires a Suspense boundary during static prerender
-  // (Next 16). The actual page contents live in PmChatPageInner below.
-  return (
-    <Suspense fallback={null}>
-      <PmChatPageInner />
-    </Suspense>
-  );
-}
-
-function PmChatPageInner() {
   const workspaceId = useCurrentWorkspaceId();
   const setCurrentWorkspaceId = useSetCurrentWorkspaceId();
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
@@ -141,8 +130,21 @@ function PmChatPageInner() {
   // Phase 6: support `?proposal=<id>` deep-links — scroll to and highlight
   // the matching proposal card on load. Cleared after first successful
   // scroll so subsequent re-renders don't keep re-scrolling.
-  const searchParams = useSearchParams();
-  const focusProposalId = searchParams?.get('proposal') ?? null;
+  //
+  // We deliberately read the param from `window.location.search` post-mount
+  // rather than via `useSearchParams()`. The hook forces a Suspense boundary
+  // during static prerender (Next 15+), and wrapping this client page in
+  // <Suspense> caused the streaming chunk for `/pm?proposal=<id>` to be
+  // inserted as a body-level sibling of the shell <main> instead of replacing
+  // the placeholder — leaving the page rendered with empty initial state and
+  // no effects ever firing. Reading post-mount avoids the prerender path
+  // entirely. See PR #271 for the repro.
+  const [focusProposalId, setFocusProposalId] = useState<string | null>(null);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    setFocusProposalId(params.get('proposal'));
+  }, []);
   const [highlightedProposalId, setHighlightedProposalId] = useState<string | null>(null);
 
   // Load workspace list once. The global switcher in the left nav owns the


### PR DESCRIPTION
## Summary

Direct navigation to `/pm?proposal=<id>` (the deep-link added in PR #270 from agent notes) rendered an empty page — workspace name missing, chat thread empty, sidebar said "No proposals yet", textarea said "No PM agent in this workspace." All while every relevant API call returned 200 when probed manually. The React effects simply never ran.

## Diagnosis

The page wrapped `PmChatPageInner` in `<Suspense fallback={null}>` to satisfy `useSearchParams()`'s static-prerender requirement. When the URL had a search param, Next.js streaming SSR rendered the page's deferred chunk as a **body-level sibling** of the shell `<main>` instead of swapping it into the suspense placeholder. DOM after load:

- shell `<main>` retained `<template id="B:0">` (pending suspense, never resolved)
- a second copy of the page rendered as a body-level `<div>` with empty initial state
- hydration latched onto the orphan tree, so no useEffect ever fired
- console showed no errors; server logs showed only the document GET (no follow-up `/api/agents`, `/api/pm/proposals` calls from the broken render)

Plain `/pm` worked because `useSearchParams()` returns an empty `URLSearchParams` for no-param URLs and Suspense never has to defer anything. `/jobs?run=<id>` works because it doesn't wrap in `<Suspense>` at all.

## Changes

- Drop the `<Suspense>` wrapper around `PmChatPageInner`; merge it back into `PmChatPage`.
- Remove the `useSearchParams()` call and instead read `proposal` from `window.location.search` inside a post-mount `useEffect`, storing it in `focusProposalId` state.
- The deep-link scroll/highlight effect is unchanged — it keys off the state-backed `focusProposalId` exactly as before, so behavior on populated proposals is identical.

## Test plan

- [x] `yarn tsc --noEmit` — no new errors (pre-existing 3 unrelated to this PR)
- [x] `yarn test` — 851/852 pass; the one failure is the pre-existing `schedule-runner: produces a brief and advances run_count` flake (CLAUDE.md flagged)
- [x] preview verify on dev `:4010`:
  - `/pm?proposal=b31d1938-...` now lists 5 recent proposals, header reads "Default Workspace · 3 draft · 5 total", target card gets `ring-2 ring-mc-accent` highlight applied, no pending `<template id="B:0">`
  - `/pm` (no param) continues to render correctly