### PR TITLE
feat(investigate): refuse concurrent audits + supersede flow (dedupe #2/3)

### DIFF
--- a/src/app/api/initiatives/[id]/investigate/route.test.ts
+++ b/src/app/api/initiatives/[id]/investigate/route.test.ts
@@ -137,6 +137,87 @@ test('POST subtree with no runner registered → 503', async () => {
   assert.equal(res.status, 503);
 });
 
+test('POST narrow with an in-flight initiative_audit → 409 audit_in_flight', async () => {
+  const ws = freshWorkspace();
+  const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'open' });
+
+  // Insert a runner so the route doesn't 503 on us before the guard runs.
+  const runnerId = `agent-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR REPLACE INTO agents
+       (id, name, role, workspace_id, gateway_agent_id, source, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 'mc-runner-dev', 'test', datetime('now'), datetime('now'))`,
+    [runnerId, 'runner', 'researcher', ws],
+  );
+
+  // Simulate an existing in-flight audit row.
+  const { startAgentRun } = await import('@/lib/db/agent-runs');
+  const liveRunId = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'agent:researcher:in-flight',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: runnerId,
+    initiative_id: i.id,
+    run_group_id: uuidv4(),
+  });
+
+  try {
+    const res = await callPost(i.id, { mode: 'narrow' });
+    assert.equal(res.status, 409);
+    const body = await res.json();
+    assert.equal(body.error, 'audit_in_flight');
+    assert.ok(Array.isArray(body.in_flight));
+    assert.equal(body.in_flight[0].run_id, liveRunId);
+    assert.equal(body.in_flight[0].status, 'running');
+  } finally {
+    clearRunner();
+    run(`DELETE FROM agent_runs WHERE id = ?`, [liveRunId]);
+  }
+});
+
+test('POST narrow with supersede=true cancels in-flight and dispatches', async () => {
+  const ws = freshWorkspace();
+  const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'open' });
+
+  const runnerId = `agent-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR REPLACE INTO agents
+       (id, name, role, workspace_id, gateway_agent_id, source, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 'mc-runner-dev', 'test', datetime('now'), datetime('now'))`,
+    [runnerId, 'runner', 'researcher', ws],
+  );
+
+  const { startAgentRun, getAgentRun } = await import('@/lib/db/agent-runs');
+  const liveRunId = startAgentRun({
+    workspace_id: ws,
+    kind: 'initiative_audit',
+    scope_key: 'agent:researcher:in-flight2',
+    scope_type: 'initiative_audit',
+    role: 'researcher',
+    agent_id: runnerId,
+    initiative_id: i.id,
+    run_group_id: uuidv4(),
+  });
+
+  try {
+    const res = await callPost(i.id, { mode: 'narrow', supersede: true });
+    // 200 because dispatch fired (background promise will fail to
+    // reach the gateway but that's not on the response path).
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.mode, 'narrow');
+    // The previously in-flight run should now be cancelled.
+    const after = getAgentRun(liveRunId);
+    assert.equal(after!.status, 'cancelled');
+  } finally {
+    clearRunner();
+    run(`DELETE FROM agent_runs WHERE initiative_id = ?`, [i.id]);
+    run(`DELETE FROM mc_sessions WHERE initiative_id = ?`, [i.id]);
+  }
+});
+
 test('POST subtree with zero non-terminal descendants → planned_nodes=1', async () => {
   const ws = freshWorkspace();
   const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'root' });

--- a/src/app/api/initiatives/[id]/investigate/route.ts
+++ b/src/app/api/initiatives/[id]/investigate/route.ts
@@ -42,6 +42,8 @@ import { buildAuditPrompt } from '@/lib/agents/audit-prompt';
 import { queryAll } from '@/lib/db';
 import { getAuditSettings } from '@/lib/db/workspaces';
 import { planSubtreeAudit, runSubtreeAudit } from '@/lib/agents/subtree-audit';
+import { cancelAgentRun, AgentRunNotCancellableError } from '@/lib/db/agent-runs';
+import type { AgentRun } from '@/lib/db/agent-runs';
 
 export const dynamic = 'force-dynamic';
 
@@ -49,7 +51,30 @@ const InvestigateSchema = z.object({
   mode: z.enum(['narrow', 'subtree']).default('narrow'),
   guidance: z.string().max(2000).nullish(),
   reaudit: z.enum(['fresh', 'build_on']).default('fresh'),
+  /**
+   * When `true`, cancel any in-flight `initiative_audit` runs on this
+   * initiative before dispatching a fresh one. When `false` (default),
+   * an in-flight audit causes the route to refuse with 409. See
+   * specs/dedupe-investigations.md §2.
+   */
+  supersede: z.boolean().optional().default(false),
 });
+
+/**
+ * Find queued/running `initiative_audit` runs already scoped to this
+ * initiative. Used by the dispatch-time guard so a second click of
+ * "Audit" on the same initiative doesn't silently spawn a duplicate.
+ */
+function findInFlightAudits(initiativeId: string): AgentRun[] {
+  return queryAll<AgentRun>(
+    `SELECT * FROM agent_runs
+      WHERE initiative_id = ?
+        AND kind = 'initiative_audit'
+        AND status IN ('queued', 'running')
+      ORDER BY created_at ASC`,
+    [initiativeId],
+  );
+}
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -131,7 +156,49 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         { status: 400 },
       );
     }
-    const { mode, guidance, reaudit } = parsed.data;
+    const { mode, guidance, reaudit, supersede } = parsed.data;
+
+    // Concurrent-audit guard (specs/dedupe-investigations.md §2). An
+    // operator clicking "Audit" twice in a row used to silently spawn
+    // duplicates; require an explicit `supersede` to cancel the
+    // in-flight run, otherwise refuse with 409 + the live run's id so
+    // the UI can surface it.
+    const inFlight = findInFlightAudits(id);
+    if (inFlight.length > 0) {
+      if (!supersede) {
+        return NextResponse.json(
+          {
+            error: 'audit_in_flight',
+            message:
+              `An initiative audit is already ${inFlight[0].status} for this initiative. ` +
+              `Re-issue with { "supersede": true } to cancel and redispatch.`,
+            in_flight: inFlight.map((r) => ({
+              run_id: r.id,
+              status: r.status,
+              kind: r.kind,
+              started_at: r.started_at,
+              created_at: r.created_at,
+            })),
+          },
+          { status: 409 },
+        );
+      }
+      // supersede=true → cancel each. cancelAgentRun is idempotent on
+      // already-terminal rows; a NotCancellable error means someone
+      // raced us to the cancel path, which is fine.
+      for (const r of inFlight) {
+        try {
+          cancelAgentRun(r.id);
+        } catch (err) {
+          if (!(err instanceof AgentRunNotCancellableError)) {
+            console.warn(
+              `[investigate] supersede: cancelAgentRun(${r.id}) failed:`,
+              (err as Error).message,
+            );
+          }
+        }
+      }
+    }
 
     const initiative = getInitiative(id, { includeTasks: true });
     if (!initiative) {

--- a/src/components/InvestigateModal.tsx
+++ b/src/components/InvestigateModal.tsx
@@ -244,6 +244,7 @@ export default function InvestigateModal({
   // confirmation panel instead of closing. Operator dismisses via
   // "Done" or jumps to the Activity strip via "View activity".
   const [dispatched, setDispatched] = useState<DispatchResult | null>(null);
+  const [inFlightConflict, setInFlightConflict] = useState<{ message: string } | null>(null);
 
   // Pre-flight: when opened in subtree mode, fetch the planned-nodes /
   // planned-layers / concurrency from the dryrun endpoint so we can
@@ -296,7 +297,7 @@ export default function InvestigateModal({
     return () => document.removeEventListener('keydown', onKey);
   }, []);
 
-  const submit = async () => {
+  const submit = async (opts?: { supersede?: boolean }) => {
     if (submitting) return;
     setSubmitting(true);
     setErr(null);
@@ -305,9 +306,10 @@ export default function InvestigateModal({
       // Subtree mode is always 'fresh' in PR 4; reaudit field is ignored
       // server-side but harmless to omit. The route default keeps narrow
       // behavior unchanged.
-      const requestBody = mode === 'subtree'
+      const requestBody: Record<string, unknown> = mode === 'subtree'
         ? { mode: 'subtree', guidance: baseBody.guidance }
-        : baseBody;
+        : { ...baseBody };
+      if (opts?.supersede) requestBody.supersede = true;
       const res = await fetch(`/api/initiatives/${initiative.id}/investigate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -316,6 +318,15 @@ export default function InvestigateModal({
       // The route returns 200 once the dispatch is queued (or the
       // subtree orchestration is kicked off). Treat any 2xx as success.
       const body = await res.json().catch(() => ({}));
+      // 409 audit_in_flight: prompt the operator to cancel the live
+      // run and redispatch. Resolved via the inline button → recurse
+      // with supersede=true. See specs/dedupe-investigations.md §2.
+      if (res.status === 409 && (body as { error?: string }).error === 'audit_in_flight') {
+        setInFlightConflict({
+          message: (body as { message?: string }).message ?? 'Audit already in flight.',
+        });
+        return;
+      }
       if (!res.ok) {
         throw new Error(
           (body as { error?: string }).error || `Investigate failed (${res.status})`,
@@ -423,6 +434,34 @@ export default function InvestigateModal({
               role="alert"
             >
               {err}
+            </div>
+          )}
+
+          {inFlightConflict && (
+            <div
+              className="p-3 rounded bg-amber-500/10 border border-amber-500/30 text-amber-200 text-sm flex flex-col gap-2"
+              role="alert"
+            >
+              <div>{inFlightConflict.message}</div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setInFlightConflict(null);
+                    void submit({ supersede: true });
+                  }}
+                  className="px-2 py-1 rounded bg-amber-500/20 hover:bg-amber-500/30 border border-amber-500/40 text-xs"
+                >
+                  Cancel & redispatch
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setInFlightConflict(null)}
+                  className="px-2 py-1 rounded hover:bg-mc-bg border border-mc-border text-xs text-mc-text-secondary"
+                >
+                  Keep existing
+                </button>
+              </div>
             </div>
           )}
 
@@ -551,7 +590,7 @@ export default function InvestigateModal({
                 Cancel
               </button>
               <button
-                onClick={submit}
+                onClick={() => submit()}
                 disabled={submitting}
                 className="inline-flex items-center gap-1.5 px-3 py-2 rounded bg-mc-accent text-white text-sm disabled:opacity-50 disabled:cursor-not-allowed"
               >


### PR DESCRIPTION
## Summary

Click "Audit" twice on the same initiative and you used to silently spawn two parallel runs. Combined with the cancellation-doesn't-stop-tools bug already fixed in #277, that's how May 7 produced two near-identical observation notes on the same initiative.

This is **#2 of 3** in the dedupe-investigations stack — see `specs/dedupe-investigations.md`. Builds on #277 but the changes are independent.

## Changes

- **POST /api/initiatives/:id/investigate** now checks for `queued`/`running` `initiative_audit` rows on the same `initiative_id` before dispatching. New `supersede: boolean` body flag (default false):
  - without `supersede` → `409 { error: 'audit_in_flight', in_flight: [{run_id, status, started_at, ...}] }`
  - with `supersede: true` → cancel each in-flight run via `cancelAgentRun` (idempotent on already-terminal rows) then proceed normally.
- **InvestigateModal** intercepts the 409, renders an inline amber banner with "Cancel & redispatch" / "Keep existing" buttons. "Cancel & redispatch" recurses through `submit({ supersede: true })`.

## Test plan

- [x] `yarn tsc --noEmit` — same 3 pre-existing errors as main, none in files this PR touches.
- [x] New unit tests in `src/app/api/initiatives/[id]/investigate/route.test.ts`:
  - In-flight `initiative_audit` → 409 with the live run id in `in_flight[0].run_id`.
  - `supersede: true` cancels the in-flight run (verified via `getAgentRun(...).status === 'cancelled'`) and dispatches.
  - Note: bracket-path test files are not currently picked up by `yarn test`'s `find` discovery; this is a **pre-existing harness issue** affecting all `[id]/route.test.ts` files (including the tests already in this file). Tests are correct and runnable directly.
- [x] `yarn test` — 863/864 pass (same single pre-existing failure as main, in `schedule-runner.test.ts`).
- [ ] Manual verify post-merge: open Investigate modal twice in quick succession on dev → second click surfaces the amber 409 banner; "Cancel & redispatch" cancels the first run and dispatches anew.

## Out of scope (follow-up)

- **#3** UI cooldown / "audited 2 min ago — re-audit?" hint for back-to-back complete audits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)