### PR TITLE
feat(pm): kind-chip + entity-first DiffRow layout; hide unreferenced $N

### DIFF
--- a/src/components/pm/ProposalDiffsList.tsx
+++ b/src/components/pm/ProposalDiffsList.tsx
@@ -41,6 +41,9 @@ export interface PmDiff {
   child_kind?: 'epic' | 'story' | 'milestone' | 'theme';
   complexity?: 'S' | 'M' | 'L' | 'XL';
   depends_on_initiative_ids?: string[];
+  /** Optional explicit placeholder id used by create_child_initiative
+   *  diffs as a dep target alternative to the ordinal `$N`. */
+  placeholder_id?: string;
   // create_task_under_initiative-only
   assigned_agent_id?: string | null;
   priority?: 'low' | 'normal' | 'high';
@@ -128,46 +131,307 @@ export function inferTargetInitiativeId(diffs: PmDiff[]): string | null {
 }
 
 /**
- * Single-row renderer. `index` is the position in the proposal's
- * `proposed_changes` array — for create kinds it doubles as the `$N`
- * placeholder id agents use to reference this row from a sibling's
- * `depends_on_initiative_ids`.
+ * Kind chip — colored uppercase badge that says, at a glance, what
+ * kind of change this row represents. Replaces the previous mix of
+ * leading-bullet / "status_check X" / arrow forms with one consistent
+ * column the operator can scan vertically.
  */
-export function DiffRow({ diff, index, resolveInitiativeTitle }: { diff: PmDiff; index: number; resolveInitiativeTitle?: InitiativeTitleResolver }) {
-  if (diff.kind === 'create_child_initiative' || diff.kind === 'create_task_under_initiative') {
-    const complexity = diff.complexity;
-    const deps = diff.depends_on_initiative_ids ?? [];
-    const isTask = diff.kind === 'create_task_under_initiative';
-    return (
-      <div className="flex items-baseline gap-2 text-xs leading-relaxed">
-        <span className="font-mono text-mc-text-secondary/60 shrink-0 w-6 text-right">${index}</span>
-        {complexity && (
-          <span
-            className={`shrink-0 px-1.5 py-0.5 rounded-sm border text-[10px] font-mono ${COMPLEXITY_BADGE[complexity]}`}
-            title={`complexity: ${complexity}`}
-          >
-            {complexity}
-          </span>
-        )}
-        {isTask && (
-          <span className="shrink-0 px-1.5 py-0.5 rounded-sm border border-violet-500/30 bg-violet-500/15 text-violet-200 text-[10px] font-mono uppercase tracking-wide">
-            task
-          </span>
-        )}
-        <span className="text-mc-text">{diff.title || <em className="text-mc-text-secondary">(untitled)</em>}</span>
-        {deps.length > 0 && (
-          <span className="text-mc-text-secondary/70 font-mono shrink-0 ml-auto">
-            ← {deps.map(formatInitiativeRef).join(', ')}
-          </span>
-        )}
-      </div>
-    );
-  }
+const KIND_CHIP: Record<string, { label: string; cls: string } | undefined> = {
+  create_epic: {
+    label: 'NEW EPIC',
+    cls: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-200',
+  },
+  create_story: {
+    label: 'NEW STORY',
+    cls: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-200',
+  },
+  create_initiative: {
+    label: 'NEW',
+    cls: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-200',
+  },
+  create_task_under_initiative: {
+    label: 'NEW TASK',
+    cls: 'border-violet-500/30 bg-violet-500/15 text-violet-200',
+  },
+  set_initiative_status: {
+    label: 'STATUS',
+    cls: 'border-sky-500/30 bg-sky-500/15 text-sky-200',
+  },
+  update_status_check: {
+    label: 'STATUS CHECK',
+    cls: 'border-indigo-500/30 bg-indigo-500/15 text-indigo-200',
+  },
+  shift_initiative_target: {
+    label: 'TARGET',
+    cls: 'border-amber-500/30 bg-amber-500/15 text-amber-200',
+  },
+  add_dependency: {
+    label: 'DEP +',
+    cls: 'border-cyan-500/30 bg-cyan-500/15 text-cyan-200',
+  },
+  remove_dependency: {
+    label: 'DEP −',
+    cls: 'border-rose-500/30 bg-rose-500/15 text-rose-200',
+  },
+  reorder_initiatives: {
+    label: 'REORDER',
+    cls: 'border-stone-500/30 bg-stone-500/15 text-stone-200',
+  },
+  add_availability: {
+    label: 'AVAIL',
+    cls: 'border-amber-500/30 bg-amber-500/15 text-amber-200',
+  },
+  set_task_status: {
+    label: 'TASK',
+    cls: 'border-violet-500/30 bg-violet-500/15 text-violet-200',
+  },
+};
+
+function KindChip({ kind }: { kind: string }) {
+  const def = KIND_CHIP[kind] ?? {
+    label: kind.toUpperCase(),
+    cls: 'border-mc-border bg-mc-bg-tertiary text-mc-text-secondary',
+  };
   return (
-    <div className="font-mono text-xs text-mc-text-secondary">
-      · {summarizeDiff(diff, resolveInitiativeTitle)}
-    </div>
+    <span
+      className={`shrink-0 px-1.5 py-0.5 rounded-sm border text-[10px] font-mono uppercase tracking-wide ${def.cls}`}
+    >
+      {def.label}
+    </span>
   );
+}
+
+/** Tight one-line preview of `status_check_md` content. Strips
+ *  markdown leaders the same way the audit-note preview does, then
+ *  caps at 60 chars. */
+function statusCheckPreview(md: string | undefined | null): string {
+  if (!md) return '';
+  for (const raw of md.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    const stripped = line
+      .replace(/^#+\s+/, '')
+      .replace(/^[-*+]\s+/, '')
+      .replace(/^\d+\.\s+/, '')
+      .replace(/^>\s+/, '')
+      .trim();
+    if (!stripped) continue;
+    return stripped.length > 60 ? `${stripped.slice(0, 59)}…` : stripped;
+  }
+  return '';
+}
+
+interface DiffRowProps {
+  diff: PmDiff;
+  /** Position in `proposed_changes` (used to render `$N` placeholder). */
+  index: number;
+  /** When true, render the `$N` placeholder before the chip — only
+   *  meaningful when another diff in the same proposal references it. */
+  showPlaceholder?: boolean;
+  resolveInitiativeTitle?: InitiativeTitleResolver;
+}
+
+/**
+ * Single-row renderer.
+ *
+ * Layout (left-to-right):
+ *   [optional $N] [KIND chip] [optional 2nd chip e.g. complexity]
+ *   <entity-or-title>  [— change-detail]  [→ arrow target / deps]
+ *
+ * The kind chip is the operator's primary cue; the rest of the row
+ * is "what entity is touched + what specifically changes".
+ */
+export function DiffRow({
+  diff,
+  index,
+  showPlaceholder = false,
+  resolveInitiativeTitle,
+}: DiffRowProps) {
+  const placeholderTag = showPlaceholder ? (
+    <span
+      className="font-mono text-mc-text-secondary/60 shrink-0 w-6 text-right"
+      title="Placeholder slot — referenced by another diff in this proposal"
+    >
+      ${index}
+    </span>
+  ) : null;
+
+  switch (diff.kind) {
+    case 'create_child_initiative': {
+      const parentLabel = labelFor(diff.parent_initiative_id, resolveInitiativeTitle);
+      const childKind = diff.child_kind ?? 'initiative';
+      const deps = diff.depends_on_initiative_ids ?? [];
+      return (
+        <div className="flex items-baseline gap-2 text-xs leading-relaxed">
+          {placeholderTag}
+          <KindChip kind={`create_${childKind}`} />
+          {diff.complexity && (
+            <span
+              className={`shrink-0 px-1.5 py-0.5 rounded-sm border text-[10px] font-mono ${COMPLEXITY_BADGE[diff.complexity]}`}
+              title={`complexity: ${diff.complexity}`}
+            >
+              {diff.complexity}
+            </span>
+          )}
+          <span className="text-mc-text-secondary shrink-0">under</span>
+          <span className="text-mc-text-secondary truncate max-w-[14ch]" title={parentLabel}>
+            {parentLabel}
+          </span>
+          <span className="text-mc-text-secondary">—</span>
+          <span className="text-mc-text">
+            {diff.title || <em className="text-mc-text-secondary">(untitled)</em>}
+          </span>
+          {deps.length > 0 && (
+            <span className="text-mc-text-secondary/70 font-mono shrink-0 ml-auto">
+              ← {deps.map(formatInitiativeRef).join(', ')}
+            </span>
+          )}
+        </div>
+      );
+    }
+    case 'create_task_under_initiative': {
+      const targetLabel = diff.initiative_id?.startsWith('$')
+        ? diff.initiative_id
+        : labelFor(diff.initiative_id, resolveInitiativeTitle);
+      return (
+        <div className="flex items-baseline gap-2 text-xs leading-relaxed">
+          {placeholderTag}
+          <KindChip kind={diff.kind} />
+          <span className="text-mc-text-secondary shrink-0">under</span>
+          <span className="text-mc-text-secondary truncate max-w-[14ch]" title={targetLabel}>
+            {targetLabel}
+          </span>
+          <span className="text-mc-text-secondary">—</span>
+          <span className="text-mc-text">
+            {diff.title || <em className="text-mc-text-secondary">(untitled)</em>}
+          </span>
+        </div>
+      );
+    }
+    case 'set_initiative_status': {
+      return (
+        <div className="flex items-baseline gap-2 text-xs leading-relaxed">
+          <KindChip kind={diff.kind} />
+          <span className="text-mc-text truncate" title={labelFor(diff.initiative_id, resolveInitiativeTitle)}>
+            {labelFor(diff.initiative_id, resolveInitiativeTitle)}
+          </span>
+          <span className="text-mc-text-secondary">→</span>
+          <span className="font-mono text-mc-text">{diff.status}</span>
+        </div>
+      );
+    }
+    case 'update_status_check': {
+      const preview = statusCheckPreview(diff.status_check_md);
+      return (
+        <div className="flex items-baseline gap-2 text-xs leading-relaxed">
+          <KindChip kind={diff.kind} />
+          <span className="text-mc-text truncate" title={labelFor(diff.initiative_id, resolveInitiativeTitle)}>
+            {labelFor(diff.initiative_id, resolveInitiativeTitle)}
+          </span>
+          {preview && (
+            <>
+              <span className="text-mc-text-secondary">—</span>
+              <span className="text-mc-text-secondary/80 italic truncate" title={diff.status_check_md ?? undefined}>
+                {preview}
+              </span>
+            </>
+          )}
+        </div>
+      );
+    }
+    case 'shift_initiative_target': {
+      return (
+        <div className="flex items-baseline gap-2 text-xs leading-relaxed">
+          <KindChip kind={diff.kind} />
+          <span className="text-mc-text truncate" title={labelFor(diff.initiative_id, resolveInitiativeTitle)}>
+            {labelFor(diff.initiative_id, resolveInitiativeTitle)}
+          </span>
+          <span className="text-mc-text-secondary">→</span>
+          <span className="font-mono text-mc-text">
+            {diff.target_start ?? '∅'} → {diff.target_end ?? '∅'}
+          </span>
+        </div>
+      );
+    }
+    case 'add_dependency': {
+      return (
+        <div className="flex items-baseline gap-2 text-xs leading-relaxed">
+          <KindChip kind={diff.kind} />
+          <span className="text-mc-text truncate">
+            {labelFor(diff.initiative_id, resolveInitiativeTitle)}
+          </span>
+          <span className="text-mc-text-secondary">blocks on</span>
+          <span className="text-mc-text truncate">
+            {labelFor(diff.depends_on_initiative_id, resolveInitiativeTitle)}
+          </span>
+        </div>
+      );
+    }
+    case 'remove_dependency': {
+      return (
+        <div className="flex items-baseline gap-2 text-xs leading-relaxed">
+          <KindChip kind={diff.kind} />
+          <span className="font-mono text-mc-text">{shortId(diff.dependency_id)}</span>
+        </div>
+      );
+    }
+    case 'reorder_initiatives': {
+      return (
+        <div className="flex items-baseline gap-2 text-xs leading-relaxed">
+          <KindChip kind={diff.kind} />
+          <span className="text-mc-text-secondary">under</span>
+          <span className="text-mc-text">
+            {labelFor(diff.parent_id ?? null, resolveInitiativeTitle) || 'root'}
+          </span>
+          <span className="text-mc-text-secondary">
+            ({diff.child_ids_in_order?.length ?? 0})
+          </span>
+        </div>
+      );
+    }
+    case 'add_availability': {
+      return (
+        <div className="flex items-baseline gap-2 text-xs leading-relaxed">
+          <KindChip kind={diff.kind} />
+          <span className="font-mono text-mc-text">{shortId(diff.agent_id)}</span>
+          <span className="text-mc-text-secondary">→</span>
+          <span className="font-mono text-mc-text">
+            {diff.start} – {diff.end}
+          </span>
+        </div>
+      );
+    }
+    default:
+      return (
+        <div className="flex items-baseline gap-2 text-xs leading-relaxed">
+          <KindChip kind={diff.kind ?? 'unknown'} />
+          <span className="font-mono text-mc-text-secondary">
+            {summarizeDiff(diff, resolveInitiativeTitle)}
+          </span>
+        </div>
+      );
+  }
+}
+
+/**
+ * Pre-compute the set of placeholder ids (`$N`, custom placeholder_id)
+ * referenced by other diffs in the same proposal. Only `create_*`
+ * rows whose placeholder is actually used as a dep target or task
+ * parent need to render `$N`; the rest are noise.
+ */
+function collectReferencedPlaceholders(diffs: PmDiff[]): Set<string> {
+  const refs = new Set<string>();
+  for (const d of diffs) {
+    if (d.kind === 'create_task_under_initiative' && typeof d.initiative_id === 'string' && d.initiative_id.startsWith('$')) {
+      refs.add(d.initiative_id);
+    }
+    if (d.kind === 'create_child_initiative') {
+      for (const dep of d.depends_on_initiative_ids ?? []) {
+        if (typeof dep === 'string' && dep.startsWith('$')) refs.add(dep);
+      }
+    }
+  }
+  return refs;
 }
 
 const DEFAULT_PREVIEW_CAP = 10;
@@ -215,6 +479,9 @@ export function ProposalDiffsList({
   const cap = showAll ? diffs.length : previewCap;
   const visible = diffs.slice(0, cap);
   const overflow = diffs.length - visible.length;
+  // Only show `$N` next to diffs that another diff actually references.
+  // Removes a column of noise on flat (non-decompose) proposals.
+  const referenced = collectReferencedPlaceholders(diffs);
   return (
     <div className={className}>
       {visible.map((c, idx) => {
@@ -222,6 +489,14 @@ export function ProposalDiffsList({
           <DiffRow
             diff={c}
             index={idx}
+            showPlaceholder={
+              (c.kind === 'create_child_initiative' ||
+                c.kind === 'create_task_under_initiative') &&
+              (referenced.has(`$${idx}`) ||
+                (c.kind === 'create_child_initiative' &&
+                  !!c.placeholder_id &&
+                  referenced.has(c.placeholder_id)))
+            }
             resolveInitiativeTitle={resolveInitiativeTitle}
           />
         );


### PR DESCRIPTION
## Summary

Operator review of partial-accept screenshots flagged that the diff rows were ambiguous. Three issues:

1. **Diff kind not visible.** Leading bullets vs arrow forms vs `status_check Title` prefixes meant the operator had to recognize the format to infer the kind.
2. **Targeted entity buried for tasks.** `create_task_under_initiative` showed the *task* title, not the parent initiative.
3. **`update_status_check` content hidden.** Row showed only the target name, no preview of what was being written.

Plus the `$0/$1` placeholder slots were rendering on every create row whether anything referenced them or not — pure noise on flat (non-decompose) proposals.

## Changes

`src/components/pm/ProposalDiffsList.tsx` — `DiffRow` rewrite. New layout, left-to-right:

```
[optional $N]  [KIND chip]  [optional 2nd chip e.g. complexity]  <entity>  [— change-detail]  [→ arrow / deps]
```

- **Kind chip** is a colored uppercase badge per kind: `NEW EPIC` / `NEW STORY` / `NEW TASK` / `STATUS` / `STATUS CHECK` / `TARGET` / `DEP +` / `DEP −` / `REORDER` / `AVAIL` / `TASK`. Operator scans vertically to triage by kind.
- **`create_task_under_initiative`** now reads `[NEW TASK] under <parent title> — <task title>`.
- **`create_child_initiative`** gains `[NEW EPIC] under <parent>` with the existing complexity badge + dep arrow.
- **`update_status_check`** now renders a 60-char preview of the new `status_check_md` content (markdown leaders stripped) so the operator sees what's being written, not just where: `[STATUS CHECK] Pick and integrate to… — [x] Story marked done per…`.
- Per-kind switch replaces the previous catch-all `summarizeDiff` fallthrough; each kind owns its row template. `summarizeDiff` is preserved for `/pm/activity` which still wants a one-line table cell.

`$N` placeholder column now only renders when another diff in the same proposal actually references it (`collectReferencedPlaceholders` pass). Flat proposals — the common case — drop the column entirely.

## Test plan

- [x] `yarn test` — 860 pass, 1 pre-existing (`schedule-runner`) unrelated.
- [x] `npx tsc --noEmit` — clean.
- [x] **Preview verify** against the dogfood 4-diff proposal:
  - Pre-fix screenshot: `$0 [TASK] Replace remaining…` / `· status_check Pick and integrate…` / `· Refactor… → in_progress` (operator's complaint).
  - Post-fix:
    - `[NEW TASK] under Refactor nat… — Replace remaining window.alert() calls in /jobs routes…`
    - `[STATUS CHECK] Pick and integrate to… — [x] Story marked **done** per audit…`
    - `[STATUS CHECK] Classify and route ale… — [ ] Story **deferred** per au…`
    - `[STATUS] Refactor native alert() calls to a custom mod… → in_progress`
    - `$0` column gone (nothing references it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)