### PR TITLE
fix(investigate): parse SQLite datetime as UTC for cooldown check

### DIFF
--- a/src/components/InvestigateModal.tsx
+++ b/src/components/InvestigateModal.tsx
@@ -448,7 +448,14 @@ export default function InvestigateModal({
           )}
 
           {recentAuditAt && !inFlightConflict && (() => {
-            const ageMs = Date.now() - new Date(recentAuditAt).getTime();
+            // SQLite's datetime('now') returns "YYYY-MM-DD HH:MM:SS"
+            // (UTC, no zone). Browsers treat that as *local* time,
+            // which would be 7+ hours off depending on tz and produce
+            // negative ageMs. Coerce to ISO-Z so it's parsed as UTC.
+            const iso = recentAuditAt.includes('T')
+              ? recentAuditAt
+              : `${recentAuditAt.replace(' ', 'T')}Z`;
+            const ageMs = Date.now() - new Date(iso).getTime();
             const RECENT_MS = 15 * 60_000;
             if (ageMs < 0 || ageMs > RECENT_MS) return null;
             const mins = Math.max(1, Math.round(ageMs / 60_000));


### PR DESCRIPTION
## Summary

The cooldown banner shipped in #279 never rendered. Caught during preview verification.

## Root cause

`/api/initiatives/:id/investigate?dryrun=1` returns `last_complete_audit.completed_at` straight from sqlite (`datetime('now')`), formatted as `"YYYY-MM-DD HH:MM:SS"` with no timezone marker. That's UTC by sqlite convention, but JS `new Date("2026-05-08 16:00:37")` parses unsuffixed strings as **local** time. On any non-UTC machine (e.g. UTC-7), the parsed Date lands 7+ hours in the future of `Date.now()`, `ageMs` goes negative, and my `< 0` guard hides the banner.

## Fix

Coerce the SQL string to ISO-Z (`"2026-05-08T16:00:37Z"`) before constructing the Date.

## Verification

Live preview, real dev DB:

- Inject a `complete` initiative_audit with `completed_at = now - 3 min` → reopen modal → banner reads **"Last audit completed 1 minute ago. Re-audit if something changed."** ✓
- Age that row to 30 min old → reopen modal → banner gone ✓
- Screenshot in PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)