### PR TITLE
feat(ui): workspace display timezone + shared <Time> component

### DIFF
--- a/specs/timestamp-handling.md
+++ b/specs/timestamp-handling.md
@@ -1,0 +1,169 @@
+# Timestamp handling: UTC drift fix + display timezone setting
+
+## Why
+
+`SQLite`'s `datetime('now')` returns `"YYYY-MM-DD HH:MM:SS"` — UTC by
+sqlite convention, but with no timezone marker. JS `new Date(s)` parses
+that as **local** time, producing dates that drift by the local UTC
+offset. PR #280 fixed one site (the InvestigateModal cooldown banner)
+by hand-coercing to ISO-Z, but the codebase has:
+
+- ~50 DB write sites using `datetime('now')`
+- Zero centralized API normalization (rows go straight to JSON)
+- ~13 unprotected `new Date(field)` reads on the client (LiveFeed,
+  ActivityLog, MissionQueue, ScheduleRow, several chat tabs at the
+  non-display call site, etc.) — all off by the local UTC offset
+- ~6 ad-hoc `endsWith('Z') ? s : s + 'Z'` workarounds scattered around
+- No shared `<Time>` / `formatTimestamp` helper
+
+Even where the UTC math is correct, display is inconsistent: some
+sites use `toLocaleString` (system zone), some use raw `Date` math
+(implicit local), and the operator has no way to override the zone if
+auto-detect is wrong.
+
+## Goal
+
+1. **Strings flow as ISO-Z everywhere.** The drift bug stops being a
+   thing.
+2. **Display zone is auto-detected from the browser**, with a
+   workspace-level override the operator can set when auto-detect is
+   wrong (default fallback: `America/Los_Angeles`).
+3. **One canonical helper / component** for rendering timestamps so
+   future contributors don't reinvent the workarounds.
+
+## Plan: two stacked PRs
+
+### PR-A — Server-side normalization at the DB boundary
+
+**Single fix, central place.** In `src/lib/db/index.ts`, wrap
+`queryAll` / `queryOne` so any string field whose value matches
+`/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)?$/` is rewritten to ISO-Z
+(`replace(' ', 'T') + 'Z'`) before the row is returned to the caller.
+
+Also patch `run()` is **not** needed — that's only used for writes.
+Reads go through `queryAll` / `queryOne`, plus the `prepare(...).all()`
+/ `.get()` calls that bypass these helpers — those get a separate
+inventory + migrated to the helpers, or wrapped.
+
+**Why this layer**: it's the choke point. Every read path — API
+responses, server components, internal helpers — gets the normalized
+value. No frontend code change needed; existing `new Date(field)`
+calls just start working, and the ad-hoc workarounds become harmless
+idempotent no-ops (`new Date("...Z")` is parseable; coercing again is
+safe).
+
+**Risk**: anyone comparing a raw row datetime back to a parameter via
+SQL string equality (`WHERE created_at = ?` with a value plucked from
+a previous row read) would now compare ISO-Z to the original SQL
+format. Mitigation:
+- Grep first: `=\s*\?\s*.*created_at|created_at\s*=` etc. across
+  `src/lib/db/**`.
+- Round-trip test: insert a row, read it back via `queryAll`, then
+  `WHERE created_at = ?` against the read value — confirm match still
+  works (the writer would re-parse ISO-Z back to UTC; sqlite compares
+  strings, so this WILL break naive code). If any callers rely on
+  this, fix them to use `<` / `>` ranges instead, or convert in SQL.
+
+**Tests**:
+- `queryAll` / `queryOne` rewrite bare datetimes to ISO-Z.
+- Subsecond precision is preserved (`"2026-05-08 16:00:37.123"` →
+  `"2026-05-08T16:00:37.123Z"`).
+- Non-datetime strings are untouched.
+- Already-Z values are untouched (idempotent).
+- NULL fields stay NULL.
+
+**Out of scope of PR-A**: any UI or display change. This PR alone
+fixes the drift bug for every site that already calls `new Date(s)`.
+
+### PR-B — Timezone setting + `<Time>` helper + display sweep
+
+Built on PR-A.
+
+#### 1. Storage
+
+Migration **086**: `workspaces.display_timezone TEXT` (nullable; NULL =
+auto-detect from browser). No backfill — empty means use the
+browser's zone.
+
+#### 2. API
+
+- `GET /api/workspaces/[id]` surfaces `display_timezone`.
+- `PATCH /api/workspaces/[id]` accepts a `display_timezone` field;
+  validated by attempting `new Intl.DateTimeFormat('en-US', {
+  timeZone: value })` and rejecting any value that throws.
+
+#### 3. UI
+
+In the workspace settings page (`src/app/(app)/workspace/[slug]/settings/page.tsx`):
+- New "Display timezone" field, free-text input with a small
+  datalist of common zones (`America/Los_Angeles`, `America/New_York`,
+  `Europe/London`, `Asia/Tokyo`, etc.).
+- Placeholder shows the auto-detected browser zone, with hint text:
+  "Leave blank to use your browser's timezone (auto-detected:
+  America/Los_Angeles)".
+- Save commits the value; clear-to-blank reverts to auto-detect.
+
+#### 4. Client helper
+
+`src/lib/timestamps.ts`:
+- `resolveDisplayTimezone(workspaceTz: string | null | undefined): string`
+  — returns workspaceTz if set, else
+  `Intl.DateTimeFormat().resolvedOptions().timeZone`, else
+  `'America/Los_Angeles'` (final fallback for environments where Intl
+  is somehow stripped — defensive only).
+- `formatTimestamp(iso: string, opts: { tz: string; mode?:
+  'absolute' | 'short' | 'datetime' | 'date' }): string` — wraps
+  `Intl.DateTimeFormat` with the resolved zone.
+- `relativeTime(iso: string): string` — uses `formatDistanceToNow`
+  from date-fns. (No tz needed — relative is zone-agnostic for past
+  events, and the underlying parse is now ISO-Z thanks to PR-A.)
+
+`src/components/Time.tsx`:
+- `<Time iso={s} mode="relative" />` — `formatDistanceToNow(s) + ' ago'`
+- `<Time iso={s} mode="absolute" />` — full date+time in resolved tz
+- `<Time iso={s} mode="short" />` — compact "May 8, 4:32 PM"
+- `<Time iso={s} mode="datetime" />` — ISO-like in resolved tz
+- `title` attribute always shows the absolute datetime (so hovering
+  any relative timestamp shows the full).
+
+The component reads tz from a `WorkspaceTimezoneContext` provider
+threaded into the app shell. SSR-safe: if no context, falls back to
+the auto-detect path on the client (server renders relative-only or
+empty placeholder, then hydrates).
+
+#### 5. Sweep
+
+Migrate the unprotected sites identified in the audit:
+- LiveFeed.tsx, ActivityLog.tsx, MissionQueue.tsx,
+  AgentActivityDashboard.tsx, DebugEventRow.tsx, ScheduleRow.tsx,
+  TaskChatTab.tsx (line 54), AgentChatTab.tsx (line 60),
+  ChatConversation.tsx (line 49), ChatInbox.tsx, MaybePool.tsx,
+  ResearchReport.tsx, SessionsList.tsx.
+
+For each: replace `formatDistanceToNow(new Date(field))` with
+`<Time iso={field} mode="relative" />` (or call `relativeTime(field)`
+if it has to stay a string). Replace `toLocaleTimeString()` calls
+with `formatTimestamp(field, { tz, mode: 'short' })`.
+
+The ad-hoc `.endsWith('Z')` workarounds can be left in place (no-op
+post-PR-A) or stripped during the sweep — either is fine. I'll strip
+them as they show up in diffed files.
+
+#### 6. Tests
+
+- TZ override flows: PATCH workspace with `display_timezone:
+  'America/New_York'`, GET returns it, invalid zone rejected with 400.
+- `formatTimestamp` renders the same instant differently in two
+  zones.
+- `<Time>` snapshot for relative + absolute modes.
+- Workspace settings page renders the picker and persists the value.
+
+### Out of scope
+
+- Backend rendering of timestamps (we keep all formatting on the
+  client; server stays zone-agnostic).
+- Per-user timezone (we have one operator per workspace; per-user
+  preference would require a sessions/users table that doesn't exist
+  yet).
+- Migration of older raw datetime strings already stored — PR-A
+  rewrites on read, so this is automatic.

--- a/src/app/(app)/workspace/[slug]/settings/page.tsx
+++ b/src/app/(app)/workspace/[slug]/settings/page.tsx
@@ -73,6 +73,9 @@ interface WorkspaceWithDefault {
   repo_url?: string | null;
   /** Default base branch for PRs (e.g. main). */
   default_base_branch?: string | null;
+  /** Operator-overridden display timezone (IANA name). NULL means
+   *  "auto-detect from browser". See specs/timestamp-handling.md §PR-B. */
+  display_timezone?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -574,6 +577,53 @@ export default function WorkspaceSettingsPage({
             }}
           />
         )}
+
+        {/* Display — operator-facing presentation knobs. Most of MC
+            is timezone-aware via the browser's Intl auto-detect; this
+            override is for the cases where that's wrong (e.g. running
+            on a UTC server in a non-UTC location). See
+            specs/timestamp-handling.md §PR-B. */}
+        <Section
+          id="display"
+          title="Display"
+          description="How the operator sees timestamps. The default — auto-detect from your browser — is right for ~all cases; override only if it's wrong."
+        >
+          <Field label="Display timezone">
+            <InlineText
+              value={workspace.display_timezone ?? ''}
+              onSave={async (next) => {
+                // Empty / whitespace clears the override (revert to
+                // auto-detect). Server validates IANA names.
+                await patch({ display_timezone: next.trim() });
+              }}
+              placeholder={(() => {
+                try {
+                  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/Los_Angeles';
+                } catch {
+                  return 'America/Los_Angeles';
+                }
+              })()}
+              label="Edit display timezone"
+            />
+            <p className="text-[11px] text-mc-text-secondary mt-1">
+              IANA name (e.g. <code className="text-mc-text">America/Los_Angeles</code>,{' '}
+              <code className="text-mc-text">America/New_York</code>,{' '}
+              <code className="text-mc-text">Europe/London</code>,{' '}
+              <code className="text-mc-text">Asia/Tokyo</code>). Leave
+              blank to use your browser&apos;s detected zone (
+              <code className="text-mc-text">
+                {(() => {
+                  try {
+                    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'unknown';
+                  } catch {
+                    return 'unknown';
+                  }
+                })()}
+              </code>
+              ). Reload after saving for the change to apply everywhere.
+            </p>
+          </Field>
+        </Section>
 
         {/* Audit defaults — workspace-scoped knobs for the initiative
             Investigate flow's subtree mode. See

--- a/src/app/api/workspaces/[id]/route.ts
+++ b/src/app/api/workspaces/[id]/route.ts
@@ -13,6 +13,7 @@ import {
   AUDIT_SUBTREE_CONCURRENCY_MAX,
 } from '@/lib/db/workspaces';
 import { resolveWorkspacePath } from '@/lib/config';
+import { isValidTimezone } from '@/lib/timestamps';
 import { hostPathToContainerPath } from '@/lib/deliverables/storage';
 
 const execFileAsync = promisify(execFile);
@@ -138,6 +139,7 @@ export async function PATCH(
       local_repo_init,
       repo_url,
       default_base_branch,
+      display_timezone,
     } = body;
 
     const db = getDb();
@@ -214,6 +216,22 @@ export async function PATCH(
       const trimmed = typeof default_base_branch === 'string' ? default_base_branch.trim() : null;
       updates.push('default_base_branch = ?');
       values.push(trimmed && trimmed.length > 0 ? trimmed : null);
+    }
+    if (display_timezone !== undefined) {
+      // Empty string / null clears the override (UI auto-detects via
+      // browser Intl). Any other value must be a valid IANA zone or
+      // we reject — see specs/timestamp-handling.md §PR-B.
+      const raw = typeof display_timezone === 'string' ? display_timezone.trim() : null;
+      if (raw && !isValidTimezone(raw)) {
+        return NextResponse.json(
+          {
+            error: 'display_timezone must be a valid IANA timezone (e.g. America/Los_Angeles, Europe/London) or empty to auto-detect',
+          },
+          { status: 400 },
+        );
+      }
+      updates.push('display_timezone = ?');
+      values.push(raw && raw.length > 0 ? raw : null);
     }
     if (audit_subtree_concurrency !== undefined) {
       const n = Number(audit_subtree_concurrency);

--- a/src/components/ActivityLog.tsx
+++ b/src/components/ActivityLog.tsx
@@ -6,7 +6,7 @@
 'use client';
 
 import { useEffect, useState, useRef, useCallback } from 'react';
-import { formatDistanceToNow } from 'date-fns';
+import { Time } from '@/components/Time';
 import type { TaskActivity } from '@/lib/types';
 
 interface ActivityLogProps {
@@ -150,7 +150,7 @@ export function ActivityLog({ taskId }: ActivityLogProps) {
 
             {/* Timestamp */}
             <div className="text-xs text-mc-text-secondary mt-2">
-              {formatDistanceToNow(new Date(activity.created_at), { addSuffix: true })}
+              <Time iso={activity.created_at} mode="relative" />
             </div>
           </div>
         </div>

--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { ChevronUp, ChevronDown, Clock, PanelRightClose, PanelRightOpen } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import type { Event } from '@/lib/types';
-import { formatDistanceToNow } from 'date-fns';
+import { Time } from '@/components/Time';
 
 type FeedFilter = 'all' | 'tasks' | 'agents';
 
@@ -168,7 +168,7 @@ function EventItem({ event }: { event: Event }) {
         </p>
         <div className="flex items-center gap-1 mt-1 text-xs text-mc-text-secondary">
           <Clock className="w-3 h-3" />
-          {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+          <Time iso={event.created_at} mode="relative" live />
         </div>
       </div>
     </div>

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -9,7 +9,7 @@ import { useUnreadCounts } from '@/hooks/useUnreadCounts';
 import type { Task, TaskStatus } from '@/lib/types';
 import { TaskModal } from './TaskModal';
 import { BlockedBadge } from './BlockedBadge';
-import { formatDistanceToNow } from 'date-fns';
+import { Time } from '@/components/Time';
 
 interface MissionQueueProps {
   workspaceId?: string;
@@ -654,7 +654,7 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
             <div className={`w-1.5 h-1.5 rounded-full ${priorityDots[task.priority]}`} />
             <span className={`text-xs capitalize ${priorityStyles[task.priority]}`}>{task.priority}</span>
           </div>
-          <span className="text-[10px] text-mc-text-secondary/60">{formatDistanceToNow(new Date(task.created_at), { addSuffix: true })}</span>
+          <span className="text-[10px] text-mc-text-secondary/60"><Time iso={task.created_at} mode="relative" /></span>
         </div>
 
         {mobileMode && (

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+/**
+ * Single source of truth for rendering a timestamp in the UI. Wraps
+ * the helpers in `src/lib/timestamps.ts` and reads the workspace
+ * display-timezone override from `useDisplayTimezone`.
+ *
+ * Use `<Time iso={row.created_at} mode="relative" />` instead of bare
+ * `formatDistanceToNow(new Date(row.created_at))`. The latter has
+ * shipped two zone-mismatch bugs already (#280; the LiveFeed sweep
+ * in PR-B); this component closes the door on a third.
+ *
+ * SSR note: when there's no provider the hook falls back to
+ * `Intl.DateTimeFormat().resolvedOptions().timeZone`, which is the
+ * server's zone in SSR. To avoid hydration mismatch on absolute
+ * timestamps, set `mode="relative"` for SSR-rendered lists or render
+ * absolute timestamps client-only.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  formatTimestamp,
+  relativeTime,
+  type TimestampMode,
+} from '@/lib/timestamps';
+import { useDisplayTimezone } from '@/hooks/useDisplayTimezone';
+
+export interface TimeProps {
+  /** ISO-Z (or any Date-parseable) string. Nullish renders empty. */
+  iso: string | null | undefined;
+  /** Default 'short'. */
+  mode?: TimestampMode;
+  /** Optional className for the wrapping <time>. */
+  className?: string;
+  /** Tooltip override. Default: full absolute formatting. */
+  title?: string;
+  /**
+   * If true, the relative text refreshes every minute. Use for
+   * always-visible feeds. Default: false (re-renders only on parent
+   * state changes).
+   */
+  live?: boolean;
+}
+
+export function Time({ iso, mode = 'short', className, title, live = false }: TimeProps) {
+  const tz = useDisplayTimezone();
+  const [, tick] = useState(0);
+
+  useEffect(() => {
+    if (!live || mode !== 'relative') return;
+    const id = setInterval(() => tick((n) => n + 1), 60_000);
+    return () => clearInterval(id);
+  }, [live, mode]);
+
+  if (!iso) return null;
+
+  const text = mode === 'relative' ? relativeTime(iso) : formatTimestamp(iso, { tz, mode });
+  const fullTitle = title ?? formatTimestamp(iso, { tz, mode: 'absolute' });
+
+  return (
+    <time className={className} dateTime={iso} title={fullTitle}>
+      {text}
+    </time>
+  );
+}

--- a/src/components/research/ScheduleRow.tsx
+++ b/src/components/research/ScheduleRow.tsx
@@ -14,7 +14,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { ArrowUpRight, Calendar as CalendarIcon, Loader2, Pause, Play, Trash2, Zap } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
+import { Time } from '@/components/Time';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { formatCadence } from './ScheduleDrawer';
 
@@ -161,11 +161,11 @@ export function ScheduleRow({ schedule, topicName, onChanged }: ScheduleRowProps
               <span className="text-mc-accent">Queued — running on next sweep</span>
             ) : (
               <span>
-                Next: {formatDistanceToNow(new Date(schedule.next_run_at), { addSuffix: true })}
+                Next: <Time iso={schedule.next_run_at} mode="relative" />
               </span>
             )}
             {schedule.last_run_at && (
-              <span>· Last: {formatDistanceToNow(new Date(schedule.last_run_at), { addSuffix: true })}</span>
+              <span>· Last: <Time iso={schedule.last_run_at} mode="relative" /></span>
             )}
             <span>· Run count: {schedule.run_count}</span>
             {lastBriefId && (

--- a/src/hooks/useDisplayTimezone.ts
+++ b/src/hooks/useDisplayTimezone.ts
@@ -1,0 +1,79 @@
+'use client';
+
+/**
+ * Resolve the display timezone for the current workspace.
+ *
+ * Reads `workspaces.display_timezone` (an IANA zone name like
+ * `America/New_York`) from `/api/workspaces/:id`. Falls back to the
+ * browser's auto-detected zone if the workspace hasn't set an
+ * override; falls back to America/Los_Angeles only if Intl is
+ * unavailable.
+ *
+ * Cached per-id at module scope so multiple `<Time>` components
+ * mounting in a single render don't each fire a fetch. The cache is
+ * populated on first read; subsequent renders return synchronously.
+ *
+ * See specs/timestamp-handling.md §PR-B.
+ */
+
+import { useEffect, useState } from 'react';
+import { resolveDisplayTimezone } from '@/lib/timestamps';
+import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
+
+const TZ_CACHE = new Map<string, string | null>();
+const PENDING = new Map<string, Promise<void>>();
+
+function fetchWorkspaceTz(workspaceId: string): Promise<void> {
+  if (PENDING.has(workspaceId)) return PENDING.get(workspaceId)!;
+  const p = (async () => {
+    try {
+      const res = await fetch(`/api/workspaces/${workspaceId}`);
+      if (!res.ok) {
+        TZ_CACHE.set(workspaceId, null);
+        return;
+      }
+      const w = (await res.json()) as { display_timezone?: string | null };
+      TZ_CACHE.set(workspaceId, w?.display_timezone ?? null);
+    } catch {
+      TZ_CACHE.set(workspaceId, null);
+    } finally {
+      PENDING.delete(workspaceId);
+    }
+  })();
+  PENDING.set(workspaceId, p);
+  return p;
+}
+
+/** Force re-fetch of the cached tz override (call after PATCHing
+ *  workspaces). Cheap — most callers don't need this. */
+export function invalidateDisplayTimezone(workspaceId: string): void {
+  TZ_CACHE.delete(workspaceId);
+}
+
+/**
+ * Hook returning the resolved IANA timezone string for display.
+ * Always returns a usable value (never null) — auto-detect or LA
+ * fallback covers the case where the override hasn't loaded yet.
+ */
+export function useDisplayTimezone(): string {
+  const workspaceId = useCurrentWorkspaceId();
+  const cached = TZ_CACHE.get(workspaceId);
+  const [tz, setTz] = useState<string>(() => resolveDisplayTimezone(cached));
+
+  useEffect(() => {
+    if (TZ_CACHE.has(workspaceId)) {
+      setTz(resolveDisplayTimezone(TZ_CACHE.get(workspaceId)));
+      return;
+    }
+    let cancelled = false;
+    fetchWorkspaceTz(workspaceId).then(() => {
+      if (cancelled) return;
+      setTz(resolveDisplayTimezone(TZ_CACHE.get(workspaceId)));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]);
+
+  return tz;
+}

--- a/src/lib/db/index.test.ts
+++ b/src/lib/db/index.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Read-side timestamp normalization.
+ *
+ * Every Statement returned by getDb().prepare(...) — including the
+ * direct .all/.get bypasses scattered through the API routes — should
+ * post-process string fields that match the bare SQLite datetime shape
+ * ("YYYY-MM-DD HH:MM:SS[.fff]") into ISO-Z. See
+ * specs/timestamp-handling.md §PR-A.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  getDb,
+  queryAll,
+  queryOne,
+  run,
+  normalizeDatetimeString,
+  SQLITE_DATETIME_RE,
+} from './index';
+
+function freshWorkspace(): string {
+  const id = `ws-tz-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+test('SQLITE_DATETIME_RE matches bare datetimes only', () => {
+  assert.equal(SQLITE_DATETIME_RE.test('2026-05-08 16:00:37'), true);
+  assert.equal(SQLITE_DATETIME_RE.test('2026-05-08 16:00:37.123'), true);
+  assert.equal(SQLITE_DATETIME_RE.test('2026-05-08T16:00:37Z'), false);
+  assert.equal(SQLITE_DATETIME_RE.test('2026-05-08'), false);
+  assert.equal(SQLITE_DATETIME_RE.test(''), false);
+  assert.equal(SQLITE_DATETIME_RE.test('hello world'), false);
+});
+
+test('normalizeDatetimeString rewrites bare datetimes to ISO-Z', () => {
+  assert.equal(
+    normalizeDatetimeString('2026-05-08 16:00:37'),
+    '2026-05-08T16:00:37Z',
+  );
+  assert.equal(
+    normalizeDatetimeString('2026-05-08 16:00:37.123'),
+    '2026-05-08T16:00:37.123Z',
+  );
+});
+
+test('normalizeDatetimeString is idempotent on already-ISO values', () => {
+  assert.equal(
+    normalizeDatetimeString('2026-05-08T16:00:37Z'),
+    '2026-05-08T16:00:37Z',
+  );
+});
+
+test('normalizeDatetimeString leaves unrelated strings alone', () => {
+  assert.equal(normalizeDatetimeString('not a date'), 'not a date');
+  assert.equal(normalizeDatetimeString('2026-05-08'), '2026-05-08');
+  assert.equal(normalizeDatetimeString(''), '');
+});
+
+test('queryOne returns ISO-Z for datetime columns', () => {
+  const ws = freshWorkspace();
+  const row = queryOne<{ id: string; created_at: string }>(
+    'SELECT id, created_at FROM workspaces WHERE id = ?',
+    [ws],
+  );
+  assert.ok(row, 'row exists');
+  assert.match(row!.created_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/);
+});
+
+test('queryAll returns ISO-Z for datetime columns across all rows', () => {
+  freshWorkspace();
+  freshWorkspace();
+  const rows = queryAll<{ id: string; created_at: string }>(
+    'SELECT id, created_at FROM workspaces ORDER BY created_at DESC LIMIT 5',
+  );
+  assert.ok(rows.length >= 2);
+  for (const r of rows) {
+    assert.match(r.created_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/);
+  }
+});
+
+test('direct prepare().all() bypass also normalizes (monkey-patch covers all read paths)', () => {
+  const ws = freshWorkspace();
+  // Mirrors patterns in src/app/api/workspaces/route.ts that read via
+  // db.prepare directly rather than queryAll.
+  const rows = getDb().prepare('SELECT id, created_at FROM workspaces WHERE id = ?').all(ws) as
+    Array<{ id: string; created_at: string }>;
+  assert.equal(rows.length, 1);
+  assert.match(rows[0].created_at, /T.*Z$/);
+});
+
+test('direct prepare().get() bypass also normalizes', () => {
+  const ws = freshWorkspace();
+  const row = getDb().prepare('SELECT id, created_at FROM workspaces WHERE id = ?').get(ws) as
+    { id: string; created_at: string };
+  assert.match(row.created_at, /T.*Z$/);
+});
+
+test('non-datetime string fields pass through unchanged', () => {
+  const ws = freshWorkspace();
+  const row = queryOne<{ id: string; name: string; slug: string }>(
+    'SELECT id, name, slug FROM workspaces WHERE id = ?',
+    [ws],
+  );
+  assert.equal(row!.id, ws);
+  assert.equal(row!.name, ws);
+  assert.equal(row!.slug, ws);
+});
+
+test('NULL datetime fields stay null', () => {
+  const ws = freshWorkspace();
+  // updated_at on workspaces is nullable in some rows.
+  const row = queryOne<{ description: string | null }>(
+    'SELECT description FROM workspaces WHERE id = ?',
+    [ws],
+  );
+  assert.equal(row!.description, null);
+});
+
+test('parsing the normalized value yields the same instant as raw UTC', () => {
+  // Round-trip sanity: write a datetime, read it back, and confirm
+  // `new Date(returned)` gives an instant matching `Date.now()` to
+  // within a few seconds. This is the actual user-visible bug PR-A
+  // closes — pre-fix, a UTC-7 box would parse the bare string as
+  // 7 hours in the future of `now`.
+  const before = Date.now();
+  const ws = freshWorkspace();
+  const row = queryOne<{ created_at: string }>(
+    'SELECT created_at FROM workspaces WHERE id = ?',
+    [ws],
+  );
+  const parsed = new Date(row!.created_at).getTime();
+  const after = Date.now();
+  // Allow a 3s window for clock skew + slow CI; the broken form
+  // would be off by 60+ minutes minimum on any non-UTC machine.
+  assert.ok(parsed >= before - 3000, `parsed=${parsed} before=${before}`);
+  assert.ok(parsed <= after + 3000, `parsed=${parsed} after=${after}`);
+});

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -100,6 +100,13 @@ export function getDb(): Database.Database {
       runMigrations(instance);
     }
 
+    // Wrap `prepare` so every Statement.all/get returned anywhere in
+    // the codebase normalizes bare SQLite datetime strings to ISO-Z
+    // before they reach JS. See specs/timestamp-handling.md §PR-A.
+    // This catches the queryAll/queryOne helpers AND the many sites
+    // that call `db.prepare(sql).all/get(...)` directly.
+    installDatetimeNormalization(instance);
+
     // Only publish the singleton after init fully succeeds. If anything above
     // throws, `db` stays null and the next call retries cleanly instead of
     // returning a poisoned handle.
@@ -129,7 +136,74 @@ export function closeDb(): void {
   }
 }
 
-// Type-safe query helpers
+// ── Timestamp normalization on read ─────────────────────────────────
+//
+// SQLite's `datetime('now')` returns "YYYY-MM-DD HH:MM:SS" — UTC by
+// sqlite convention but with no timezone marker. Browsers parse such
+// strings as *local* time, producing dates that drift by the local
+// UTC offset. Rather than fix every read site, we monkey-patch
+// `db.prepare` once at init so every Statement returned anywhere in
+// the codebase normalizes string fields shaped like bare SQLite
+// datetimes to ISO-Z ("YYYY-MM-DDTHH:MM:SSZ") before they reach JS.
+// See specs/timestamp-handling.md §PR-A.
+//
+// We rewrite only string fields that match the bare-SQLite-datetime
+// shape. Subseconds are preserved; already-Z values are untouched
+// (idempotent); unrelated strings, numbers, nulls, and `pluck()`
+// scalar returns all pass through unchanged.
+export const SQLITE_DATETIME_RE =
+  /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)?$/;
+
+export function normalizeDatetimeString(v: string): string {
+  return SQLITE_DATETIME_RE.test(v) ? `${v.replace(' ', 'T')}Z` : v;
+}
+
+function normalizeRow<T>(row: T): T {
+  if (!row || typeof row !== 'object') return row;
+  // Mutate in place — the row is a fresh object per query, never shared.
+  const r = row as Record<string, unknown>;
+  for (const k in r) {
+    const v = r[k];
+    if (typeof v === 'string') {
+      const nv = normalizeDatetimeString(v);
+      if (nv !== v) r[k] = nv;
+    }
+  }
+  return row;
+}
+
+function installDatetimeNormalization(instance: Database.Database): void {
+  // Each statement holds its own .all / .get methods. We wrap them
+  // lazily the first time the statement is used — this dodges the
+  // edge case where better-sqlite3's bound functions check `this`.
+  const origPrepare = instance.prepare.bind(instance);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (instance as any).prepare = function patchedPrepare(
+    this: Database.Database,
+    sql: string,
+  ): Database.Statement {
+    const stmt = origPrepare(sql);
+    const origAll = stmt.all.bind(stmt);
+    const origGet = stmt.get.bind(stmt);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stmt.all = ((...params: unknown[]) => {
+      const rows = origAll(...(params as [])) as unknown;
+      if (!Array.isArray(rows)) return rows as unknown;
+      for (const row of rows) normalizeRow(row);
+      return rows;
+    }) as typeof stmt.all;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stmt.get = ((...params: unknown[]) => {
+      const row = origGet(...(params as [])) as unknown;
+      return row === undefined ? undefined : normalizeRow(row);
+    }) as typeof stmt.get;
+    return stmt;
+  } as typeof instance.prepare;
+}
+
+// Type-safe query helpers. Normalization happens inside
+// `installDatetimeNormalization`'s prepare wrapper, so these helpers
+// stay thin.
 export function queryAll<T>(sql: string, params: unknown[] = []): T[] {
   const stmt = getDb().prepare(sql);
   return stmt.all(...params) as T[];

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4515,6 +4515,24 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    id: '086',
+    name: 'workspaces_display_timezone',
+    up: (db) => {
+      // Per-workspace display timezone. NULL means "auto-detect from
+      // browser via Intl.DateTimeFormat().resolvedOptions().timeZone".
+      // The operator can override on the workspace settings page when
+      // auto-detect is wrong (e.g. running on a UTC server but
+      // located in PT). See specs/timestamp-handling.md §PR-B.
+      const cols = db.prepare(`PRAGMA table_info(workspaces)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'display_timezone')) {
+        db.exec(`ALTER TABLE workspaces ADD COLUMN display_timezone TEXT`);
+        console.log('[Migration 086] workspaces.display_timezone added (nullable; NULL = auto-detect).');
+      } else {
+        console.log('[Migration 086] workspaces.display_timezone already present; skipping.');
+      }
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/timestamps.test.ts
+++ b/src/lib/timestamps.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Display-side timestamp helpers.
+ *
+ * Cover the IANA validation, the tz override resolution, and the
+ * format paths. Note: we don't snapshot the exact formatted strings
+ * across modes since `Intl.DateTimeFormat` output varies subtly by
+ * Node version — we verify the *shape* (zone abbreviation present
+ * for absolute mode, no zone for short, etc.).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  formatTimestamp,
+  isValidTimezone,
+  relativeTime,
+  resolveDisplayTimezone,
+} from './timestamps';
+
+test('isValidTimezone accepts well-formed IANA names', () => {
+  assert.equal(isValidTimezone('America/Los_Angeles'), true);
+  assert.equal(isValidTimezone('Europe/London'), true);
+  assert.equal(isValidTimezone('UTC'), true);
+  assert.equal(isValidTimezone('Asia/Tokyo'), true);
+});
+
+test('isValidTimezone rejects garbage', () => {
+  assert.equal(isValidTimezone('Mars/Olympus_Mons'), false);
+  assert.equal(isValidTimezone('Not_A_Zone'), false);
+  assert.equal(isValidTimezone(''), false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assert.equal(isValidTimezone(null as any), false);
+});
+
+test('resolveDisplayTimezone honors the override first', () => {
+  assert.equal(
+    resolveDisplayTimezone('America/New_York'),
+    'America/New_York',
+  );
+  // Whitespace-only treated as no override.
+  const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  assert.equal(resolveDisplayTimezone('   '), detected);
+  assert.equal(resolveDisplayTimezone(null), detected);
+  assert.equal(resolveDisplayTimezone(undefined), detected);
+});
+
+test('formatTimestamp renders the same instant differently in two zones', () => {
+  // 2026-05-08 00:00:00 UTC. In NY that's 2026-05-07 evening; in
+  // Tokyo that's 2026-05-08 morning. Different display dates.
+  const iso = '2026-05-08T00:00:00Z';
+  const ny = formatTimestamp(iso, { tz: 'America/New_York', mode: 'short' });
+  const tokyo = formatTimestamp(iso, { tz: 'Asia/Tokyo', mode: 'short' });
+  assert.notEqual(ny, tokyo);
+  // NY is the previous calendar day at this UTC instant.
+  assert.match(ny, /May 7/);
+  assert.match(tokyo, /May 8/);
+});
+
+test('formatTimestamp absolute mode includes timezone label', () => {
+  const out = formatTimestamp('2026-05-08T16:00:00Z', {
+    tz: 'America/Los_Angeles',
+    mode: 'absolute',
+  });
+  // PDT or PST depending on date; both end with 'T'.
+  assert.match(out, /\bPDT\b|\bPST\b/);
+});
+
+test('formatTimestamp short mode excludes timezone label', () => {
+  const out = formatTimestamp('2026-05-08T16:00:00Z', {
+    tz: 'America/Los_Angeles',
+    mode: 'short',
+  });
+  assert.doesNotMatch(out, /\bPDT\b|\bPST\b/);
+});
+
+test('formatTimestamp returns empty string for nullish or unparseable input', () => {
+  assert.equal(formatTimestamp(null), '');
+  assert.equal(formatTimestamp(undefined), '');
+  assert.equal(formatTimestamp(''), '');
+  assert.equal(formatTimestamp('not a date'), '');
+});
+
+test('formatTimestamp falls back gracefully when the override tz is rejected', () => {
+  // We let invalid tz reach formatTimestamp at runtime because the
+  // workspace value might be stale or an env quirk; the helper must
+  // not throw out of a render.
+  const out = formatTimestamp('2026-05-08T16:00:00Z', {
+    tz: 'Mars/Olympus_Mons',
+    mode: 'short',
+  });
+  assert.ok(out.length > 0, 'falls back to default Intl');
+});
+
+test('relativeTime returns a human-readable past phrase', () => {
+  const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString();
+  const out = relativeTime(fiveMinAgo);
+  assert.match(out, /ago$/);
+  assert.match(out, /minute/);
+});
+
+test('relativeTime handles future timestamps with "in" prefix', () => {
+  const fiveMinFromNow = new Date(Date.now() + 5 * 60_000).toISOString();
+  const out = relativeTime(fiveMinFromNow);
+  assert.match(out, /^in /);
+});
+
+test('relativeTime returns empty string for unparseable input', () => {
+  assert.equal(relativeTime(''), '');
+  assert.equal(relativeTime(null), '');
+  assert.equal(relativeTime('garbage'), '');
+});

--- a/src/lib/timestamps.ts
+++ b/src/lib/timestamps.ts
@@ -1,0 +1,180 @@
+/**
+ * Timestamp formatting helpers, timezone-aware.
+ *
+ * Use these (or the `<Time>` component built on top) instead of bare
+ * `new Date(...).toLocaleString()` calls. Reasons:
+ *
+ *  1. The DB layer normalizes SQLite datetimes to ISO-Z on read (PR
+ *     #281), so every timestamp the app sees is a real instant. JS
+ *     `new Date(iso)` parses it correctly. These helpers don't add
+ *     parsing-correctness — they add **display consistency** across
+ *     the app.
+ *
+ *  2. The operator can override the auto-detected timezone via the
+ *     workspace settings page (`workspaces.display_timezone`). All
+ *     formatting must respect that override. Bare
+ *     `toLocaleString()` doesn't.
+ *
+ * See specs/timestamp-handling.md §PR-B.
+ */
+
+import { formatDistanceToNow, formatDistanceToNowStrict, parseISO } from 'date-fns';
+
+/** Final fallback if the browser is somehow stripped of `Intl`. */
+const ULTIMATE_FALLBACK_TZ = 'America/Los_Angeles';
+
+/**
+ * Resolve the timezone string to use for display. Precedence:
+ *   1. The workspace-level override (if non-empty).
+ *   2. The browser's auto-detected zone via Intl.
+ *   3. America/Los_Angeles, as a last-resort fallback.
+ *
+ * Pass `null` / `undefined` for `workspaceTz` when the override isn't
+ * known yet (SSR boundary, before context hydrates).
+ */
+export function resolveDisplayTimezone(
+  workspaceTz?: string | null,
+): string {
+  const override = (workspaceTz ?? '').trim();
+  if (override) return override;
+  try {
+    const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (detected) return detected;
+  } catch {
+    /* fall through to ultimate fallback */
+  }
+  return ULTIMATE_FALLBACK_TZ;
+}
+
+/**
+ * Validate that a string is a usable IANA timezone identifier.
+ * Returns true if the browser/runtime accepts it as a `timeZone`
+ * option. Used by the workspace settings PATCH route to reject
+ * garbage input before persisting it.
+ */
+export function isValidTimezone(tz: string): boolean {
+  if (!tz || typeof tz !== 'string') return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export type TimestampMode =
+  /** "5 minutes ago" — relative, zone-agnostic */
+  | 'relative'
+  /** "May 8, 4:32 PM" — short absolute */
+  | 'short'
+  /** "May 8, 2026 at 4:32:07 PM PDT" — full absolute with zone */
+  | 'absolute'
+  /** "2026-05-08 16:32" — datetime-input-friendly */
+  | 'datetime'
+  /** "May 8, 2026" — date only */
+  | 'date'
+  /** "4:32 PM" — time only */
+  | 'time';
+
+export interface FormatOptions {
+  /** Resolved IANA timezone. Use `resolveDisplayTimezone()` to get one. */
+  tz?: string;
+  /** Default 'short'. */
+  mode?: TimestampMode;
+}
+
+/**
+ * Format an ISO-Z (or any Date-parseable) timestamp string for
+ * display. Returns `''` for nullish / unparseable inputs so callers
+ * can render `{formatTimestamp(field)}` without conditional checks.
+ */
+export function formatTimestamp(
+  iso: string | null | undefined,
+  opts: FormatOptions = {},
+): string {
+  if (!iso) return '';
+  const date = typeof iso === 'string' ? safeParse(iso) : null;
+  if (!date) return '';
+
+  const tz = opts.tz ?? resolveDisplayTimezone();
+  const mode = opts.mode ?? 'short';
+
+  if (mode === 'relative') {
+    return relativeTime(iso);
+  }
+
+  const fmt: Intl.DateTimeFormatOptions = (() => {
+    switch (mode) {
+      case 'short':
+        return { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' };
+      case 'absolute':
+        return {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit',
+          second: '2-digit',
+          timeZoneName: 'short',
+        };
+      case 'datetime':
+        return {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false,
+        };
+      case 'date':
+        return { year: 'numeric', month: 'short', day: 'numeric' };
+      case 'time':
+        return { hour: 'numeric', minute: '2-digit' };
+      default:
+        return { month: 'short', day: 'numeric' };
+    }
+  })();
+
+  try {
+    return new Intl.DateTimeFormat('en-US', { ...fmt, timeZone: tz }).format(date);
+  } catch {
+    // tz could be invalid (operator override that we somehow let
+    // through). Retry with auto-detect; never throw out of a render.
+    return new Intl.DateTimeFormat('en-US', fmt).format(date);
+  }
+}
+
+/**
+ * "5 minutes ago" / "in 2 hours". Wraps date-fns `formatDistanceToNow`
+ * with `addSuffix:true` so past *and* future tenses come out right —
+ * zone-independent because the underlying instant is what matters.
+ */
+export function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = safeParse(iso);
+  if (!d) return '';
+  return formatDistanceToNow(d, { addSuffix: true });
+}
+
+/** Like `relativeTime` but without the trailing " ago" and using
+ *  `Strict` (no rounding to "about"). For sites that build their own
+ *  surrounding text. */
+export function relativeTimeStrict(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = safeParse(iso);
+  if (!d) return '';
+  return formatDistanceToNowStrict(d);
+}
+
+function safeParse(iso: string): Date | null {
+  // parseISO handles ISO-Z; new Date is the fallback for ad-hoc
+  // formats that might still be in the wild.
+  try {
+    const d = parseISO(iso);
+    if (!Number.isNaN(d.getTime())) return d;
+  } catch {
+    /* fall through */
+  }
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : d;
+}


### PR DESCRIPTION
## Summary

**Stacked on #281** (DB-layer ISO-Z normalization). Stage 2 of two from `specs/timestamp-handling.md`.

PR-A made every timestamp the app reads a real instant (parses to the right UTC moment everywhere). This PR makes the **display side** consistent and operator-overridable: a workspace `display_timezone` setting, a `<Time>` component everyone should use, and a sweep of the four highest-traffic display surfaces.

## What lands

- **Migration 086** — `workspaces.display_timezone TEXT`. NULL = auto-detect from browser; non-empty must be a valid IANA name.
- **Workspace settings UI** — new "Display" section with an inline editor. Placeholder shows the auto-detected zone. Help text reminds the operator to reload after saving.
- **PATCH /api/workspaces/[id]** — accepts `display_timezone`, validates via `Intl.DateTimeFormat({ timeZone })`, rejects garbage with 400.
- **`src/lib/timestamps.ts`** — `formatTimestamp` / `relativeTime` / `resolveDisplayTimezone` / `isValidTimezone` (11 unit tests).
- **`<Time iso={...} mode="relative|short|absolute|date|time|datetime" />`** — reads workspace override via `useDisplayTimezone()`. Handles past + future tenses, nullish input, optional `live` auto-refresh, `title` always shows full absolute formatting on hover.
- **Display sweep**: `LiveFeed`, `ActivityLog`, `MissionQueue` (task age), `ScheduleRow` (next/last run). Drops their direct `date-fns formatDistanceToNow` imports.

## Verified live

| Path | Result |
|---|---|
| `/workspace/default/settings` | Display section shows, placeholder = auto-detected zone (`America/Los_Angeles` on the test machine). Screenshot in PR thread. |
| PATCH `display_timezone: 'Mars/Olympus_Mons'` | 400 + helpful message |
| PATCH `'Asia/Tokyo'` then reload | All `<time>` `title` attrs render with `GMT+9`. |
| PATCH `''` (clear) | Titles revert to PDT. |
| LiveFeed `<time>` element | `dateTime="2026-04-29T22:03:25.629Z"` (the ISO-Z from PR-A), `title="Apr 29, 2026, 3:03:25 PM PDT"`, text `"9 days ago"`. |

## Out of scope (intentional)

Sites still on the bare-`new Date(field)` pattern (AgentActivityDashboard, DebugEventRow, ChatInbox, SessionsList, ResearchReport, MaybePool, several chat tabs) keep working because PR-A already gave them correct UTC. They can migrate to `<Time>` opportunistically as files are touched. The four chosen for this PR are the ones with the highest visibility per render.

## Test plan

- [x] `yarn test` — 885/886 (1 pre-existing unrelated failure on `schedule-runner` from main).
- [x] `yarn tsc --noEmit` — same 3 pre-existing errors as main; nothing new from this PR.
- [x] New tests cover: `isValidTimezone` accept/reject; tz override precedence; cross-zone rendering of the same instant; absolute mode includes zone label, short mode doesn't; nullish input → empty string; invalid override falls back to default Intl; relative tense for past/future.
- [x] Live: settings screenshot + Tokyo override round-trip + LiveFeed `<time>` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)