### PR TITLE
feat(audit): phase 4 — L3 synthesizer + hard cutover (remove mode='subtree')

### DIFF
--- a/src/app/api/initiatives/[id]/investigate/resynthesize/route.test.ts
+++ b/src/app/api/initiatives/[id]/investigate/resynthesize/route.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for POST /api/initiatives/:id/investigate/resynthesize.
+ *
+ * Phase 4 of specs/subtree-audit-proposals-spec.md (§6.1). Covers:
+ *   - happy path: existing manifest + proposals → L3 fires (via test
+ *     seam) and the response carries the new synthesis_note_id.
+ *   - missing manifest: 400 with the documented error.
+ *   - missing runner: 503.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { POST, __setSynthesizerOverrideForTests } from './route';
+import { run } from '@/lib/db';
+import { createInitiative } from '@/lib/db/initiatives';
+import { createNote, listNotes } from '@/lib/db/agent-notes';
+import type { SynthesizerResult } from '@/lib/agents/audit-synthesizer';
+
+function freshWorkspace(): string {
+  const id = `ws-rs-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function clearRunner(): void {
+  run(`DELETE FROM agents WHERE gateway_agent_id IN ('mc-runner','mc-runner-dev')`);
+}
+
+function ensureRunner(): void {
+  run(
+    `INSERT OR REPLACE INTO agents
+       (id, name, role, workspace_id, gateway_agent_id, source, created_at, updated_at)
+     VALUES (?, ?, ?, 'default', 'mc-runner-dev', 'test', datetime('now'), datetime('now'))`,
+    [`agent-${uuidv4().slice(0, 8)}`, 'runner', 'researcher'],
+  );
+}
+
+async function callPost(id: string, body: unknown = {}): Promise<Response> {
+  const req = new NextRequest(
+    `http://localhost/api/initiatives/${id}/investigate/resynthesize`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+  return await POST(req, { params: Promise.resolve({ id }) });
+}
+
+test.afterEach(() => {
+  __setSynthesizerOverrideForTests(null);
+  clearRunner();
+});
+
+test('resynthesize: missing manifest → 400 with clear error', async () => {
+  const ws = freshWorkspace();
+  const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'no-manifest root' });
+  ensureRunner();
+  const res = await callPost(i.id);
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.match(body.error, /no audit_manifest exists/i);
+  assert.match(body.error, /run a full audit first/i);
+});
+
+test('resynthesize: missing runner → 503', async () => {
+  const ws = freshWorkspace();
+  const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'no-runner root' });
+  clearRunner();
+  const res = await callPost(i.id);
+  assert.equal(res.status, 503);
+});
+
+test('resynthesize: happy path — synthesizer fires and note id returned', async () => {
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'rs root' });
+  const leaf = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'rs leaf',
+    parent_initiative_id: root.id,
+  });
+  ensureRunner();
+
+  // Seed an audit_manifest on the root.
+  const manifestBody = JSON.stringify({
+    version: 1,
+    root_initiative_id: root.id,
+    attempt: 1,
+    previous_synthesis_run_group_id: null,
+    summary: 'seed',
+    nodes: [
+      {
+        initiative_id: leaf.id,
+        title: leaf.title,
+        current_status: 'in_progress',
+        hypothesis: 'needs-deep-dive',
+        confidence: 'medium',
+        investigation_prompt: 'dig',
+        scoped_evidence_hints: [],
+        skip: false,
+      },
+    ],
+    cross_cutting_questions: [],
+  });
+  createNote({
+    workspace_id: ws,
+    agent_id: null,
+    initiative_id: root.id,
+    scope_key: `initiative-${root.id}:audit-survey:1`,
+    role: 'auditor',
+    run_group_id: uuidv4(),
+    kind: 'audit_manifest',
+    audience: 'pm',
+    body: manifestBody,
+    importance: 1,
+  });
+
+  // Seed a leaf audit_proposal so the synthesizer briefing has input.
+  const propBody = JSON.stringify({
+    version: 1,
+    node_initiative_id: leaf.id,
+    current_mc_status: 'in_progress',
+    current_mc_target_end: null,
+    proposed_action: 'mark_done',
+    proposed_changes: { note: 'shipped via PR #999' },
+    repo_evidence: [{ kind: 'pr', ref: 'https://example/pull/999' }],
+    rationale: 'shipped',
+    confidence: 'high',
+    would_confirm_by: null,
+    continuation_note_id: null,
+  });
+  createNote({
+    workspace_id: ws,
+    agent_id: null,
+    initiative_id: leaf.id,
+    scope_key: `initiative-${root.id}:audit:1`,
+    role: 'auditor',
+    run_group_id: uuidv4(),
+    kind: 'audit_proposal',
+    audience: 'pm',
+    body: propBody,
+    importance: 2,
+  });
+
+  // Override the synthesizer: write the synthesis note + return ok.
+  let dispatchCount = 0;
+  __setSynthesizerOverrideForTests(async (args): Promise<SynthesizerResult> => {
+    dispatchCount += 1;
+    const synthBody = JSON.stringify({
+      version: 1,
+      root_initiative_id: args.rootId,
+      attempt: args.attempt,
+      completion_sentinel:
+        'Audit complete: 1 node — 1 mark_done; epic dates unchanged',
+      epic_proposals: [],
+      cross_node_proposals: [],
+    });
+    const note = createNote({
+      workspace_id: args.workspaceId,
+      agent_id: null,
+      initiative_id: args.rootId,
+      scope_key: `initiative-${args.rootId}:audit-synthesis:${args.attempt}`,
+      role: 'auditor',
+      run_group_id: uuidv4(),
+      kind: 'audit_synthesis',
+      audience: 'pm',
+      body: synthBody,
+      importance: 2,
+    });
+    return {
+      synthesis: JSON.parse(synthBody),
+      synthesisNoteId: note.id,
+      dispatchOutcome: 'ok',
+    };
+  });
+
+  const res = await callPost(root.id);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.dispatch_outcome, 'ok');
+  assert.equal(typeof body.synthesis_note_id, 'string');
+  assert.equal(dispatchCount, 1);
+
+  // Verify the synthesis note actually landed.
+  const synthNotes = listNotes({
+    initiative_id: root.id,
+    kinds: ['audit_synthesis'],
+    limit: 5,
+  });
+  assert.equal(synthNotes.length, 1);
+  assert.equal(synthNotes[0].id, body.synthesis_note_id);
+});

--- a/src/app/api/initiatives/[id]/investigate/resynthesize/route.ts
+++ b/src/app/api/initiatives/[id]/investigate/resynthesize/route.ts
@@ -1,0 +1,175 @@
+/**
+ * POST /api/initiatives/:id/investigate/resynthesize
+ *
+ * Re-runs ONLY the L3 synthesizer against the existing audit_manifest +
+ * the most recent audit_proposal notes per descendant. Spec
+ * `specs/subtree-audit-proposals-spec.md` §6.1.
+ *
+ * Cheap; useful when L3 fails or the operator wants to re-roll the
+ * cross-cutting reasoning without re-grepping the repo.
+ *
+ * Authorization: same as the parent investigate route (workspace
+ * membership is implicit through the initiative lookup; the route
+ * doesn't gate further today).
+ *
+ * Request body: empty / `{ guidance?: string }` (optional focus area).
+ *
+ * Response (200): { ok, synthesis_note_id, dispatch_outcome }.
+ * Response (400): no audit_manifest exists for this initiative — the
+ *   operator should run the full audit first.
+ * Response (404): initiative not found.
+ * Response (503): runner agent missing.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getInitiative } from '@/lib/db/initiatives';
+import { getRunnerAgent } from '@/lib/agents/runner';
+import { listNotes } from '@/lib/db/agent-notes';
+import { queryAll } from '@/lib/db';
+import {
+  validateAuditNoteBody,
+  type AuditManifestBody,
+} from '@/lib/agents/audit-proposals/schemas';
+import {
+  runSynthesizer,
+  loadProposalsForSubtree,
+  type SynthesizerResult,
+} from '@/lib/agents/audit-synthesizer';
+
+export const dynamic = 'force-dynamic';
+
+const ResynthSchema = z.object({
+  guidance: z.string().max(2000).nullish(),
+});
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/** Compute the next attempt number for the synthesis dispatch. */
+function nextAuditAttempt(initiativeId: string): number {
+  const rows = queryAll<{ n: number }>(
+    `SELECT COUNT(*) as n
+       FROM mc_sessions
+      WHERE scope_type = 'initiative_audit'
+        AND initiative_id = ?`,
+    [initiativeId],
+  );
+  return (rows[0]?.n ?? 0) + 1;
+}
+
+/**
+ * Test seam — set via `__setSynthesizerOverrideForTests` so unit tests
+ * can stub the synthesizer dispatch without exercising the openclaw
+ * gateway. Mirrors the override pattern in `subtree-audit.ts`.
+ */
+let _synthesizerOverride:
+  | ((args: Parameters<typeof runSynthesizer>[0]) => Promise<SynthesizerResult>)
+  | null = null;
+
+export function __setSynthesizerOverrideForTests(
+  override:
+    | ((args: Parameters<typeof runSynthesizer>[0]) => Promise<SynthesizerResult>)
+    | null,
+): void {
+  _synthesizerOverride = override;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: RouteParams,
+): Promise<Response> {
+  try {
+    const { id } = await params;
+    const raw = await request.json().catch(() => ({}));
+    const parsed = ResynthSchema.safeParse(raw);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const { guidance } = parsed.data;
+
+    const initiative = getInitiative(id);
+    if (!initiative) {
+      return NextResponse.json(
+        { error: 'Initiative not found' },
+        { status: 404 },
+      );
+    }
+
+    const runner = getRunnerAgent();
+    if (!runner) {
+      return NextResponse.json(
+        {
+          error:
+            'Runner agent not registered (mc-runner-dev / mc-runner missing)',
+        },
+        { status: 503 },
+      );
+    }
+
+    // Pull the most recent audit_manifest. Without it, the operator
+    // hasn't run a full audit yet — punt with a clear message.
+    const manifestRows = listNotes({
+      initiative_id: id,
+      kinds: ['audit_manifest'],
+      limit: 1,
+      order: 'desc',
+    });
+    const manifestRow = manifestRows[0];
+    if (!manifestRow) {
+      return NextResponse.json(
+        {
+          error:
+            'no audit_manifest exists for this initiative; run a full audit first',
+        },
+        { status: 400 },
+      );
+    }
+    const manifestParsed = validateAuditNoteBody('audit_manifest', manifestRow.body);
+    const manifest: AuditManifestBody | null = manifestParsed.ok
+      ? (manifestParsed.parsed as AuditManifestBody)
+      : null;
+
+    const proposalSummaries = loadProposalsForSubtree(id, initiative.workspace_id);
+
+    const attempt = nextAuditAttempt(id);
+    const synthFn = _synthesizerOverride ?? runSynthesizer;
+    let result: SynthesizerResult;
+    try {
+      result = await synthFn({
+        rootId: id,
+        workspaceId: initiative.workspace_id,
+        attempt,
+        runner,
+        parentRunId: null,
+        manifest,
+        proposalSummaries,
+        guidance: guidance ?? null,
+      });
+    } catch (err) {
+      result = {
+        synthesis: null,
+        synthesisNoteId: null,
+        dispatchOutcome: 'failed',
+        errorMessage: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    return NextResponse.json({
+      ok: result.dispatchOutcome === 'ok',
+      dispatch_outcome: result.dispatchOutcome,
+      synthesis_note_id: result.synthesisNoteId,
+      error_message: result.errorMessage ?? null,
+    });
+  } catch (error) {
+    console.error('[investigate/resynthesize] route error:', error);
+    return NextResponse.json(
+      { error: (error as Error).message ?? 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/initiatives/[id]/investigate/route.test.ts
+++ b/src/app/api/initiatives/[id]/investigate/route.test.ts
@@ -86,7 +86,7 @@ test('GET ?dryrun=1&mode=subtree → returns layer plan from helper', async () =
   const res = await callGet(root.id, '?dryrun=1&mode=subtree');
   assert.equal(res.status, 200);
   const body = await res.json();
-  assert.equal(body.mode, 'subtree');
+  assert.equal(body.mode, 'subtree-proposal');
   assert.equal(body.planned_nodes, 3);
   assert.equal(body.planned_layers, 3);
   assert.ok(body.concurrency >= 1);
@@ -107,6 +107,18 @@ test('GET without ?dryrun=1 → 400', async () => {
   assert.equal(res.status, 400);
 });
 
+test('POST mode=subtree (legacy) → 400 with removed-mode error', async () => {
+  const ws = freshWorkspace();
+  const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'open' });
+  const res = await callPost(i.id, { mode: 'subtree' });
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.match(body.error, /mode subtree was removed/i);
+  assert.match(body.error, /subtree-proposal/);
+  // Reference the spec section so callers can find the rationale.
+  assert.match(body.error, /§6\.3/);
+});
+
 test('POST subtree with terminal-status root → 400', async () => {
   const ws = freshWorkspace();
   const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'closed' });
@@ -120,7 +132,7 @@ test('POST subtree with terminal-status root → 400', async () => {
     [`agent-${uuidv4().slice(0, 8)}`, 'runner', 'researcher'],
   );
   try {
-    const res = await callPost(i.id, { mode: 'subtree' });
+    const res = await callPost(i.id, { mode: 'subtree-proposal' });
     assert.equal(res.status, 400);
     const body = await res.json();
     assert.match(body.error, /terminal-state initiative/i);
@@ -133,7 +145,7 @@ test('POST subtree with no runner registered → 503', async () => {
   const ws = freshWorkspace();
   const i = createInitiative({ workspace_id: ws, kind: 'epic', title: 'open' });
   clearRunner();
-  const res = await callPost(i.id, { mode: 'subtree' });
+  const res = await callPost(i.id, { mode: 'subtree-proposal' });
   assert.equal(res.status, 503);
 });
 
@@ -242,12 +254,12 @@ test('POST subtree with zero non-terminal descendants → planned_nodes=1', asyn
     [runnerId, 'runner', 'researcher'],
   );
   try {
-    const res = await callPost(root.id, { mode: 'subtree' });
+    const res = await callPost(root.id, { mode: 'subtree-proposal' });
     // Drain any unhandled background rejection into a black-hole; the
     // route's `.catch` handler already swallows + logs.
     assert.equal(res.status, 200);
     const body = await res.json();
-    assert.equal(body.mode, 'subtree');
+    assert.equal(body.mode, 'subtree-proposal');
     assert.equal(body.planned_nodes, 1);
     assert.equal(body.planned_layers, 1);
     assert.ok(typeof body.root_scope_key === 'string');

--- a/src/app/api/initiatives/[id]/investigate/route.ts
+++ b/src/app/api/initiatives/[id]/investigate/route.ts
@@ -9,16 +9,20 @@
  *
  * Request body:
  *   {
- *     mode: 'narrow' | 'subtree',
- *     guidance?: string,                // optional operator focus area
- *     reaudit?: 'fresh' | 'build_on'    // narrow only; subtree always fresh
+ *     mode: 'narrow' | 'subtree-proposal',
+ *     guidance?: string,                       // optional operator focus area
+ *     reaudit?: 'fresh' | 'build_on'           // narrow only; subtree-proposal always fresh
  *   }
+ *
+ * Phase 4 hard cutover: legacy `mode: 'subtree'` was removed (see
+ * specs/subtree-audit-proposals-spec.md §6.3). Posting it now returns
+ * 400 with a clear "use subtree-proposal" error.
  *
  * Response (200):
  *   For narrow: { ok, mode: 'narrow', scope_key, scope_keys, attempt, dispatched_at }
- *   For subtree: { ok, mode: 'subtree', root_scope_key, planned_layers,
- *                  planned_nodes, concurrency, per_node_timeout_ms,
- *                  dispatched_at }
+ *   For subtree-proposal: { ok, mode: 'subtree-proposal', root_scope_key,
+ *                           planned_layers, planned_nodes, concurrency,
+ *                           per_node_timeout_ms, dispatched_at }
  *
  * GET /api/initiatives/:id/investigate?dryrun=1&mode=subtree
  *   Returns the subtree plan ({ planned_layers, planned_nodes,
@@ -48,7 +52,9 @@ import type { AgentRun } from '@/lib/db/agent-runs';
 export const dynamic = 'force-dynamic';
 
 const InvestigateSchema = z.object({
-  mode: z.enum(['narrow', 'subtree', 'subtree-proposal']).default('narrow'),
+  // Default stays 'narrow' (was 'narrow' pre-Phase-4 — this is a hard
+  // cutover for the subtree shape only; narrow callers are unaffected).
+  mode: z.enum(['narrow', 'subtree-proposal']).default('narrow'),
   guidance: z.string().max(2000).nullish(),
   reaudit: z.enum(['fresh', 'build_on']).default('fresh'),
   /**
@@ -129,7 +135,12 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       { status: 400 },
     );
   }
-  const mode = url.searchParams.get('mode') ?? 'subtree';
+  // Default GET ?mode is the subtree-proposal shape — narrow callers
+  // pass `mode=narrow` explicitly. Legacy `mode=subtree` is mapped to
+  // `subtree-proposal` here too (the GET is read-only / cheap; we don't
+  // 400 the old query value, just the POST).
+  const rawMode = url.searchParams.get('mode');
+  const mode = !rawMode || rawMode === 'subtree' ? 'subtree-proposal' : rawMode;
   const initiative = getInitiative(id);
   if (!initiative) {
     return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
@@ -157,7 +168,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   const plan = planSubtreeAudit(id, initiative.workspace_id);
   return NextResponse.json({
     ok: true,
-    mode: 'subtree',
+    mode: 'subtree-proposal',
     planned_nodes: plan.plannedNodes,
     planned_layers: plan.plannedLayers,
     concurrency: settings.subtreeConcurrency,
@@ -171,6 +182,23 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const { id } = await params;
 
     const raw = await request.json().catch(() => ({}));
+    // Phase 4 hard cutover: legacy `mode: 'subtree'` is removed. Surface
+    // a clear, documented error so older callers (operator scripts,
+    // stale UI builds) get a useful pointer instead of a generic Zod
+    // validation failure.
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      (raw as { mode?: unknown }).mode === 'subtree'
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            'mode subtree was removed; use subtree-proposal (see specs/subtree-audit-proposals-spec.md §6.3)',
+        },
+        { status: 400 },
+      );
+    }
     const parsed = InvestigateSchema.safeParse(raw);
     if (!parsed.success) {
       return NextResponse.json(
@@ -241,7 +269,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    if (mode === 'subtree' || mode === 'subtree-proposal') {
+    if (mode === 'subtree-proposal') {
       // Subtree mode: reject terminal-status roots — auditing a
       // done/cancelled initiative's whole subtree is meaningless.
       if (TERMINAL_STATUSES.has(initiative.status)) {

--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -294,7 +294,7 @@ export function InitiativeDetailView({
   // specs/initiative-investigate.md). Subtree mode lives in PR 4.
   const [showInvestigateModal, setShowInvestigateModal] = useState(false);
   // PR 4 of specs/initiative-investigate.md — subtree mode added.
-  const [investigateMode, setInvestigateMode] = useState<'narrow' | 'subtree'>('narrow');
+  const [investigateMode, setInvestigateMode] = useState<'narrow' | 'subtree-proposal'>('narrow');
   // Selected task for the inline TaskModal — clicking a task in the
   // children list opens it here instead of navigating away.
   const [taskModalTask, setTaskModalTask] = useState<Task | null>(null);
@@ -1301,9 +1301,9 @@ const INVESTIGATE_OPTIONS: InvestigateOption[] = [
     description: 'One researcher dispatch. Reads description, status check, and direct child tasks.',
   },
   {
-    id: 'subtree',
+    id: 'subtree-proposal',
     label: 'Whole subtree (bottom-up)',
-    description: 'MC fans researchers across non-terminal descendants layer by layer, then rolls up into a parent verdict.',
+    description: 'MC fans researchers across non-terminal descendants layer by layer, then synthesizes typed proposals at the root.',
   },
 ];
 

--- a/src/components/InvestigateModal.tsx
+++ b/src/components/InvestigateModal.tsx
@@ -41,7 +41,7 @@ export interface InvestigateModalProps {
    */
   priorAuditCount: number;
   /** Audit scope. Drives radio visibility + endpoint mode. */
-  mode?: 'narrow' | 'subtree';
+  mode?: 'narrow' | 'subtree-proposal';
   onClose: () => void;
   /**
    * Called after a successful dispatch. The modal stays open and shows
@@ -50,7 +50,7 @@ export interface InvestigateModalProps {
    * View Activity).
    */
   onDispatched: (result: {
-    mode: 'narrow' | 'subtree';
+    mode: 'narrow' | 'subtree-proposal';
     scope_key?: string;
     root_scope_key?: string;
     attempt?: number;
@@ -153,7 +153,7 @@ function DispatchedPanel({
   const failedCount = justCompleted.filter((r) => r.status === 'failed' || r.status === 'cancelled').length;
 
   const summary =
-    result.mode === 'subtree'
+    result.mode === 'subtree-proposal'
       ? `${result.planned_nodes} initiative${result.planned_nodes === 1 ? '' : 's'} across ${result.planned_layers} layer${result.planned_layers === 1 ? '' : 's'} (up to ${result.concurrency} parallel)`
       : `Narrow audit, attempt ${result.attempt}`;
 
@@ -216,7 +216,7 @@ type Reaudit = 'fresh' | 'build_on';
 const GUIDANCE_MAX = 2000;
 
 interface DispatchResult {
-  mode: 'narrow' | 'subtree';
+  mode: 'narrow' | 'subtree-proposal';
   scope_key?: string;
   root_scope_key?: string;
   attempt?: number;
@@ -272,10 +272,10 @@ export default function InvestigateModal({
         const last = (body as { last_complete_audit?: { completed_at: string | null } | null })
           .last_complete_audit;
         setRecentAuditAt(last?.completed_at ?? null);
-        if (mode === 'subtree') setPlan(body as SubtreePlan);
+        if (mode === 'subtree-proposal') setPlan(body as SubtreePlan);
       })
       .catch((e) => {
-        if (!cancelled && mode === 'subtree') {
+        if (!cancelled && mode === 'subtree-proposal') {
           setPlanErr(e instanceof Error ? e.message : String(e));
         }
       });
@@ -316,8 +316,8 @@ export default function InvestigateModal({
       // Subtree mode is always 'fresh' in PR 4; reaudit field is ignored
       // server-side but harmless to omit. The route default keeps narrow
       // behavior unchanged.
-      const requestBody: Record<string, unknown> = mode === 'subtree'
-        ? { mode: 'subtree', guidance: baseBody.guidance }
+      const requestBody: Record<string, unknown> = mode === 'subtree-proposal'
+        ? { mode: 'subtree-proposal', guidance: baseBody.guidance }
         : { ...baseBody };
       if (opts?.supersede) requestBody.supersede = true;
       const res = await fetch(`/api/initiatives/${initiative.id}/investigate`, {
@@ -343,7 +343,7 @@ export default function InvestigateModal({
         );
       }
       const dispatchedAt = new Date().toISOString();
-      if (mode === 'subtree') {
+      if (mode === 'subtree-proposal') {
         const { root_scope_key, planned_nodes, planned_layers, concurrency } =
           body as {
             root_scope_key: string;
@@ -352,7 +352,7 @@ export default function InvestigateModal({
             concurrency: number;
           };
         const result: DispatchResult = {
-          mode: 'subtree',
+          mode: 'subtree-proposal',
           root_scope_key,
           planned_nodes,
           planned_layers,
@@ -405,10 +405,10 @@ export default function InvestigateModal({
             <div className="min-w-0">
               <h2 className="text-base font-semibold leading-tight">
                 {dispatched
-                  ? mode === 'subtree'
+                  ? mode === 'subtree-proposal'
                     ? 'Subtree audit dispatched'
                     : 'Audit dispatched'
-                  : mode === 'subtree'
+                  : mode === 'subtree-proposal'
                     ? 'Investigate subtree (bottom-up)'
                     : 'Investigate initiative'}
               </h2>
@@ -562,7 +562,7 @@ export default function InvestigateModal({
             </span>
           </label>
 
-          {mode === 'subtree' ? (
+          {mode === 'subtree-proposal' ? (
             <div className="text-xs text-mc-text-secondary leading-relaxed border border-mc-border/60 rounded p-3 bg-mc-bg/40">
               {planErr ? (
                 <span className="text-red-300">Couldn&apos;t plan subtree: {planErr}</span>

--- a/src/components/inline/InvestigatePicker.tsx
+++ b/src/components/inline/InvestigatePicker.tsx
@@ -15,7 +15,7 @@ import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { ChevronDown, Search } from 'lucide-react';
 
 export interface InvestigateOption {
-  id: 'narrow' | 'subtree';
+  id: 'narrow' | 'subtree-proposal';
   label: string;
   description: string;
   disabled?: boolean;

--- a/src/lib/agents/audit-prompt.test.ts
+++ b/src/lib/agents/audit-prompt.test.ts
@@ -198,3 +198,53 @@ test('audit-prompt: greenfield early-exit instruction is present', () => {
   assert.match(out, /early-exit/);
   assert.match(out, /never built — planned-only/);
 });
+
+test('audit-prompt: mode=synthesis includes manifest + proposal summaries via summarizeProposalForBriefing', () => {
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+    childInitiatives: [],
+    mode: 'synthesis',
+    synthesisInput: {
+      rootId: baseInitiative.id,
+      attempt: 7,
+      manifest: {
+        version: 1,
+        root_initiative_id: baseInitiative.id,
+        attempt: 7,
+        previous_synthesis_run_group_id: null,
+        summary: 'M1',
+        nodes: [],
+        cross_cutting_questions: [],
+      },
+      proposalSummaries: [
+        {
+          noteId: 'note-1',
+          initiativeId: 'leaf-1',
+          initiativeTitle: 'Leaf one',
+          body: {
+            version: 1,
+            node_initiative_id: 'leaf-1',
+            current_mc_status: 'in_progress',
+            current_mc_target_end: null,
+            proposed_action: 'mark_done',
+            proposed_changes: { note: 'shipped via #123' },
+            repo_evidence: [{ kind: 'pr', ref: 'https://example/pull/123' }],
+            rationale: 'PR closes the story; tests green.',
+            confidence: 'high',
+            would_confirm_by: null,
+            continuation_note_id: null,
+          },
+        },
+      ],
+    },
+  });
+  assert.match(out, /L3 SYNTHESIZER/);
+  assert.match(out, /audit_synthesis/);
+  assert.match(out, /completion_sentinel/);
+  assert.match(out, /Leaf one/);
+  // The synthesizer should see prose summaries, not raw JSON.
+  assert.match(out, /Proposed action: \*\*mark_done\*\*/);
+  assert.match(out, /Completion note: shipped via #123/);
+  assert.match(out, /Evidence: 1 ref/);
+});

--- a/src/lib/agents/audit-prompt.ts
+++ b/src/lib/agents/audit-prompt.ts
@@ -22,6 +22,11 @@
 
 import type { Initiative } from '@/lib/db/initiatives';
 import type { AgentNote } from '@/lib/db/agent-notes';
+import type {
+  AuditManifestBody,
+  AuditProposalBody,
+} from '@/lib/agents/audit-proposals/schemas';
+import { summarizeProposalForBriefing } from './subtree-audit-summarize';
 
 export interface BuildAuditPromptInput {
   initiative: Pick<
@@ -71,8 +76,17 @@ export interface BuildAuditPromptInput {
     /** True when the child's audit failed/timed out — render with a banner. */
     failed?: boolean;
   }>;
-  /** Subtree-vs-narrow flavor. Defaults to 'narrow'. PR 4. */
-  mode?: 'narrow' | 'subtree' | 'survey' | 'subtree-proposal';
+  /**
+   * Audit flavor. Defaults to 'narrow'.
+   * - 'narrow' — single-node audit (PR 2 / unchanged).
+   * - 'survey' — L1 surveyor (Phase 2).
+   * - 'subtree-proposal' — L2 per-node typed proposal (Phase 3).
+   * - 'synthesis' — L3 synthesizer (Phase 4).
+   *
+   * The legacy 'subtree' mode was removed in Phase 4 (hard cutover —
+   * see specs/subtree-audit-proposals-spec.md §6.3).
+   */
+  mode?: 'narrow' | 'survey' | 'subtree-proposal' | 'synthesis';
   /**
    * Per-node briefing inputs for `mode: 'subtree-proposal'` (Phase 3).
    * The orchestrator threads in the manifest entry so the auditor sees
@@ -109,6 +123,24 @@ export interface BuildAuditPromptInput {
     /** Most recent prior `audit_synthesis` body (verbatim) or null. */
     priorSynthesisBody?: string | null;
   };
+  /**
+   * L3 synthesizer briefing inputs (mode: 'synthesis'). The orchestrator
+   * pre-loads the manifest + every L2 proposal body so the synthesizer
+   * agent doesn't need tree-walk tools. See spec §3.3 / §4.4.
+   */
+  synthesisInput?: {
+    rootId: string;
+    attempt: number;
+    /** Verbatim L1 manifest body, or null if surveyor failed/fallback. */
+    manifest: AuditManifestBody | null;
+    /** Per-node L2 proposal summaries (synthetic + real). */
+    proposalSummaries: ReadonlyArray<{
+      noteId: string;
+      initiativeId: string;
+      initiativeTitle: string;
+      body: AuditProposalBody;
+    }>;
+  };
 }
 
 /**
@@ -128,6 +160,7 @@ export function buildAuditPrompt(input: BuildAuditPromptInput): string {
     mode = 'narrow',
     surveyInput,
     proposalInput,
+    synthesisInput,
   } = input;
 
   if (mode === 'survey') {
@@ -142,6 +175,14 @@ export function buildAuditPrompt(input: BuildAuditPromptInput): string {
       guidance: guidance ?? null,
       childFindings,
       proposalInput,
+    });
+  }
+
+  if (mode === 'synthesis') {
+    return buildSynthesisPrompt({
+      initiative,
+      guidance: guidance ?? null,
+      synthesisInput,
     });
   }
 
@@ -598,5 +639,187 @@ queue retains full coverage.
 - If the node has no associated code (planned-only), emit a \`keep\`
   proposal with \`confidence: 'low'\` and a one-line rationale +
   \`would_confirm_by\`. Don't burn ten minutes greenfield-grepping.
+`;
+}
+
+/**
+ * Build the L3 synthesizer briefing (mode: 'synthesis'). The orchestrator
+ * pre-loads the L1 manifest + every L2 audit_proposal body, summarizes
+ * the proposals via `summarizeProposalForBriefing`, and lays out the §4.4
+ * audit_synthesis schema with a concrete example.
+ *
+ * Spec: specs/subtree-audit-proposals-spec.md §3.3, §4.4.
+ */
+function buildSynthesisPrompt(args: {
+  initiative: BuildAuditPromptInput['initiative'];
+  guidance: string | null;
+  synthesisInput?: BuildAuditPromptInput['synthesisInput'];
+}): string {
+  const { initiative, guidance, synthesisInput } = args;
+  if (!synthesisInput) {
+    throw new Error('buildAuditPrompt(mode=synthesis): synthesisInput is required');
+  }
+  const { rootId, attempt, manifest, proposalSummaries } = synthesisInput;
+
+  const targetWindow =
+    initiative.target_start || initiative.target_end
+      ? `${initiative.target_start ?? '?'} → ${initiative.target_end ?? '?'}`
+      : '_(no target window set)_';
+
+  const description = initiative.description?.trim()
+    ? initiative.description.trim()
+    : '_(no description)_';
+
+  const statusCheck = initiative.status_check_md?.trim()
+    ? initiative.status_check_md.trim()
+    : '_(none)_';
+
+  const guidanceBlock = guidance?.trim()
+    ? `\n## Operator focus\n\n${guidance.trim()}\n`
+    : '';
+
+  const manifestBlock = manifest
+    ? `\n## L1 Manifest (verbatim)\n\n\`\`\`json\n${JSON.stringify(manifest, null, 2)}\n\`\`\`\n`
+    : '\n## L1 Manifest\n\n_(manifest unavailable — surveyor used fallback or failed; reason in operator focus if any)_\n';
+
+  const proposalsBlock =
+    proposalSummaries.length === 0
+      ? '\n## L2 Proposals\n\n_(no L2 proposals were emitted — empty or unaudited subtree)_\n'
+      : `\n## L2 Proposals (one per descendant node)\n\nEach summary below comes from a per-node \`audit_proposal\` note. Read across them — your job is *cross-cutting* reasoning, not re-deriving the per-node verdicts.\n\n${proposalSummaries
+          .map(
+            (p, i) =>
+              `### Proposal ${i + 1} — ${p.initiativeTitle} (id=${p.initiativeId}, note=${p.noteId})\n\n${summarizeProposalForBriefing(p.body)}\n`,
+          )
+          .join('\n---\n\n')}\n`;
+
+  const exampleBody = `{
+  "version": 1,
+  "root_initiative_id": "${rootId}",
+  "attempt": ${attempt},
+  "completion_sentinel": "Audit complete: 7 nodes — 1 done, 2 cancel, 1 keep, 2 modify_scope, 1 new_story; epic dates +14d",
+  "epic_proposals": [
+    {
+      "proposed_action": "modify_epic_dates",
+      "proposed_changes": { "target_end": "2026-05-27" },
+      "rationale": "Two stories slipped; realistic finish is 2 weeks out.",
+      "confidence": "medium"
+    },
+    {
+      "proposed_action": "modify_epic_scope",
+      "proposed_changes": { "description": "…revised body…" },
+      "rationale": "Body still references the old shim path that was removed.",
+      "confidence": "high"
+    }
+  ],
+  "cross_node_proposals": [
+    {
+      "proposed_action": "merge_stories",
+      "subject_initiative_ids": ["6379b104-…", "9ab40f1f-…"],
+      "rationale": "Both reference the same alert-shim; one PR closes both.",
+      "confidence": "medium"
+    },
+    {
+      "proposed_action": "new_story",
+      "proposed_new_node": {
+        "kind": "story",
+        "title": "Audit + remove dead alert hook in extensions/browser",
+        "description": "…",
+        "estimated_effort_hours": 2
+      },
+      "rationale": "Found in repo grep but absent from the epic.",
+      "confidence": "medium"
+    }
+  ]
+}`;
+
+  const takeNoteCall = `take_note({
+  agent_id: '<your agent_id>',
+  kind: 'audit_synthesis',
+  initiative_id: '${rootId}',
+  scope_key: '<from briefing>',
+  role: 'auditor',
+  run_group_id: '<from briefing>',
+  audience: 'pm',
+  importance: 2,
+  body: JSON.stringify(<the JSON object above>),
+})`;
+
+  return `**Initiative audit — L3 SYNTHESIZER (mode: synthesis)**
+
+You are running the *synthesis* stage. The L1 surveyor produced a
+manifest; the L2 per-node auditors produced one \`audit_proposal\` each.
+Your only job is to emit ONE \`audit_synthesis\` note carrying the
+cross-cutting + epic-level reasoning the per-node auditors couldn't see.
+
+Target root: ${initiative.title}  (kind=${initiative.kind}, status=${initiative.status}, id=${initiative.id})
+Attempt: ${attempt}
+
+Description:
+> ${description.replace(/\n/g, '\n> ')}
+
+Status check:
+${statusCheck}
+
+Target window: ${targetWindow}
+${guidanceBlock}${manifestBlock}${proposalsBlock}
+## Contract
+
+- Slice: cross-cutting + epic-level reasoning across the L2 proposals.
+- Expected deliverable: exactly ONE \`take_note\` call:
+  - kind: 'audit_synthesis'
+  - initiative_id: '${rootId}'
+  - audience: 'pm'
+  - importance: 2
+  - body: JSON.stringify of an object conforming to the audit_synthesis v1 schema.
+- Acceptance criteria:
+  * Body parses as the audit_synthesis v1 schema.
+  * \`completion_sentinel\` is the FIRST line of the body's narrative — required, single line, ≥1 char, summary of audit results across nodes (e.g., "Audit complete: 7 nodes — 1 done, 2 cancel, 1 keep, 2 modify_scope, 1 new_story; epic dates +14d").
+  * \`epic_proposals\` carries only \`modify_epic_dates\` and \`modify_epic_scope\`. No other actions.
+  * \`cross_node_proposals\` carries only \`merge_stories\` (≥2 subjects), \`split_story\` (exactly 1 subject), and \`new_story\` (no existing node). Per-node verdicts (keep/mark_done/cancel/modify_scope/modify_dates) are NOT duplicated here — the queue UI derives them from the L2 proposals.
+- Expected duration: < 5 minutes wall clock. You're synthesizing; you're not re-grepping the repo.
+
+## Schema (audit_synthesis v1)
+
+Top-level fields:
+- \`version\`: literal \`1\`.
+- \`root_initiative_id\`: this root's initiative id (\`${rootId}\`).
+- \`attempt\`: the L3 attempt number (\`${attempt}\`).
+- \`completion_sentinel\`: required single-line summary; the queue UI surfaces this in feed views.
+- \`epic_proposals\`: array (may be empty) of \`{ proposed_action: 'modify_epic_dates' | 'modify_epic_scope', proposed_changes, rationale, confidence }\`.
+- \`cross_node_proposals\`: array (may be empty) of \`{ proposed_action: 'merge_stories' | 'split_story' | 'new_story', ..., rationale, confidence }\`.
+
+Example body:
+
+\`\`\`jsonc
+${exampleBody}
+\`\`\`
+
+## How to emit
+
+\`\`\`
+${takeNoteCall}
+\`\`\`
+
+## Retries on validation failure
+
+The MCP \`take_note\` handler validates the body against the schema +
+the 3000-char cap. On failure it returns a structured error naming the
+failing field. **Retry up to 2 times** with a tightened body (drop a
+weak proposal, shorten a rationale). After 2 failures, give up — the
+operator still has the L2 proposal queue and a "synthesis missing"
+affordance to re-run just L3.
+
+## Discipline
+
+- ONE \`audit_synthesis\` note. No \`breadcrumb\` / \`discovery\` /
+  \`question\` chatter during the synthesis.
+- Auditors are read-only. Do **not** call \`update_task_status\`,
+  \`update_initiative\`, or \`register_deliverable\`.
+- Do **not** re-derive per-node verdicts here. If a per-node proposal
+  looks wrong, that's a queue-review concern, not a synthesis concern.
+- Stay under ~2900 chars in the body so a tightening retry has room.
+- It is OK to emit empty \`epic_proposals\` and \`cross_node_proposals\`
+  arrays if the subtree shows no cross-cutting drift — but the
+  \`completion_sentinel\` must still summarize the overall verdict.
 `;
 }

--- a/src/lib/agents/audit-synthesizer.ts
+++ b/src/lib/agents/audit-synthesizer.ts
@@ -1,0 +1,272 @@
+/**
+ * L3 synthesizer for the structured-audit pipeline.
+ *
+ * Runs ONE auditor dispatch scoped to the root initiative; the auditor
+ * emits a single `audit_synthesis` note carrying the cross-cutting
+ * proposals (merge_stories / split_story / new_story) + epic-level
+ * proposals (modify_epic_dates / modify_epic_scope) + the one-line
+ * completion sentinel.
+ *
+ * Spec: specs/subtree-audit-proposals-spec.md §3.3, §4.4, §5.1.
+ *
+ * On failure / no-synthesis the orchestrator does NOT emit a synthetic
+ * fallback (per spec §5.5). The L2 proposal queue still gives the
+ * operator full coverage; the queue UI surfaces a "synthesis missing"
+ * affordance.
+ */
+
+import { listInitiatives } from '@/lib/db/initiatives';
+import { listNotes } from '@/lib/db/agent-notes';
+import { dispatchScope } from '@/lib/agents/dispatch-scope';
+import { buildAuditPrompt } from '@/lib/agents/audit-prompt';
+import {
+  validateAuditNoteBody,
+  auditProposalBodySchema,
+  type AuditManifestBody,
+  type AuditProposalBody,
+  type AuditSynthesisBody,
+} from '@/lib/agents/audit-proposals/schemas';
+import type { Agent } from '@/lib/types';
+
+export interface ProposalSummaryInput {
+  /** Source `audit_proposal` note id — surfaced for traceability. */
+  noteId: string;
+  /** Owning initiative (descendant of root). */
+  initiativeId: string;
+  /** Pretty title of the node, for the briefing. */
+  initiativeTitle: string;
+  /** Parsed proposal body. */
+  body: AuditProposalBody;
+}
+
+export interface RunSynthesizerInput {
+  rootId: string;
+  workspaceId: string;
+  attempt: number;
+  /** The runner / gateway agent to dispatch through. */
+  runner: Agent;
+  /** Forwarded to dispatchScope. */
+  parentRunId: string | null;
+  /** Manifest output from L1 — included verbatim in the briefing. */
+  manifest: AuditManifestBody | null;
+  /** Pre-loaded L2 proposals across the descendant subtree. */
+  proposalSummaries: ReadonlyArray<ProposalSummaryInput>;
+  /** Optional operator-supplied focus area; threaded into the briefing. */
+  guidance?: string | null;
+  /** Per-dispatch timeout (ms). */
+  timeoutMs?: number;
+}
+
+export interface SynthesizerResult {
+  synthesis: AuditSynthesisBody | null;
+  synthesisNoteId: string | null;
+  /**
+   * 'ok' — auditor dispatched + valid synthesis landed.
+   * 'no-synthesis' — dispatch succeeded but no audit_synthesis note appeared
+   *   (or the body failed validation).
+   * 'failed' — dispatch threw / errored.
+   */
+  dispatchOutcome: 'ok' | 'failed' | 'no-synthesis';
+  /** Captured for diagnostics / tests. */
+  errorMessage?: string;
+}
+
+/**
+ * Read back the most recent `audit_synthesis` note on the root after
+ * the synthesizer dispatch returns.
+ */
+function loadFreshSynthesisNote(rootId: string): {
+  noteId: string;
+  body: string;
+} | null {
+  const rows = listNotes({
+    initiative_id: rootId,
+    kinds: ['audit_synthesis'],
+    limit: 1,
+    order: 'desc',
+  });
+  const note = rows[0];
+  if (!note) return null;
+  return { noteId: note.id, body: note.body };
+}
+
+/**
+ * Walk the workspace's initiatives to find every descendant of `rootId`
+ * (excluding the root itself). Used by callers (the orchestrator + the
+ * resynthesize endpoint) to pull `audit_proposal` notes for the
+ * synthesizer's briefing.
+ */
+export function enumerateDescendantIds(
+  rootId: string,
+  workspaceId: string,
+): string[] {
+  const all = listInitiatives({ workspace_id: workspaceId });
+  const byParent = new Map<string, typeof all>();
+  for (const i of all) {
+    if (!i.parent_initiative_id) continue;
+    const list = byParent.get(i.parent_initiative_id) ?? [];
+    list.push(i);
+    byParent.set(i.parent_initiative_id, list);
+  }
+  const out: string[] = [];
+  const stack: string[] = [rootId];
+  while (stack.length) {
+    const cur = stack.pop()!;
+    const kids = byParent.get(cur) ?? [];
+    for (const k of kids) {
+      out.push(k.id);
+      stack.push(k.id);
+    }
+  }
+  return out;
+}
+
+/**
+ * Pull the most-recent `audit_proposal` note for each descendant of
+ * `rootId`. Synthetic-keep proposals (Phase 2) and synthetic-fallback
+ * proposals (Phase 3) ARE included — they're valid `audit_proposal`
+ * rows. Used by both the orchestrator (immediately after L2 settles)
+ * and the resynthesize endpoint.
+ */
+export function loadProposalsForSubtree(
+  rootId: string,
+  workspaceId: string,
+): ProposalSummaryInput[] {
+  const all = listInitiatives({ workspace_id: workspaceId });
+  const titlesById = new Map(all.map((i) => [i.id, i.title]));
+  const descendantIds = enumerateDescendantIds(rootId, workspaceId);
+  const out: ProposalSummaryInput[] = [];
+  for (const id of descendantIds) {
+    const rows = listNotes({
+      initiative_id: id,
+      kinds: ['audit_proposal'],
+      limit: 1,
+      order: 'desc',
+    });
+    const row = rows[0];
+    if (!row) continue;
+    let parsed: AuditProposalBody;
+    try {
+      const result = auditProposalBodySchema.safeParse(JSON.parse(row.body));
+      if (!result.success) continue;
+      parsed = result.data;
+    } catch {
+      continue;
+    }
+    out.push({
+      noteId: row.id,
+      initiativeId: id,
+      initiativeTitle: titlesById.get(id) ?? `(initiative ${id})`,
+      body: parsed,
+    });
+  }
+  return out;
+}
+
+/**
+ * Dispatch the L3 synthesizer. Returns the parsed synthesis + outcome
+ * marker. The caller decides what to do with a non-'ok' outcome —
+ * spec §5.5 says NO synthetic fallback at the orchestrator; the L2
+ * proposal queue is the operator's safety net.
+ */
+export async function runSynthesizer(
+  input: RunSynthesizerInput,
+): Promise<SynthesizerResult> {
+  const {
+    rootId,
+    workspaceId,
+    attempt,
+    runner,
+    parentRunId,
+    manifest,
+    proposalSummaries,
+    guidance,
+    timeoutMs,
+  } = input;
+
+  const all = listInitiatives({ workspace_id: workspaceId });
+  const root = all.find((i) => i.id === rootId);
+  if (!root) {
+    return {
+      synthesis: null,
+      synthesisNoteId: null,
+      dispatchOutcome: 'failed',
+      errorMessage: `synthesizer: root ${rootId} not found in workspace ${workspaceId}`,
+    };
+  }
+
+  const triggerBody = buildAuditPrompt({
+    initiative: root,
+    tasks: [],
+    childInitiatives: [],
+    guidance: guidance ?? null,
+    priorFindings: [],
+    childFindings: [],
+    mode: 'synthesis',
+    synthesisInput: {
+      rootId,
+      attempt,
+      manifest,
+      proposalSummaries: proposalSummaries.map((p) => ({
+        noteId: p.noteId,
+        initiativeId: p.initiativeId,
+        initiativeTitle: p.initiativeTitle,
+        body: p.body,
+      })),
+    },
+  });
+
+  const sessionSuffix = `initiative-${rootId}:audit-synthesis:${attempt}`;
+
+  try {
+    await dispatchScope({
+      workspace_id: workspaceId,
+      role: 'auditor',
+      agent: runner,
+      session_suffix: sessionSuffix,
+      scope_type: 'initiative_audit',
+      initiative_id: rootId,
+      trigger_body: triggerBody,
+      attempt_strategy: 'fresh',
+      timeoutMs: timeoutMs ?? 5 * 60_000,
+      idempotencyKey: `audit-synthesis-${rootId}-${attempt}-${Date.now()}`,
+      parent_run_id: parentRunId,
+      source_kind: 'fanout',
+      source_ref: rootId,
+      label: `Audit synthesis: ${root.title}`,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      synthesis: null,
+      synthesisNoteId: null,
+      dispatchOutcome: 'failed',
+      errorMessage: message,
+    };
+  }
+
+  const fresh = loadFreshSynthesisNote(rootId);
+  if (!fresh) {
+    return {
+      synthesis: null,
+      synthesisNoteId: null,
+      dispatchOutcome: 'no-synthesis',
+      errorMessage:
+        'synthesizer dispatch returned but no audit_synthesis note appeared',
+    };
+  }
+  const parsed = validateAuditNoteBody('audit_synthesis', fresh.body);
+  if (!parsed.ok) {
+    return {
+      synthesis: null,
+      synthesisNoteId: fresh.noteId,
+      dispatchOutcome: 'no-synthesis',
+      errorMessage: `synthesizer body did not validate: ${parsed.error}`,
+    };
+  }
+  return {
+    synthesis: parsed.parsed as AuditSynthesisBody,
+    synthesisNoteId: fresh.noteId,
+    dispatchOutcome: 'ok',
+  };
+}

--- a/src/lib/agents/subtree-audit-summarize.ts
+++ b/src/lib/agents/subtree-audit-summarize.ts
@@ -1,0 +1,47 @@
+/**
+ * Standalone helper: render a parsed `audit_proposal` body as ~3-5
+ * lines of prose, suitable for use as a parent-layer briefing summary
+ * (childFindings) or as an L3 synthesizer briefing item.
+ *
+ * Lives in its own file to avoid a cycle between `audit-prompt.ts`
+ * (which renders proposal summaries in the synthesizer briefing) and
+ * `subtree-audit.ts` (which renders proposal summaries for parent-layer
+ * childFindings and also imports `audit-prompt`).
+ *
+ * Re-exported from `subtree-audit.ts` so existing callers keep working.
+ */
+
+import type { AuditProposalBody } from '@/lib/agents/audit-proposals/schemas';
+
+export function summarizeProposalForBriefing(body: AuditProposalBody): string {
+  const lines: string[] = [];
+  lines.push(
+    `Proposed action: **${body.proposed_action}** (confidence: ${body.confidence}).`,
+  );
+  if (body.proposed_action === 'mark_done') {
+    lines.push(`Completion note: ${body.proposed_changes.note}`);
+  } else if (body.proposed_action === 'cancel') {
+    lines.push(`Cancel reason: ${body.proposed_changes.reason}`);
+  } else if (body.proposed_action === 'modify_scope') {
+    const parts: string[] = [];
+    if (body.proposed_changes.title) parts.push(`title→"${body.proposed_changes.title}"`);
+    if (body.proposed_changes.description) parts.push('description updated');
+    lines.push(`Scope change: ${parts.join(', ')}`);
+  } else if (body.proposed_action === 'modify_dates') {
+    const parts: string[] = [];
+    if (body.proposed_changes.target_start)
+      parts.push(`target_start→${body.proposed_changes.target_start}`);
+    if (body.proposed_changes.target_end)
+      parts.push(`target_end→${body.proposed_changes.target_end}`);
+    lines.push(`Date change: ${parts.join(', ')}`);
+  }
+  // Rationale — keep first ~240 chars.
+  const r = body.rationale.trim();
+  lines.push(`Rationale: ${r.length > 240 ? r.slice(0, 240) + '…' : r}`);
+  if (body.would_confirm_by && body.would_confirm_by.trim()) {
+    lines.push(`Would confirm by: ${body.would_confirm_by.trim()}`);
+  }
+  const evCount = body.repo_evidence.length;
+  lines.push(`Evidence: ${evCount} ref${evCount === 1 ? '' : 's'}.`);
+  return lines.join('\n');
+}

--- a/src/lib/agents/subtree-audit.test.ts
+++ b/src/lib/agents/subtree-audit.test.ts
@@ -25,14 +25,26 @@ import {
 import { createInitiative } from '@/lib/db/initiatives';
 import { createNote, listNotes } from '@/lib/db/agent-notes';
 import { auditProposalBodySchema } from '@/lib/agents/audit-proposals/schemas';
-import { getAgentRun } from '@/lib/db/agent-runs';
 import type { SurveyorResult } from './audit-survey';
+import type { SynthesizerResult } from './audit-synthesizer';
 import {
   __setSendChatClientForTests,
   type ChatEvent,
   type SendChatClient,
 } from '@/lib/openclaw/send-chat';
 import type { Agent } from '@/lib/types';
+
+/**
+ * Default synthesizer stub for Phase 2/3 tests that only care about
+ * L1/L2 behavior. Returns 'no-synthesis' without dispatching, so the
+ * orchestrator records a failed root outcome but no agent_runs row is
+ * created for the root.
+ */
+const noopSynthesizer = async (): Promise<SynthesizerResult> => ({
+  synthesis: null,
+  synthesisNoteId: null,
+  dispatchOutcome: 'no-synthesis',
+});
 
 type Lite = Parameters<typeof enumerateLayersBottomUp>[1][number];
 
@@ -237,72 +249,10 @@ test.afterEach(() => {
   __setSendChatClientForTests(null);
 });
 
-test('runSubtreeAudit: creates synthetic parent + child rows linked by parent_run_id', async () => {
-  __setSendChatClientForTests(stubClient());
-  const ws = freshWorkspace();
-  // Tree: root -> 3 stories.
-  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Root epic' });
-  const c1 = createInitiative({ workspace_id: ws, kind: 'story', title: 'Story 1', parent_initiative_id: root.id });
-  const c2 = createInitiative({ workspace_id: ws, kind: 'story', title: 'Story 2', parent_initiative_id: root.id });
-  const c3 = createInitiative({ workspace_id: ws, kind: 'story', title: 'Story 3', parent_initiative_id: root.id });
-
-  const result = await runSubtreeAudit({
-    rootId: root.id,
-    workspaceId: ws,
-    guidance: null,
-    perNodeTimeoutMs: 10_000,
-    subtreeConcurrency: 2,
-    runner: fakeRunner(),
-  });
-
-  // Synthetic parent row exists with the expected shape.
-  assert.ok(result.parentRunId);
-  const parent = getAgentRun(result.parentRunId!)!;
-  assert.equal(parent.kind, 'initiative_audit');
-  assert.equal(parent.source_kind, 'fanout');
-  assert.equal(parent.parent_run_id, null);
-  assert.equal(parent.initiative_id, root.id);
-  assert.match(parent.label ?? '', /Subtree audit:/);
-
-  // Child rows: one per node (3 stories + 1 root re-audit at top layer = 4).
-  const children = queryAll<{ id: string; parent_run_id: string | null; initiative_id: string | null }>(
-    `SELECT id, parent_run_id, initiative_id FROM agent_runs
-       WHERE workspace_id = ? AND parent_run_id = ?
-       ORDER BY created_at`,
-    [ws, result.parentRunId],
-  );
-  assert.equal(children.length, 4, '3 stories + root self-audit');
-  const childInitiativeIds = new Set(children.map((c) => c.initiative_id));
-  for (const id of [root.id, c1.id, c2.id, c3.id]) {
-    assert.ok(childInitiativeIds.has(id), `child for initiative ${id} present`);
-  }
-  for (const c of children) {
-    assert.equal(c.parent_run_id, result.parentRunId);
-  }
-});
-
-test('runSubtreeAudit: parent rolls up to complete when all children succeed', async () => {
-  __setSendChatClientForTests(stubClient());
-  const ws = freshWorkspace();
-  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'OK epic' });
-  // No children — single-node fan-out (just the root).
-  const result = await runSubtreeAudit({
-    rootId: root.id,
-    workspaceId: ws,
-    guidance: null,
-    perNodeTimeoutMs: 10_000,
-    subtreeConcurrency: 1,
-    runner: fakeRunner(),
-  });
-  // The single-node dispatch lands but won't have a take_note row; the
-  // orchestrator records that as a failure outcome. With 1/1 failed
-  // (>50%), the parent rolls up to failed. That's expected behavior —
-  // see SUBTREE_FAILURE_THRESHOLD. Assert the rollup ran (parent is
-  // terminal, not stuck running) regardless of branch.
-  const parent = getAgentRun(result.parentRunId!)!;
-  assert.ok(['complete', 'failed'].includes(parent.status), 'parent rolled up');
-  assert.ok(parent.completed_at);
-});
+// NOTE: The original `mode: 'subtree'` (free-form observation output)
+// tests were deleted in Phase 4 — the mode no longer exists. Coverage
+// for the synthetic-parent rollup + child linkage is preserved by the
+// `subtree-proposal` tests below.
 
 // ─── runSubtreeAudit: mode='subtree-proposal' (Phase 2) ────────────
 
@@ -368,6 +318,7 @@ test('runSubtreeAudit (subtree-proposal): manifest skip → synthetic audit_prop
     runner: fakeRunner(),
     mode: 'subtree-proposal',
     surveyorOverride,
+    synthesizerOverride: noopSynthesizer,
   });
 
   // skipMe must NOT have an agent_runs child row (no dispatch).
@@ -433,6 +384,7 @@ test('runSubtreeAudit (subtree-proposal): surveyor failure → fallback dispatch
     runner: fakeRunner(),
     mode: 'subtree-proposal',
     surveyorOverride,
+    synthesizerOverride: noopSynthesizer,
   });
 
   // The two children are dispatched. The root is NOT dispatched in
@@ -576,6 +528,7 @@ test('runSubtreeAudit (subtree-proposal): happy path — auditor emits valid pro
     runner: fakeRunner(),
     mode: 'subtree-proposal',
     surveyorOverride,
+    synthesizerOverride: noopSynthesizer,
   });
 
   // Per-node outcome for leaf is ok; root is deferred.
@@ -591,15 +544,23 @@ test('runSubtreeAudit (subtree-proposal): happy path — auditor emits valid pro
   const parsed = JSON.parse(proposalsForLeaf[0].body);
   assert.equal(parsed.proposed_action, 'mark_done');
 
-  // Root outcome is the deferred placeholder; root was NOT dispatched.
+  // Root outcome reflects the L3 synthesizer stub (Phase 4). With the
+  // noopSynthesizer override, dispatchOutcome === 'no-synthesis', so
+  // the orchestrator records a failed root outcome with no agent_runs
+  // row (the override doesn't actually call dispatchScope).
   const rootOutcome = result.perNodeOutcomes.find((o) => o.initiativeId === root.id);
   assert.ok(rootOutcome);
-  assert.match(rootOutcome!.note ?? '', /root deferred to L3 synthesizer/);
+  assert.equal(rootOutcome!.status, 'failed');
+  assert.match(rootOutcome!.error ?? '', /synthesis no-synthesis/);
   const rootRuns = queryAll<{ id: string }>(
     `SELECT id FROM agent_runs WHERE workspace_id = ? AND initiative_id = ? AND parent_run_id = ?`,
     [ws, root.id, result.parentRunId],
   );
-  assert.equal(rootRuns.length, 0, 'root must NOT be dispatched in subtree-proposal mode');
+  assert.equal(
+    rootRuns.length,
+    0,
+    'noop synthesizer override means no dispatched agent_runs row for the root',
+  );
 });
 
 test('runSubtreeAudit (subtree-proposal): no proposal landed → synthetic fallback keep with low confidence', async () => {
@@ -666,6 +627,7 @@ test('runSubtreeAudit (subtree-proposal): no proposal landed → synthetic fallb
     runner: fakeRunner(),
     mode: 'subtree-proposal',
     surveyorOverride,
+    synthesizerOverride: noopSynthesizer,
   });
 
   const leafOutcome = result.perNodeOutcomes.find((o) => o.initiativeId === leaf.id);
@@ -729,4 +691,193 @@ test('summarizeProposalForBriefing: each proposed_action enum produces ≤6 line
     assert.match(out, /Evidence:/);
     assert.ok(out.split('\n').length <= 6, `too many lines for ${c.proposed_action}: ${out}`);
   }
+});
+
+// ─── Phase 4 — L3 synthesizer integration ───────────────────────────
+
+test('runSubtreeAudit (Phase 4): L3 happy path — synthesizer note threaded into root outcome', async () => {
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'L3 root' });
+  const leaf = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'L3 leaf',
+    parent_initiative_id: root.id,
+  });
+
+  // No live gateway dispatch — the surveyor + synthesizer overrides
+  // bypass openclaw entirely. The L2 leaf dispatch DOES fall through
+  // to the live path; default stubClient returns no proposal so the
+  // synthetic-fallback keep is emitted.
+  __setSendChatClientForTests(stubClient());
+
+  const surveyorOverride = async (): Promise<SurveyorResult> => ({
+    manifest: {
+      version: 1,
+      root_initiative_id: root.id,
+      attempt: 1,
+      previous_synthesis_run_group_id: null,
+      summary: 'L3 happy',
+      nodes: [
+        {
+          initiative_id: leaf.id,
+          title: leaf.title,
+          current_status: 'in_progress',
+          hypothesis: 'needs-deep-dive',
+          confidence: 'medium',
+          investigation_prompt: 'Dig.',
+          scoped_evidence_hints: [],
+          skip: false,
+        },
+      ],
+      cross_cutting_questions: [],
+    },
+    surveyorNoteId: null,
+    dispatchOutcome: 'ok',
+  });
+
+  const synthSentinel =
+    'Audit complete: 2 nodes — 1 keep, 1 modify_scope; epic dates +14d';
+
+  const synthesizerOverride = async (
+    args: Parameters<typeof import('./audit-synthesizer').runSynthesizer>[0],
+  ) => {
+    // Stand in for the gateway: write the audit_synthesis note that
+    // the orchestrator will read back. Routes through createNote so
+    // the body is the literal JSON string the read-back parses.
+    const body = JSON.stringify({
+      version: 1,
+      root_initiative_id: args.rootId,
+      attempt: args.attempt,
+      completion_sentinel: synthSentinel,
+      epic_proposals: [
+        {
+          proposed_action: 'modify_epic_dates',
+          proposed_changes: { target_end: '2026-05-27' },
+          rationale: 'two stories slipped',
+          confidence: 'medium',
+        },
+      ],
+      cross_node_proposals: [],
+    });
+    const note = createNote({
+      workspace_id: args.workspaceId,
+      agent_id: null,
+      initiative_id: args.rootId,
+      scope_key: `initiative-${args.rootId}:audit-synthesis:${args.attempt}`,
+      role: 'auditor',
+      run_group_id: uuidv4(),
+      kind: 'audit_synthesis',
+      audience: 'pm',
+      body,
+      importance: 2,
+    });
+    return {
+      synthesis: JSON.parse(body),
+      synthesisNoteId: note.id,
+      dispatchOutcome: 'ok' as const,
+    };
+  };
+
+  const result = await runSubtreeAudit({
+    rootId: root.id,
+    workspaceId: ws,
+    guidance: null,
+    perNodeTimeoutMs: 10_000,
+    subtreeConcurrency: 1,
+    runner: fakeRunner(),
+    mode: 'subtree-proposal',
+    surveyorOverride,
+    synthesizerOverride,
+  });
+
+  // The synthesis note exists on the root.
+  const synthNotes = listNotes({
+    initiative_id: root.id,
+    kinds: ['audit_synthesis'],
+    limit: 5,
+  });
+  assert.equal(synthNotes.length, 1);
+  const sb = JSON.parse(synthNotes[0].body);
+  assert.equal(sb.completion_sentinel, synthSentinel);
+  assert.equal(sb.epic_proposals.length, 1);
+
+  // Root outcome reflects L3 success — note carries the sentinel.
+  const rootOutcome = result.perNodeOutcomes.find((o) => o.initiativeId === root.id);
+  assert.ok(rootOutcome);
+  assert.equal(rootOutcome!.status, 'ok');
+  assert.equal(rootOutcome!.note, synthSentinel);
+});
+
+test('runSubtreeAudit (Phase 4): L3 failure → no synthetic fallback, root outcome failed', async () => {
+  __setSendChatClientForTests(stubClient());
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'L3 sad root' });
+  const leaf = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'leaf',
+    parent_initiative_id: root.id,
+  });
+
+  const surveyorOverride = async (): Promise<SurveyorResult> => ({
+    manifest: {
+      version: 1,
+      root_initiative_id: root.id,
+      attempt: 1,
+      previous_synthesis_run_group_id: null,
+      summary: 'L3 sad',
+      nodes: [
+        {
+          initiative_id: leaf.id,
+          title: leaf.title,
+          current_status: 'in_progress',
+          hypothesis: 'needs-deep-dive',
+          confidence: 'low',
+          investigation_prompt: 'dig',
+          scoped_evidence_hints: [],
+          skip: false,
+        },
+      ],
+      cross_cutting_questions: [],
+    },
+    surveyorNoteId: null,
+    dispatchOutcome: 'ok',
+  });
+
+  const synthesizerOverride = async (): Promise<SynthesizerResult> => ({
+    synthesis: null,
+    synthesisNoteId: null,
+    dispatchOutcome: 'no-synthesis',
+    errorMessage: 'agent ghost-walked',
+  });
+
+  const result = await runSubtreeAudit({
+    rootId: root.id,
+    workspaceId: ws,
+    guidance: null,
+    perNodeTimeoutMs: 10_000,
+    subtreeConcurrency: 1,
+    runner: fakeRunner(),
+    mode: 'subtree-proposal',
+    surveyorOverride,
+    synthesizerOverride,
+  });
+
+  // No synthesis note landed.
+  const synthNotes = listNotes({
+    initiative_id: root.id,
+    kinds: ['audit_synthesis'],
+    limit: 5,
+  });
+  assert.equal(synthNotes.length, 0, 'no synthesis emitted');
+
+  // Per spec §5.5 — no synthetic fallback at the orchestrator (no
+  // synthesis note magically appears). Root outcome is `failed` with
+  // a marker referencing the dispatchOutcome.
+  const rootOutcome = result.perNodeOutcomes.find((o) => o.initiativeId === root.id);
+  assert.ok(rootOutcome);
+  assert.equal(rootOutcome!.status, 'failed');
+  assert.match(rootOutcome!.error ?? '', /synthesis no-synthesis/);
+  assert.match(rootOutcome!.error ?? '', /ghost-walked/);
 });

--- a/src/lib/agents/subtree-audit.ts
+++ b/src/lib/agents/subtree-audit.ts
@@ -47,8 +47,13 @@ import {
   auditProposalBodySchema,
   type AuditManifestBody,
   type AuditManifestNode,
-  type AuditProposalBody,
 } from '@/lib/agents/audit-proposals/schemas';
+import { summarizeProposalForBriefing } from './subtree-audit-summarize';
+import {
+  runSynthesizer,
+  loadProposalsForSubtree,
+  type SynthesizerResult,
+} from '@/lib/agents/audit-synthesizer';
 
 const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
 
@@ -60,43 +65,12 @@ const TERMINAL_STATUSES = new Set(['done', 'cancelled']);
 export const SUBTREE_FAILURE_THRESHOLD = 0.5;
 
 /**
- * Render a parsed `audit_proposal` body as ~3-5 lines of prose for use
- * as childFindings input to a parent-layer briefing in
- * `mode: 'subtree-proposal'`. Pure / exported for tests.
+ * Re-export of `summarizeProposalForBriefing` — moved to
+ * `subtree-audit-summarize.ts` in Phase 4 to break a cycle between
+ * `audit-prompt.ts` (which now also renders proposal summaries in the
+ * synthesizer briefing) and this file.
  */
-export function summarizeProposalForBriefing(body: AuditProposalBody): string {
-  const lines: string[] = [];
-  lines.push(
-    `Proposed action: **${body.proposed_action}** (confidence: ${body.confidence}).`,
-  );
-  if (body.proposed_action === 'mark_done') {
-    lines.push(`Completion note: ${body.proposed_changes.note}`);
-  } else if (body.proposed_action === 'cancel') {
-    lines.push(`Cancel reason: ${body.proposed_changes.reason}`);
-  } else if (body.proposed_action === 'modify_scope') {
-    const parts: string[] = [];
-    if (body.proposed_changes.title) parts.push(`title→"${body.proposed_changes.title}"`);
-    if (body.proposed_changes.description) parts.push('description updated');
-    lines.push(`Scope change: ${parts.join(', ')}`);
-  } else if (body.proposed_action === 'modify_dates') {
-    const parts: string[] = [];
-    if (body.proposed_changes.target_start)
-      parts.push(`target_start→${body.proposed_changes.target_start}`);
-    if (body.proposed_changes.target_end)
-      parts.push(`target_end→${body.proposed_changes.target_end}`);
-    lines.push(`Date change: ${parts.join(', ')}`);
-  }
-  // Rationale — keep first ~240 chars; the parent briefing has many of
-  // these and we don't want to blow the context budget.
-  const r = body.rationale.trim();
-  lines.push(`Rationale: ${r.length > 240 ? r.slice(0, 240) + '…' : r}`);
-  if (body.would_confirm_by && body.would_confirm_by.trim()) {
-    lines.push(`Would confirm by: ${body.would_confirm_by.trim()}`);
-  }
-  const evCount = body.repo_evidence.length;
-  lines.push(`Evidence: ${evCount} ref${evCount === 1 ? '' : 's'}.`);
-  return lines.join('\n');
-}
+export { summarizeProposalForBriefing };
 
 /** Initiative shape we need internally — kept narrow on purpose. */
 type LiteInitiative = Pick<
@@ -254,14 +228,16 @@ export interface RunSubtreeAuditInput {
   runner: Agent;
   /**
    * Output mode for the subtree audit.
-   * - 'subtree' — today's free-form per-node `observation` notes (PR 4
-   *   shape, default).
-   * - 'subtree-proposal' — Phase 2 of the structured-proposals spec:
-   *   adds an L1 surveyor + manifest-driven filter; L2 still emits
-   *   free-form notes (Phase 3 will switch them to typed proposals).
-   * Defaults to 'subtree' for back-compat with existing call sites.
+   * - 'subtree-proposal' — the only supported subtree shape (Phase 4
+   *   hard cutover). L1 surveyor + manifest-driven filter; L2 typed
+   *   `audit_proposal` per node; L3 synthesizer emits `audit_synthesis`
+   *   on the root.
+   *
+   * The legacy 'subtree' mode (free-form per-node `observation` notes)
+   * was removed in Phase 4 — see specs/subtree-audit-proposals-spec.md
+   * §6.3.
    */
-  mode?: 'subtree' | 'subtree-proposal';
+  mode?: 'subtree-proposal';
   /**
    * Test seam — overrides the surveyor function so tests can stub
    * dispatch + manifest readback without exercising openclaw.
@@ -269,6 +245,13 @@ export interface RunSubtreeAuditInput {
   surveyorOverride?: (
     args: Parameters<typeof runSurveyor>[0],
   ) => Promise<SurveyorResult>;
+  /**
+   * Test seam — overrides the synthesizer function so tests can stub
+   * dispatch + synthesis-note readback. Parallels `surveyorOverride`.
+   */
+  synthesizerOverride?: (
+    args: Parameters<typeof runSynthesizer>[0],
+  ) => Promise<SynthesizerResult>;
 }
 
 export interface SubtreeAuditResult {
@@ -322,8 +305,9 @@ export async function runSubtreeAudit(
     perNodeTimeoutMs,
     subtreeConcurrency,
     runner,
-    mode = 'subtree',
+    mode = 'subtree-proposal',
     surveyorOverride,
+    synthesizerOverride,
   } = input;
   const { layers } = planSubtreeAudit(rootId, workspaceId);
 
@@ -367,14 +351,17 @@ export async function runSubtreeAudit(
   const findingsByInitiative = new Map<string, { body: string; failed: boolean }>();
   const perNodeOutcomes: SubtreeAuditResult['perNodeOutcomes'] = [];
 
-  // ─── L1 surveyor + manifest filter (mode: 'subtree-proposal') ──────
+  // ─── L1 surveyor + manifest filter ────────────────────────────────
   // Skipped nodes (manifest.skip === true && confidence === 'high') are
   // not dispatched; instead we emit a synthetic `audit_proposal` note
   // and record an 'ok' outcome so the synthesized body flows up to
   // parent layers via the existing childFindings path.
+  // (Phase 4: `mode` is always 'subtree-proposal' at this point.)
   let manifest: AuditManifestBody | null = null;
   let manifestNoteId: string | null = null;
-  if (mode === 'subtree-proposal') {
+  // Eagerly bind `mode` so callers reading deeper-down still see it.
+  void mode;
+  {
     const surveyAttempt = nextAuditAttempt(rootId);
     const surveyorFn = surveyorOverride ?? runSurveyor;
     let surveyResult: SurveyorResult;
@@ -544,24 +531,17 @@ export async function runSubtreeAudit(
         ? `${(runner as { session_key_prefix?: string | null }).session_key_prefix}:${sessionSuffix}`
         : sessionSuffix;
 
-      // Root deferred to L3 synthesizer (Phase 4). For now, no L2
-      // dispatch happens for the root in subtree-proposal mode — record
-      // a placeholder outcome so the rollup math still has full coverage.
-      if (mode === 'subtree-proposal' && isRootLayer && node.id === rootId) {
-        perNodeOutcomes.push({
-          initiativeId: node.id,
-          layerIndex: layerIdx,
-          scopeKey,
-          status: 'ok',
-          note: '(root deferred to L3 synthesizer; not implemented in Phase 3)',
-        });
+      // Root deferred to L3 synthesizer. The L3 dispatch lands AFTER
+      // the layer loop completes, and updates the root's outcome at
+      // that point. For now, skip the L2 dispatch.
+      if (isRootLayer && node.id === rootId) {
         return;
       }
 
       // Manifest-driven skip: don't dispatch — emit a synthetic keep
       // proposal and record the outcome so the parent layer's
       // childFindings includes a synthesized body.
-      if (mode === 'subtree-proposal') {
+      {
         const m = manifestNodeFor(node.id);
         if (m && isManifestSkip(node.id)) {
           const synth = emitSyntheticKeepProposal(node, m);
@@ -599,7 +579,7 @@ export async function runSubtreeAudit(
             // In subtree-proposal mode, child findings are JSON
             // audit_proposal bodies — summarize them as prose for the
             // parent auditor.
-            if (mode === 'subtree-proposal' && f?.body && !f.failed) {
+            if (f?.body && !f.failed) {
               try {
                 const parsed = auditProposalBodySchema.safeParse(JSON.parse(f.body));
                 if (parsed.success) {
@@ -644,8 +624,7 @@ export async function runSubtreeAudit(
         [node.id],
       );
 
-      const manifestEntryForNode =
-        mode === 'subtree-proposal' ? manifestNodeFor(node.id) : null;
+      const manifestEntryForNode = manifestNodeFor(node.id);
       const triggerBody = buildAuditPrompt({
         initiative: node,
         tasks: tasksForNode,
@@ -653,27 +632,23 @@ export async function runSubtreeAudit(
         guidance: guidance ?? null,
         priorFindings: [],
         childFindings,
-        mode: mode === 'subtree-proposal' ? 'subtree-proposal' : 'subtree',
-        proposalInput:
-          mode === 'subtree-proposal'
-            ? {
-                rootId,
-                attempt,
-                manifestNode: {
-                  hypothesis: manifestEntryForNode?.hypothesis ?? 'needs-deep-dive',
-                  confidence: manifestEntryForNode?.confidence ?? 'low',
-                  investigation_prompt:
-                    manifestEntryForNode?.investigation_prompt ??
-                    `Audit ${node.title} against repo + MC reality and emit a structured proposal.`,
-                  scoped_evidence_hints:
-                    manifestEntryForNode?.scoped_evidence_hints ?? [],
-                },
-              }
-            : undefined,
+        mode: 'subtree-proposal',
+        proposalInput: {
+          rootId,
+          attempt,
+          manifestNode: {
+            hypothesis: manifestEntryForNode?.hypothesis ?? 'needs-deep-dive',
+            confidence: manifestEntryForNode?.confidence ?? 'low',
+            investigation_prompt:
+              manifestEntryForNode?.investigation_prompt ??
+              `Audit ${node.title} against repo + MC reality and emit a structured proposal.`,
+            scoped_evidence_hints:
+              manifestEntryForNode?.scoped_evidence_hints ?? [],
+          },
+        },
       });
 
-      const dispatchRole: 'researcher' | 'auditor' =
-        mode === 'subtree-proposal' ? 'auditor' : 'researcher';
+      const dispatchRole = 'auditor' as const;
 
       try {
         await dispatchScope({
@@ -693,78 +668,45 @@ export async function runSubtreeAudit(
           label: `Audit: ${node.title}`,
         });
 
-        if (mode === 'subtree-proposal') {
-          // Look for the most recent audit_proposal note on this node.
-          // The MCP take_note validator from Phase 1 has already
-          // enforced schema validity at write time — if a row exists,
-          // it parses cleanly.
-          const propNotes = listNotes({
-            initiative_id: node.id,
-            kinds: ['audit_proposal'],
-            limit: 1,
-            order: 'desc',
-          });
-          const propBody = propNotes[0]?.body?.trim();
-          if (propBody) {
-            findingsByInitiative.set(node.id, { body: propBody, failed: false });
-            perNodeOutcomes.push({
-              initiativeId: node.id,
-              layerIndex: layerIdx,
-              scopeKey,
-              status: 'ok',
-              note: propBody,
-            });
-          } else {
-            // No audit_proposal landed — emit synthetic fallback.
-            const synth = emitFallbackKeepProposal(node);
-            const fallbackBody =
-              synth?.body ??
-              `(audit failed: invalid proposal body after retries; synthetic fallback createNote also failed for ${node.id})`;
-            findingsByInitiative.set(node.id, {
-              body: fallbackBody,
-              failed: true,
-            });
-            perNodeOutcomes.push({
-              initiativeId: node.id,
-              layerIndex: layerIdx,
-              scopeKey,
-              status: 'failed',
-              error: 'no audit_proposal landed; synthetic fallback emitted',
-            });
-          }
-          return;
-        }
-
-        // mode === 'subtree' — original prose-observation flow.
-        const notes = listNotes({
+        // Look for the most recent audit_proposal note on this node.
+        // The MCP take_note validator from Phase 1 has already
+        // enforced schema validity at write time — if a row exists,
+        // it parses cleanly.
+        const propNotes = listNotes({
           initiative_id: node.id,
-          audience: 'pm',
-          min_importance: 2,
+          kinds: ['audit_proposal'],
           limit: 1,
           order: 'desc',
         });
-        const body = notes[0]?.body?.trim();
-        if (body) {
-          findingsByInitiative.set(node.id, { body, failed: false });
+        const propBody = propNotes[0]?.body?.trim();
+        if (propBody) {
+          findingsByInitiative.set(node.id, { body: propBody, failed: false });
           perNodeOutcomes.push({
             initiativeId: node.id,
             layerIndex: layerIdx,
             scopeKey,
             status: 'ok',
-            note: body,
+            note: propBody,
           });
         } else {
-          // Researcher returned but didn't take_note — treat as failure.
-          const placeholder = `(audit failed: researcher reply received but no take_note(initiative_id=${node.id}, audience='pm', importance=2) row landed)`;
-          findingsByInitiative.set(node.id, { body: placeholder, failed: true });
+          // No audit_proposal landed — emit synthetic fallback.
+          const synth = emitFallbackKeepProposal(node);
+          const fallbackBody =
+            synth?.body ??
+            `(audit failed: invalid proposal body after retries; synthetic fallback createNote also failed for ${node.id})`;
+          findingsByInitiative.set(node.id, {
+            body: fallbackBody,
+            failed: true,
+          });
           perNodeOutcomes.push({
             initiativeId: node.id,
             layerIndex: layerIdx,
             scopeKey,
             status: 'failed',
-            error: 'no take_note row',
+            error: 'no audit_proposal landed; synthetic fallback emitted',
           });
         }
+        return;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         const placeholder = `(audit failed: ${message})`;
@@ -784,6 +726,64 @@ export async function runSubtreeAudit(
     });
 
     await boundedAll(tasks, subtreeConcurrency);
+  }
+
+  // ─── L3 synthesizer dispatch (root layer replacement) ─────────────
+  // Pre-load every L2 audit_proposal across the descendant subtree —
+  // synthetic-keep + synthetic-fallback rows are valid proposals and
+  // MUST be included so the synthesizer sees full coverage.
+  // The result is recorded as the root's per-node outcome. On failure
+  // / no-synthesis we do NOT emit a synthetic fallback (spec §5.5);
+  // the queue UI surfaces a "synthesis missing — re-run synth only"
+  // affordance instead.
+  {
+    const synthAttempt = nextAuditAttempt(rootId);
+    const proposalSummaries = loadProposalsForSubtree(rootId, workspaceId);
+    const synthFn = synthesizerOverride ?? runSynthesizer;
+    const rootScopeKey = (runner as { session_key_prefix?: string | null })
+      .session_key_prefix
+      ? `${(runner as { session_key_prefix?: string | null }).session_key_prefix}:initiative-${rootId}:audit-synthesis:${synthAttempt}`
+      : `initiative-${rootId}:audit-synthesis:${synthAttempt}`;
+    let synthResult: SynthesizerResult;
+    try {
+      synthResult = await synthFn({
+        rootId,
+        workspaceId,
+        attempt: synthAttempt,
+        runner,
+        parentRunId,
+        manifest,
+        proposalSummaries,
+        guidance: guidance ?? null,
+        timeoutMs: perNodeTimeoutMs,
+      });
+    } catch (err) {
+      synthResult = {
+        synthesis: null,
+        synthesisNoteId: null,
+        dispatchOutcome: 'failed',
+        errorMessage: err instanceof Error ? err.message : String(err),
+      };
+    }
+    const rootLayerIdx = Math.max(0, layers.length - 1);
+    if (synthResult.dispatchOutcome === 'ok' && synthResult.synthesis) {
+      perNodeOutcomes.push({
+        initiativeId: rootId,
+        layerIndex: rootLayerIdx,
+        scopeKey: rootScopeKey,
+        status: 'ok',
+        note: synthResult.synthesis.completion_sentinel,
+      });
+    } else {
+      perNodeOutcomes.push({
+        initiativeId: rootId,
+        layerIndex: rootLayerIdx,
+        scopeKey: rootScopeKey,
+        status: 'failed',
+        error: `(synthesis ${synthResult.dispatchOutcome}: ${synthResult.errorMessage ?? 'no error message'})`,
+      });
+    }
+    void manifestNoteId; // reference kept for traceability; not surfaced in outcome.
   }
 
   const failedCount = perNodeOutcomes.filter((o) => o.status === 'failed').length;


### PR DESCRIPTION
## Summary
Phase 4 of [spec #284](https://github.com/smb209/mission-control/pull/284). The cutover phase. Two big changes:

1. **L3 synthesizer dispatch** that emits `audit_synthesis` on the root, plus `POST .../investigate/resynthesize` to re-run just L3 against existing manifest + proposals.
2. **`mode: 'subtree'` removed entirely.** `subtree-proposal` is the only multi-node audit shape now; `narrow` (single-node) is unchanged.

Stacks on [#285](https://github.com/smb209/mission-control/pull/285), [#286](https://github.com/smb209/mission-control/pull/286), [#287](https://github.com/smb209/mission-control/pull/287) — all merged.

## L3 synthesizer
- **New** `src/lib/agents/audit-synthesizer.ts` — `runSynthesizer` dispatches via `dispatchScope` as `role: 'auditor'` with `mode: 'synthesis'`, reads back `kind: 'audit_synthesis'` from the root, returns `{ synthesis, synthesisNoteId, dispatchOutcome }`. Per spec §5.5, **no synthetic fallback on L3 failure** — operator still has the L2 queue and the queue UI surfaces "synthesis missing — re-run synth only". `synthesizerOverride` test seam parallel to Phase 2's `surveyorOverride`.
- **`audit-prompt.ts`** new `mode: 'synthesis'` branch — manifest verbatim, L2 proposal summaries via `summarizeProposalForBriefing`, root state (description/dates/status_check_md), §4.4 schema field-by-field with example, retry guidance, read-only discipline.
- **`subtree-audit.ts`** — after L2 layers complete, collect descendant `audit_proposal` bodies (incl synthetic keep + fallback proposals from Phases 2/3), call `runSynthesizer`, record outcome on the root (no longer the deferred placeholder Phase 3 left).

## Resynthesize endpoint
- **New** `POST /api/initiatives/[id]/investigate/resynthesize` — reads most recent manifest + proposals, dispatches just L3, returns the new `audit_synthesis` note id. 400 when no manifest exists (operator must run the full audit first). `__setSynthesizerOverrideForTests` module-level setter (Next.js route handlers don't take third-arg test seams idiomatically).

## Hard cutover
- **`investigate/route.ts`** Zod enum is `'narrow' | 'subtree-proposal'` (default `'narrow'` preserved per existing behavior — see deviation below). Legacy `mode: 'subtree'` intercepted with a documented 400 pointing at spec §6.3.
- **`audit-prompt.ts`** — `mode: 'subtree'` branch deleted; mode union dropped.
- **`subtree-audit.ts`** — layer-loop legacy branch removed; `mode` parameter is just `'subtree-proposal'`.
- **`subtree-audit.test.ts`** — original `mode: 'subtree'` tests deleted (Phase 2/3 `subtree-proposal` tests cover the orchestration shape).
- **UI**: `InvestigateModal.tsx` + `inline/InvestigatePicker.tsx` + `InitiativeDetailView.tsx` — `'subtree'` → `'subtree-proposal'` in type unions, request bodies, conditionals. Labels/copy unchanged.

## Refactor
- **New** `src/lib/agents/subtree-audit-summarize.ts` — `summarizeProposalForBriefing` extracted here to break an import cycle (`audit-prompt.ts` now imports it for synthesis mode; `subtree-audit.ts` already imports `audit-prompt.ts`). Re-exported from `subtree-audit.ts` for Phase 3 test-import compatibility.

## Spec deviations (documented; subagent report)
- **POST default mode preserved as `'narrow'`** rather than flipping to `'subtree-proposal'`. The actual default at HEAD was `'narrow'`; flipping to `'subtree-proposal'` would silently change behavior for callers that omit `mode`. UI callers explicitly pass `'subtree-proposal'` so the operator-facing flow is unaffected. Documented in the route comment.
- **L3 failure**: `perNodeOutcomes` for the root carries `status: 'failed'` with a marker like `(synthesis no-synthesis: <error>)`. No synthetic fallback note emitted at L3 — matches spec §5.5.
- **`__setSynthesizerOverrideForTests`** module-level setter on the resynthesize route, instead of a third POST argument. Next.js route handlers have a strict `(req, ctx)` signature.

## Test plan
- [x] `yarn test`: **923 pass, 1 fail**. Single fail is the same pre-existing `schedule-runner: produces a brief and advances run_count`.
- [x] `yarn run tsc --noEmit`: only 3 pre-existing errors remain. All Phase-4-touched files typecheck clean.
- [x] New tests: synthesizer happy/failure/no-synthesis; L3 happy + L3 failure paths in `subtree-audit.test.ts`; resynthesize endpoint missing-manifest 400 + happy path; `mode: 'subtree'` returns 400 with documented spec link; synthesis-mode briefing snapshot.
- [ ] **Preview-verify**: changes to `InvestigateModal.tsx` are pure wire-value swaps (`'subtree'` → `'subtree-proposal'`). Labels, copy, plan-fetch path, dispatch-confirmation panel are preserved verbatim. Route + Zod tests cover the request body change end-to-end. Will run a quick preview pass before merge to confirm modal still renders correctly.

## What this PR does NOT do (deferred per spec §10)
- L1 surveyor reading prior `audit_synthesis` to emit a delta manifest (Phase 5).
- Operator proposal queue UI / accept/reject endpoints (Phase 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)