### PR TITLE
fix(costs): bind SQLite datetime cutoffs in bare-UTC shape

### DIFF
--- a/src/lib/autopilot/health-score.ts
+++ b/src/lib/autopilot/health-score.ts
@@ -14,7 +14,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { queryOne, queryAll, run, transaction } from '@/lib/db';
+import { queryOne, queryAll, run, transaction, toSqliteUtc } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import type {
   HealthWeightConfig,
@@ -130,7 +130,7 @@ function computePipelineDepth(productId: string): { score: number; rawValue: num
  * 0   = no swipes
  */
 function computeSwipeVelocity(productId: string): { score: number; rawValue: number; hasData: boolean } {
-  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const sevenDaysAgo = toSqliteUtc(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000));
   const result = queryOne<{ count: number }>(
     `SELECT COUNT(*) as count FROM swipe_history WHERE product_id = ? AND created_at >= ?`,
     [productId, sevenDaysAgo]
@@ -176,7 +176,7 @@ function computeBuildSuccess(productId: string): { score: number; rawValue: numb
  * Inverse relationship — lower cost = higher score
  */
 function computeCostEfficiency(productId: string): { score: number; rawValue: number; hasData: boolean } {
-  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const thirtyDaysAgo = toSqliteUtc(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000));
 
   const totalCost = queryOne<{ total: number }>(
     `SELECT COALESCE(SUM(cost_usd), 0) as total FROM cost_events WHERE product_id = ? AND created_at >= ?`,

--- a/src/lib/autopilot/swipe.ts
+++ b/src/lib/autopilot/swipe.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { queryOne, queryAll, run, transaction } from '@/lib/db';
+import { queryOne, queryAll, run, transaction, toSqliteUtc } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { internalDispatch } from '@/lib/internal-dispatch';
 import { rebuildPreferenceModel } from './preferences';
@@ -307,7 +307,7 @@ function createTaskFromIdea(idea: Idea, opts?: { urgent?: boolean; notes?: strin
     const monthlySpend = queryOne<{ total: number }>(
       `SELECT COALESCE(SUM(cost_usd), 0) as total FROM cost_events
        WHERE product_id = ? AND created_at >= ?`,
-      [idea.product_id, monthStart.toISOString()]
+      [idea.product_id, toSqliteUtc(monthStart)]
     );
     if (monthlySpend && monthlySpend.total >= product.cost_cap_monthly) {
       // Cap exceeded — queue to inbox instead of auto-dispatching

--- a/src/lib/costs/caps.ts
+++ b/src/lib/costs/caps.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { queryOne, queryAll, run } from '@/lib/db';
+import { queryOne, queryAll, run, toSqliteUtc } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import type { CostCap } from '@/lib/types';
 
@@ -92,14 +92,14 @@ export function checkCaps(workspaceId: string, productId?: string): {
     const now = new Date();
 
     if (cap.cap_type === 'daily') {
-      const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+      const todayStart = toSqliteUtc(new Date(now.getFullYear(), now.getMonth(), now.getDate()));
       const result = queryOne<{ total: number }>(
         `SELECT COALESCE(SUM(cost_usd), 0) as total FROM cost_events WHERE workspace_id = ? AND created_at >= ?`,
         [workspaceId, todayStart]
       );
       currentSpend = result?.total || 0;
     } else if (cap.cap_type === 'monthly') {
-      const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+      const monthStart = toSqliteUtc(new Date(now.getFullYear(), now.getMonth(), 1));
       const result = queryOne<{ total: number }>(
         `SELECT COALESCE(SUM(cost_usd), 0) as total FROM cost_events WHERE workspace_id = ? AND created_at >= ?`,
         [workspaceId, monthStart]
@@ -107,7 +107,7 @@ export function checkCaps(workspaceId: string, productId?: string): {
       currentSpend = result?.total || 0;
     } else if (cap.cap_type === 'per_product_monthly' && (cap.product_id || productId)) {
       const pid = cap.product_id || productId;
-      const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+      const monthStart = toSqliteUtc(new Date(now.getFullYear(), now.getMonth(), 1));
       const result = queryOne<{ total: number }>(
         `SELECT COALESCE(SUM(cost_usd), 0) as total FROM cost_events WHERE product_id = ? AND created_at >= ?`,
         [pid, monthStart]

--- a/src/lib/costs/reporting.test.ts
+++ b/src/lib/costs/reporting.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression test: SQLite stores `created_at` as bare "YYYY-MM-DD HH:MM:SS"
+ * (via `datetime('now')`) and compares datetime columns as text. If a query
+ * binds an ISO-Z cutoff like "2026-05-08T00:00:00.000Z", the `T` (0x54) sorts
+ * after the space (0x20) at byte 11 — silently excluding rows from the same
+ * day. The fix is to bind the cutoff in the same bare-SQLite shape.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run, toSqliteUtc } from '@/lib/db';
+import { getCostOverview } from './reporting';
+import { checkCaps } from './caps';
+
+function seedWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT INTO workspaces (id, slug, name, created_at, updated_at)
+     VALUES (?, ?, 'test-ws', datetime('now'), datetime('now'))`,
+    [id, id],
+  );
+  return id;
+}
+
+function seedCostEvent(opts: {
+  workspaceId: string;
+  productId?: string | null;
+  costUsd: number;
+  createdAt: string; // bare-SQLite shape, e.g. "2026-05-08 09:30:00"
+}) {
+  run(
+    `INSERT INTO cost_events (id, workspace_id, product_id, event_type, cost_usd, created_at)
+     VALUES (?, ?, ?, 'agent_dispatch', ?, ?)`,
+    [uuidv4(), opts.workspaceId, opts.productId ?? null, opts.costUsd, opts.createdAt],
+  );
+}
+
+test('toSqliteUtc emits bare-SQLite shape with no T or Z', () => {
+  const d = new Date(Date.UTC(2026, 4, 8, 9, 30, 15));
+  assert.equal(toSqliteUtc(d), '2026-05-08 09:30:15');
+});
+
+test('getCostOverview includes today\'s rows in daily total', () => {
+  const wsId = seedWorkspace();
+
+  // Seed two rows stamped at "now" — both unambiguously fall inside the
+  // "today" window (local-day-start ≤ now < local-day-start + 24h). Under
+  // the bug, the daily query binds an ISO-Z cutoff and excludes them
+  // because "T" > " " at byte 11; with the fix it binds bare-SQLite shape
+  // and the rows match.
+  const nowBare = toSqliteUtc(new Date());
+  seedCostEvent({ workspaceId: wsId, costUsd: 1.23, createdAt: nowBare });
+  seedCostEvent({ workspaceId: wsId, costUsd: 2.5, createdAt: nowBare });
+
+  const overview = getCostOverview(wsId);
+  assert.ok(
+    Math.abs(overview.today - 3.73) < 1e-9,
+    `today total should be 3.73, got ${overview.today}`,
+  );
+  assert.ok(
+    Math.abs(overview.this_month - 3.73) < 1e-9,
+    `month total should be 3.73, got ${overview.this_month}`,
+  );
+});
+
+test('checkCaps daily window includes today\'s rows', () => {
+  const wsId = seedWorkspace();
+
+  const capId = uuidv4();
+  run(
+    `INSERT INTO cost_caps (id, workspace_id, cap_type, limit_usd, status)
+     VALUES (?, ?, 'daily', 5.0, 'active')`,
+    [capId, wsId],
+  );
+
+  // Seed a same-second row that exceeds the cap. Under the bug, the daily
+  // recalc misses it; with the fix the cap recalculates above the limit.
+  seedCostEvent({ workspaceId: wsId, costUsd: 10.0, createdAt: toSqliteUtc(new Date()) });
+
+  const result = checkCaps(wsId);
+  assert.ok(
+    result.exceeded.some(c => c.id === capId),
+    'daily cap should be flagged as exceeded once today\'s rows are counted',
+  );
+});

--- a/src/lib/costs/reporting.ts
+++ b/src/lib/costs/reporting.ts
@@ -1,4 +1,4 @@
-import { queryOne, queryAll } from '@/lib/db';
+import { queryOne, queryAll, toSqliteUtc } from '@/lib/db';
 
 interface CostOverview {
   today: number;
@@ -22,14 +22,14 @@ interface PerFeatureStats {
 
 export function getCostOverview(workspaceId: string): CostOverview {
   const now = new Date();
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+  const todayStart = toSqliteUtc(new Date(now.getFullYear(), now.getMonth(), now.getDate()));
 
   // Start of week (Monday)
   const dayOfWeek = now.getDay();
   const diffToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
-  const weekStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - diffToMonday).toISOString();
+  const weekStart = toSqliteUtc(new Date(now.getFullYear(), now.getMonth(), now.getDate() - diffToMonday));
 
-  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+  const monthStart = toSqliteUtc(new Date(now.getFullYear(), now.getMonth(), 1));
 
   const today = queryOne<{ total: number }>(
     `SELECT COALESCE(SUM(cost_usd), 0) as total FROM cost_events WHERE workspace_id = ? AND created_at >= ?`,

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -158,6 +158,16 @@ export function normalizeDatetimeString(v: string): string {
   return SQLITE_DATETIME_RE.test(v) ? `${v.replace(' ', 'T')}Z` : v;
 }
 
+// Format a Date as a bare-SQLite UTC datetime string ("YYYY-MM-DD HH:MM:SS")
+// for use as a bound parameter against `created_at` / `updated_at` columns.
+// SQLite's CURRENT_TIMESTAMP writes this exact shape, and SQLite compares
+// datetime columns as text — so an ISO-Z parameter with `T` at byte 11 will
+// always sort after a same-second stored value with a space, silently
+// excluding rows that should match `>=`.
+export function toSqliteUtc(d: Date): string {
+  return d.toISOString().slice(0, 19).replace('T', ' ');
+}
+
 function normalizeRow<T>(row: T): T {
   if (!row || typeof row !== 'object') return row;
   // Mutate in place — the row is a fresh object per query, never shared.


### PR DESCRIPTION
## Summary

SQLite stores `created_at` as `"YYYY-MM-DD HH:MM:SS"` via `datetime('now')` and compares datetime columns as text. Binding an ISO-Z cutoff like `"2026-05-08T00:00:00.000Z"` puts `T` (0x54) at byte 11 where stored rows have a space (0x20) — the cutoff sorts after every same-day row, so the `>=` filter silently excludes today's spend.

Independent of the read-side normalization PR (#281); both can land in either order.

## Changes

- New `toSqliteUtc(d)` helper in `src/lib/db/index.ts`, sibling to `normalizeDatetimeString`.
- Switched datetime-cutoff binds to bare-SQLite shape in:
  - `src/lib/costs/caps.ts` — daily, monthly, per-product-monthly cap recalcs
  - `src/lib/costs/reporting.ts` — today / week / month overview totals
  - `src/lib/autopilot/health-score.ts` — 7-day swipe velocity, 30-day cost efficiency (covers both the `created_at` and `updated_at` cutoffs)
  - `src/lib/autopilot/swipe.ts` — auto-build cost-cap pre-check
- New `src/lib/costs/reporting.test.ts` regression test.

## Test plan

- [x] `yarn test` — 888/889 pass; the one failure (`schedule-runner: produces a brief and advances run_count`) is pre-existing on `main` and unrelated to this change
- [x] New tests: `toSqliteUtc` shape, today's rows included in `getCostOverview.today`, daily `checkCaps` flips to `exceeded` on a same-day overspend
- [x] `tsc --noEmit` — no new errors in changed files (3 pre-existing failures elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)