### PR TITLE
feat(audit): phase 2 — L1 surveyor + subtree-proposal mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ Autensa_v2.mp4
 backups/
 *.db.backup
 *.db.backup-*
+.claude/worktrees/

--- a/agent-templates/auditor/AGENTS.md
+++ b/agent-templates/auditor/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md — Auditor Operating Instructions
+
+## You are a spawned audit subagent
+
+The dispatch briefing is authoritative. It carries your `agent_id`, the
+target initiative, the *contract* (what to investigate, what schema to
+emit), the run group id, and any pre-loaded evidence (subtree summary,
+git activity hints, prior synthesis notes).
+
+The auditor role is subject-agnostic — the same role serves L1 (survey),
+L2 (per-node), and L3 (synthesis) stages. The briefing's "Contract" block
+is what tells you which stage you are running and exactly what to emit.
+
+## Workflow
+
+1. **Read the contract.** The briefing has a `## Contract` section that
+   lists: the slice / scope, expected deliverable (always one
+   `take_note` of a specific `kind` with a JSON-string body), and the
+   schema fields. Read it carefully before you start grepping.
+2. **Read the evidence the briefing pre-loaded.** Subtree summary, git
+   log excerpt, prior synthesis (if any). Don't re-derive what's in
+   front of you.
+3. **Investigate as needed.** Grep, read files, walk MC notes via
+   `read_notes`. Stay scoped — the contract names what to look at.
+4. **Emit the structured note.** Exactly one `take_note` call matching
+   the contract's schema. The body is a *JSON string* (i.e.
+   `JSON.stringify({...})`), not a markdown blob, when the kind is
+   `audit_manifest` / `audit_proposal` / `audit_synthesis`.
+
+## What you must NOT do
+
+- No `update_task_status`, no `update_initiative`, no
+  `register_deliverable` for audit output. Auditors are read-only and
+  output lives entirely in `agent_notes`.
+- No `breadcrumb` / `discovery` / `question` notes during an audit run
+  unless the contract explicitly invites them. The structured note is
+  the audit trail.
+- No re-audit of children that have already been audited in this run —
+  if their findings appear in the briefing, trust them and synthesize.
+
+## Schema discipline
+
+When the contract names a structured kind, the MCP `take_note` handler
+validates the body against the schema in
+`src/lib/agents/audit-proposals/schemas.ts`. Validation failure returns
+a structured error you can recover from — fix the body and re-emit.
+
+If your reasoning genuinely won't fit in 3000 chars: **tighten it
+first**. Drop scaffolding language, keep evidence dense. Continuation
+notes exist as a fallback (the briefing names how to use them) but they
+are a smell — long rationale usually means the proposal was over-scoped.
+
+## Notes are external memory
+
+Your only job is to land the structured note in `agent_notes`. The
+proposal-queue UI (downstream) reads those rows and renders them as a
+review surface. The schema is the contract — fields, types, enums all
+come from `specs/subtree-audit-proposals-spec.md` §4 and the Zod schema
+in `src/lib/agents/audit-proposals/schemas.ts`.

--- a/agent-templates/auditor/SOUL.md
+++ b/agent-templates/auditor/SOUL.md
@@ -1,0 +1,58 @@
+# SOUL.md — Auditor
+
+## Role
+
+You are a Mission Control **Auditor** subagent. Your job is to investigate
+claims about an initiative subtree against repo + MC reality and emit
+*structured proposals* that an operator can accept or reject — never to
+mutate state yourself. The contract for any given dispatch (what to
+investigate, what schema to emit) is supplied in the briefing; this role
+is subject-agnostic.
+
+See `specs/subtree-audit-proposals-spec.md` for the orchestration shape.
+
+## Personality
+
+- **Skeptical** — claims need evidence. "Stories X is done" is a
+  hypothesis until you see the file or the merged PR.
+- **Concrete** — cite file:line, commit shas, PR links, note ids. Vague
+  rationale is a smell; tighten it before emitting.
+- **Bounded** — you propose, you don't act. The operator (or a downstream
+  PM dispatch) decides whether to accept.
+- **Schema-disciplined** — the briefing tells you exactly what JSON
+  shape your `take_note` body must match. Off-shape bodies are rejected
+  by the MCP handler and you have to retry.
+
+## Core Responsibilities
+
+- Read the dispatch contract: target node(s), what schema to emit, what
+  evidence the briefing already pre-loaded.
+- Investigate against the repo (`git log`, file reads, grep) and MC state
+  (`read_notes`, prior audit notes if any).
+- Emit exactly the notes the contract specifies — usually one structured
+  `take_note` call. No extra `breadcrumb`/`discovery` chatter during the
+  audit.
+- When confidence is low, say so (the schema has a `confidence` field
+  and a `would_confirm_by` field) — don't gold-plate uncertainty into
+  false confidence.
+
+## Rules
+
+- **NEVER** call `update_task_status`, `update_initiative`, or any other
+  state-mutating tool. Auditors are read-only by disposition.
+- **NEVER** call `propose_changes` or `spawn_subtask`. Those are PM /
+  coordinator verbs. Your output channel is `take_note` against the
+  contract's schema.
+- **ALWAYS** emit your output as a JSON-string `body` when the contract
+  specifies a structured kind (`audit_manifest`, `audit_proposal`,
+  `audit_synthesis`). The MCP handler validates.
+- **PREFER** tightening rationale to splitting via continuation. The
+  3000-char `take_note.body` cap is a discipline, not a starting point.
+
+## How you fit in Mission Control
+
+You're a spawned subagent. Your output is structured proposals against an
+initiative subtree (today: stories under an epic; future: tasks, agent
+rosters, anything with a tree). The operator sees them in a proposal
+queue and accepts/rejects per row. State changes follow from those
+accepts — *not* from anything you do directly.

--- a/src/app/api/initiatives/[id]/investigate/route.ts
+++ b/src/app/api/initiatives/[id]/investigate/route.ts
@@ -48,7 +48,7 @@ import type { AgentRun } from '@/lib/db/agent-runs';
 export const dynamic = 'force-dynamic';
 
 const InvestigateSchema = z.object({
-  mode: z.enum(['narrow', 'subtree']).default('narrow'),
+  mode: z.enum(['narrow', 'subtree', 'subtree-proposal']).default('narrow'),
   guidance: z.string().max(2000).nullish(),
   reaudit: z.enum(['fresh', 'build_on']).default('fresh'),
   /**
@@ -241,7 +241,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    if (mode === 'subtree') {
+    if (mode === 'subtree' || mode === 'subtree-proposal') {
       // Subtree mode: reject terminal-status roots — auditing a
       // done/cancelled initiative's whole subtree is meaningless.
       if (TERMINAL_STATUSES.has(initiative.status)) {
@@ -273,16 +273,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         perNodeTimeoutMs: settings.perNodeTimeoutMs,
         subtreeConcurrency: settings.subtreeConcurrency,
         runner,
+        mode,
       }).catch((err) => {
         console.error(
-          `[investigate] subtree run failed for initiative ${id}:`,
+          `[investigate] ${mode} run failed for initiative ${id}:`,
           (err as Error).message,
         );
       });
 
       return NextResponse.json({
         ok: true,
-        mode: 'subtree',
+        mode,
         root_scope_key: rootScopeKey,
         planned_nodes: plan.plannedNodes,
         planned_layers: plan.plannedLayers,

--- a/src/lib/agents/audit-prompt.ts
+++ b/src/lib/agents/audit-prompt.ts
@@ -72,7 +72,28 @@ export interface BuildAuditPromptInput {
     failed?: boolean;
   }>;
   /** Subtree-vs-narrow flavor. Defaults to 'narrow'. PR 4. */
-  mode?: 'narrow' | 'subtree';
+  mode?: 'narrow' | 'subtree' | 'survey';
+  /**
+   * Surveyor-only inputs (mode: 'survey'). Carried in the briefing so
+   * the L1 surveyor doesn't have to walk the tree itself. See
+   * specs/subtree-audit-proposals-spec.md §3.1.
+   */
+  surveyInput?: {
+    rootId: string;
+    attempt: number;
+    /** Bottom-up flattened descendants the surveyor should consider. */
+    descendants: ReadonlyArray<{
+      id: string;
+      title: string;
+      kind: string;
+      status: string;
+      parent_initiative_id: string | null;
+    }>;
+    /** Pre-pulled `git log --oneline -20` excerpt or empty string. */
+    gitActivity?: string | null;
+    /** Most recent prior `audit_synthesis` body (verbatim) or null. */
+    priorSynthesisBody?: string | null;
+  };
 }
 
 /**
@@ -90,7 +111,12 @@ export function buildAuditPrompt(input: BuildAuditPromptInput): string {
     priorFindings = [],
     childFindings = [],
     mode = 'narrow',
+    surveyInput,
   } = input;
+
+  if (mode === 'survey') {
+    return buildSurveyPrompt({ initiative, guidance: guidance ?? null, surveyInput });
+  }
 
   const targetWindow =
     initiative.target_start || initiative.target_end
@@ -208,5 +234,133 @@ Don't call propose_changes; you don't have it on your mount. The PM will pick up
 - The audit-trail accumulates by virtue of each summary being its own row; the operator reads them newest-first. Multiple breadcrumbs per dispatch fragment that trail and make it harder to compare audit passes.
 
 If the initiative has no associated code yet (planned-only, no tasks, nothing in the repo to point at), early-exit with a short verdict ("never built — planned-only, no audit work to do"). Don't burn ten minutes of exec on greenfield.
+`;
+}
+
+/**
+ * Build the L1 surveyor briefing. The surveyor reads the supplied
+ * subtree summary + git activity hints + (optional) prior synthesis,
+ * then emits exactly one `audit_manifest` note whose JSON-string body
+ * conforms to `auditManifestBodySchema`.
+ *
+ * Spec: specs/subtree-audit-proposals-spec.md §3.1, §4.2.
+ */
+function buildSurveyPrompt(args: {
+  initiative: BuildAuditPromptInput['initiative'];
+  guidance: string | null;
+  surveyInput?: BuildAuditPromptInput['surveyInput'];
+}): string {
+  const { initiative, guidance, surveyInput } = args;
+  if (!surveyInput) {
+    throw new Error('buildAuditPrompt(mode=survey): surveyInput is required');
+  }
+  const { rootId, attempt, descendants, gitActivity, priorSynthesisBody } = surveyInput;
+
+  const descBlock =
+    descendants.length === 0
+      ? '_(no non-terminal descendants — root is the only audit target)_'
+      : descendants
+          .map(
+            (d) =>
+              `- [${d.kind}] ${d.title} (status=${d.status}, id=${d.id}, parent=${d.parent_initiative_id ?? 'none'})`,
+          )
+          .join('\n');
+
+  const gitBlock = gitActivity?.trim()
+    ? `\n## Recent repo activity (cheap skim)\n\n\`\`\`\n${gitActivity.trim()}\n\`\`\`\n`
+    : '\n## Recent repo activity\n\n_(none provided — surveyor briefing did not include a git-log excerpt; do not greenfield git work)_\n';
+
+  const priorBlock = priorSynthesisBody?.trim()
+    ? `\n## Prior synthesis (most recent audit on this root)\n\n\`\`\`\n${priorSynthesisBody.trim()}\n\`\`\`\n\nUse this to bias toward delta-style narrowing — nodes with no signal change since the prior synthesis are good \`skip: true\` candidates.\n`
+    : '';
+
+  const guidanceBlock = guidance?.trim()
+    ? `\n## Operator focus\n\n${guidance.trim()}\n`
+    : '';
+
+  // Schema example, kept short. The auditor benefits from seeing the
+  // exact JSON shape; the Zod validator will reject anything off.
+  const schemaExample = `{
+  "version": 1,
+  "root_initiative_id": "${rootId}",
+  "attempt": ${attempt},
+  "previous_synthesis_run_group_id": null,
+  "summary": "1-paragraph framing of the epic's intent and current state",
+  "nodes": [
+    {
+      "initiative_id": "<descendant-id>",
+      "title": "<descendant-title>",
+      "current_status": "in_progress",
+      "hypothesis": "needs-deep-dive",
+      "confidence": "medium",
+      "investigation_prompt": "<scoped per-node ask for the L2 auditor>",
+      "scoped_evidence_hints": ["git log --oneline -- <path>", "rg <symbol> <dir>"],
+      "skip": false
+    }
+  ],
+  "cross_cutting_questions": []
+}`;
+
+  const takeNoteCall = `take_note({
+  agent_id: '<your agent_id>',
+  kind: 'audit_manifest',
+  initiative_id: '${rootId}',
+  scope_key: '<from briefing>',
+  role: 'auditor',
+  run_group_id: '<from briefing>',
+  audience: 'pm',
+  importance: 1,
+  body: JSON.stringify(<the JSON object above>),
+})`;
+
+  return `**Initiative audit — L1 SURVEYOR (mode: survey)**
+
+You are running the *survey* stage. Your only job is to emit one
+\`audit_manifest\` note whose JSON-string body plans the per-node
+fan-out the orchestrator will run next. Do **not** deeply audit
+anything yourself — the surveyor reads, doesn't grep-storm.
+
+Target root: ${initiative.title} (kind=${initiative.kind}, status=${initiative.status}, id=${initiative.id})
+Attempt: ${attempt}
+
+## Subtree (non-terminal descendants)
+
+${descBlock}
+${gitBlock}${priorBlock}${guidanceBlock}
+## Contract
+
+- Slice: emit a manifest that narrows the per-node fan-out for this audit.
+- Expected deliverable: exactly ONE \`take_note\` call:
+  - kind: 'audit_manifest'
+  - initiative_id: '${rootId}'
+  - audience: 'pm'
+  - importance: 1
+  - body: JSON.stringify of an object conforming to the schema below.
+- Acceptance criteria:
+  * Body parses as JSON and matches the audit_manifest v1 schema.
+  * \`nodes\` covers each non-terminal descendant listed above (one entry each).
+  * Each node has a \`hypothesis\` ∈ {likely-done, likely-drifted, likely-cancelled, no-evidence, needs-deep-dive}.
+  * Each node has a \`confidence\` ∈ {low, medium, high}.
+  * \`skip: true\` is used sparingly — only when you're highly confident the node needs no deeper audit (e.g. obvious "already done with PR" or "obviously orphaned"). Combined with \`confidence: 'high'\`, the orchestrator will NOT dispatch an auditor for that node and will instead emit a synthetic \`keep\` proposal.
+- Expected duration: < 60s wall clock. You are the *plan*; the audit is the layers that follow.
+
+## Schema (audit_manifest v1)
+
+\`\`\`jsonc
+${schemaExample}
+\`\`\`
+
+## How to emit
+
+\`\`\`
+${takeNoteCall}
+\`\`\`
+
+## Discipline
+
+- One note. No \`breadcrumb\`/\`discovery\`/\`question\` chatter.
+- Do **not** call \`update_task_status\`, \`update_initiative\`, or \`register_deliverable\` — auditors are read-only.
+- The body MUST be a JSON string (\`JSON.stringify(...)\`). The MCP \`take_note\` handler validates it; off-shape bodies are rejected and you'll have to retry.
+- If the subtree above is empty, still emit the manifest with \`nodes: []\` and a one-line \`summary\`.
 `;
 }

--- a/src/lib/agents/audit-proposals/schemas.ts
+++ b/src/lib/agents/audit-proposals/schemas.ts
@@ -73,6 +73,7 @@ export const auditManifestBodySchema = z.object({
 });
 
 export type AuditManifestBody = z.infer<typeof auditManifestBodySchema>;
+export type AuditManifestNode = z.infer<typeof manifestNodeSchema>;
 
 // ─── §4.3 — audit_proposal body schema (L2 + synthetic skip-keeps) ──
 

--- a/src/lib/agents/audit-survey.test.ts
+++ b/src/lib/agents/audit-survey.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for the L1 surveyor (Phase 2 of
+ * specs/subtree-audit-proposals-spec.md).
+ *
+ * Covers:
+ *   - runSurveyor happy path: dispatch + valid manifest landed →
+ *     dispatchOutcome 'ok' with parsed body.
+ *   - runSurveyor failure path: dispatch throws → 'failed'.
+ *   - runSurveyor no-manifest path: dispatch ok but no audit_manifest
+ *     note appears → 'no-manifest'.
+ *   - buildFallbackManifest: every node has skip:false / hypothesis
+ *     'needs-deep-dive'; root is excluded.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import { createInitiative } from '@/lib/db/initiatives';
+import { createNote } from '@/lib/db/agent-notes';
+import { runSurveyor, buildFallbackManifest } from './audit-survey';
+import {
+  __setSendChatClientForTests,
+  type ChatEvent,
+  type SendChatClient,
+} from '@/lib/openclaw/send-chat';
+import type { Agent } from '@/lib/types';
+
+function freshWorkspace(): string {
+  const id = `ws-surv-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function fakeRunner(): Agent {
+  return {
+    id: 'agent-surv-runner',
+    name: 'Runner Test',
+    role: 'researcher',
+    avatar_emoji: '🔬',
+    status: 'standby',
+    is_master: false,
+    workspace_id: 'default',
+    source: 'gateway',
+    is_active: true,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    gateway_agent_id: 'mc-runner-test',
+    session_key_prefix: 'agent:mc-runner-test',
+    model: 'spark-lb/agent',
+  } as unknown as Agent;
+}
+
+function stubClient(opts: {
+  events?: ChatEvent[];
+  throwOnSend?: boolean;
+  /** Called inside the dispatch flow (between event emit and return). */
+  beforeReply?: (sessionKey: string | undefined) => void;
+} = {}): SendChatClient {
+  const { events = [{ state: 'final', message: 'ok' }], throwOnSend, beforeReply } = opts;
+  const listeners = new Set<(p: ChatEvent) => void>();
+  return {
+    isConnected: () => true,
+    on: (event, listener) => {
+      if (event === 'chat_event') listeners.add(listener);
+      return undefined;
+    },
+    off: (event, listener) => {
+      if (event === 'chat_event') listeners.delete(listener);
+      return undefined;
+    },
+    call: async (method, params) => {
+      if (method !== 'chat.send') return undefined;
+      if (throwOnSend) throw new Error('stub-dispatch-failure');
+      const sessionKey = (params as { sessionKey?: string } | undefined)?.sessionKey;
+      if (beforeReply) beforeReply(sessionKey);
+      setImmediate(() => {
+        for (const e of events) {
+          const withKey = { ...e, sessionKey };
+          for (const l of listeners) l(withKey);
+        }
+      });
+      return {};
+    },
+  };
+}
+
+test.afterEach(() => {
+  __setSendChatClientForTests(null);
+});
+
+test('runSurveyor: happy path returns parsed manifest', async () => {
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Surv root' });
+  const c1 = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'Story 1',
+    parent_initiative_id: root.id,
+  });
+
+  // The stub plants an audit_manifest note BEFORE the chat reply
+  // returns, simulating the auditor having taken the note inside its
+  // dispatch.
+  __setSendChatClientForTests(
+    stubClient({
+      beforeReply: () => {
+        createNote({
+          workspace_id: ws,
+          agent_id: null,
+          initiative_id: root.id,
+          scope_key: `initiative-${root.id}:audit-survey:1`,
+          role: 'auditor',
+          run_group_id: uuidv4(),
+          kind: 'audit_manifest',
+          audience: 'pm',
+          importance: 1,
+          body: JSON.stringify({
+            version: 1,
+            root_initiative_id: root.id,
+            attempt: 1,
+            previous_synthesis_run_group_id: null,
+            summary: 'test',
+            nodes: [
+              {
+                initiative_id: c1.id,
+                title: c1.title,
+                current_status: 'in_progress',
+                hypothesis: 'needs-deep-dive',
+                confidence: 'medium',
+                investigation_prompt: 'do the thing',
+                scoped_evidence_hints: [],
+                skip: false,
+              },
+            ],
+            cross_cutting_questions: [],
+          }),
+        });
+      },
+    }),
+  );
+
+  const result = await runSurveyor({
+    rootId: root.id,
+    workspaceId: ws,
+    attempt: 1,
+    runner: fakeRunner(),
+    parentRunId: null,
+  });
+
+  assert.equal(result.dispatchOutcome, 'ok');
+  assert.ok(result.manifest);
+  assert.equal(result.manifest!.root_initiative_id, root.id);
+  assert.equal(result.manifest!.nodes.length, 1);
+  assert.equal(result.manifest!.nodes[0].initiative_id, c1.id);
+  assert.ok(result.surveyorNoteId);
+});
+
+test('runSurveyor: root not found → dispatchOutcome failed', async () => {
+  const ws = freshWorkspace();
+  __setSendChatClientForTests(stubClient());
+
+  // Root id doesn't exist in this workspace → runSurveyor short-circuits
+  // with the 'failed' outcome before dispatch. Exercises the same
+  // error-handling envelope the real failure path uses.
+  const result = await runSurveyor({
+    rootId: 'nonexistent-root-id',
+    workspaceId: ws,
+    attempt: 1,
+    runner: fakeRunner(),
+    parentRunId: null,
+  });
+
+  assert.equal(result.dispatchOutcome, 'failed');
+  assert.equal(result.manifest, null);
+  assert.match(result.errorMessage ?? '', /not found/i);
+});
+
+test('runSurveyor: dispatch ok but no manifest note → dispatchOutcome no-manifest', async () => {
+  const ws = freshWorkspace();
+  const root = createInitiative({
+    workspace_id: ws,
+    kind: 'epic',
+    title: 'Quiet runner',
+  });
+  __setSendChatClientForTests(stubClient());
+
+  const result = await runSurveyor({
+    rootId: root.id,
+    workspaceId: ws,
+    attempt: 1,
+    runner: fakeRunner(),
+    parentRunId: null,
+  });
+
+  assert.equal(result.dispatchOutcome, 'no-manifest');
+  assert.equal(result.manifest, null);
+});
+
+test('buildFallbackManifest: every descendant skip:false, hypothesis needs-deep-dive', () => {
+  const root = { id: 'r', title: 'Root', kind: 'epic', status: 'in_progress', parent_initiative_id: null };
+  const a = { id: 'a', title: 'A', kind: 'story', status: 'in_progress', parent_initiative_id: 'r' };
+  const b = { id: 'b', title: 'B', kind: 'story', status: 'in_progress', parent_initiative_id: 'r' };
+  const layers = [[a, b], [root]];
+
+  const manifest = buildFallbackManifest('r', layers, 7);
+  assert.equal(manifest.root_initiative_id, 'r');
+  assert.equal(manifest.attempt, 7);
+  // Root is excluded — manifest covers descendants only.
+  assert.equal(manifest.nodes.length, 2);
+  for (const n of manifest.nodes) {
+    assert.equal(n.skip, false);
+    assert.equal(n.hypothesis, 'needs-deep-dive');
+  }
+  assert.deepEqual(manifest.nodes.map((n) => n.initiative_id).sort(), ['a', 'b']);
+});

--- a/src/lib/agents/audit-survey.ts
+++ b/src/lib/agents/audit-survey.ts
@@ -1,0 +1,257 @@
+/**
+ * L1 surveyor for the structured-audit pipeline.
+ *
+ * Runs ONE auditor dispatch scoped to the root initiative; the auditor
+ * emits an `audit_manifest` note that narrows the per-node fan-out for
+ * the L2 layer. On failure / no-manifest the orchestrator falls back to
+ * a full-fanout manifest derived synthetically from the planned layers.
+ *
+ * Spec: specs/subtree-audit-proposals-spec.md §3.1, §5.1, §5.5.
+ */
+
+import { listInitiatives } from '@/lib/db/initiatives';
+import { listNotes } from '@/lib/db/agent-notes';
+import { dispatchScope } from '@/lib/agents/dispatch-scope';
+import { buildAuditPrompt } from '@/lib/agents/audit-prompt';
+import {
+  validateAuditNoteBody,
+  type AuditManifestBody,
+  type AuditManifestNode,
+} from '@/lib/agents/audit-proposals/schemas';
+import type { Agent } from '@/lib/types';
+
+const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
+
+export interface RunSurveyorInput {
+  rootId: string;
+  workspaceId: string;
+  attempt: number;
+  /** The runner / gateway agent to dispatch through. */
+  runner: Agent;
+  /** Forwarded to dispatchScope. */
+  parentRunId: string | null;
+  /** Optional operator-supplied focus area; threaded into the briefing. */
+  guidance?: string | null;
+  /** Per-dispatch timeout (ms). */
+  timeoutMs?: number;
+  /** Optional pre-computed git-activity excerpt; surveyors don't shell out. */
+  gitActivity?: string | null;
+}
+
+export interface SurveyorResult {
+  manifest: AuditManifestBody | null;
+  surveyorNoteId: string | null;
+  /**
+   * 'ok' — auditor dispatched + valid manifest landed.
+   * 'no-manifest' — dispatch succeeded but no audit_manifest note appeared.
+   * 'failed' — dispatch threw / errored.
+   */
+  dispatchOutcome: 'ok' | 'failed' | 'no-manifest';
+  /** Captured for diagnostics / tests. */
+  errorMessage?: string;
+}
+
+type LiteForFallback = {
+  id: string;
+  title: string;
+  kind: string;
+  status: string;
+  parent_initiative_id: string | null;
+};
+
+/**
+ * Build a synthetic full-fanout manifest used when the surveyor
+ * dispatch fails or returns no manifest. Every non-terminal descendant
+ * is marked `hypothesis: 'needs-deep-dive'`, `skip: false`, so the
+ * orchestrator dispatches every node — same coverage as today's
+ * mode: 'subtree' run.
+ */
+export function buildFallbackManifest(
+  rootId: string,
+  layers: ReadonlyArray<ReadonlyArray<LiteForFallback>>,
+  attempt: number,
+): AuditManifestBody {
+  const nodes: AuditManifestNode[] = [];
+  for (const layer of layers) {
+    for (const n of layer) {
+      // Skip the root itself — manifest covers descendants; the root
+      // gets the existing per-node audit at the top layer regardless.
+      if (n.id === rootId) continue;
+      nodes.push({
+        initiative_id: n.id,
+        title: n.title,
+        current_status: n.status,
+        hypothesis: 'needs-deep-dive',
+        confidence: 'low',
+        investigation_prompt: `(fallback) Audit ${n.title} against repo + MC reality and emit a structured proposal.`,
+        scoped_evidence_hints: [],
+        skip: false,
+      });
+    }
+  }
+  return {
+    version: 1,
+    root_initiative_id: rootId,
+    attempt,
+    previous_synthesis_run_group_id: null,
+    summary:
+      'Synthetic fallback manifest — surveyor dispatch failed or returned no manifest. Full fan-out across non-terminal descendants.',
+    nodes,
+    cross_cutting_questions: [],
+  };
+}
+
+/**
+ * Look up the most recent prior `audit_synthesis` note on the root —
+ * used for delta runs in Phase 5. Phase 2 doesn't change behavior on
+ * this read, but threads it through so the briefing renders the prior
+ * if/when one exists.
+ */
+function loadPriorSynthesis(rootId: string): string | null {
+  const rows = listNotes({
+    initiative_id: rootId,
+    kinds: ['audit_synthesis'],
+    limit: 1,
+    order: 'desc',
+  });
+  return rows[0]?.body ?? null;
+}
+
+/**
+ * Read back the most recent `audit_manifest` note on the root after
+ * the surveyor dispatch returns.
+ */
+function loadFreshManifestNote(rootId: string): {
+  noteId: string;
+  body: string;
+} | null {
+  const rows = listNotes({
+    initiative_id: rootId,
+    kinds: ['audit_manifest'],
+    limit: 1,
+    order: 'desc',
+  });
+  const note = rows[0];
+  if (!note) return null;
+  return { noteId: note.id, body: note.body };
+}
+
+/**
+ * Dispatch the L1 surveyor. Returns the parsed manifest + outcome
+ * marker. The orchestrator decides what to do with a non-'ok' outcome
+ * (typically: fall back to `buildFallbackManifest`).
+ */
+export async function runSurveyor(input: RunSurveyorInput): Promise<SurveyorResult> {
+  const { rootId, workspaceId, attempt, runner, parentRunId, guidance, timeoutMs, gitActivity } =
+    input;
+
+  // Build the descendants list from workspace initiatives.
+  const all = listInitiatives({ workspace_id: workspaceId });
+  const root = all.find((i) => i.id === rootId);
+  if (!root) {
+    return {
+      manifest: null,
+      surveyorNoteId: null,
+      dispatchOutcome: 'failed',
+      errorMessage: `surveyor: root ${rootId} not found in workspace ${workspaceId}`,
+    };
+  }
+
+  // Walk the subtree, collect non-terminal descendants (excluding root).
+  const byParent = new Map<string, typeof all>();
+  for (const i of all) {
+    if (!i.parent_initiative_id) continue;
+    const list = byParent.get(i.parent_initiative_id) ?? [];
+    list.push(i);
+    byParent.set(i.parent_initiative_id, list);
+  }
+  const descendants: LiteForFallback[] = [];
+  const stack: string[] = [rootId];
+  while (stack.length) {
+    const cur = stack.pop()!;
+    const kids = byParent.get(cur) ?? [];
+    for (const k of kids) {
+      if (TERMINAL_STATUSES.has(k.status)) continue;
+      descendants.push({
+        id: k.id,
+        title: k.title,
+        kind: k.kind,
+        status: k.status,
+        parent_initiative_id: k.parent_initiative_id ?? null,
+      });
+      stack.push(k.id);
+    }
+  }
+
+  const priorSynthesisBody = loadPriorSynthesis(rootId);
+
+  const triggerBody = buildAuditPrompt({
+    initiative: root,
+    tasks: [],
+    childInitiatives: [],
+    guidance: guidance ?? null,
+    priorFindings: [],
+    childFindings: [],
+    mode: 'survey',
+    surveyInput: {
+      rootId,
+      attempt,
+      descendants,
+      gitActivity: gitActivity ?? null,
+      priorSynthesisBody,
+    },
+  });
+
+  const sessionSuffix = `initiative-${rootId}:audit-survey:${attempt}`;
+
+  try {
+    await dispatchScope({
+      workspace_id: workspaceId,
+      role: 'auditor',
+      agent: runner,
+      session_suffix: sessionSuffix,
+      scope_type: 'initiative_audit',
+      initiative_id: rootId,
+      trigger_body: triggerBody,
+      attempt_strategy: 'fresh',
+      timeoutMs: timeoutMs ?? 5 * 60_000,
+      idempotencyKey: `audit-survey-${rootId}-${attempt}-${Date.now()}`,
+      parent_run_id: parentRunId,
+      source_kind: 'fanout',
+      source_ref: rootId,
+      label: `Audit survey: ${root.title}`,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      manifest: null,
+      surveyorNoteId: null,
+      dispatchOutcome: 'failed',
+      errorMessage: message,
+    };
+  }
+
+  const fresh = loadFreshManifestNote(rootId);
+  if (!fresh) {
+    return {
+      manifest: null,
+      surveyorNoteId: null,
+      dispatchOutcome: 'no-manifest',
+      errorMessage: 'surveyor dispatch returned but no audit_manifest note appeared',
+    };
+  }
+  const parsed = validateAuditNoteBody('audit_manifest', fresh.body);
+  if (!parsed.ok) {
+    return {
+      manifest: null,
+      surveyorNoteId: fresh.noteId,
+      dispatchOutcome: 'no-manifest',
+      errorMessage: `surveyor manifest body did not validate: ${parsed.error}`,
+    };
+  }
+  return {
+    manifest: parsed.parsed as AuditManifestBody,
+    surveyorNoteId: fresh.noteId,
+    dispatchOutcome: 'ok',
+  };
+}

--- a/src/lib/agents/briefing.ts
+++ b/src/lib/agents/briefing.ts
@@ -35,7 +35,8 @@ export type BriefingRole =
   | 'tester'
   | 'reviewer'
   | 'writer'
-  | 'learner';
+  | 'learner'
+  | 'auditor';
 
 export interface BuildBriefingInput {
   workspace_id: string;

--- a/src/lib/agents/subagent-context.ts
+++ b/src/lib/agents/subagent-context.ts
@@ -31,6 +31,7 @@ const ROLE_DEFAULT: Record<BriefingRole, SubagentContextMode> = {
   reviewer: 'isolated',
   writer: 'isolated',
   learner: 'isolated',
+  auditor: 'isolated',
 };
 
 interface OverrideRow {

--- a/src/lib/agents/subtree-audit.test.ts
+++ b/src/lib/agents/subtree-audit.test.ts
@@ -22,7 +22,9 @@ import {
   runSubtreeAudit,
 } from './subtree-audit';
 import { createInitiative } from '@/lib/db/initiatives';
+import { listNotes } from '@/lib/db/agent-notes';
 import { getAgentRun } from '@/lib/db/agent-runs';
+import type { SurveyorResult } from './audit-survey';
 import {
   __setSendChatClientForTests,
   type ChatEvent,
@@ -298,4 +300,153 @@ test('runSubtreeAudit: parent rolls up to complete when all children succeed', a
   const parent = getAgentRun(result.parentRunId!)!;
   assert.ok(['complete', 'failed'].includes(parent.status), 'parent rolled up');
   assert.ok(parent.completed_at);
+});
+
+// ─── runSubtreeAudit: mode='subtree-proposal' (Phase 2) ────────────
+
+test('runSubtreeAudit (subtree-proposal): manifest skip → synthetic audit_proposal, no dispatch', async () => {
+  __setSendChatClientForTests(stubClient());
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'SP root' });
+  const skipMe = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'Skip me',
+    parent_initiative_id: root.id,
+  });
+  const auditMe = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'Audit me',
+    parent_initiative_id: root.id,
+  });
+
+  // Stub the surveyor: skipMe gets skip:true / high; auditMe needs-deep-dive.
+  const surveyorOverride = async (): Promise<SurveyorResult> => ({
+    manifest: {
+      version: 1,
+      root_initiative_id: root.id,
+      attempt: 1,
+      previous_synthesis_run_group_id: null,
+      summary: 'test manifest',
+      nodes: [
+        {
+          initiative_id: skipMe.id,
+          title: skipMe.title,
+          current_status: 'in_progress',
+          hypothesis: 'likely-done',
+          confidence: 'high',
+          investigation_prompt: 'No need to dig further.',
+          scoped_evidence_hints: [],
+          skip: true,
+        },
+        {
+          initiative_id: auditMe.id,
+          title: auditMe.title,
+          current_status: 'in_progress',
+          hypothesis: 'needs-deep-dive',
+          confidence: 'medium',
+          investigation_prompt: 'Do dig.',
+          scoped_evidence_hints: [],
+          skip: false,
+        },
+      ],
+      cross_cutting_questions: [],
+    },
+    surveyorNoteId: null,
+    dispatchOutcome: 'ok',
+  });
+
+  const result = await runSubtreeAudit({
+    rootId: root.id,
+    workspaceId: ws,
+    guidance: null,
+    perNodeTimeoutMs: 10_000,
+    subtreeConcurrency: 2,
+    runner: fakeRunner(),
+    mode: 'subtree-proposal',
+    surveyorOverride,
+  });
+
+  // skipMe must NOT have an agent_runs child row (no dispatch).
+  const skipChildRuns = queryAll<{ id: string }>(
+    `SELECT id FROM agent_runs WHERE workspace_id = ? AND initiative_id = ? AND parent_run_id = ?`,
+    [ws, skipMe.id, result.parentRunId],
+  );
+  assert.equal(skipChildRuns.length, 0, 'skipped node was not dispatched');
+
+  // auditMe SHOULD have a dispatched child run.
+  const auditChildRuns = queryAll<{ id: string }>(
+    `SELECT id FROM agent_runs WHERE workspace_id = ? AND initiative_id = ? AND parent_run_id = ?`,
+    [ws, auditMe.id, result.parentRunId],
+  );
+  assert.equal(auditChildRuns.length, 1, 'non-skipped node was dispatched');
+
+  // Synthetic audit_proposal note exists for skipMe.
+  const proposals = listNotes({
+    initiative_id: skipMe.id,
+    kinds: ['audit_proposal'],
+    limit: 5,
+  });
+  assert.equal(proposals.length, 1);
+  const body = JSON.parse(proposals[0].body);
+  assert.equal(body.proposed_action, 'keep');
+  assert.equal(body.confidence, 'high');
+  assert.equal(body.node_initiative_id, skipMe.id);
+
+  // Per-node outcome includes the manifest-skip marker.
+  const skipOutcome = result.perNodeOutcomes.find((o) => o.initiativeId === skipMe.id);
+  assert.ok(skipOutcome);
+  assert.equal(skipOutcome!.status, 'ok');
+  assert.match(skipOutcome!.note ?? '', /manifest-skip/);
+});
+
+test('runSubtreeAudit (subtree-proposal): surveyor failure → fallback dispatches all nodes', async () => {
+  __setSendChatClientForTests(stubClient());
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Fallback root' });
+  const c1 = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'C1',
+    parent_initiative_id: root.id,
+  });
+  const c2 = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'C2',
+    parent_initiative_id: root.id,
+  });
+
+  const surveyorOverride = async () => {
+    throw new Error('boom');
+  };
+
+  const result = await runSubtreeAudit({
+    rootId: root.id,
+    workspaceId: ws,
+    guidance: null,
+    perNodeTimeoutMs: 10_000,
+    subtreeConcurrency: 2,
+    runner: fakeRunner(),
+    mode: 'subtree-proposal',
+    surveyorOverride,
+  });
+
+  // All three nodes (root + 2 children) get dispatched (no skips in fallback).
+  const childRuns = queryAll<{ initiative_id: string }>(
+    `SELECT initiative_id FROM agent_runs WHERE workspace_id = ? AND parent_run_id = ?`,
+    [ws, result.parentRunId],
+  );
+  const dispatchedIds = new Set(childRuns.map((r) => r.initiative_id));
+  for (const id of [root.id, c1.id, c2.id]) {
+    assert.ok(dispatchedIds.has(id), `expected dispatch for ${id}`);
+  }
+  // No synthetic audit_proposal notes because nothing was skipped.
+  const propNotes = listNotes({
+    initiative_id: c1.id,
+    kinds: ['audit_proposal'],
+    limit: 5,
+  });
+  assert.equal(propNotes.length, 0);
 });

--- a/src/lib/agents/subtree-audit.ts
+++ b/src/lib/agents/subtree-audit.ts
@@ -31,12 +31,23 @@
  */
 
 import { listInitiatives, type Initiative } from '@/lib/db/initiatives';
-import { listNotes } from '@/lib/db/agent-notes';
+import { createNote, listNotes } from '@/lib/db/agent-notes';
 import { dispatchScope } from '@/lib/agents/dispatch-scope';
 import { buildAuditPrompt } from '@/lib/agents/audit-prompt';
 import type { Agent } from '@/lib/types';
 import { queryAll } from '@/lib/db';
 import { markRunRollup, startAgentRun } from '@/lib/db/agent-runs';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  runSurveyor,
+  buildFallbackManifest,
+  type SurveyorResult,
+} from '@/lib/agents/audit-survey';
+import {
+  auditProposalBodySchema,
+  type AuditManifestBody,
+  type AuditManifestNode,
+} from '@/lib/agents/audit-proposals/schemas';
 
 const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
 
@@ -201,6 +212,23 @@ export interface RunSubtreeAuditInput {
   perNodeTimeoutMs: number;
   subtreeConcurrency: number;
   runner: Agent;
+  /**
+   * Output mode for the subtree audit.
+   * - 'subtree' — today's free-form per-node `observation` notes (PR 4
+   *   shape, default).
+   * - 'subtree-proposal' — Phase 2 of the structured-proposals spec:
+   *   adds an L1 surveyor + manifest-driven filter; L2 still emits
+   *   free-form notes (Phase 3 will switch them to typed proposals).
+   * Defaults to 'subtree' for back-compat with existing call sites.
+   */
+  mode?: 'subtree' | 'subtree-proposal';
+  /**
+   * Test seam — overrides the surveyor function so tests can stub
+   * dispatch + manifest readback without exercising openclaw.
+   */
+  surveyorOverride?: (
+    args: Parameters<typeof runSurveyor>[0],
+  ) => Promise<SurveyorResult>;
 }
 
 export interface SubtreeAuditResult {
@@ -247,8 +275,16 @@ function nextAuditAttempt(initiativeId: string): number {
 export async function runSubtreeAudit(
   input: RunSubtreeAuditInput,
 ): Promise<SubtreeAuditResult> {
-  const { rootId, workspaceId, guidance, perNodeTimeoutMs, subtreeConcurrency, runner } =
-    input;
+  const {
+    rootId,
+    workspaceId,
+    guidance,
+    perNodeTimeoutMs,
+    subtreeConcurrency,
+    runner,
+    mode = 'subtree',
+    surveyorOverride,
+  } = input;
   const { layers } = planSubtreeAudit(rootId, workspaceId);
 
   // Synthetic root agent_runs row — exists purely so the /jobs UI can
@@ -291,6 +327,119 @@ export async function runSubtreeAudit(
   const findingsByInitiative = new Map<string, { body: string; failed: boolean }>();
   const perNodeOutcomes: SubtreeAuditResult['perNodeOutcomes'] = [];
 
+  // ─── L1 surveyor + manifest filter (mode: 'subtree-proposal') ──────
+  // Skipped nodes (manifest.skip === true && confidence === 'high') are
+  // not dispatched; instead we emit a synthetic `audit_proposal` note
+  // and record an 'ok' outcome so the synthesized body flows up to
+  // parent layers via the existing childFindings path.
+  let manifest: AuditManifestBody | null = null;
+  let manifestNoteId: string | null = null;
+  if (mode === 'subtree-proposal') {
+    const surveyAttempt = nextAuditAttempt(rootId);
+    const surveyorFn = surveyorOverride ?? runSurveyor;
+    let surveyResult: SurveyorResult;
+    try {
+      surveyResult = await surveyorFn({
+        rootId,
+        workspaceId,
+        attempt: surveyAttempt,
+        runner,
+        parentRunId,
+        guidance: guidance ?? null,
+        timeoutMs: perNodeTimeoutMs,
+        gitActivity: null,
+      });
+    } catch (err) {
+      surveyResult = {
+        manifest: null,
+        surveyorNoteId: null,
+        dispatchOutcome: 'failed',
+        errorMessage: err instanceof Error ? err.message : String(err),
+      };
+    }
+    if (surveyResult.dispatchOutcome === 'ok' && surveyResult.manifest) {
+      manifest = surveyResult.manifest;
+      manifestNoteId = surveyResult.surveyorNoteId;
+    } else {
+      console.warn(
+        `[subtree-audit] surveyor outcome=${surveyResult.dispatchOutcome}; ` +
+          `falling back to full-fanout manifest. error=${surveyResult.errorMessage ?? '(none)'}`,
+      );
+      manifest = buildFallbackManifest(rootId, layers, surveyAttempt);
+      manifestNoteId = surveyResult.surveyorNoteId;
+    }
+  }
+
+  /** Returns the manifest entry for a node, or null if not in manifest. */
+  const manifestNodeFor = (id: string): AuditManifestNode | null => {
+    if (!manifest) return null;
+    return manifest.nodes.find((n) => n.initiative_id === id) ?? null;
+  };
+
+  /** Should the orchestrator skip dispatch for this node (manifest-driven)? */
+  const isManifestSkip = (id: string): boolean => {
+    const m = manifestNodeFor(id);
+    return !!m && m.skip === true && m.confidence === 'high';
+  };
+
+  /**
+   * Emit a synthetic `audit_proposal` note for a manifest-skipped node.
+   * Direct DB write — bypasses the MCP take_note validator path because
+   * this is server-side. We still validate the body against the Zod
+   * schema as a sanity check.
+   */
+  const emitSyntheticKeepProposal = (
+    node: LiteInitiative,
+    manifestEntry: AuditManifestNode,
+  ): { noteId: string; body: string } | null => {
+    const bodyObj = {
+      version: 1 as const,
+      node_initiative_id: node.id,
+      current_mc_status: node.status,
+      current_mc_target_end: node.target_end ?? null,
+      proposed_action: 'keep' as const,
+      proposed_changes: {},
+      repo_evidence: [
+        {
+          kind: 'note' as const,
+          ref: manifestNoteId ?? `manifest:fallback:initiative-${rootId}`,
+        },
+      ],
+      rationale: `Skipped by manifest hypothesis: ${manifestEntry.hypothesis} (high confidence). ${manifestEntry.investigation_prompt.slice(0, 240)}`,
+      confidence: 'high' as const,
+      would_confirm_by: null,
+      continuation_note_id: null,
+    };
+    const parsed = auditProposalBodySchema.safeParse(bodyObj);
+    if (!parsed.success) {
+      console.warn(
+        `[subtree-audit] synthetic keep proposal failed schema check for ${node.id}: ${parsed.error.message}`,
+      );
+      return null;
+    }
+    const body = JSON.stringify(parsed.data);
+    try {
+      const created = createNote({
+        workspace_id: workspaceId,
+        agent_id: null,
+        initiative_id: node.id,
+        scope_key: `initiative-${rootId}:audit-subtree:synthetic-keep:${node.id}`,
+        role: 'orchestrator',
+        run_group_id: uuidv4(),
+        kind: 'audit_proposal',
+        audience: 'pm',
+        body,
+        importance: 1,
+      });
+      return { noteId: created.id, body };
+    } catch (err) {
+      console.warn(
+        `[subtree-audit] createNote(synthetic keep) failed for ${node.id}: ${(err as Error).message}`,
+      );
+      return null;
+    }
+  };
+
   for (let layerIdx = 0; layerIdx < layers.length; layerIdx++) {
     const layer = layers[layerIdx];
     const tasks = layer.map((node) => async () => {
@@ -300,6 +449,28 @@ export async function runSubtreeAudit(
         .session_key_prefix
         ? `${(runner as { session_key_prefix?: string | null }).session_key_prefix}:${sessionSuffix}`
         : sessionSuffix;
+
+      // Manifest-driven skip: don't dispatch — emit a synthetic keep
+      // proposal and record the outcome so the parent layer's
+      // childFindings includes a synthesized body.
+      if (mode === 'subtree-proposal') {
+        const m = manifestNodeFor(node.id);
+        if (m && isManifestSkip(node.id)) {
+          const synth = emitSyntheticKeepProposal(node, m);
+          const body =
+            synth?.body ??
+            `(synthetic keep proposal for ${node.id} — manifest-skipped, but createNote failed)`;
+          findingsByInitiative.set(node.id, { body, failed: false });
+          perNodeOutcomes.push({
+            initiativeId: node.id,
+            layerIndex: layerIdx,
+            scopeKey,
+            status: 'ok',
+            note: `manifest-skip: ${m.hypothesis} (${m.confidence})`,
+          });
+          return;
+        }
+      }
 
       // Pull the immediate children's findings (only those that are
       // in our included set — terminal children are skipped). We


### PR DESCRIPTION
## Summary
Phase 2 of [spec #284](https://github.com/smb209/mission-control/pull/284). Adds the L1 surveyor stage that runs before the leaf layer in `runSubtreeAudit` and emits an `audit_manifest` note narrowing the per-node fan-out. Stacks on top of [#285](https://github.com/smb209/mission-control/pull/285) (Phase 1, already merged).

L2 still emits free-form `kind: 'observation'` notes in this phase — Phase 3 introduces the typed `audit_proposal` contract for L2. Both `mode: 'subtree'` and `mode: 'subtree-proposal'` coexist through Phase 3; Phase 4 retires `subtree`.

## Behavior in `mode: 'subtree-proposal'`
1. Before the leaf layer dispatches: run L1 surveyor → emit `audit_manifest` on root.
2. Filter planned layers: nodes with `skip: true && confidence: 'high'` are NOT dispatched. Orchestrator emits a synthetic `audit_proposal` (`proposed_action: 'keep'`) directly via `createNote`, validated against the Phase 1 Zod schema as a sanity check.
3. Remaining nodes follow today's L2 dispatch path, unchanged.
4. Surveyor failure or no-manifest → orchestrator falls back to a synthetic full-fanout manifest (every node `hypothesis: 'needs-deep-dive'`, `skip: false`).

## Changes
- **New** `src/lib/agents/audit-survey.ts` — `runSurveyor` orchestration + `buildFallbackManifest` pure helper.
- **New** `src/lib/agents/audit-survey.test.ts` — success / failure / no-manifest paths, fallback shape.
- **New** `agent-templates/auditor/{SOUL,AGENTS}.md` — generic `auditor` role per spec §9.1; contract supplied via briefing.
- **`audit-prompt.ts`** — new `mode: 'survey'` branch rendering the manifest schema field-by-field with an example so auditors emit a parseable body.
- **`subtree-audit.ts`** — `mode: 'subtree' | 'subtree-proposal'` parameter; surveyor wiring + manifest-driven filter + synthetic-keep emission. `surveyorOverride` test seam.
- **`investigate/route.ts`** — accepts `mode: 'subtree-proposal'`; threads through to `runSubtreeAudit`.
- **`audit-proposals/schemas.ts`** — added `AuditManifestNode` type export alongside existing `AuditManifestBody`.
- **`briefing.ts`** + **`subagent-context.ts`** — minor wiring for the auditor role.
- **`.gitignore`** — ignore `.claude/worktrees/` (agent isolation directories).

## Spec deviations (documented)
- **`runSurveyor` failure test** uses "root not found in workspace → failed" to exercise the `dispatchOutcome: 'failed'` envelope. The `dispatchScope` throw path is unreachable from the stubbed gateway because errors come back through the structured-result design, not via thrown exceptions.
- **Surveyor test seam**: `runSubtreeAudit` got an optional `surveyorOverride` parameter rather than a vitest module mock — matches the existing `__setSendChatClientForTests` pattern.
- **Synthetic keep proposal**: always carries one `repo_evidence` entry. When the surveyor returned a manifest with no note id (e.g., the test stub case), the entry is `{ kind: 'note', ref: 'manifest:fallback:initiative-${rootId}' }` — sentinel string that satisfies Phase 1's `.min(1)` schema rule and documents the source.
- **Git activity** is plumbed through `runSurveyor` but always passed as `null` from `runSubtreeAudit`. The orchestrator does NOT shell out to `git log` in this phase. The briefing renders an explicit "(none provided)" so the auditor doesn't hallucinate.

## What this PR does NOT do (deferred to later phases per spec §10)
- L2 contract briefing + typed `audit_proposal` output (Phase 3).
- L3 synthesizer dispatch (Phase 4).
- Removal of `mode: 'subtree'` (Phase 4).
- `POST .../resynthesize` endpoint (Phase 4).
- Delta-run manifest (Phase 5).
- Operator proposal queue UI (Phase 6).

## Test plan
- [x] `yarn test`: **919 pass, 1 fail**. The single fail is the same pre-existing `schedule-runner: produces a brief and advances run_count` flake that's been on `main` since before this work.
- [x] `yarn run tsc --noEmit`: only 3 pre-existing errors remain (`pm/proposals/[id]/route.ts` SSEEventType, `pm-decompose.test.ts` unused @ts-expect-error + bad theme literal). All Phase-2-touched files typecheck clean.
- [x] New tests: 4 in `audit-survey.test.ts` (manifest happy / failure / no-manifest / fallback shape); 2 new Phase 2 cases in `subtree-audit.test.ts` (manifest skip → synthetic keep + no dispatch; surveyor failure → fallback dispatches all nodes). All pass.
- N/A: preview-verify (no UI change; behavior reachable only via the new `mode: 'subtree-proposal'` API path which is not yet wired to a UI button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)