### PR TITLE
feat(mcp): block take_note writes from cancelled runs (dedupe #1/3)

### DIFF
--- a/specs/dedupe-investigations.md
+++ b/specs/dedupe-investigations.md
@@ -1,0 +1,157 @@
+# Dedupe redundant initiative investigations
+
+## Why
+
+Operator clicked "Audit" on an initiative twice in 24 seconds (at 23:30:13
+and 23:30:37 on May 7 2026). The first dispatch was cancelled; the second
+ran to completion. Both ended up writing observation notes (`agent_notes`
+ids `43b6502f…` and `fe345c99…`) — same audit, slightly different prose,
+~50 seconds apart. The operator had to read both to confirm they were
+redundant.
+
+Three failure modes are tangled here:
+
+1. **Cancelled runs still persist tool writes** — the openclaw worker is
+   not killed when `agent_runs.status` flips to `cancelled` (gateway abort
+   is best-effort; the worker keeps executing tools until it polls
+   heartbeat or hits timeout). So a cancelled run can still call
+   `take_note`, `register_deliverable`, `log_activity`, etc.
+
+2. **No dispatch-time guard** — `POST /api/initiatives/:id/investigate`
+   doesn't check whether an `initiative_audit` is already
+   `queued`/`running` for this initiative.
+
+3. **No throttle on back-to-back complete audits** — even with #1+#2
+   fixed, an operator can re-audit 30s after a clean completion without
+   any UI hint that the previous one already finished.
+
+This spec ships #1 first as a standalone change. #2 and #3 follow as
+separate PRs that build on the run-group-id linkage added here.
+
+## Scope of this PR (#1 only)
+
+**Goal**: A cancelled `agent_run` cannot persist `agent_notes`. If a
+worker calls `take_note` after its run was cancelled, the call is
+rejected and the row is not written.
+
+Out of scope (follow-ups):
+- Same gating on `register_deliverable`, `log_activity`, etc. (mentioned
+  in §Future, not built here).
+- Dispatch-time guard against concurrent audits (#2).
+- UI cooldown / "audited 2 min ago" hint (#3).
+
+## Design
+
+### Linking notes back to their run
+
+Today `agent_notes` carries `run_group_id` (UUID minted in
+`dispatch-scope.ts` at dispatch time, baked into the briefing, passed
+back by the agent on every `take_note`). But `agent_runs` does **not**
+store `run_group_id` — there's no way to look up a run from a
+`run_group_id`.
+
+Match on `scope_key` alone won't work: scope_key is reused across runs,
+and in the redundant-audit case the *most recent* run for that scope_key
+is the new (complete) run, not the cancelled one whose worker is the
+actual caller.
+
+**Fix**: persist `run_group_id` on `agent_runs` so it can be the join
+key.
+
+### Migration 085
+
+Add `run_group_id TEXT` to `agent_runs`, plus an index. Backfill is
+unnecessary — older runs won't be checked (their workers are long dead).
+Column is nullable so legacy rows continue to load.
+
+```sql
+ALTER TABLE agent_runs ADD COLUMN run_group_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_agent_runs_run_group
+  ON agent_runs(run_group_id) WHERE run_group_id IS NOT NULL;
+```
+
+### Code changes
+
+1. `src/lib/db/agent-runs.ts`
+   - `StartAgentRunInput.run_group_id?: string` (optional for backwards
+     compat / brief-dispatch which manages its own row).
+   - INSERT writes the column.
+   - New `getRunByGroupId(run_group_id: string): AgentRun | null` —
+     returns the single row matching this run_group_id, or null.
+
+2. `src/lib/agents/dispatch-scope.ts`
+   - Pass `run_group_id` into the `startAgentRun` call (currently does
+     not).
+
+3. `src/lib/mcp/groups/core.ts` — `take_note` handler
+   - Before calling `createNote`, look up the run via
+     `getRunByGroupId(args.run_group_id)`.
+   - If found AND `status === 'cancelled'`: return a structured MCP
+     error (`{ error: 'run_cancelled', message: '…' }`) with `isError:
+     true`. Do **not** insert.
+   - If not found (legacy run, no run_group_id, or fresh insert race):
+     proceed — fail open. Logging this case as a warning is fine but not
+     required; we don't want to block legitimate writes if the lookup
+     misses.
+   - If status is anything else (`queued`, `running`, `complete`,
+     `failed`): proceed. We only block `cancelled`, not `complete` —
+     a worker writing to a `complete` run is a different bug (the run
+     finalize raced ahead) and we'd rather have the data.
+
+### Failure modes considered
+
+- **Race: worker calls `take_note` between `cancelAgentRun` flipping
+  status and the abort signal landing.** Handled — the status flip is
+  the canonical source of truth. The check sees `cancelled` and refuses.
+
+- **Legacy runs with no `run_group_id`.** Handled — `getRunByGroupId`
+  returns null, take_note falls through. These are old runs whose
+  workers are no longer alive anyway.
+
+- **Brief dispatch path (`skip_run_row: true`).** No `agent_runs` row
+  exists at all. Lookup returns null, take_note proceeds. Brief
+  dispatches don't have a cancellation pathway today.
+
+- **Multiple agent_runs sharing a run_group_id.** Shouldn't happen —
+  run_group_id is a per-dispatch UUID. If it does, `getRunByGroupId`
+  can `LIMIT 1 ORDER BY created_at DESC` defensively.
+
+## Test plan
+
+Unit tests in `src/lib/db/agent-runs.test.ts`:
+- `startAgentRun` persists `run_group_id` when provided.
+- `getRunByGroupId` returns the row.
+- `getRunByGroupId` returns null for unknown id.
+
+Unit/integration test for take_note guard
+(`src/lib/mcp/groups/core.test.ts` or new file):
+- Dispatch a run with `run_group_id=X`, mark it `cancelled` via
+  `cancelAgentRun`, call `take_note` with `run_group_id=X` → MCP returns
+  `isError: true`, no row in `agent_notes`.
+- Same setup but status stays `running` → take_note succeeds, row
+  inserted.
+- `take_note` with unknown `run_group_id` → succeeds (fail-open).
+
+Manual verify:
+- Dispatch an `initiative_audit`, immediately cancel it via the /jobs UI
+  before the worker finishes, watch the worker log a 4xx-style error on
+  `take_note` instead of writing the orphan note. Inspect `agent_notes`
+  to confirm no row.
+
+## Future (not this PR)
+
+- **#2 Dispatch-time guard**: in
+  `POST /api/initiatives/:id/investigate`, check
+  `agent_runs WHERE initiative_id=? AND kind='initiative_audit' AND
+  status IN ('queued','running')`. If found, refuse with 409 + a
+  message that the operator can re-issue with `?supersede=1` to
+  cancel-and-redispatch atomically.
+
+- **#3 UI cooldown**: client-side check on the audit button — if the
+  most recent complete `initiative_audit` for this initiative is < 5 min
+  old, render "Last audited 2 min ago — re-audit?" with a confirm.
+
+- **Generalize the cancelled-run guard** to `register_deliverable`,
+  `log_activity`, `propose_changes`. Same lookup, same refuse path.
+  Probably a small `assertRunNotCancelled(run_group_id)` helper
+  imported into each tool.

--- a/src/lib/agents/dispatch-scope.ts
+++ b/src/lib/agents/dispatch-scope.ts
@@ -239,6 +239,11 @@ export async function dispatchScope(input: DispatchScopeInput): Promise<Dispatch
         // trigger_body) so the operator sees the full system context.
         trigger_body: briefing,
         pm_proposal_id: input.pm_proposal_id ?? null,
+        // Persist the briefing's run_group_id on the agent_runs row so
+        // downstream tools (take_note, …) can map a worker's
+        // run_group_id back to its run and refuse writes after cancel.
+        // See specs/dedupe-investigations.md.
+        run_group_id,
       });
     } catch (err) {
       // Don't let an agent_runs write failure break dispatch. Log and

--- a/src/lib/db/agent-runs.test.ts
+++ b/src/lib/db/agent-runs.test.ts
@@ -25,6 +25,7 @@ import {
   markRunRollup,
   reapStaleRunning,
   startAgentRun,
+  getRunByGroupId,
   completeAgentRun,
   failAgentRun,
   scopeTypeToRunKind,
@@ -247,6 +248,29 @@ test('startAgentRun: writes a row in running state with attribution', () => {
   assert.equal(row!.agent_id, 'mc-pm-default');
   assert.equal(row!.label, 'PM chat: ping');
   assert.ok(row!.started_at);
+});
+
+test('startAgentRun: persists run_group_id and getRunByGroupId looks it up', () => {
+  const ws = freshWorkspace();
+  const groupId = uuidv4();
+  const id = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'agent:researcher:foo',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: 'a',
+    run_group_id: groupId,
+  });
+  const row = getAgentRun(id);
+  assert.equal(row!.run_group_id, groupId);
+
+  const looked = getRunByGroupId(groupId);
+  assert.ok(looked, 'getRunByGroupId returns the row');
+  assert.equal(looked!.id, id);
+
+  assert.equal(getRunByGroupId(uuidv4()), null, 'unknown group id → null');
+  assert.equal(getRunByGroupId(''), null, 'empty group id → null');
 });
 
 test('startAgentRun: rejects empty workspace_id', () => {

--- a/src/lib/db/agent-runs.ts
+++ b/src/lib/db/agent-runs.ts
@@ -56,6 +56,11 @@ export interface AgentRun {
    *  row, this points at that proposal so the cancel cascade can flip
    *  it to `synth_only` (PR 5). */
   pm_proposal_id: string | null;
+  /** UUID minted by dispatch-scope; matches the `run_group_id` baked
+   *  into the agent's briefing and tagged on every `agent_notes` row
+   *  this run produces. Nullable for pre-085 rows and brief dispatches
+   *  that skip the agent_runs row. */
+  run_group_id: string | null;
   started_at: string | null;
   completed_at: string | null;
   created_at: string;
@@ -291,6 +296,12 @@ export interface StartAgentRunInput {
    *  the cancel cascade to flip `pending_agent` → `synth_only` when
    *  an in-flight PM chat is killed before the agent replies. */
   pm_proposal_id?: string | null;
+  /** UUID minted by dispatch-scope and baked into the agent's
+   *  briefing. Persisted here so tools (e.g. take_note) can map a
+   *  caller's run_group_id back to its agent_runs row and refuse
+   *  writes from a worker whose run was already cancelled.
+   *  See specs/dedupe-investigations.md. */
+  run_group_id?: string | null;
 }
 
 /**
@@ -309,9 +320,9 @@ export function startAgentRun(input: StartAgentRunInput): string {
        id, workspace_id, kind, status, source_kind, source_ref,
        scope_key, scope_type, role, agent_id,
        initiative_id, task_id, parent_run_id, label,
-       trigger_body, pm_proposal_id,
+       trigger_body, pm_proposal_id, run_group_id,
        cost_ceiling_cents, started_at, created_at, updated_at
-     ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), datetime('now'))`,
+     ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), datetime('now'))`,
     [
       id,
       input.workspace_id,
@@ -328,10 +339,31 @@ export function startAgentRun(input: StartAgentRunInput): string {
       input.label ?? null,
       input.trigger_body ?? null,
       input.pm_proposal_id ?? null,
+      input.run_group_id ?? null,
       input.cost_ceiling_cents ?? null,
     ],
   );
   return id;
+}
+
+/**
+ * Look up an agent_run by its dispatch-time `run_group_id`. Returns
+ * the matching row, or null if none. Used by MCP tools (currently
+ * `take_note`) to gate writes on run status — a worker whose run was
+ * cancelled while it was mid-flight should not be able to persist
+ * orphan rows. See specs/dedupe-investigations.md.
+ */
+export function getRunByGroupId(run_group_id: string): AgentRun | null {
+  if (!run_group_id) return null;
+  return (
+    queryOne<AgentRun>(
+      `SELECT * FROM agent_runs
+       WHERE run_group_id = ?
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [run_group_id],
+    ) ?? null
+  );
 }
 
 export interface CompleteAgentRunInput {

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4493,6 +4493,28 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    id: '085',
+    name: 'agent_runs_run_group_id',
+    up: (db) => {
+      // Link agent_runs back to the run_group_id minted by
+      // dispatch-scope. Lets tools (take_note first; later
+      // register_deliverable, log_activity, propose_changes) refuse
+      // writes from a worker whose run was already cancelled.
+      // See specs/dedupe-investigations.md.
+      const cols = db.prepare(`PRAGMA table_info(agent_runs)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'run_group_id')) {
+        db.exec(`ALTER TABLE agent_runs ADD COLUMN run_group_id TEXT`);
+        console.log('[Migration 085] agent_runs.run_group_id added (nullable).');
+      } else {
+        console.log('[Migration 085] agent_runs.run_group_id already present; skipping.');
+      }
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_agent_runs_run_group
+        ON agent_runs(run_group_id) WHERE run_group_id IS NOT NULL
+      `);
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/mcp/groups/core.ts
+++ b/src/lib/mcp/groups/core.ts
@@ -29,6 +29,7 @@ import {
   type NoteImportance,
   type NoteKind,
 } from '@/lib/db/agent-notes';
+import { getRunByGroupId } from '@/lib/db/agent-runs';
 import { broadcast } from '@/lib/events';
 
 import {
@@ -405,6 +406,24 @@ export function registerCoreTools(server: McpServer): void {
     },
     trace('take_note', async (args) => {
       try {
+        // Refuse writes from a worker whose run was already cancelled
+        // by the operator. Without this guard, the openclaw worker
+        // (which isn't actually killed when agent_runs.status flips to
+        // 'cancelled') keeps executing tools and can leave orphan
+        // notes — see specs/dedupe-investigations.md and the May 7
+        // duplicate-audit incident.
+        const owningRun = getRunByGroupId(args.run_group_id);
+        if (owningRun && owningRun.status === 'cancelled') {
+          const message =
+            `Refusing to write note: run ${owningRun.id} (run_group_id=${args.run_group_id}) was cancelled. ` +
+            `Stop work and exit cleanly.`;
+          return {
+            isError: true,
+            content: [{ type: 'text', text: message }],
+            structuredContent: { error: 'run_cancelled', message, run_id: owningRun.id },
+          };
+        }
+
         const note = createNote({
           workspace_id: deriveWorkspaceFromAgent(args.agent_id),
           agent_id: args.agent_id,

--- a/src/lib/mcp/mcp.test.ts
+++ b/src/lib/mcp/mcp.test.ts
@@ -589,3 +589,96 @@ test('propose_changes rejects an unknown diff kind', async () => {
   }
   assert.ok(rejected || isError, 'unknown diff kind must not silently pass schema validation');
 });
+
+// ─── take_note: cancelled-run guard ─────────────────────────────────
+//
+// Regression: a worker whose agent_runs row was already cancelled used
+// to be able to keep calling take_note (the openclaw worker isn't
+// actually killed when status flips to 'cancelled'). That left orphan
+// observation notes — see specs/dedupe-investigations.md and the
+// May 7 duplicate-audit incident.
+
+test('take_note refuses to write when the owning run is cancelled', async () => {
+  // Avoid a circular import at module top; pull from the DAO at call time.
+  const { startAgentRun, cancelAgentRun } = await import('@/lib/db/agent-runs');
+  const { client } = await makePair();
+  const me = seedAgent();
+  const groupId = crypto.randomUUID();
+  const runId = startAgentRun({
+    workspace_id: 'default',
+    kind: 'initiative_audit',
+    scope_key: 'agent:researcher:cancel-test',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: me,
+    run_group_id: groupId,
+  });
+  cancelAgentRun(runId);
+
+  const before = (queryOne<{ n: number }>('SELECT COUNT(*) as n FROM agent_notes')?.n) ?? 0;
+
+  const res = await client.callTool({
+    name: 'take_note',
+    arguments: {
+      agent_id: me,
+      kind: 'observation',
+      body: 'should not land',
+      scope_key: 'agent:researcher:cancel-test',
+      role: 'researcher',
+      run_group_id: groupId,
+    },
+  });
+
+  assert.equal(res.isError, true, 'take_note must error');
+  const payload = parseStructured<{ error: string }>(res);
+  assert.equal(payload.error, 'run_cancelled');
+
+  const after = (queryOne<{ n: number }>('SELECT COUNT(*) as n FROM agent_notes')?.n) ?? 0;
+  assert.equal(after, before, 'agent_notes row count unchanged');
+});
+
+test('take_note succeeds when the owning run is still running', async () => {
+  const { startAgentRun } = await import('@/lib/db/agent-runs');
+  const { client } = await makePair();
+  const me = seedAgent();
+  const groupId = crypto.randomUUID();
+  startAgentRun({
+    workspace_id: 'default',
+    kind: 'initiative_audit',
+    scope_key: 'agent:researcher:running-test',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: me,
+    run_group_id: groupId,
+  });
+
+  const res = await client.callTool({
+    name: 'take_note',
+    arguments: {
+      agent_id: me,
+      kind: 'observation',
+      body: 'live note',
+      scope_key: 'agent:researcher:running-test',
+      role: 'researcher',
+      run_group_id: groupId,
+    },
+  });
+  assert.equal(res.isError, undefined);
+});
+
+test('take_note fails open when run_group_id is unknown (legacy / brief dispatch)', async () => {
+  const { client } = await makePair();
+  const me = seedAgent();
+  const res = await client.callTool({
+    name: 'take_note',
+    arguments: {
+      agent_id: me,
+      kind: 'observation',
+      body: 'no run row exists for this group',
+      scope_key: 'agent:legacy:scope',
+      role: 'builder',
+      run_group_id: crypto.randomUUID(),
+    },
+  });
+  assert.equal(res.isError, undefined);
+});


### PR DESCRIPTION
## Summary

Cancelled `agent_runs` aren't actually killed — the openclaw worker keeps executing tools until it polls heartbeat or hits timeout. That's how the May 7 duplicate-audit incident left two near-identical observation notes on the same initiative: the cancelled run's worker still flushed its `take_note` before terminating, then the rerun added its own.

This PR closes the data-integrity hole by persisting `run_group_id` on `agent_runs` and refusing `take_note` writes from a worker whose run is already cancelled.

This is **#1 of 3** in the dedupe-investigations stack — see `specs/dedupe-investigations.md` for the full plan. #2 (dispatch-time guard against concurrent audits) and #3 (UI cooldown after recent audits) follow as separate PRs and build on this linkage.

## Changes

- **Migration 085** — `agent_runs.run_group_id TEXT` + partial index. Backfill skipped: pre-085 runs' workers are long dead so the guard wouldn't apply anyway.
- `startAgentRun` / `AgentRun` interface accept and persist `run_group_id`. New `getRunByGroupId(id)` lookup.
- `dispatch-scope.ts` passes the briefing's `run_group_id` into `startAgentRun` so the linkage exists at dispatch time.
- `take_note` MCP handler looks up the owning run by `run_group_id`. If `status='cancelled'`, return `{ error: 'run_cancelled' }` and skip the insert. Fail-open if the run isn't found (legacy / brief dispatch).

## Test plan

- [x] `yarn test` — 863/864 pass; the 1 failure (`schedule-runner: produces a brief and advances run_count`) is **pre-existing on main**, unrelated to this change.
- [x] `yarn tsc --noEmit` — same 3 pre-existing errors as main, none in files this PR touches.
- [x] New unit tests:
  - `startAgentRun` persists `run_group_id`; `getRunByGroupId` round-trips and returns null for unknown / empty ids.
  - `take_note` errors with `run_cancelled` and writes no row when the owning run is `cancelled`.
  - `take_note` succeeds when the owning run is `running`.
  - `take_note` fails open when `run_group_id` matches no run row.
- [ ] Manual verify (post-merge, on dev): dispatch an `initiative_audit`, cancel via /jobs UI before the worker finishes, confirm the worker logs a `run_cancelled` error on `take_note` and `agent_notes` has no orphan row.

## Out of scope (follow-ups)

- Same gating for `register_deliverable`, `log_activity`, `propose_changes` — same lookup, mechanical roll-out.
- **#2** Dispatch-time refusal of concurrent `initiative_audit` runs on the same initiative.
- **#3** UI cooldown / "audited 2 min ago — re-audit?" hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)