### PR TITLE
feat(audit): phase 1 — note kinds + body validators

### DIFF
--- a/src/lib/agents/audit-proposals/schemas.test.ts
+++ b/src/lib/agents/audit-proposals/schemas.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Round-trip + rejection tests for the audit-proposal note schemas.
+ *
+ * Mirrors the spec §4 examples and the §10 Phase 1 acceptance criteria:
+ *  - Each schema accepts a canonical example.
+ *  - Missing required fields, wrong enums, and shape/action mismatches
+ *    are rejected with a structured error.
+ *  - validateAuditNoteBody wraps JSON.parse + schema check and returns
+ *    a `{ ok, error }` shape the MCP handler can relay verbatim.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  MAX_AUDIT_NOTE_BODY_CHARS,
+  auditManifestBodySchema,
+  auditProposalBodySchema,
+  auditSynthesisBodySchema,
+  isAuditNoteKind,
+  validateAuditNoteBody,
+} from './schemas';
+
+// ─── Canonical fixtures ─────────────────────────────────────────────
+
+function manifestFixture() {
+  return {
+    version: 1 as const,
+    root_initiative_id: '0c9419ff-d511-4511-86c6-57a6387e19f7',
+    attempt: 11,
+    previous_synthesis_run_group_id: null,
+    summary: 'Refactor native alert() calls to a custom modal component.',
+    nodes: [
+      {
+        initiative_id: '6379b104-aaaa-bbbb-cccc-dddddddddddd',
+        title: 'Build AlertDialog mirroring ConfirmDialog',
+        current_status: 'done',
+        hypothesis: 'likely-drifted' as const,
+        confidence: 'medium' as const,
+        investigation_prompt: 'Verify AlertDialog landed somewhere in src/components.',
+        scoped_evidence_hints: ['rg AlertDialog src/components'],
+        skip: false,
+      },
+    ],
+    cross_cutting_questions: ['Does the alert() shim still exist anywhere?'],
+  };
+}
+
+interface ProposalFixture {
+  version: 1;
+  node_initiative_id: string;
+  current_mc_status: string;
+  current_mc_target_end: string | null;
+  proposed_action: string;
+  proposed_changes: Record<string, unknown>;
+  repo_evidence: Array<{ kind: string; ref: string }>;
+  rationale: string;
+  confidence: 'low' | 'medium' | 'high';
+  would_confirm_by: string | null;
+  continuation_note_id: string | null;
+}
+
+function proposalFixture(): ProposalFixture {
+  return {
+    version: 1,
+    node_initiative_id: '6379b104-aaaa-bbbb-cccc-dddddddddddd',
+    current_mc_status: 'done',
+    current_mc_target_end: '2026-05-13',
+    proposed_action: 'modify_scope',
+    proposed_changes: { description: 'Revised body documenting the actual landed scope.' },
+    repo_evidence: [
+      { kind: 'file', ref: 'src/components/AlertDialog.tsx:1' },
+      { kind: 'git', ref: '0cc50ce' },
+    ],
+    rationale: 'Story marked done but scope drifted; description needs to reflect ship reality.',
+    confidence: 'medium',
+    would_confirm_by: 'Reading src/components/AlertDialog.tsx end-to-end.',
+    continuation_note_id: null,
+  };
+}
+
+interface SynthesisFixture {
+  version: 1;
+  root_initiative_id: string;
+  attempt: number;
+  completion_sentinel: string;
+  epic_proposals: Array<Record<string, unknown>>;
+  cross_node_proposals: Array<Record<string, unknown>>;
+}
+
+function synthesisFixture(): SynthesisFixture {
+  return {
+    version: 1,
+    root_initiative_id: '0c9419ff-d511-4511-86c6-57a6387e19f7',
+    attempt: 11,
+    completion_sentinel:
+      'Audit complete: 3 nodes — 1 keep, 1 modify_scope, 1 cancel; epic dates +14d',
+    epic_proposals: [
+      {
+        proposed_action: 'modify_epic_dates',
+        proposed_changes: { target_end: '2026-05-27' },
+        rationale: 'Two stories are still open.',
+        confidence: 'medium',
+      },
+    ],
+    cross_node_proposals: [
+      {
+        proposed_action: 'merge_stories',
+        subject_initiative_ids: [
+          '6379b104-aaaa-bbbb-cccc-dddddddddddd',
+          '9ab40f1f-aaaa-bbbb-cccc-dddddddddddd',
+        ],
+        rationale: 'Both close on the same alert-shim PR.',
+        confidence: 'medium',
+      },
+    ],
+  };
+}
+
+// ─── Round-trip ─────────────────────────────────────────────────────
+
+test('auditManifestBodySchema: accepts canonical example', () => {
+  const result = auditManifestBodySchema.safeParse(manifestFixture());
+  assert.equal(result.success, true, JSON.stringify(result, null, 2));
+});
+
+test('auditProposalBodySchema: accepts canonical example', () => {
+  const result = auditProposalBodySchema.safeParse(proposalFixture());
+  assert.equal(result.success, true, JSON.stringify(result, null, 2));
+});
+
+test('auditSynthesisBodySchema: accepts canonical example', () => {
+  const result = auditSynthesisBodySchema.safeParse(synthesisFixture());
+  assert.equal(result.success, true, JSON.stringify(result, null, 2));
+});
+
+// ─── Manifest rejection ─────────────────────────────────────────────
+
+test('auditManifestBodySchema: rejects bad hypothesis enum', () => {
+  const m = manifestFixture();
+  // @ts-expect-error — bad value on purpose.
+  m.nodes[0].hypothesis = 'absolutely-done';
+  const result = auditManifestBodySchema.safeParse(m);
+  assert.equal(result.success, false);
+});
+
+test('auditManifestBodySchema: rejects missing summary', () => {
+  const m = manifestFixture() as Partial<ReturnType<typeof manifestFixture>>;
+  delete m.summary;
+  const result = auditManifestBodySchema.safeParse(m);
+  assert.equal(result.success, false);
+});
+
+// ─── Proposal rejection ─────────────────────────────────────────────
+
+test('auditProposalBodySchema: rejects when proposed_changes shape mismatches action', () => {
+  const p = proposalFixture();
+  p.proposed_action = 'cancel';
+  // proposed_changes still has the modify_scope shape (no `reason`).
+  const result = auditProposalBodySchema.safeParse(p);
+  assert.equal(result.success, false);
+});
+
+test('auditProposalBodySchema: rejects empty repo_evidence', () => {
+  const p = proposalFixture();
+  p.repo_evidence = [];
+  const result = auditProposalBodySchema.safeParse(p);
+  assert.equal(result.success, false);
+});
+
+test('auditProposalBodySchema: rejects unknown action enum', () => {
+  const p = proposalFixture() as unknown as Record<string, unknown>;
+  p.proposed_action = 'rewrite_history';
+  const result = auditProposalBodySchema.safeParse(p);
+  assert.equal(result.success, false);
+});
+
+test('auditProposalBodySchema: requires would_confirm_by when confidence < high', () => {
+  const p = proposalFixture();
+  p.confidence = 'low';
+  p.would_confirm_by = '';
+  const result = auditProposalBodySchema.safeParse(p);
+  assert.equal(result.success, false);
+});
+
+test('auditProposalBodySchema: allows missing would_confirm_by when confidence=high', () => {
+  const p = proposalFixture();
+  p.confidence = 'high';
+  p.would_confirm_by = null;
+  const result = auditProposalBodySchema.safeParse(p);
+  assert.equal(result.success, true);
+});
+
+test('auditProposalBodySchema: keep action requires empty proposed_changes', () => {
+  const p = proposalFixture() as unknown as Record<string, unknown>;
+  p.proposed_action = 'keep';
+  p.proposed_changes = { reason: 'should not be here' };
+  const result = auditProposalBodySchema.safeParse(p);
+  assert.equal(result.success, false);
+});
+
+// ─── Synthesis rejection ────────────────────────────────────────────
+
+test('auditSynthesisBodySchema: rejects merge_stories with <2 ids', () => {
+  const s = synthesisFixture();
+  s.cross_node_proposals[0] = {
+    proposed_action: 'merge_stories' as const,
+    subject_initiative_ids: ['only-one'],
+    rationale: 'r',
+    confidence: 'low' as const,
+  };
+  const result = auditSynthesisBodySchema.safeParse(s);
+  assert.equal(result.success, false);
+});
+
+test('auditSynthesisBodySchema: rejects missing completion_sentinel', () => {
+  const s = synthesisFixture() as Partial<ReturnType<typeof synthesisFixture>>;
+  delete s.completion_sentinel;
+  const result = auditSynthesisBodySchema.safeParse(s);
+  assert.equal(result.success, false);
+});
+
+// ─── validateAuditNoteBody ──────────────────────────────────────────
+
+test('validateAuditNoteBody: round-trip on canonical proposal', () => {
+  const json = JSON.stringify(proposalFixture());
+  const result = validateAuditNoteBody('audit_proposal', json);
+  assert.equal(result.ok, true);
+});
+
+test('validateAuditNoteBody: returns structured error citing field path', () => {
+  const broken = proposalFixture() as unknown as Record<string, unknown>;
+  delete broken.rationale;
+  const json = JSON.stringify(broken);
+  const result = validateAuditNoteBody('audit_proposal', json);
+  assert.equal(result.ok, false);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.error, /audit_proposal/);
+    assert.match(result.error, /rationale/);
+  }
+});
+
+test('validateAuditNoteBody: rejects malformed JSON', () => {
+  const result = validateAuditNoteBody('audit_manifest', '{not json');
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.error, /JSON\.parse/);
+  }
+});
+
+test('validateAuditNoteBody: refuses non-audit kinds defensively', () => {
+  const result = validateAuditNoteBody('discovery', '{}');
+  assert.equal(result.ok, false);
+});
+
+test('isAuditNoteKind: correct membership', () => {
+  assert.equal(isAuditNoteKind('audit_manifest'), true);
+  assert.equal(isAuditNoteKind('audit_proposal'), true);
+  assert.equal(isAuditNoteKind('audit_synthesis'), true);
+  assert.equal(isAuditNoteKind('discovery'), false);
+  assert.equal(isAuditNoteKind('observation'), false);
+});
+
+test('MAX_AUDIT_NOTE_BODY_CHARS leaves headroom under DB cap', () => {
+  // Spec §4.5: orchestrator caps at 2900, DB at 3000. Headroom is for a
+  // tightening retry to land before hitting the hard cap.
+  assert.equal(MAX_AUDIT_NOTE_BODY_CHARS, 2900);
+});

--- a/src/lib/agents/audit-proposals/schemas.ts
+++ b/src/lib/agents/audit-proposals/schemas.ts
@@ -1,0 +1,317 @@
+/**
+ * Zod schemas for the subtree-audit proposal pipeline.
+ *
+ * See specs/subtree-audit-proposals-spec.md §4 (note kinds + body
+ * schemas). All three schemas describe JSON payloads stored in
+ * `agent_notes.body` (a TEXT column with a 3000-char cap). The
+ * orchestrator's pre-cap budget is `MAX_AUDIT_NOTE_BODY_CHARS` (2900),
+ * leaving ~100 chars of headroom under the underlying take_note cap.
+ *
+ * Validation runs in the MCP `take_note` handler iff
+ * `kind ∈ {audit_manifest, audit_proposal, audit_synthesis}` so
+ * auditor agents get immediate, structured feedback they can recover
+ * from on the same dispatch (mirrors the cancelled-run guard pattern
+ * at src/lib/mcp/groups/core.ts).
+ */
+
+import { z } from 'zod';
+
+import type { NoteKind } from '@/lib/db/agent-notes';
+
+// ─── Constants ──────────────────────────────────────────────────────
+
+/**
+ * Pre-cap budget for audit note bodies. The underlying DB column /
+ * take_note cap is 3000 chars; the orchestrator instructs auditors to
+ * stay under 2900 so a tightening retry has room to land. See
+ * spec §4.5.
+ */
+export const MAX_AUDIT_NOTE_BODY_CHARS = 2900;
+
+// ─── Shared fragments ───────────────────────────────────────────────
+
+const confidenceEnum = z.enum(['low', 'medium', 'high']);
+
+const hypothesisEnum = z.enum([
+  'likely-done',
+  'likely-drifted',
+  'likely-cancelled',
+  'no-evidence',
+  'needs-deep-dive',
+]);
+
+const evidenceRefSchema = z.object({
+  kind: z.enum(['file', 'git', 'pr', 'note']),
+  ref: z.string().min(1),
+});
+
+const isoDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'must be YYYY-MM-DD');
+
+// ─── §4.2 — audit_manifest body schema (L1 surveyor output) ─────────
+
+const manifestNodeSchema = z.object({
+  initiative_id: z.string().min(1),
+  title: z.string().min(1),
+  current_status: z.string().min(1),
+  hypothesis: hypothesisEnum,
+  confidence: confidenceEnum,
+  investigation_prompt: z.string().min(1),
+  scoped_evidence_hints: z.array(z.string()).default([]),
+  skip: z.boolean(),
+});
+
+export const auditManifestBodySchema = z.object({
+  version: z.literal(1),
+  root_initiative_id: z.string().min(1),
+  attempt: z.number().int().nonnegative(),
+  previous_synthesis_run_group_id: z.string().nullable(),
+  summary: z.string().min(1),
+  nodes: z.array(manifestNodeSchema),
+  cross_cutting_questions: z.array(z.string()).default([]),
+});
+
+export type AuditManifestBody = z.infer<typeof auditManifestBodySchema>;
+
+// ─── §4.3 — audit_proposal body schema (L2 + synthetic skip-keeps) ──
+
+// §4.3.1 — discriminated union by `proposed_action`.
+const proposedChangesByAction = z.discriminatedUnion('proposed_action', [
+  z.object({
+    proposed_action: z.literal('keep'),
+    // `keep` proposes no mutation — the changes object must be empty.
+    // We validate this via superRefine below rather than relying on
+    // .strict() inside an intersection, which doesn't preserve strict
+    // mode reliably across all zod chains.
+    proposed_changes: z.record(z.string(), z.unknown()),
+  }),
+  z.object({
+    proposed_action: z.literal('mark_done'),
+    proposed_changes: z.object({ note: z.string().min(1) }).strict(),
+  }),
+  z.object({
+    proposed_action: z.literal('cancel'),
+    proposed_changes: z.object({ reason: z.string().min(1) }).strict(),
+  }),
+  z.object({
+    proposed_action: z.literal('modify_scope'),
+    proposed_changes: z
+      .object({
+        title: z.string().min(1).optional(),
+        description: z.string().min(1).optional(),
+      })
+      .strict()
+      .refine(
+        (v) => v.title !== undefined || v.description !== undefined,
+        'modify_scope requires at least one of {title, description}',
+      ),
+  }),
+  z.object({
+    proposed_action: z.literal('modify_dates'),
+    proposed_changes: z
+      .object({
+        target_start: isoDateSchema.optional(),
+        target_end: isoDateSchema.optional(),
+      })
+      .strict()
+      .refine(
+        (v) => v.target_start !== undefined || v.target_end !== undefined,
+        'modify_dates requires at least one of {target_start, target_end}',
+      ),
+  }),
+]);
+
+const proposalCommonSchema = z.object({
+  version: z.literal(1),
+  node_initiative_id: z.string().min(1),
+  current_mc_status: z.string().min(1),
+  current_mc_target_end: z.string().nullable(),
+  repo_evidence: z
+    .array(evidenceRefSchema)
+    .min(1, 'repo_evidence must have at least one entry'),
+  rationale: z.string().min(1),
+  confidence: confidenceEnum,
+  would_confirm_by: z.string().nullable().optional(),
+  continuation_note_id: z.string().nullable().optional(),
+});
+
+export const auditProposalBodySchema = proposalCommonSchema
+  .and(proposedChangesByAction)
+  .superRefine((data, ctx) => {
+    // Spec §4.3: when confidence < high, would_confirm_by is required.
+    if (
+      data.confidence !== 'high' &&
+      (data.would_confirm_by == null || data.would_confirm_by.trim() === '')
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'would_confirm_by is required when confidence is low or medium',
+        path: ['would_confirm_by'],
+      });
+    }
+    // §4.3.1: `keep` proposes no mutation — proposed_changes must be {}.
+    if (
+      data.proposed_action === 'keep' &&
+      Object.keys(data.proposed_changes as Record<string, unknown>).length > 0
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "proposed_changes must be an empty object when proposed_action is 'keep'",
+        path: ['proposed_changes'],
+      });
+    }
+  });
+
+export type AuditProposalBody = z.infer<typeof auditProposalBodySchema>;
+
+// ─── §4.4 — audit_synthesis body schema (L3 synthesizer output) ─────
+
+const epicProposalSchema = z.discriminatedUnion('proposed_action', [
+  z.object({
+    proposed_action: z.literal('modify_epic_dates'),
+    proposed_changes: z
+      .object({
+        target_start: isoDateSchema.optional(),
+        target_end: isoDateSchema.optional(),
+      })
+      .strict()
+      .refine(
+        (v) => v.target_start !== undefined || v.target_end !== undefined,
+        'modify_epic_dates requires at least one of {target_start, target_end}',
+      ),
+    rationale: z.string().min(1),
+    confidence: confidenceEnum,
+  }),
+  z.object({
+    proposed_action: z.literal('modify_epic_scope'),
+    proposed_changes: z
+      .object({
+        title: z.string().min(1).optional(),
+        description: z.string().min(1).optional(),
+      })
+      .strict()
+      .refine(
+        (v) => v.title !== undefined || v.description !== undefined,
+        'modify_epic_scope requires at least one of {title, description}',
+      ),
+    rationale: z.string().min(1),
+    confidence: confidenceEnum,
+  }),
+]);
+
+const crossNodeProposalSchema = z.discriminatedUnion('proposed_action', [
+  z.object({
+    proposed_action: z.literal('merge_stories'),
+    subject_initiative_ids: z.array(z.string().min(1)).min(2),
+    rationale: z.string().min(1),
+    confidence: confidenceEnum,
+  }),
+  z.object({
+    proposed_action: z.literal('split_story'),
+    subject_initiative_ids: z.array(z.string().min(1)).length(1),
+    rationale: z.string().min(1),
+    confidence: confidenceEnum,
+  }),
+  z.object({
+    proposed_action: z.literal('new_story'),
+    proposed_new_node: z.object({
+      kind: z.enum(['epic', 'story']),
+      title: z.string().min(1),
+      description: z.string().min(1),
+      estimated_effort_hours: z.number().nonnegative().optional(),
+    }),
+    rationale: z.string().min(1),
+    confidence: confidenceEnum,
+  }),
+]);
+
+export const auditSynthesisBodySchema = z.object({
+  version: z.literal(1),
+  root_initiative_id: z.string().min(1),
+  attempt: z.number().int().nonnegative(),
+  completion_sentinel: z.string().min(1),
+  epic_proposals: z.array(epicProposalSchema).default([]),
+  cross_node_proposals: z.array(crossNodeProposalSchema).default([]),
+});
+
+export type AuditSynthesisBody = z.infer<typeof auditSynthesisBodySchema>;
+
+// ─── Validation helper ──────────────────────────────────────────────
+
+export type AuditNoteKind =
+  | 'audit_manifest'
+  | 'audit_proposal'
+  | 'audit_synthesis';
+
+export function isAuditNoteKind(kind: NoteKind): kind is AuditNoteKind {
+  return (
+    kind === 'audit_manifest' ||
+    kind === 'audit_proposal' ||
+    kind === 'audit_synthesis'
+  );
+}
+
+export type ValidateAuditNoteResult =
+  | { ok: true; parsed: unknown }
+  | { ok: false; error: string };
+
+/**
+ * Parse a JSON-stringified body and validate it against the Zod schema
+ * for the given audit kind. Returns a structured result the MCP
+ * `take_note` handler relays to the auditor agent so retry logic can
+ * key on the failing field path.
+ *
+ * No-op (returns `{ ok: false, error: 'not an audit kind' }`) when
+ * called with a non-audit kind — the handler should pre-filter via
+ * `isAuditNoteKind` so this branch is defensive.
+ */
+export function validateAuditNoteBody(
+  kind: NoteKind,
+  bodyJson: string,
+): ValidateAuditNoteResult {
+  if (!isAuditNoteKind(kind)) {
+    return { ok: false, error: `not an audit kind: ${kind}` };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyJson);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: `body must be a JSON string for kind=${kind} — JSON.parse failed: ${msg}`,
+    };
+  }
+
+  const schema =
+    kind === 'audit_manifest'
+      ? auditManifestBodySchema
+      : kind === 'audit_proposal'
+        ? auditProposalBodySchema
+        : auditSynthesisBodySchema;
+
+  const result = schema.safeParse(parsed);
+  if (result.success) {
+    return { ok: true, parsed: result.data };
+  }
+
+  // Compact, agent-readable error: "field.path: message; field.path: message".
+  // Avoids dumping the full ZodError tree.
+  const issues = result.error.issues.slice(0, 5).map((iss) => {
+    const path = iss.path.length > 0 ? iss.path.join('.') : '<root>';
+    return `${path}: ${iss.message}`;
+  });
+  const more =
+    result.error.issues.length > issues.length
+      ? ` (+${result.error.issues.length - issues.length} more)`
+      : '';
+  return {
+    ok: false,
+    error:
+      `body failed ${kind} schema validation — ${issues.join('; ')}${more}`,
+  };
+}

--- a/src/lib/db/agent-notes.test.ts
+++ b/src/lib/db/agent-notes.test.ts
@@ -143,6 +143,46 @@ test('listNotes: kinds filter', () => {
   assert.ok(blockerOrDiscovery.every((n) => n.kind === 'blocker' || n.kind === 'discovery'));
 });
 
+test('listNotes: exclude_kinds filter (audit kinds excluded by default cross-audit reads)', () => {
+  const ws = freshWorkspace();
+  createNote(baseInput(ws, { workspace_id: ws, body: 'd', kind: 'discovery' }));
+  createNote(baseInput(ws, { workspace_id: ws, body: 'o', kind: 'observation' }));
+  // Audit kinds — must be filtered out by default cross-audit readers
+  // (briefing builder, Notes Rail). See spec §4.1.
+  createNote(
+    baseInput(ws, {
+      workspace_id: ws,
+      body: JSON.stringify({ version: 1 }),
+      kind: 'audit_manifest',
+    }),
+  );
+  createNote(
+    baseInput(ws, {
+      workspace_id: ws,
+      body: JSON.stringify({ version: 1 }),
+      kind: 'audit_proposal',
+    }),
+  );
+  createNote(
+    baseInput(ws, {
+      workspace_id: ws,
+      body: JSON.stringify({ version: 1 }),
+      kind: 'audit_synthesis',
+    }),
+  );
+
+  const filtered = listNotes({
+    workspace_id: ws,
+    exclude_kinds: ['audit_manifest', 'audit_proposal', 'audit_synthesis'],
+  });
+  const kinds = filtered.map((n) => n.kind).sort();
+  assert.deepEqual(kinds, ['discovery', 'observation']);
+
+  // Sanity: without the filter all five are visible.
+  const all = listNotes({ workspace_id: ws });
+  assert.equal(all.length, 5);
+});
+
 test('listNotes: audience filter accepts NULL or exact match', () => {
   const ws = freshWorkspace();
   createNote(baseInput(ws, { body: 'public', audience: null }));

--- a/src/lib/db/agent-notes.ts
+++ b/src/lib/db/agent-notes.ts
@@ -23,7 +23,10 @@ export type NoteKind =
   | 'decision'
   | 'observation'
   | 'question'
-  | 'breadcrumb';
+  | 'breadcrumb'
+  | 'audit_manifest'
+  | 'audit_proposal'
+  | 'audit_synthesis';
 
 export const NOTE_KINDS: ReadonlyArray<NoteKind> = [
   'discovery',
@@ -33,6 +36,23 @@ export const NOTE_KINDS: ReadonlyArray<NoteKind> = [
   'observation',
   'question',
   'breadcrumb',
+  'audit_manifest',
+  'audit_proposal',
+  'audit_synthesis',
+];
+
+/**
+ * Note kinds emitted by the subtree-audit pipeline (see
+ * specs/subtree-audit-proposals-spec.md). These are excluded by default
+ * from cross-audit reads (briefing builder, Notes Rail, default
+ * `listNotes` calls) so audit artifacts don't bleed into unrelated
+ * agent context. The proposal queue UI and the audit orchestrator
+ * itself read them explicitly via the `kinds` filter.
+ */
+export const AUDIT_NOTE_KINDS: ReadonlyArray<NoteKind> = [
+  'audit_manifest',
+  'audit_proposal',
+  'audit_synthesis',
 ];
 
 export type NoteImportance = 0 | 1 | 2;
@@ -155,6 +175,16 @@ export interface ListNotesFilter {
   audience?: string;
   /** When set, restrict to these note kinds. */
   kinds?: ReadonlyArray<NoteKind>;
+  /**
+   * When set, exclude these note kinds. Applied AFTER `kinds` (i.e. the
+   * intersection: kept iff `kind ∈ kinds` and `kind ∉ exclude_kinds`).
+   * Used by cross-audit readers (briefing assembly, Notes Rail) to
+   * filter out audit-pipeline artifacts (`audit_manifest`,
+   * `audit_proposal`, `audit_synthesis`) without enumerating the
+   * allow-list each time. See `AUDIT_NOTE_KINDS` and
+   * specs/subtree-audit-proposals-spec.md §4.1.
+   */
+  exclude_kinds?: ReadonlyArray<NoteKind>;
   /** When set, exclude notes whose `consumed_by_stages` already includes this stage. */
   not_consumed_by_stage?: string;
   /** When set, include archived notes; default excludes them. */
@@ -205,6 +235,11 @@ export function listNotes(filter: ListNotesFilter): AgentNote[] {
     const placeholders = filter.kinds.map(() => '?').join(',');
     where.push(`kind IN (${placeholders})`);
     args.push(...filter.kinds);
+  }
+  if (filter.exclude_kinds && filter.exclude_kinds.length > 0) {
+    const placeholders = filter.exclude_kinds.map(() => '?').join(',');
+    where.push(`kind NOT IN (${placeholders})`);
+    args.push(...filter.exclude_kinds);
   }
   if (filter.not_consumed_by_stage) {
     // SQLite has no native JSON containment in older builds; we do a

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4533,6 +4533,65 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    id: '087',
+    name: 'agent_notes_audit_kinds',
+    up: (db) => {
+      // Phase 1 of specs/subtree-audit-proposals-spec.md adds three new
+      // NoteKind values (audit_manifest, audit_proposal,
+      // audit_synthesis). The migration-065 CHECK constraint enumerates
+      // the allowed kinds, so we have to rebuild the table to extend
+      // it. Standard SQLite "table swap" recipe.
+      db.exec('PRAGMA foreign_keys = OFF');
+      db.exec(`
+        CREATE TABLE agent_notes_new (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+          task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
+          initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
+          scope_key TEXT NOT NULL,
+          role TEXT NOT NULL,
+          run_group_id TEXT NOT NULL,
+          kind TEXT NOT NULL CHECK (kind IN (
+            'discovery','blocker','uncertainty','decision',
+            'observation','question','breadcrumb',
+            'audit_manifest','audit_proposal','audit_synthesis'
+          )),
+          audience TEXT,
+          body TEXT NOT NULL,
+          attached_files TEXT,
+          importance INTEGER NOT NULL DEFAULT 0 CHECK (importance IN (0,1,2)),
+          consumed_by_stages TEXT,
+          archived_at TEXT,
+          archived_reason TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          pm_proposal_ids TEXT
+        );
+      `);
+      db.exec(`
+        INSERT INTO agent_notes_new
+          (id, workspace_id, agent_id, task_id, initiative_id, scope_key, role,
+           run_group_id, kind, audience, body, attached_files, importance,
+           consumed_by_stages, archived_at, archived_reason, created_at,
+           pm_proposal_ids)
+        SELECT id, workspace_id, agent_id, task_id, initiative_id, scope_key, role,
+           run_group_id, kind, audience, body, attached_files, importance,
+           consumed_by_stages, archived_at, archived_reason, created_at,
+           pm_proposal_ids
+        FROM agent_notes;
+      `);
+      db.exec(`DROP TABLE agent_notes`);
+      db.exec(`ALTER TABLE agent_notes_new RENAME TO agent_notes`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_notes_task ON agent_notes(task_id, created_at DESC) WHERE task_id IS NOT NULL`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_notes_initiative ON agent_notes(initiative_id, created_at DESC) WHERE initiative_id IS NOT NULL`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_notes_workspace ON agent_notes(workspace_id, created_at DESC)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_notes_run_group ON agent_notes(run_group_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_notes_importance ON agent_notes(workspace_id, importance, created_at DESC) WHERE archived_at IS NULL`);
+      db.exec('PRAGMA foreign_keys = ON');
+      console.log('[Migration 087] agent_notes.kind extended with audit_manifest / audit_proposal / audit_synthesis.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/mcp/groups/core.ts
+++ b/src/lib/mcp/groups/core.ts
@@ -29,6 +29,11 @@ import {
   type NoteImportance,
   type NoteKind,
 } from '@/lib/db/agent-notes';
+import {
+  isAuditNoteKind,
+  validateAuditNoteBody,
+  MAX_AUDIT_NOTE_BODY_CHARS,
+} from '@/lib/agents/audit-proposals/schemas';
 import { getRunByGroupId } from '@/lib/db/agent-runs';
 import { broadcast } from '@/lib/events';
 
@@ -422,6 +427,45 @@ export function registerCoreTools(server: McpServer): void {
             content: [{ type: 'text', text: message }],
             structuredContent: { error: 'run_cancelled', message, run_id: owningRun.id },
           };
+        }
+
+        // Audit-pipeline kinds (audit_manifest / audit_proposal /
+        // audit_synthesis) carry a JSON-stringified body that must
+        // match a strict Zod schema and stay under the orchestrator's
+        // pre-cap budget. Validation runs here so auditor agents get
+        // structured feedback in the same dispatch and can retry by
+        // tightening rationale / fixing the schema. See
+        // specs/subtree-audit-proposals-spec.md §4 + §5.2.
+        const noteKind = args.kind as NoteKind;
+        if (isAuditNoteKind(noteKind)) {
+          if (args.body.length > MAX_AUDIT_NOTE_BODY_CHARS) {
+            const message =
+              `Body exceeds ${MAX_AUDIT_NOTE_BODY_CHARS} chars (got ${args.body.length}). ` +
+              `Tighten the rationale or split via continuation_note_id (see spec §4.5).`;
+            return {
+              isError: true,
+              content: [{ type: 'text', text: message }],
+              structuredContent: {
+                error: 'audit_body_too_large',
+                message,
+                limit: MAX_AUDIT_NOTE_BODY_CHARS,
+                got: args.body.length,
+                kind: noteKind,
+              },
+            };
+          }
+          const validation = validateAuditNoteBody(noteKind, args.body);
+          if (!validation.ok) {
+            return {
+              isError: true,
+              content: [{ type: 'text', text: validation.error }],
+              structuredContent: {
+                error: 'audit_body_invalid',
+                message: validation.error,
+                kind: noteKind,
+              },
+            };
+          }
         }
 
         const note = createNote({

--- a/src/lib/mcp/mcp.test.ts
+++ b/src/lib/mcp/mcp.test.ts
@@ -682,3 +682,123 @@ test('take_note fails open when run_group_id is unknown (legacy / brief dispatch
   });
   assert.equal(res.isError, undefined);
 });
+
+// ─── take_note: audit-kind body validation ──────────────────────────
+//
+// Phase 1 of specs/subtree-audit-proposals-spec.md adds three new note
+// kinds (audit_manifest, audit_proposal, audit_synthesis) whose bodies
+// must JSON-parse and conform to a Zod schema. Validation runs in the
+// MCP handler so auditor agents get structured feedback in the same
+// dispatch and can recover.
+
+test('take_note rejects audit_proposal with malformed body and returns structured error', async () => {
+  const { client } = await makePair();
+  const me = seedAgent();
+  const res = await client.callTool({
+    name: 'take_note',
+    arguments: {
+      agent_id: me,
+      // Missing required fields (proposed_action, repo_evidence, …).
+      kind: 'audit_proposal',
+      body: JSON.stringify({ version: 1, node_initiative_id: 'n', current_mc_status: 'done' }),
+      scope_key: 'agent:auditor:scope',
+      role: 'auditor',
+      run_group_id: crypto.randomUUID(),
+    },
+  });
+  assert.equal(res.isError, true, 'malformed audit_proposal body must error');
+  const payload = parseStructured<{ error: string; message: string; kind: string }>(res);
+  assert.equal(payload.error, 'audit_body_invalid');
+  assert.equal(payload.kind, 'audit_proposal');
+  assert.match(payload.message, /audit_proposal/);
+});
+
+test('take_note rejects audit_manifest with non-JSON body', async () => {
+  const { client } = await makePair();
+  const me = seedAgent();
+  const res = await client.callTool({
+    name: 'take_note',
+    arguments: {
+      agent_id: me,
+      kind: 'audit_manifest',
+      body: 'not even close to JSON',
+      scope_key: 'agent:auditor:scope',
+      role: 'auditor',
+      run_group_id: crypto.randomUUID(),
+    },
+  });
+  assert.equal(res.isError, true);
+  const payload = parseStructured<{ error: string; message: string }>(res);
+  assert.equal(payload.error, 'audit_body_invalid');
+  assert.match(payload.message, /JSON\.parse/);
+});
+
+test('take_note rejects audit body that exceeds the orchestrator pre-cap budget', async () => {
+  const { client } = await makePair();
+  const me = seedAgent();
+  // 2950 chars — under the DB cap (3000) but over the audit pre-cap (2900).
+  const oversized = 'x'.repeat(2950);
+  const res = await client.callTool({
+    name: 'take_note',
+    arguments: {
+      agent_id: me,
+      kind: 'audit_synthesis',
+      body: oversized,
+      scope_key: 'agent:auditor:scope',
+      role: 'auditor',
+      run_group_id: crypto.randomUUID(),
+    },
+  });
+  assert.equal(res.isError, true);
+  const payload = parseStructured<{ error: string; message: string; limit: number }>(res);
+  assert.equal(payload.error, 'audit_body_too_large');
+  assert.equal(payload.limit, 2900);
+  assert.match(payload.message, /Tighten the rationale/);
+});
+
+test('take_note accepts a schema-conformant audit_proposal body', async () => {
+  const { client } = await makePair();
+  const me = seedAgent();
+  const validBody = {
+    version: 1,
+    node_initiative_id: 'init-x',
+    current_mc_status: 'done',
+    current_mc_target_end: null,
+    proposed_action: 'keep',
+    proposed_changes: {},
+    repo_evidence: [{ kind: 'file', ref: 'src/x.ts:1' }],
+    rationale: 'No drift detected.',
+    confidence: 'high',
+    would_confirm_by: null,
+    continuation_note_id: null,
+  };
+  const res = await client.callTool({
+    name: 'take_note',
+    arguments: {
+      agent_id: me,
+      kind: 'audit_proposal',
+      body: JSON.stringify(validBody),
+      scope_key: 'agent:auditor:scope',
+      role: 'auditor',
+      run_group_id: crypto.randomUUID(),
+    },
+  });
+  assert.equal(res.isError, undefined, JSON.stringify(res));
+});
+
+test('take_note leaves non-audit kinds untouched (no JSON requirement on observation)', async () => {
+  const { client } = await makePair();
+  const me = seedAgent();
+  const res = await client.callTool({
+    name: 'take_note',
+    arguments: {
+      agent_id: me,
+      kind: 'observation',
+      body: 'a perfectly normal prose observation',
+      scope_key: 'agent:researcher:scope',
+      role: 'researcher',
+      run_group_id: crypto.randomUUID(),
+    },
+  });
+  assert.equal(res.isError, undefined);
+});

--- a/src/lib/mcp/shared.ts
+++ b/src/lib/mcp/shared.ts
@@ -15,9 +15,11 @@ import { authzErrorToToolResult, internalErrorToToolResult } from './errors';
 import { logMcpToolCall } from './debug';
 import { PmProposalValidationError } from '@/lib/db/pm-proposals';
 import {
+  NOTE_KINDS,
   parseAttachedFiles,
   parsePmProposalIds,
   type AgentNote,
+  type NoteKind,
 } from '@/lib/db/agent-notes';
 
 // ─── shared zod fragments ────────────────────────────────────────────
@@ -167,8 +169,11 @@ export function deriveWorkspaceFromAgent(agentId: string): string {
 
 // ─── notes spine helpers (shared by core take/read + work consume/archive) ───
 
+// Single source of truth: NOTE_KINDS from the DB module. The Zod enum
+// picks up new kinds (e.g. audit_manifest / audit_proposal /
+// audit_synthesis) automatically — no schema duplication.
 export const noteKindArg = z
-  .enum(['discovery', 'blocker', 'uncertainty', 'decision', 'observation', 'question', 'breadcrumb'])
+  .enum(NOTE_KINDS as readonly [NoteKind, ...NoteKind[]])
   .describe('What kind of note this is. See agent-templates/_shared/notetaker.md for guidance.');
 
 export const noteImportanceArg = z


### PR DESCRIPTION
## Summary
Phase 1 of [spec #284](https://github.com/smb209/mission-control/pull/284) ([specs/subtree-audit-proposals-spec.md](specs/subtree-audit-proposals-spec.md)). Pure schema + plumbing — no behavior changes to existing audits. Lays the groundwork Phases 2–4 build on.

## Changes
- **`NoteKind` extended** with `audit_manifest` / `audit_proposal` / `audit_synthesis` (`src/lib/db/agent-notes.ts`).
- **Migration 087** rebuilds `agent_notes` to extend the `kind` CHECK constraint — standard SQLite table-swap recipe (FK off, recreate, copy, drop, rename, indexes back, FK on).
- **`src/lib/agents/audit-proposals/schemas.ts`** (new) — Zod schemas for §4.2 manifest, §4.3 proposal (discriminated union over `proposed_action` per §4.3.1), §4.4 synthesis. Exports `validateAuditNoteBody`, `isAuditNoteKind`, `MAX_AUDIT_NOTE_BODY_CHARS = 2900` (orchestrator pre-cap budget under the 3000-char `take_note` cap).
- **`take_note` MCP handler** validates body length + schema iff `kind ∈ AUDIT_NOTE_KINDS`. Returns `audit_body_too_large` / `audit_body_invalid` structured errors mirroring the cancelled-run guard so auditor agents recover on the same dispatch.
- **`listNotes`** gains an `exclude_kinds` filter; `AUDIT_NOTE_KINDS` const exported for future cross-audit readers (Phase 2+ wires this into briefing-side reads).

## Spec deviations (documented in §9.1; subagent report)
- `briefing.ts` doesn't call `listNotes` directly — agents read notes via the `read_notes` MCP tool. So instead of "modify briefing builder's note-pull," the filter primitive is added to `listNotes` itself; Phase 2 will adopt it where notes are pulled for the surveyor's briefing.
- Migration 087 wasn't called out in the spec but is load-bearing — the migration-065 CHECK constraint enumerates allowed kinds.
- `keep`-action empty `proposed_changes` enforced via `superRefine` rather than `.strict()` inside the discriminated union (Zod chain didn't preserve strictness reliably; the refine is more readable and produces a clean field-path error).

## Test plan
- [x] `yarn test`: **913 pass, 1 fail**. The one fail is pre-existing on main: `src/lib/research/eval/schedule-runner.test.ts: produces a brief and advances run_count` (`0 !== 1`) — unrelated to this change, verified via `git stash`.
- [x] New tests: round-trip + rejection for each schema; `exclude_kinds` filter coverage; end-to-end `take_note` tests for the three new validation paths (malformed, non-JSON, oversize, schema-conformant accept, non-audit kind passthrough).
- [ ] Pre-existing TypeScript errors elsewhere (not in this change set):
  - `src/app/api/pm/proposals/[id]/route.ts:55` — `'pm_proposal_deleted'` not in `SSEEventType`
  - `src/lib/agents/pm-decompose.test.ts:169,173` — unused `@ts-expect-error` + bad `'theme'` literal
- N/A: preview-verify (no UI / runtime behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)