### PR TITLE
fix(pm-mcp): forbid agent from setting initiative status to done/cancelled

### DIFF
--- a/src/lib/agents/pm-soul.md
+++ b/src/lib/agents/pm-soul.md
@@ -104,6 +104,7 @@ Each diff is one of:
 - `{ "kind": "reorder_initiatives", "parent_id": "...", "child_ids_in_order": ["..."] }`
 - `{ "kind": "update_status_check", "initiative_id": "...", "status_check_md": "..." }`
 - `{ "kind": "create_child_initiative", "parent_initiative_id": "...", "title": "...", "child_kind": "epic|story", "complexity": "S|M|L|XL", "depends_on_initiative_ids": ["..."] }` — only emitted from a `decompose_initiative` proposal.
+- `{ "kind": "create_task_under_initiative", "initiative_id": "...", "title": "...", "description"?: "...", "role"?: "builder|tester|reviewer|...", "complexity"?: "S|M|L|XL" }` — emitted from `notes_intake` / status-check follow-ups when an audit identifies concrete builder work. The `initiative_id` may be a `placeholder_id` (or `$N`) referring to a `create_child_initiative` earlier in the same proposal.
 
 Apply is all-or-nothing in v1. Keep diffs minimal — propose only what the
 operator asked about plus any cascading status flips that follow logically.

--- a/src/lib/mcp/diff-schema.test.ts
+++ b/src/lib/mcp/diff-schema.test.ts
@@ -1,0 +1,60 @@
+/**
+ * DiffSchema regression tests.
+ *
+ * Locks the operator-vs-agent boundary on `set_initiative_status` —
+ * agent-proposed status updates may NOT include `done` or `cancelled`,
+ * those are operator territory. Discovered when a real PM audit run
+ * autonomously closed 4 stories on its own interpretation despite the
+ * SOUL forbidding it; the SOUL was advisory and the schema let it
+ * through. See chat-Margaret-Maps-Hamilton-1778204006063.md.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DiffSchema } from './shared';
+
+test('DiffSchema: set_initiative_status accepts non-terminal statuses', () => {
+  for (const status of ['planned', 'in_progress', 'at_risk', 'blocked']) {
+    const result = DiffSchema.safeParse({
+      kind: 'set_initiative_status',
+      initiative_id: 'init-1',
+      status,
+    });
+    assert.equal(result.success, true, `expected ${status} to validate`);
+  }
+});
+
+test('DiffSchema: set_initiative_status REJECTS done', () => {
+  const result = DiffSchema.safeParse({
+    kind: 'set_initiative_status',
+    initiative_id: 'init-1',
+    status: 'done',
+  });
+  assert.equal(
+    result.success,
+    false,
+    'agent-proposed set_initiative_status with status=done must be rejected; closure is operator territory',
+  );
+});
+
+test('DiffSchema: set_initiative_status REJECTS cancelled', () => {
+  const result = DiffSchema.safeParse({
+    kind: 'set_initiative_status',
+    initiative_id: 'init-1',
+    status: 'cancelled',
+  });
+  assert.equal(
+    result.success,
+    false,
+    'agent-proposed set_initiative_status with status=cancelled must be rejected; cancellation is operator territory',
+  );
+});
+
+test('DiffSchema: set_initiative_status REJECTS unknown status', () => {
+  const result = DiffSchema.safeParse({
+    kind: 'set_initiative_status',
+    initiative_id: 'init-1',
+    status: 'rumor',
+  });
+  assert.equal(result.success, false);
+});

--- a/src/lib/mcp/shared.ts
+++ b/src/lib/mcp/shared.ts
@@ -228,7 +228,18 @@ export const DiffSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('set_initiative_status'),
     initiative_id: z.string().min(1),
-    status: z.enum(['planned', 'in_progress', 'at_risk', 'blocked', 'done', 'cancelled']),
+    // Agent-proposed status updates intentionally exclude `done` and
+    // `cancelled` — those terminal states are operator territory per
+    // pm-soul.md ("What you NEVER do"). The full InitiativeStatus enum
+    // (6 values) still lives on the column; the applier and
+    // prev_status capture still handle all 6 because operator-driven
+    // mutations and revert paths need them. We just refuse to let
+    // the agent autonomously close work via this diff.
+    status: z
+      .enum(['planned', 'in_progress', 'at_risk', 'blocked'])
+      .describe(
+        "Status to set. Excludes 'done' and 'cancelled' — terminal states are operator territory; surface evidence via update_status_check + a task and let the operator flip to done themselves.",
+      ),
   }),
   z.object({
     kind: z.literal('add_dependency'),


### PR DESCRIPTION
## Summary

The PM SOUL says terminal statuses (`done` / `cancelled`) are off-limits — \"Promotion is operator-driven at every layer.\" But the schema enum on `set_initiative_status` allowed all 6 InitiativeStatus values, so the rule was advisory. Discovered when a real PM audit run ([chat-Margaret-Maps-Hamilton-1778204006063.md](.)) autonomously closed **4 stories** on its own audit interpretation. The SOUL didn't stop it; the schema let it through.

This tightens at the schema layer so the rule is enforced rather than aspirational.

## Changes

**Schema** (`src/lib/mcp/shared.ts`)
- `DiffSchema.set_initiative_status.status`: restrict to `['planned', 'in_progress', 'at_risk', 'blocked']`.
- Inline comment + `.describe()` explain why and what to do instead — \"surface evidence via `update_status_check` + a task and let the operator flip to done themselves.\"

**Applier** (`src/lib/db/pm-proposals.ts:930`)
- Unchanged. Still writes whatever status it gets — operator-driven mutations and revert paths still need the full 6-value enum on the column. The schema is where the agent boundary lives.

**SOUL doc** (`src/lib/agents/pm-soul.md:106`)
- Add `create_task_under_initiative` to the diff list. Was missing — the agent used it correctly via the schema's own description, but the SOUL is the canonical doc and was out of sync.

**Tests** (`src/lib/mcp/diff-schema.test.ts`)
- 4 new regression tests asserting the accept/reject contract — `done` / `cancelled` rejected, the four non-terminal statuses accepted, unknown statuses rejected.

## Test plan

- [x] `yarn test` — 856 pass (+4 new), 1 pre-existing (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.
- [x] Schema-level reject verified via the new unit tests, which run the actual `DiffSchema` (zod discriminated union) against done/cancelled and confirm rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)