### PR TITLE
feat(audit): phase 3 — L2 typed proposals + Delegation Contract briefing

### DIFF
--- a/src/lib/agents/audit-prompt.ts
+++ b/src/lib/agents/audit-prompt.ts
@@ -72,7 +72,22 @@ export interface BuildAuditPromptInput {
     failed?: boolean;
   }>;
   /** Subtree-vs-narrow flavor. Defaults to 'narrow'. PR 4. */
-  mode?: 'narrow' | 'subtree' | 'survey';
+  mode?: 'narrow' | 'subtree' | 'survey' | 'subtree-proposal';
+  /**
+   * Per-node briefing inputs for `mode: 'subtree-proposal'` (Phase 3).
+   * The orchestrator threads in the manifest entry so the auditor sees
+   * the surveyor's hypothesis + scoped investigation prompt.
+   */
+  proposalInput?: {
+    rootId: string;
+    attempt: number;
+    manifestNode: {
+      hypothesis: string;
+      confidence: 'low' | 'medium' | 'high';
+      investigation_prompt: string;
+      scoped_evidence_hints: ReadonlyArray<string>;
+    };
+  };
   /**
    * Surveyor-only inputs (mode: 'survey'). Carried in the briefing so
    * the L1 surveyor doesn't have to walk the tree itself. See
@@ -112,10 +127,22 @@ export function buildAuditPrompt(input: BuildAuditPromptInput): string {
     childFindings = [],
     mode = 'narrow',
     surveyInput,
+    proposalInput,
   } = input;
 
   if (mode === 'survey') {
     return buildSurveyPrompt({ initiative, guidance: guidance ?? null, surveyInput });
+  }
+
+  if (mode === 'subtree-proposal') {
+    return buildSubtreeProposalPrompt({
+      initiative,
+      tasks,
+      childInitiatives,
+      guidance: guidance ?? null,
+      childFindings,
+      proposalInput,
+    });
   }
 
   const targetWindow =
@@ -362,5 +389,214 @@ ${takeNoteCall}
 - Do **not** call \`update_task_status\`, \`update_initiative\`, or \`register_deliverable\` — auditors are read-only.
 - The body MUST be a JSON string (\`JSON.stringify(...)\`). The MCP \`take_note\` handler validates it; off-shape bodies are rejected and you'll have to retry.
 - If the subtree above is empty, still emit the manifest with \`nodes: []\` and a one-line \`summary\`.
+`;
+}
+
+/**
+ * Build the L2 per-node briefing for `mode: 'subtree-proposal'` (Phase 3
+ * of specs/subtree-audit-proposals-spec.md). Mirrors the
+ * Delegation-Contract shape from §3.2 of
+ * specs/coordinator-delegation-via-convoy-spec.md: slice / deliverables /
+ * acceptance criteria. Includes the §4.3 audit_proposal schema reminder
+ * + retry guidance.
+ */
+function buildSubtreeProposalPrompt(args: {
+  initiative: BuildAuditPromptInput['initiative'];
+  tasks: BuildAuditPromptInput['tasks'];
+  childInitiatives: NonNullable<BuildAuditPromptInput['childInitiatives']>;
+  guidance: string | null;
+  childFindings: NonNullable<BuildAuditPromptInput['childFindings']>;
+  proposalInput?: BuildAuditPromptInput['proposalInput'];
+}): string {
+  const { initiative, tasks, childInitiatives, guidance, childFindings, proposalInput } = args;
+  if (!proposalInput) {
+    throw new Error('buildAuditPrompt(mode=subtree-proposal): proposalInput is required');
+  }
+  const { manifestNode } = proposalInput;
+
+  const targetWindow =
+    initiative.target_start || initiative.target_end
+      ? `${initiative.target_start ?? '?'} → ${initiative.target_end ?? '?'}`
+      : '_(no target window set)_';
+
+  const description = initiative.description?.trim()
+    ? initiative.description.trim()
+    : '_(no description)_';
+
+  const statusCheck = initiative.status_check_md?.trim()
+    ? initiative.status_check_md.trim()
+    : '_(none)_';
+
+  const tasksBlock =
+    tasks.length === 0
+      ? '_(this initiative has no direct child tasks)_'
+      : tasks.map((t) => `- ${t.title} (${t.status}) [task ${t.id}]`).join('\n');
+
+  const childInitiativesBlock =
+    childInitiatives.length === 0
+      ? '_(this initiative has no direct child initiatives)_'
+      : childInitiatives
+          .map((c) => `- [${c.kind}] ${c.title} (${c.status}) [initiative ${c.id}]`)
+          .join('\n');
+
+  const guidanceBlock = guidance?.trim()
+    ? `\n## Operator focus\n\n${guidance.trim()}\n`
+    : '';
+
+  const childBlock =
+    childFindings.length === 0
+      ? ''
+      : `\n## Findings from child initiatives (already audited)\n\nThese summaries came from per-node auditors we dispatched against this initiative's children in a prior layer. Synthesize them — don't re-audit each child from scratch — and roll their signal into your proposal for THIS node.\n\n${childFindings
+          .map((f, i) => {
+            const banner = f.failed
+              ? '> **Audit failed for this child.** Treat as an explicit gap.\n\n'
+              : '';
+            return `### Child ${i + 1}: ${f.childTitle} (id=${f.childId})\n\n${banner}${f.body.trim()}\n`;
+          })
+          .join('\n---\n\n')}\n`;
+
+  const hintsBlock =
+    manifestNode.scoped_evidence_hints.length === 0
+      ? '_(none)_'
+      : manifestNode.scoped_evidence_hints.map((h) => `- \`${h}\``).join('\n');
+
+  const exampleBody = `{
+  "version": 1,
+  "node_initiative_id": "${initiative.id}",
+  "current_mc_status": "${initiative.status}",
+  "current_mc_target_end": ${initiative.target_end ? `"${initiative.target_end}"` : 'null'},
+  "proposed_action": "keep",
+  "proposed_changes": {},
+  "repo_evidence": [
+    { "kind": "file", "ref": "path/to/file.ts:42" },
+    { "kind": "git",  "ref": "0cc50ce" }
+  ],
+  "rationale": "1-paragraph narrative — why this action.",
+  "confidence": "medium",
+  "would_confirm_by": "Reading X to confirm Y.",
+  "continuation_note_id": null
+}`;
+
+  const takeNoteCall = `take_note({
+  agent_id: '<your agent_id>',
+  kind: 'audit_proposal',
+  initiative_id: '${initiative.id}',
+  scope_key: '<from briefing>',
+  role: 'auditor',
+  run_group_id: '<from briefing>',
+  audience: 'pm',
+  importance: 2,
+  body: JSON.stringify(<the JSON object above>),
+})`;
+
+  const fallbackCall = `take_note({
+  agent_id: '<your agent_id>',
+  kind: 'observation',
+  initiative_id: '${initiative.id}',
+  scope_key: '<from briefing>',
+  role: 'auditor',
+  run_group_id: '<from briefing>',
+  audience: 'pm',
+  importance: 2,
+  body: '<short reason — what you found, why no clean proposal>',
+})`;
+
+  return `**Initiative audit — L2 PER-NODE (mode: subtree-proposal)**
+
+You are auditing ONE node of a subtree. The L1 surveyor has already
+narrowed the slice for you (see Contract below). Your job is to emit
+exactly one structured \`audit_proposal\` note for this node.
+
+Target: ${initiative.title}  (kind=${initiative.kind}, status=${initiative.status}, id=${initiative.id})
+
+Description:
+> ${description.replace(/\n/g, '\n> ')}
+
+Status check:
+${statusCheck}
+
+Target window: ${targetWindow}
+
+## Direct child initiatives (decomposed scope)
+
+${childInitiativesBlock}
+
+## Direct child tasks
+
+${tasksBlock}
+${guidanceBlock}${childBlock}
+## Contract
+
+- Slice: ${manifestNode.investigation_prompt}
+- Hypothesis: ${manifestNode.hypothesis} (confidence: ${manifestNode.confidence})
+- Expected deliverables: 1 \`take_note(kind='audit_proposal', initiative_id='${initiative.id}')\`, body matches the audit_proposal v1 schema (§4.3).
+- Acceptance criteria:
+  * Body parses as the audit_proposal v1 schema.
+  * \`repo_evidence\` has ≥1 entry of kind ∈ {file, git, pr, note}.
+  * If \`confidence\` is \`low\` or \`medium\`, \`would_confirm_by\` is non-empty.
+  * If \`proposed_action\` is \`keep\`, \`proposed_changes\` is the empty object \`{}\`.
+- Expected duration: ≤ 5 minutes. You are scoped to this node — don't audit siblings.
+
+## Scoped evidence hints (from surveyor)
+
+${hintsBlock}
+
+## Schema reminder (audit_proposal v1)
+
+Top-level fields:
+- \`version\`: literal \`1\`.
+- \`node_initiative_id\`: this node's initiative id (\`${initiative.id}\`).
+- \`current_mc_status\`: current MC status string.
+- \`current_mc_target_end\`: ISO \`YYYY-MM-DD\` or \`null\`.
+- \`proposed_action\`: one of \`keep\` | \`mark_done\` | \`cancel\` | \`modify_scope\` | \`modify_dates\`.
+- \`proposed_changes\`: shape depends on action:
+  * \`keep\` → \`{}\`
+  * \`mark_done\` → \`{ note: string }\`
+  * \`cancel\` → \`{ reason: string }\`
+  * \`modify_scope\` → \`{ title?: string, description?: string }\` (≥1 required)
+  * \`modify_dates\` → \`{ target_start?: 'YYYY-MM-DD', target_end?: 'YYYY-MM-DD' }\` (≥1 required)
+- \`repo_evidence\`: array (min 1) of \`{ kind: 'file'|'git'|'pr'|'note', ref: string }\`.
+- \`rationale\`: 1-paragraph string.
+- \`confidence\`: \`low\` | \`medium\` | \`high\`.
+- \`would_confirm_by\`: required (non-empty string) when confidence is \`low\` or \`medium\`; may be \`null\` when high.
+- \`continuation_note_id\`: \`null\` unless overflow splitting (rare).
+
+Example body:
+
+\`\`\`jsonc
+${exampleBody}
+\`\`\`
+
+## How to emit
+
+\`\`\`
+${takeNoteCall}
+\`\`\`
+
+## Retries on validation failure
+
+The MCP \`take_note\` handler validates the body against the schema +
+the 3000-char cap. On failure it returns a structured error naming the
+failing field. **Retry up to 2 times** with a tightened body. After 2
+failures, fall back to:
+
+\`\`\`
+${fallbackCall}
+\`\`\`
+
+The orchestrator will detect the missing \`audit_proposal\` row and emit
+a synthetic \`keep\` proposal with \`confidence: 'low'\` so the proposal
+queue retains full coverage.
+
+## Discipline
+
+- ONE \`audit_proposal\` note for this node. No \`breadcrumb\` /
+  \`discovery\` / \`question\` chatter during the audit.
+- Auditors are read-only. Do **not** call \`update_task_status\`,
+  \`update_initiative\`, or \`register_deliverable\`.
+- Stay under ~2900 chars in the body so a tightening retry has room.
+- If the node has no associated code (planned-only), emit a \`keep\`
+  proposal with \`confidence: 'low'\` and a one-line rationale +
+  \`would_confirm_by\`. Don't burn ten minutes greenfield-grepping.
 `;
 }

--- a/src/lib/agents/subtree-audit.test.ts
+++ b/src/lib/agents/subtree-audit.test.ts
@@ -20,9 +20,11 @@ import {
   enumerateLayersBottomUp,
   boundedAll,
   runSubtreeAudit,
+  summarizeProposalForBriefing,
 } from './subtree-audit';
 import { createInitiative } from '@/lib/db/initiatives';
-import { listNotes } from '@/lib/db/agent-notes';
+import { createNote, listNotes } from '@/lib/db/agent-notes';
+import { auditProposalBodySchema } from '@/lib/agents/audit-proposals/schemas';
 import { getAgentRun } from '@/lib/db/agent-runs';
 import type { SurveyorResult } from './audit-survey';
 import {
@@ -433,20 +435,298 @@ test('runSubtreeAudit (subtree-proposal): surveyor failure → fallback dispatch
     surveyorOverride,
   });
 
-  // All three nodes (root + 2 children) get dispatched (no skips in fallback).
+  // The two children are dispatched. The root is NOT dispatched in
+  // subtree-proposal mode — it's deferred to the L3 synthesizer
+  // (Phase 4).
   const childRuns = queryAll<{ initiative_id: string }>(
     `SELECT initiative_id FROM agent_runs WHERE workspace_id = ? AND parent_run_id = ?`,
     [ws, result.parentRunId],
   );
   const dispatchedIds = new Set(childRuns.map((r) => r.initiative_id));
-  for (const id of [root.id, c1.id, c2.id]) {
+  for (const id of [c1.id, c2.id]) {
     assert.ok(dispatchedIds.has(id), `expected dispatch for ${id}`);
   }
-  // No synthetic audit_proposal notes because nothing was skipped.
+  assert.ok(!dispatchedIds.has(root.id), 'root must not be dispatched in subtree-proposal mode');
+  // The default stubClient never writes an audit_proposal, so each
+  // dispatched leaf falls into the Phase-3 synthetic-keep fallback path.
   const propNotes = listNotes({
     initiative_id: c1.id,
     kinds: ['audit_proposal'],
     limit: 5,
   });
-  assert.equal(propNotes.length, 0);
+  assert.equal(propNotes.length, 1, 'fallback keep proposal emitted');
+  const fb = JSON.parse(propNotes[0].body);
+  assert.equal(fb.proposed_action, 'keep');
+  assert.equal(fb.confidence, 'low');
+});
+
+// ─── runSubtreeAudit: mode='subtree-proposal' (Phase 3) ────────────
+
+/**
+ * Stub client variant that, on each `chat.send`, optionally lets the
+ * test create an audit_proposal note for the dispatched initiative
+ * before emitting the final event. Initiative id is parsed out of the
+ * trigger message (the per-node briefing puts `id=<initiativeId>` in
+ * the Target line).
+ */
+function stubClientWithProposalHook(
+  hook: (initiativeId: string | null) => void,
+): SendChatClient {
+  const listeners = new Set<(p: ChatEvent) => void>();
+  return {
+    isConnected: () => true,
+    on: (event, listener) => {
+      if (event === 'chat_event') listeners.add(listener);
+      return undefined;
+    },
+    off: (event, listener) => {
+      if (event === 'chat_event') listeners.delete(listener);
+      return undefined;
+    },
+    call: async (method, params) => {
+      if (method !== 'chat.send') return undefined;
+      const sessionKey = (params as { sessionKey?: string } | undefined)?.sessionKey;
+      const message = (params as { message?: string } | undefined)?.message ?? '';
+      // Parse initiative id from the briefing's "id=..." marker.
+      const m = /id=([^),\s]+)/.exec(message);
+      const initiativeId = m ? m[1] : null;
+      hook(initiativeId);
+      setImmediate(() => {
+        for (const l of listeners) l({ state: 'final', message: 'ok', sessionKey } as ChatEvent);
+      });
+      return {};
+    },
+  };
+}
+
+test('runSubtreeAudit (subtree-proposal): happy path — auditor emits valid proposal, picked up + threaded', async () => {
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Happy root' });
+  const leaf = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'Happy leaf',
+    parent_initiative_id: root.id,
+  });
+
+  // Stubbed auditor: when dispatched against the leaf, write a
+  // schema-conformant audit_proposal note.
+  __setSendChatClientForTests(
+    stubClientWithProposalHook((initiativeId) => {
+      if (initiativeId !== leaf.id) return;
+      const body = JSON.stringify({
+        version: 1,
+        node_initiative_id: leaf.id,
+        current_mc_status: 'in_progress',
+        current_mc_target_end: null,
+        proposed_action: 'mark_done',
+        proposed_changes: { note: 'PR #999 closes this story; tests green.' },
+        repo_evidence: [{ kind: 'pr', ref: 'https://example/pull/999' }],
+        rationale: 'PR #999 implements the happy path and ships tests.',
+        confidence: 'high',
+        would_confirm_by: null,
+        continuation_note_id: null,
+      });
+      createNote({
+        workspace_id: ws,
+        agent_id: null,
+        initiative_id: leaf.id,
+        scope_key: `initiative-${root.id}:audit:test`,
+        role: 'auditor',
+        run_group_id: uuidv4(),
+        kind: 'audit_proposal',
+        audience: 'pm',
+        body,
+        importance: 2,
+      });
+    }),
+  );
+
+  const surveyorOverride = async (): Promise<SurveyorResult> => ({
+    manifest: {
+      version: 1,
+      root_initiative_id: root.id,
+      attempt: 1,
+      previous_synthesis_run_group_id: null,
+      summary: 'happy',
+      nodes: [
+        {
+          initiative_id: leaf.id,
+          title: leaf.title,
+          current_status: 'in_progress',
+          hypothesis: 'likely-done',
+          confidence: 'medium',
+          investigation_prompt: 'Confirm this story is done.',
+          scoped_evidence_hints: [],
+          skip: false,
+        },
+      ],
+      cross_cutting_questions: [],
+    },
+    surveyorNoteId: null,
+    dispatchOutcome: 'ok',
+  });
+
+  const result = await runSubtreeAudit({
+    rootId: root.id,
+    workspaceId: ws,
+    guidance: null,
+    perNodeTimeoutMs: 10_000,
+    subtreeConcurrency: 1,
+    runner: fakeRunner(),
+    mode: 'subtree-proposal',
+    surveyorOverride,
+  });
+
+  // Per-node outcome for leaf is ok; root is deferred.
+  const leafOutcome = result.perNodeOutcomes.find((o) => o.initiativeId === leaf.id);
+  assert.ok(leafOutcome);
+  assert.equal(leafOutcome!.status, 'ok');
+  const proposalsForLeaf = listNotes({
+    initiative_id: leaf.id,
+    kinds: ['audit_proposal'],
+    limit: 5,
+  });
+  assert.equal(proposalsForLeaf.length, 1);
+  const parsed = JSON.parse(proposalsForLeaf[0].body);
+  assert.equal(parsed.proposed_action, 'mark_done');
+
+  // Root outcome is the deferred placeholder; root was NOT dispatched.
+  const rootOutcome = result.perNodeOutcomes.find((o) => o.initiativeId === root.id);
+  assert.ok(rootOutcome);
+  assert.match(rootOutcome!.note ?? '', /root deferred to L3 synthesizer/);
+  const rootRuns = queryAll<{ id: string }>(
+    `SELECT id FROM agent_runs WHERE workspace_id = ? AND initiative_id = ? AND parent_run_id = ?`,
+    [ws, root.id, result.parentRunId],
+  );
+  assert.equal(rootRuns.length, 0, 'root must NOT be dispatched in subtree-proposal mode');
+});
+
+test('runSubtreeAudit (subtree-proposal): no proposal landed → synthetic fallback keep with low confidence', async () => {
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Fallback proposal root' });
+  const leaf = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'Sad leaf',
+    parent_initiative_id: root.id,
+  });
+
+  // Stubbed auditor "completes" but writes the wrong kind (observation),
+  // simulating the agent's last-resort fallback path.
+  __setSendChatClientForTests(
+    stubClientWithProposalHook((initiativeId) => {
+      if (initiativeId !== leaf.id) return;
+      createNote({
+        workspace_id: ws,
+        agent_id: null,
+        initiative_id: leaf.id,
+        scope_key: `initiative-${root.id}:audit:test`,
+        role: 'auditor',
+        run_group_id: uuidv4(),
+        kind: 'observation',
+        audience: 'pm',
+        body: 'gave up after 2 retries',
+        importance: 2,
+      });
+    }),
+  );
+
+  const surveyorOverride = async (): Promise<SurveyorResult> => ({
+    manifest: {
+      version: 1,
+      root_initiative_id: root.id,
+      attempt: 1,
+      previous_synthesis_run_group_id: null,
+      summary: 'sad',
+      nodes: [
+        {
+          initiative_id: leaf.id,
+          title: leaf.title,
+          current_status: 'in_progress',
+          hypothesis: 'needs-deep-dive',
+          confidence: 'low',
+          investigation_prompt: 'Dig.',
+          scoped_evidence_hints: [],
+          skip: false,
+        },
+      ],
+      cross_cutting_questions: [],
+    },
+    surveyorNoteId: null,
+    dispatchOutcome: 'ok',
+  });
+
+  const result = await runSubtreeAudit({
+    rootId: root.id,
+    workspaceId: ws,
+    guidance: null,
+    perNodeTimeoutMs: 10_000,
+    subtreeConcurrency: 1,
+    runner: fakeRunner(),
+    mode: 'subtree-proposal',
+    surveyorOverride,
+  });
+
+  const leafOutcome = result.perNodeOutcomes.find((o) => o.initiativeId === leaf.id);
+  assert.ok(leafOutcome);
+  assert.equal(leafOutcome!.status, 'failed');
+  assert.match(leafOutcome!.error ?? '', /no audit_proposal landed/);
+
+  const proposals = listNotes({
+    initiative_id: leaf.id,
+    kinds: ['audit_proposal'],
+    limit: 5,
+  });
+  assert.equal(proposals.length, 1, 'synthetic fallback proposal exists');
+  const body = JSON.parse(proposals[0].body);
+  assert.equal(body.proposed_action, 'keep');
+  assert.equal(body.confidence, 'low');
+  assert.match(body.rationale, /audit failed.*invalid proposal body/);
+  assert.ok(body.would_confirm_by && body.would_confirm_by.length > 0);
+});
+
+test('summarizeProposalForBriefing: each proposed_action enum produces ≤6 lines of prose', () => {
+  const base = {
+    version: 1 as const,
+    node_initiative_id: 'i1',
+    current_mc_status: 'in_progress',
+    current_mc_target_end: null,
+    repo_evidence: [{ kind: 'file' as const, ref: 'a.ts' }],
+    rationale: 'because',
+    confidence: 'medium' as const,
+    would_confirm_by: 'reading b.ts',
+    continuation_note_id: null,
+  };
+  const cases = [
+    { ...base, proposed_action: 'keep' as const, proposed_changes: {} },
+    {
+      ...base,
+      proposed_action: 'mark_done' as const,
+      proposed_changes: { note: 'shipped' },
+    },
+    {
+      ...base,
+      proposed_action: 'cancel' as const,
+      proposed_changes: { reason: 'obsolete' },
+    },
+    {
+      ...base,
+      proposed_action: 'modify_scope' as const,
+      proposed_changes: { title: 'New', description: 'Different' },
+    },
+    {
+      ...base,
+      proposed_action: 'modify_dates' as const,
+      proposed_changes: { target_start: '2026-01-01', target_end: '2026-02-01' },
+    },
+  ];
+  for (const c of cases) {
+    const parsed = auditProposalBodySchema.parse(c);
+    const out = summarizeProposalForBriefing(parsed);
+    assert.match(out, /Proposed action:/);
+    assert.match(out, /Rationale:/);
+    assert.match(out, /Evidence:/);
+    assert.ok(out.split('\n').length <= 6, `too many lines for ${c.proposed_action}: ${out}`);
+  }
 });

--- a/src/lib/agents/subtree-audit.ts
+++ b/src/lib/agents/subtree-audit.ts
@@ -47,6 +47,7 @@ import {
   auditProposalBodySchema,
   type AuditManifestBody,
   type AuditManifestNode,
+  type AuditProposalBody,
 } from '@/lib/agents/audit-proposals/schemas';
 
 const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
@@ -57,6 +58,45 @@ const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
  * display semantic — orchestration always finishes the layered fan-out.
  */
 export const SUBTREE_FAILURE_THRESHOLD = 0.5;
+
+/**
+ * Render a parsed `audit_proposal` body as ~3-5 lines of prose for use
+ * as childFindings input to a parent-layer briefing in
+ * `mode: 'subtree-proposal'`. Pure / exported for tests.
+ */
+export function summarizeProposalForBriefing(body: AuditProposalBody): string {
+  const lines: string[] = [];
+  lines.push(
+    `Proposed action: **${body.proposed_action}** (confidence: ${body.confidence}).`,
+  );
+  if (body.proposed_action === 'mark_done') {
+    lines.push(`Completion note: ${body.proposed_changes.note}`);
+  } else if (body.proposed_action === 'cancel') {
+    lines.push(`Cancel reason: ${body.proposed_changes.reason}`);
+  } else if (body.proposed_action === 'modify_scope') {
+    const parts: string[] = [];
+    if (body.proposed_changes.title) parts.push(`title→"${body.proposed_changes.title}"`);
+    if (body.proposed_changes.description) parts.push('description updated');
+    lines.push(`Scope change: ${parts.join(', ')}`);
+  } else if (body.proposed_action === 'modify_dates') {
+    const parts: string[] = [];
+    if (body.proposed_changes.target_start)
+      parts.push(`target_start→${body.proposed_changes.target_start}`);
+    if (body.proposed_changes.target_end)
+      parts.push(`target_end→${body.proposed_changes.target_end}`);
+    lines.push(`Date change: ${parts.join(', ')}`);
+  }
+  // Rationale — keep first ~240 chars; the parent briefing has many of
+  // these and we don't want to blow the context budget.
+  const r = body.rationale.trim();
+  lines.push(`Rationale: ${r.length > 240 ? r.slice(0, 240) + '…' : r}`);
+  if (body.would_confirm_by && body.would_confirm_by.trim()) {
+    lines.push(`Would confirm by: ${body.would_confirm_by.trim()}`);
+  }
+  const evCount = body.repo_evidence.length;
+  lines.push(`Evidence: ${evCount} ref${evCount === 1 ? '' : 's'}.`);
+  return lines.join('\n');
+}
 
 /** Initiative shape we need internally — kept narrow on purpose. */
 type LiteInitiative = Pick<
@@ -440,8 +480,62 @@ export async function runSubtreeAudit(
     }
   };
 
+  /**
+   * Emit a synthetic fallback `audit_proposal` (proposed_action: 'keep',
+   * confidence: 'low') for an L2 node where the auditor returned but
+   * didn't land a valid proposal. Spec §5.5.
+   */
+  const emitFallbackKeepProposal = (
+    node: LiteInitiative,
+  ): { noteId: string; body: string } | null => {
+    const bodyObj = {
+      version: 1 as const,
+      node_initiative_id: node.id,
+      current_mc_status: node.status,
+      current_mc_target_end: node.target_end ?? null,
+      proposed_action: 'keep' as const,
+      proposed_changes: {},
+      repo_evidence: [
+        { kind: 'note' as const, ref: `audit-fallback:initiative-${node.id}` },
+      ],
+      rationale: '(audit failed: invalid proposal body after retries)',
+      confidence: 'low' as const,
+      would_confirm_by: 'Re-running the audit on this node specifically.',
+      continuation_note_id: null,
+    };
+    const parsed = auditProposalBodySchema.safeParse(bodyObj);
+    if (!parsed.success) {
+      console.warn(
+        `[subtree-audit] synthetic fallback proposal failed schema check for ${node.id}: ${parsed.error.message}`,
+      );
+      return null;
+    }
+    const body = JSON.stringify(parsed.data);
+    try {
+      const created = createNote({
+        workspace_id: workspaceId,
+        agent_id: null,
+        initiative_id: node.id,
+        scope_key: `initiative-${rootId}:audit-subtree:fallback-keep:${node.id}`,
+        role: 'orchestrator',
+        run_group_id: uuidv4(),
+        kind: 'audit_proposal',
+        audience: 'pm',
+        body,
+        importance: 1,
+      });
+      return { noteId: created.id, body };
+    } catch (err) {
+      console.warn(
+        `[subtree-audit] createNote(fallback keep) failed for ${node.id}: ${(err as Error).message}`,
+      );
+      return null;
+    }
+  };
+
   for (let layerIdx = 0; layerIdx < layers.length; layerIdx++) {
     const layer = layers[layerIdx];
+    const isRootLayer = layerIdx === layers.length - 1;
     const tasks = layer.map((node) => async () => {
       const attempt = nextAuditAttempt(node.id);
       const sessionSuffix = `initiative-${node.id}:audit:${attempt}`;
@@ -449,6 +543,20 @@ export async function runSubtreeAudit(
         .session_key_prefix
         ? `${(runner as { session_key_prefix?: string | null }).session_key_prefix}:${sessionSuffix}`
         : sessionSuffix;
+
+      // Root deferred to L3 synthesizer (Phase 4). For now, no L2
+      // dispatch happens for the root in subtree-proposal mode — record
+      // a placeholder outcome so the rollup math still has full coverage.
+      if (mode === 'subtree-proposal' && isRootLayer && node.id === rootId) {
+        perNodeOutcomes.push({
+          initiativeId: node.id,
+          layerIndex: layerIdx,
+          scopeKey,
+          status: 'ok',
+          note: '(root deferred to L3 synthesizer; not implemented in Phase 3)',
+        });
+        return;
+      }
 
       // Manifest-driven skip: don't dispatch — emit a synthetic keep
       // proposal and record the outcome so the parent layer's
@@ -486,10 +594,26 @@ export async function runSubtreeAudit(
         for (const candidate of layers[prior]) {
           if (candidate.parent_initiative_id === node.id) {
             const f = findingsByInitiative.get(candidate.id);
+            let renderedBody =
+              f?.body ?? '_(no finding recorded — child audit did not run)_';
+            // In subtree-proposal mode, child findings are JSON
+            // audit_proposal bodies — summarize them as prose for the
+            // parent auditor.
+            if (mode === 'subtree-proposal' && f?.body && !f.failed) {
+              try {
+                const parsed = auditProposalBodySchema.safeParse(JSON.parse(f.body));
+                if (parsed.success) {
+                  renderedBody = summarizeProposalForBriefing(parsed.data);
+                }
+              } catch {
+                // Leave renderedBody as-is; the parent briefing will
+                // still see the raw JSON or placeholder.
+              }
+            }
             childFindings.push({
               childId: candidate.id,
               childTitle: candidate.title,
-              body: f?.body ?? '_(no finding recorded — child audit did not run)_',
+              body: renderedBody,
               failed: f?.failed ?? true,
             });
           }
@@ -520,6 +644,8 @@ export async function runSubtreeAudit(
         [node.id],
       );
 
+      const manifestEntryForNode =
+        mode === 'subtree-proposal' ? manifestNodeFor(node.id) : null;
       const triggerBody = buildAuditPrompt({
         initiative: node,
         tasks: tasksForNode,
@@ -527,13 +653,32 @@ export async function runSubtreeAudit(
         guidance: guidance ?? null,
         priorFindings: [],
         childFindings,
-        mode: 'subtree',
+        mode: mode === 'subtree-proposal' ? 'subtree-proposal' : 'subtree',
+        proposalInput:
+          mode === 'subtree-proposal'
+            ? {
+                rootId,
+                attempt,
+                manifestNode: {
+                  hypothesis: manifestEntryForNode?.hypothesis ?? 'needs-deep-dive',
+                  confidence: manifestEntryForNode?.confidence ?? 'low',
+                  investigation_prompt:
+                    manifestEntryForNode?.investigation_prompt ??
+                    `Audit ${node.title} against repo + MC reality and emit a structured proposal.`,
+                  scoped_evidence_hints:
+                    manifestEntryForNode?.scoped_evidence_hints ?? [],
+                },
+              }
+            : undefined,
       });
+
+      const dispatchRole: 'researcher' | 'auditor' =
+        mode === 'subtree-proposal' ? 'auditor' : 'researcher';
 
       try {
         await dispatchScope({
           workspace_id: workspaceId,
-          role: 'researcher',
+          role: dispatchRole,
           agent: runner,
           session_suffix: sessionSuffix,
           scope_type: 'initiative_audit',
@@ -548,9 +693,49 @@ export async function runSubtreeAudit(
           label: `Audit: ${node.title}`,
         });
 
-        // Pull the most recent observation/pm/importance=2 note for
-        // this initiative — the researcher's report. listNotes orders
-        // by created_at desc by default.
+        if (mode === 'subtree-proposal') {
+          // Look for the most recent audit_proposal note on this node.
+          // The MCP take_note validator from Phase 1 has already
+          // enforced schema validity at write time — if a row exists,
+          // it parses cleanly.
+          const propNotes = listNotes({
+            initiative_id: node.id,
+            kinds: ['audit_proposal'],
+            limit: 1,
+            order: 'desc',
+          });
+          const propBody = propNotes[0]?.body?.trim();
+          if (propBody) {
+            findingsByInitiative.set(node.id, { body: propBody, failed: false });
+            perNodeOutcomes.push({
+              initiativeId: node.id,
+              layerIndex: layerIdx,
+              scopeKey,
+              status: 'ok',
+              note: propBody,
+            });
+          } else {
+            // No audit_proposal landed — emit synthetic fallback.
+            const synth = emitFallbackKeepProposal(node);
+            const fallbackBody =
+              synth?.body ??
+              `(audit failed: invalid proposal body after retries; synthetic fallback createNote also failed for ${node.id})`;
+            findingsByInitiative.set(node.id, {
+              body: fallbackBody,
+              failed: true,
+            });
+            perNodeOutcomes.push({
+              initiativeId: node.id,
+              layerIndex: layerIdx,
+              scopeKey,
+              status: 'failed',
+              error: 'no audit_proposal landed; synthetic fallback emitted',
+            });
+          }
+          return;
+        }
+
+        // mode === 'subtree' — original prose-observation flow.
         const notes = listNotes({
           initiative_id: node.id,
           audience: 'pm',


### PR DESCRIPTION
## Summary
Phase 3 of [spec #284](https://github.com/smb209/mission-control/pull/284). L2 dispatches in `mode: 'subtree-proposal'` now emit structured `audit_proposal` notes against a per-node Delegation Contract briefing — replacing the free-form `kind: 'observation'` output today's `mode: 'subtree'` branch produces.

Stacks on [#285](https://github.com/smb209/mission-control/pull/285) (merged) + [#286](https://github.com/smb209/mission-control/pull/286) (merged).

## Behavior in `mode: 'subtree-proposal'`
1. **Root layer** is skipped from L2 fan-out — reserved for Phase 4's L3 synthesizer. Placeholder `perNodeOutcome` records `(root deferred to L3 synthesizer; not implemented in Phase 3)`.
2. **Non-root, non-manifest-skipped nodes** dispatched as `role: 'auditor'` with the new `mode: 'subtree-proposal'` audit prompt. Manifest entry from L1 threaded into the briefing.
3. **After each L2 dispatch**: orchestrator looks for `kind: 'audit_proposal'` on `initiative_id = node.id`. The Phase 1 `take_note` validator has already enforced schema validity at write time.
4. **Fallback when no proposal landed**: orchestrator emits synthetic keep with `confidence: 'low'`, `rationale: '(audit failed: invalid proposal body after retries)'` via direct `createNote` (mirrors Phase 2's `emitSyntheticKeepProposal` pattern). `perNodeOutcome.status = 'failed'`.
5. **childFindings**: leaf-layer `audit_proposal` bodies are summarized via the new pure helper `summarizeProposalForBriefing` (~3–5 lines of prose) so intermediate-layer auditors see them in readable form.

`mode: 'subtree'` is **untouched** — both modes coexist through Phase 3. Phase 4 retires `subtree`.

## Changes
- **`audit-prompt.ts`** — new `mode: 'subtree-proposal'` branch via `buildSubtreeProposalPrompt`. Contract block (slice/hypothesis/deliverables/acceptance/duration), §4.3 schema reminder field-by-field with one-line example, retry/fallback guidance, read-only auditor discipline. `BuildAuditPromptInput` extended with `proposalInput` (rootId/attempt/manifestNode).
- **`subtree-audit.ts`** — exported pure `summarizeProposalForBriefing(body)`; new `emitFallbackKeepProposal(node)` for the synthetic low-confidence fallback; layer-loop body branched on `mode` so `subtree-proposal` skips root + uses auditor role + dispatches new prompt mode + does the audit_proposal readback.
- **`subtree-audit.test.ts`** — three new Phase 3 tests (happy path, no-proposal fallback, root deferred), plus `summarizeProposalForBriefing` table test for all 5 `proposed_action` enum values.

## Spec deviations (documented; subagent report)
- **Phase 2 surveyor-failure test updated.** Phase 3 changes its preconditions: root is now deferred (was previously dispatched in `subtree-proposal` mode) and the default `stubClient` writes no proposal so the synthetic fallback fires. Updated in place rather than duplicated.
- **`stubClientWithProposalHook`** parses `id=<initiativeId>` from the briefing and side-effects a real `audit_proposal` row before the final event. Avoids dragging openclaw/MCP plumbing into unit tests while still exercising the orchestrator's readback path end-to-end.
- **L2 manifest fallback**: when a node has no manifest entry (e.g. surveyor failure → fallback manifest synthesized by Phase 2's `buildFallbackManifest`), the L2 briefing fills in `hypothesis: 'needs-deep-dive'`, `confidence: 'low'`, a synthesized `investigation_prompt`, and empty hints. Documented inline.

## What this PR does NOT do (deferred per spec §10)
- L3 synthesizer dispatch + removal of `mode: 'subtree'` (Phase 4).
- `POST .../resynthesize` endpoint (Phase 4).
- Delta-run manifest in L1 (Phase 5).
- Operator proposal queue UI (Phase 6).

## Test plan
- [x] `yarn test`: **922 pass, 1 fail**. Single fail is the same pre-existing `schedule-runner: produces a brief and advances run_count`.
- [x] `yarn run tsc --noEmit`: only the 3 pre-existing errors remain. All Phase-3-touched files typecheck clean.
- [x] New tests: 3 in `subtree-audit.test.ts` for the Phase 3 paths; `summarizeProposalForBriefing` table for all proposed_action enum values. All pass.
- N/A: preview-verify (no UI change; behavior reachable only via the existing `mode: 'subtree-proposal'` API path which is not yet wired to a UI button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)