### PR TITLE
feat(investigate): recent-audit cooldown hint (dedupe #3/3)

### DIFF
--- a/src/app/api/initiatives/[id]/investigate/route.ts
+++ b/src/app/api/initiatives/[id]/investigate/route.ts
@@ -76,6 +76,26 @@ function findInFlightAudits(initiativeId: string): AgentRun[] {
   );
 }
 
+/**
+ * Find the most recent successfully-completed `initiative_audit` for
+ * this initiative. Surfaced via `?dryrun=1` so the modal can render a
+ * soft "audited recently" cooldown hint. See
+ * specs/dedupe-investigations.md §3.
+ */
+function lastCompleteAudit(initiativeId: string): { run_id: string; completed_at: string | null } | null {
+  const rows = queryAll<{ id: string; completed_at: string | null }>(
+    `SELECT id, completed_at FROM agent_runs
+      WHERE initiative_id = ?
+        AND kind = 'initiative_audit'
+        AND status = 'complete'
+      ORDER BY COALESCE(completed_at, created_at) DESC
+      LIMIT 1`,
+    [initiativeId],
+  );
+  if (rows.length === 0) return null;
+  return { run_id: rows[0].id, completed_at: rows[0].completed_at };
+}
+
 interface RouteParams {
   params: Promise<{ id: string }>;
 }
@@ -123,6 +143,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       planned_layers: 1,
       concurrency: 1,
       per_node_timeout_ms: settings.perNodeTimeoutMs,
+      last_complete_audit: lastCompleteAudit(id),
     });
   }
   if (TERMINAL_STATUSES.has(initiative.status)) {
@@ -141,6 +162,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     planned_layers: plan.plannedLayers,
     concurrency: settings.subtreeConcurrency,
     per_node_timeout_ms: settings.perNodeTimeoutMs,
+    last_complete_audit: lastCompleteAudit(id),
   });
 }
 

--- a/src/components/InvestigateModal.tsx
+++ b/src/components/InvestigateModal.tsx
@@ -245,17 +245,21 @@ export default function InvestigateModal({
   // "Done" or jumps to the Activity strip via "View activity".
   const [dispatched, setDispatched] = useState<DispatchResult | null>(null);
   const [inFlightConflict, setInFlightConflict] = useState<{ message: string } | null>(null);
+  // Soft cooldown: when the most recent complete initiative_audit on
+  // this initiative is < RECENT_AUDIT_MS old, surface a non-blocking
+  // "audited X ago" hint so back-to-back reruns are intentional rather
+  // than accidental. Populated from the dryrun GET response.
+  // See specs/dedupe-investigations.md §3.
+  const [recentAuditAt, setRecentAuditAt] = useState<string | null>(null);
 
-  // Pre-flight: when opened in subtree mode, fetch the planned-nodes /
-  // planned-layers / concurrency from the dryrun endpoint so we can
-  // render an accurate ETA banner. Falls back to a generic message if
-  // the request fails.
+  // Pre-flight: fetch the dryrun endpoint to populate plan info
+  // (subtree only) and the recent-audit timestamp (both modes). Falls
+  // back to a generic message if the request fails.
   useEffect(() => {
-    if (mode !== 'subtree') return;
     let cancelled = false;
     setPlanErr(null);
     fetch(
-      `/api/initiatives/${initiative.id}/investigate?dryrun=1&mode=subtree`,
+      `/api/initiatives/${initiative.id}/investigate?dryrun=1&mode=${mode}`,
     )
       .then(async (res) => {
         const body = await res.json().catch(() => ({}));
@@ -264,10 +268,16 @@ export default function InvestigateModal({
             (body as { error?: string }).error || `Plan fetch failed (${res.status})`,
           );
         }
-        if (!cancelled) setPlan(body as SubtreePlan);
+        if (cancelled) return;
+        const last = (body as { last_complete_audit?: { completed_at: string | null } | null })
+          .last_complete_audit;
+        setRecentAuditAt(last?.completed_at ?? null);
+        if (mode === 'subtree') setPlan(body as SubtreePlan);
       })
       .catch((e) => {
-        if (!cancelled) setPlanErr(e instanceof Error ? e.message : String(e));
+        if (!cancelled && mode === 'subtree') {
+          setPlanErr(e instanceof Error ? e.message : String(e));
+        }
       });
     return () => {
       cancelled = true;
@@ -436,6 +446,21 @@ export default function InvestigateModal({
               {err}
             </div>
           )}
+
+          {recentAuditAt && !inFlightConflict && (() => {
+            const ageMs = Date.now() - new Date(recentAuditAt).getTime();
+            const RECENT_MS = 15 * 60_000;
+            if (ageMs < 0 || ageMs > RECENT_MS) return null;
+            const mins = Math.max(1, Math.round(ageMs / 60_000));
+            return (
+              <div
+                className="p-2 rounded bg-mc-bg/40 border border-mc-border text-xs text-mc-text-secondary"
+                role="status"
+              >
+                Last audit completed {mins} minute{mins === 1 ? '' : 's'} ago. Re-audit if something changed.
+              </div>
+            );
+          })()}
 
           {inFlightConflict && (
             <div


### PR DESCRIPTION
## Summary

Stacked on #278. Closes the third failure mode from `specs/dedupe-investigations.md`: an operator dispatches an audit, doesn't realize it already finished 30 seconds ago, and dispatches again. With #277 + #278 the system no longer produces orphan notes or silent duplicates, but a fresh complete audit followed seconds later by another fresh complete audit is still wasteful.

This is a soft, non-blocking hint — the operator can dispatch anyway.

## Changes

- `GET /api/initiatives/:id/investigate?dryrun=1&mode=…` now returns `last_complete_audit: { run_id, completed_at } | null` for both narrow and subtree responses.
- `InvestigateModal` pre-fetches the dryrun endpoint unconditionally (was subtree-only) and reads `last_complete_audit`. If `completed_at` is < 15 minutes old, an inline secondary-styled banner reads:
  > Last audit completed N minutes ago. Re-audit if something changed.

No new schema, no new tables, no new tests beyond the route change which is a one-liner. Manual verify covers the UX.

## Test plan

- [x] `yarn tsc --noEmit` — same 3 pre-existing errors as main, none in files this PR touches.
- [ ] Manual verify post-merge: complete an audit, immediately reopen the Investigate modal → cooldown hint visible. Wait 16 minutes → hint gone. Dispatch button still works either way.

## Stack

- #277 — block take_note writes from cancelled runs (merged)
- #278 — refuse concurrent audits + supersede flow (parent)
- **This PR** — recent-audit cooldown hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)