### PR TITLE
feat(db): normalize SQLite datetime reads to ISO-Z

### DIFF
--- a/specs/timestamp-handling.md
+++ b/specs/timestamp-handling.md
@@ -1,0 +1,169 @@
+# Timestamp handling: UTC drift fix + display timezone setting
+
+## Why
+
+`SQLite`'s `datetime('now')` returns `"YYYY-MM-DD HH:MM:SS"` — UTC by
+sqlite convention, but with no timezone marker. JS `new Date(s)` parses
+that as **local** time, producing dates that drift by the local UTC
+offset. PR #280 fixed one site (the InvestigateModal cooldown banner)
+by hand-coercing to ISO-Z, but the codebase has:
+
+- ~50 DB write sites using `datetime('now')`
+- Zero centralized API normalization (rows go straight to JSON)
+- ~13 unprotected `new Date(field)` reads on the client (LiveFeed,
+  ActivityLog, MissionQueue, ScheduleRow, several chat tabs at the
+  non-display call site, etc.) — all off by the local UTC offset
+- ~6 ad-hoc `endsWith('Z') ? s : s + 'Z'` workarounds scattered around
+- No shared `<Time>` / `formatTimestamp` helper
+
+Even where the UTC math is correct, display is inconsistent: some
+sites use `toLocaleString` (system zone), some use raw `Date` math
+(implicit local), and the operator has no way to override the zone if
+auto-detect is wrong.
+
+## Goal
+
+1. **Strings flow as ISO-Z everywhere.** The drift bug stops being a
+   thing.
+2. **Display zone is auto-detected from the browser**, with a
+   workspace-level override the operator can set when auto-detect is
+   wrong (default fallback: `America/Los_Angeles`).
+3. **One canonical helper / component** for rendering timestamps so
+   future contributors don't reinvent the workarounds.
+
+## Plan: two stacked PRs
+
+### PR-A — Server-side normalization at the DB boundary
+
+**Single fix, central place.** In `src/lib/db/index.ts`, wrap
+`queryAll` / `queryOne` so any string field whose value matches
+`/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)?$/` is rewritten to ISO-Z
+(`replace(' ', 'T') + 'Z'`) before the row is returned to the caller.
+
+Also patch `run()` is **not** needed — that's only used for writes.
+Reads go through `queryAll` / `queryOne`, plus the `prepare(...).all()`
+/ `.get()` calls that bypass these helpers — those get a separate
+inventory + migrated to the helpers, or wrapped.
+
+**Why this layer**: it's the choke point. Every read path — API
+responses, server components, internal helpers — gets the normalized
+value. No frontend code change needed; existing `new Date(field)`
+calls just start working, and the ad-hoc workarounds become harmless
+idempotent no-ops (`new Date("...Z")` is parseable; coercing again is
+safe).
+
+**Risk**: anyone comparing a raw row datetime back to a parameter via
+SQL string equality (`WHERE created_at = ?` with a value plucked from
+a previous row read) would now compare ISO-Z to the original SQL
+format. Mitigation:
+- Grep first: `=\s*\?\s*.*created_at|created_at\s*=` etc. across
+  `src/lib/db/**`.
+- Round-trip test: insert a row, read it back via `queryAll`, then
+  `WHERE created_at = ?` against the read value — confirm match still
+  works (the writer would re-parse ISO-Z back to UTC; sqlite compares
+  strings, so this WILL break naive code). If any callers rely on
+  this, fix them to use `<` / `>` ranges instead, or convert in SQL.
+
+**Tests**:
+- `queryAll` / `queryOne` rewrite bare datetimes to ISO-Z.
+- Subsecond precision is preserved (`"2026-05-08 16:00:37.123"` →
+  `"2026-05-08T16:00:37.123Z"`).
+- Non-datetime strings are untouched.
+- Already-Z values are untouched (idempotent).
+- NULL fields stay NULL.
+
+**Out of scope of PR-A**: any UI or display change. This PR alone
+fixes the drift bug for every site that already calls `new Date(s)`.
+
+### PR-B — Timezone setting + `<Time>` helper + display sweep
+
+Built on PR-A.
+
+#### 1. Storage
+
+Migration **086**: `workspaces.display_timezone TEXT` (nullable; NULL =
+auto-detect from browser). No backfill — empty means use the
+browser's zone.
+
+#### 2. API
+
+- `GET /api/workspaces/[id]` surfaces `display_timezone`.
+- `PATCH /api/workspaces/[id]` accepts a `display_timezone` field;
+  validated by attempting `new Intl.DateTimeFormat('en-US', {
+  timeZone: value })` and rejecting any value that throws.
+
+#### 3. UI
+
+In the workspace settings page (`src/app/(app)/workspace/[slug]/settings/page.tsx`):
+- New "Display timezone" field, free-text input with a small
+  datalist of common zones (`America/Los_Angeles`, `America/New_York`,
+  `Europe/London`, `Asia/Tokyo`, etc.).
+- Placeholder shows the auto-detected browser zone, with hint text:
+  "Leave blank to use your browser's timezone (auto-detected:
+  America/Los_Angeles)".
+- Save commits the value; clear-to-blank reverts to auto-detect.
+
+#### 4. Client helper
+
+`src/lib/timestamps.ts`:
+- `resolveDisplayTimezone(workspaceTz: string | null | undefined): string`
+  — returns workspaceTz if set, else
+  `Intl.DateTimeFormat().resolvedOptions().timeZone`, else
+  `'America/Los_Angeles'` (final fallback for environments where Intl
+  is somehow stripped — defensive only).
+- `formatTimestamp(iso: string, opts: { tz: string; mode?:
+  'absolute' | 'short' | 'datetime' | 'date' }): string` — wraps
+  `Intl.DateTimeFormat` with the resolved zone.
+- `relativeTime(iso: string): string` — uses `formatDistanceToNow`
+  from date-fns. (No tz needed — relative is zone-agnostic for past
+  events, and the underlying parse is now ISO-Z thanks to PR-A.)
+
+`src/components/Time.tsx`:
+- `<Time iso={s} mode="relative" />` — `formatDistanceToNow(s) + ' ago'`
+- `<Time iso={s} mode="absolute" />` — full date+time in resolved tz
+- `<Time iso={s} mode="short" />` — compact "May 8, 4:32 PM"
+- `<Time iso={s} mode="datetime" />` — ISO-like in resolved tz
+- `title` attribute always shows the absolute datetime (so hovering
+  any relative timestamp shows the full).
+
+The component reads tz from a `WorkspaceTimezoneContext` provider
+threaded into the app shell. SSR-safe: if no context, falls back to
+the auto-detect path on the client (server renders relative-only or
+empty placeholder, then hydrates).
+
+#### 5. Sweep
+
+Migrate the unprotected sites identified in the audit:
+- LiveFeed.tsx, ActivityLog.tsx, MissionQueue.tsx,
+  AgentActivityDashboard.tsx, DebugEventRow.tsx, ScheduleRow.tsx,
+  TaskChatTab.tsx (line 54), AgentChatTab.tsx (line 60),
+  ChatConversation.tsx (line 49), ChatInbox.tsx, MaybePool.tsx,
+  ResearchReport.tsx, SessionsList.tsx.
+
+For each: replace `formatDistanceToNow(new Date(field))` with
+`<Time iso={field} mode="relative" />` (or call `relativeTime(field)`
+if it has to stay a string). Replace `toLocaleTimeString()` calls
+with `formatTimestamp(field, { tz, mode: 'short' })`.
+
+The ad-hoc `.endsWith('Z')` workarounds can be left in place (no-op
+post-PR-A) or stripped during the sweep — either is fine. I'll strip
+them as they show up in diffed files.
+
+#### 6. Tests
+
+- TZ override flows: PATCH workspace with `display_timezone:
+  'America/New_York'`, GET returns it, invalid zone rejected with 400.
+- `formatTimestamp` renders the same instant differently in two
+  zones.
+- `<Time>` snapshot for relative + absolute modes.
+- Workspace settings page renders the picker and persists the value.
+
+### Out of scope
+
+- Backend rendering of timestamps (we keep all formatting on the
+  client; server stays zone-agnostic).
+- Per-user timezone (we have one operator per workspace; per-user
+  preference would require a sessions/users table that doesn't exist
+  yet).
+- Migration of older raw datetime strings already stored — PR-A
+  rewrites on read, so this is automatic.

--- a/src/lib/db/index.test.ts
+++ b/src/lib/db/index.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Read-side timestamp normalization.
+ *
+ * Every Statement returned by getDb().prepare(...) — including the
+ * direct .all/.get bypasses scattered through the API routes — should
+ * post-process string fields that match the bare SQLite datetime shape
+ * ("YYYY-MM-DD HH:MM:SS[.fff]") into ISO-Z. See
+ * specs/timestamp-handling.md §PR-A.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  getDb,
+  queryAll,
+  queryOne,
+  run,
+  normalizeDatetimeString,
+  SQLITE_DATETIME_RE,
+} from './index';
+
+function freshWorkspace(): string {
+  const id = `ws-tz-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+test('SQLITE_DATETIME_RE matches bare datetimes only', () => {
+  assert.equal(SQLITE_DATETIME_RE.test('2026-05-08 16:00:37'), true);
+  assert.equal(SQLITE_DATETIME_RE.test('2026-05-08 16:00:37.123'), true);
+  assert.equal(SQLITE_DATETIME_RE.test('2026-05-08T16:00:37Z'), false);
+  assert.equal(SQLITE_DATETIME_RE.test('2026-05-08'), false);
+  assert.equal(SQLITE_DATETIME_RE.test(''), false);
+  assert.equal(SQLITE_DATETIME_RE.test('hello world'), false);
+});
+
+test('normalizeDatetimeString rewrites bare datetimes to ISO-Z', () => {
+  assert.equal(
+    normalizeDatetimeString('2026-05-08 16:00:37'),
+    '2026-05-08T16:00:37Z',
+  );
+  assert.equal(
+    normalizeDatetimeString('2026-05-08 16:00:37.123'),
+    '2026-05-08T16:00:37.123Z',
+  );
+});
+
+test('normalizeDatetimeString is idempotent on already-ISO values', () => {
+  assert.equal(
+    normalizeDatetimeString('2026-05-08T16:00:37Z'),
+    '2026-05-08T16:00:37Z',
+  );
+});
+
+test('normalizeDatetimeString leaves unrelated strings alone', () => {
+  assert.equal(normalizeDatetimeString('not a date'), 'not a date');
+  assert.equal(normalizeDatetimeString('2026-05-08'), '2026-05-08');
+  assert.equal(normalizeDatetimeString(''), '');
+});
+
+test('queryOne returns ISO-Z for datetime columns', () => {
+  const ws = freshWorkspace();
+  const row = queryOne<{ id: string; created_at: string }>(
+    'SELECT id, created_at FROM workspaces WHERE id = ?',
+    [ws],
+  );
+  assert.ok(row, 'row exists');
+  assert.match(row!.created_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/);
+});
+
+test('queryAll returns ISO-Z for datetime columns across all rows', () => {
+  freshWorkspace();
+  freshWorkspace();
+  const rows = queryAll<{ id: string; created_at: string }>(
+    'SELECT id, created_at FROM workspaces ORDER BY created_at DESC LIMIT 5',
+  );
+  assert.ok(rows.length >= 2);
+  for (const r of rows) {
+    assert.match(r.created_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/);
+  }
+});
+
+test('direct prepare().all() bypass also normalizes (monkey-patch covers all read paths)', () => {
+  const ws = freshWorkspace();
+  // Mirrors patterns in src/app/api/workspaces/route.ts that read via
+  // db.prepare directly rather than queryAll.
+  const rows = getDb().prepare('SELECT id, created_at FROM workspaces WHERE id = ?').all(ws) as
+    Array<{ id: string; created_at: string }>;
+  assert.equal(rows.length, 1);
+  assert.match(rows[0].created_at, /T.*Z$/);
+});
+
+test('direct prepare().get() bypass also normalizes', () => {
+  const ws = freshWorkspace();
+  const row = getDb().prepare('SELECT id, created_at FROM workspaces WHERE id = ?').get(ws) as
+    { id: string; created_at: string };
+  assert.match(row.created_at, /T.*Z$/);
+});
+
+test('non-datetime string fields pass through unchanged', () => {
+  const ws = freshWorkspace();
+  const row = queryOne<{ id: string; name: string; slug: string }>(
+    'SELECT id, name, slug FROM workspaces WHERE id = ?',
+    [ws],
+  );
+  assert.equal(row!.id, ws);
+  assert.equal(row!.name, ws);
+  assert.equal(row!.slug, ws);
+});
+
+test('NULL datetime fields stay null', () => {
+  const ws = freshWorkspace();
+  // updated_at on workspaces is nullable in some rows.
+  const row = queryOne<{ description: string | null }>(
+    'SELECT description FROM workspaces WHERE id = ?',
+    [ws],
+  );
+  assert.equal(row!.description, null);
+});
+
+test('parsing the normalized value yields the same instant as raw UTC', () => {
+  // Round-trip sanity: write a datetime, read it back, and confirm
+  // `new Date(returned)` gives an instant matching `Date.now()` to
+  // within a few seconds. This is the actual user-visible bug PR-A
+  // closes — pre-fix, a UTC-7 box would parse the bare string as
+  // 7 hours in the future of `now`.
+  const before = Date.now();
+  const ws = freshWorkspace();
+  const row = queryOne<{ created_at: string }>(
+    'SELECT created_at FROM workspaces WHERE id = ?',
+    [ws],
+  );
+  const parsed = new Date(row!.created_at).getTime();
+  const after = Date.now();
+  // Allow a 3s window for clock skew + slow CI; the broken form
+  // would be off by 60+ minutes minimum on any non-UTC machine.
+  assert.ok(parsed >= before - 3000, `parsed=${parsed} before=${before}`);
+  assert.ok(parsed <= after + 3000, `parsed=${parsed} after=${after}`);
+});

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -100,6 +100,13 @@ export function getDb(): Database.Database {
       runMigrations(instance);
     }
 
+    // Wrap `prepare` so every Statement.all/get returned anywhere in
+    // the codebase normalizes bare SQLite datetime strings to ISO-Z
+    // before they reach JS. See specs/timestamp-handling.md §PR-A.
+    // This catches the queryAll/queryOne helpers AND the many sites
+    // that call `db.prepare(sql).all/get(...)` directly.
+    installDatetimeNormalization(instance);
+
     // Only publish the singleton after init fully succeeds. If anything above
     // throws, `db` stays null and the next call retries cleanly instead of
     // returning a poisoned handle.
@@ -129,7 +136,74 @@ export function closeDb(): void {
   }
 }
 
-// Type-safe query helpers
+// ── Timestamp normalization on read ─────────────────────────────────
+//
+// SQLite's `datetime('now')` returns "YYYY-MM-DD HH:MM:SS" — UTC by
+// sqlite convention but with no timezone marker. Browsers parse such
+// strings as *local* time, producing dates that drift by the local
+// UTC offset. Rather than fix every read site, we monkey-patch
+// `db.prepare` once at init so every Statement returned anywhere in
+// the codebase normalizes string fields shaped like bare SQLite
+// datetimes to ISO-Z ("YYYY-MM-DDTHH:MM:SSZ") before they reach JS.
+// See specs/timestamp-handling.md §PR-A.
+//
+// We rewrite only string fields that match the bare-SQLite-datetime
+// shape. Subseconds are preserved; already-Z values are untouched
+// (idempotent); unrelated strings, numbers, nulls, and `pluck()`
+// scalar returns all pass through unchanged.
+export const SQLITE_DATETIME_RE =
+  /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)?$/;
+
+export function normalizeDatetimeString(v: string): string {
+  return SQLITE_DATETIME_RE.test(v) ? `${v.replace(' ', 'T')}Z` : v;
+}
+
+function normalizeRow<T>(row: T): T {
+  if (!row || typeof row !== 'object') return row;
+  // Mutate in place — the row is a fresh object per query, never shared.
+  const r = row as Record<string, unknown>;
+  for (const k in r) {
+    const v = r[k];
+    if (typeof v === 'string') {
+      const nv = normalizeDatetimeString(v);
+      if (nv !== v) r[k] = nv;
+    }
+  }
+  return row;
+}
+
+function installDatetimeNormalization(instance: Database.Database): void {
+  // Each statement holds its own .all / .get methods. We wrap them
+  // lazily the first time the statement is used — this dodges the
+  // edge case where better-sqlite3's bound functions check `this`.
+  const origPrepare = instance.prepare.bind(instance);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (instance as any).prepare = function patchedPrepare(
+    this: Database.Database,
+    sql: string,
+  ): Database.Statement {
+    const stmt = origPrepare(sql);
+    const origAll = stmt.all.bind(stmt);
+    const origGet = stmt.get.bind(stmt);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stmt.all = ((...params: unknown[]) => {
+      const rows = origAll(...(params as [])) as unknown;
+      if (!Array.isArray(rows)) return rows as unknown;
+      for (const row of rows) normalizeRow(row);
+      return rows;
+    }) as typeof stmt.all;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stmt.get = ((...params: unknown[]) => {
+      const row = origGet(...(params as [])) as unknown;
+      return row === undefined ? undefined : normalizeRow(row);
+    }) as typeof stmt.get;
+    return stmt;
+  } as typeof instance.prepare;
+}
+
+// Type-safe query helpers. Normalization happens inside
+// `installDatetimeNormalization`'s prepare wrapper, so these helpers
+// stay thin.
 export function queryAll<T>(sql: string, params: unknown[] = []): T[] {
   const stmt = getDb().prepare(sql);
   return stmt.all(...params) as T[];


### PR DESCRIPTION
## Summary

SQLite's `datetime('now')` returns `"YYYY-MM-DD HH:MM:SS"` — UTC by sqlite convention, but with no timezone marker. JS `new Date()` parses such strings as **local** time, producing dates that drift by the local UTC offset. PR #280 fixed one site by hand-coercing to ISO-Z; the audit revealed ~13 unprotected `new Date(field)` sites in the codebase plus ~6 ad-hoc `.endsWith('Z')` workarounds.

This PR fixes it at the choke point.

**Stage 1 of two** — see `specs/timestamp-handling.md`. Stage 2 (next PR) adds the workspace `display_timezone` setting and a shared `<Time>` helper, plus a sweep through the high-traffic display sites.

## How

Monkey-patch `db.prepare()` once at `getDb()` init so every `Statement.all` / `.get` returned anywhere in the codebase post-processes string fields matching the bare-SQLite-datetime shape into ISO-Z (`"2026-05-08T16:00:37Z"`). This covers:

- `queryAll` / `queryOne` helpers
- All `db.prepare(sql).all/get(...)` direct call sites (workspaces, openclaw_sessions, tasks, etc.)
- Existing ad-hoc `.endsWith('Z')` workarounds become harmless idempotent no-ops
- Existing `new Date(field)` reads "just start working" everywhere

## Why this layer (not API or client)

| Approach | Cost | Coverage |
|---|---|---|
| **Patch `db.prepare`** ← this PR | ~30 lines, one place | 100% of read paths |
| Wrap `NextResponse.json` | every route already calls it directly; partial | 90% w/ lint |
| Client-side `parseDbTimestamp` helper | high; needs sweep + lint rule | depends on diligence |

## Risk audit

Grep for SQL `WHERE col = ?` / `WHERE col < ?` on datetime columns where `?` is bound to a value that came from a previous read:

- All `(updated_at|created_at|completed_at) = ?` matches are SET clauses (writes), not WHERE reads.
- `>= ?` range queries (cost-cap, autopilot health) pass `Date.toISOString()` against stored raw-SQLite strings — that's a **pre-existing** lexicographic-comparison bug (`T` > space at byte 11), not introduced by this PR. Flagged separately as a follow-up.

So the monkey-patch can't break anything that round-trips a datetime back into a WHERE clause.

## Test plan

- [x] `yarn test` — 874/875 pass; 1 failure (`schedule-runner: produces a brief and advances run_count`) is **pre-existing on main**, unrelated.
- [x] New `src/lib/db/index.test.ts` (11 tests):
  - `SQLITE_DATETIME_RE` matches bare datetimes, rejects ISO/non-dates
  - `normalizeDatetimeString` rewrites + is idempotent + leaves unrelated strings alone
  - `queryOne` / `queryAll` return ISO-Z for datetime columns
  - **Direct `prepare(...).all/get` bypass also normalizes** (the whole point of monkey-patching)
  - Non-datetime string columns (`name`, `slug`) pass through unchanged
  - NULL columns stay null
  - Round-trip: `new Date(returned).getTime()` matches `Date.now()` within 3s (the bug it closes)
- [x] Live preview: `/api/jobs` returns `started_at: "2026-05-08T15:58:42Z"` (was `"2026-05-08 15:58:42"` pre-fix); /jobs page renders without errors.

## Out of scope (Stage 2 PR)

- `workspaces.display_timezone TEXT` setting + workspace-settings UI for override
- Shared `<Time>` component + `formatTimestamp` helper
- Sweep of LiveFeed, ActivityLog, MissionQueue, ScheduleRow, AgentChatTab et al. to use the helper

## Out of scope (separate spawned task)

- Cost-cap / autopilot health-score `WHERE created_at >= ?` queries that pass ISO-Z params against raw-SQLite stored values (pre-existing bug, lex-compare drift at the `T`/space boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)