### PR TITLE
feat(audit): phase 5 — delta runs (L1 reads prior synthesis)

### DIFF
--- a/src/lib/agents/audit-prompt.ts
+++ b/src/lib/agents/audit-prompt.ts
@@ -120,8 +120,20 @@ export interface BuildAuditPromptInput {
     }>;
     /** Pre-pulled `git log --oneline -20` excerpt or empty string. */
     gitActivity?: string | null;
-    /** Most recent prior `audit_synthesis` body (verbatim) or null. */
-    priorSynthesisBody?: string | null;
+    /**
+     * Compact ref to the most recent prior `audit_synthesis` note on
+     * the root, used as a delta-baseline. Null when no prior audit
+     * exists or the prior body failed to validate. The orchestrator
+     * pre-resolves the timestamp + run_group_id from the DB row so the
+     * surveyor doesn't have to walk notes itself.
+     *
+     * Spec: specs/subtree-audit-proposals-spec.md §7, §10 Phase 5.
+     */
+    priorSynthesis?: {
+      created_at: string;
+      run_group_id: string;
+      completion_sentinel: string;
+    } | null;
   };
   /**
    * L3 synthesizer briefing inputs (mode: 'synthesis'). The orchestrator
@@ -322,7 +334,7 @@ function buildSurveyPrompt(args: {
   if (!surveyInput) {
     throw new Error('buildAuditPrompt(mode=survey): surveyInput is required');
   }
-  const { rootId, attempt, descendants, gitActivity, priorSynthesisBody } = surveyInput;
+  const { rootId, attempt, descendants, gitActivity, priorSynthesis } = surveyInput;
 
   const descBlock =
     descendants.length === 0
@@ -338,9 +350,13 @@ function buildSurveyPrompt(args: {
     ? `\n## Recent repo activity (cheap skim)\n\n\`\`\`\n${gitActivity.trim()}\n\`\`\`\n`
     : '\n## Recent repo activity\n\n_(none provided — surveyor briefing did not include a git-log excerpt; do not greenfield git work)_\n';
 
-  const priorBlock = priorSynthesisBody?.trim()
-    ? `\n## Prior synthesis (most recent audit on this root)\n\n\`\`\`\n${priorSynthesisBody.trim()}\n\`\`\`\n\nUse this to bias toward delta-style narrowing — nodes with no signal change since the prior synthesis are good \`skip: true\` candidates.\n`
-    : '';
+  // Phase 5: always render a `## Prior audit` section so the surveyor
+  // is unambiguously instructed about delta-mode behavior — present or
+  // absent. With a prior, encourage `skip: true` for unchanged nodes;
+  // without one, force a fresh full-fanout investigation.
+  const priorBlock = priorSynthesis
+    ? `\n## Prior audit\n\nA prior audit completed at ${priorSynthesis.created_at}.\nLast sentinel: "${priorSynthesis.completion_sentinel}"\n\nUse this as a delta baseline. For each descendant in your manifest:\n- If you can confidently say nothing meaningful has changed since the\n  prior audit (no MC status flip, no scope change in the description,\n  no recent activity hinting at a re-investigation), set\n  \`hypothesis: 'likely-done'\` (or whatever was established) AND\n  \`skip: true\` AND \`confidence: 'high'\`. The orchestrator will skip\n  those nodes and emit a synthetic keep proposal.\n- If anything has changed (MC status, description text, target dates,\n  or there's recent activity), set \`skip: false\` regardless of\n  hypothesis. Do not skip on uncertainty.\n\nThis is a delta-run optimization. When in doubt, do not skip.\n\nIn your emitted manifest, set \`previous_synthesis_run_group_id\` to\nexactly: \`"${priorSynthesis.run_group_id}"\`\n`
+    : `\n## Prior audit\n\n(no prior audit synthesis on this root — investigate every node\nfreshly).\n\nIn your emitted manifest, set \`previous_synthesis_run_group_id: null\`.\n`;
 
   const guidanceBlock = guidance?.trim()
     ? `\n## Operator focus\n\n${guidance.trim()}\n`
@@ -352,7 +368,7 @@ function buildSurveyPrompt(args: {
   "version": 1,
   "root_initiative_id": "${rootId}",
   "attempt": ${attempt},
-  "previous_synthesis_run_group_id": null,
+  "previous_synthesis_run_group_id": ${priorSynthesis ? `"${priorSynthesis.run_group_id}"` : 'null'},
   "summary": "1-paragraph framing of the epic's intent and current state",
   "nodes": [
     {

--- a/src/lib/agents/audit-survey.test.ts
+++ b/src/lib/agents/audit-survey.test.ts
@@ -17,7 +17,8 @@ import assert from 'node:assert/strict';
 import { v4 as uuidv4 } from 'uuid';
 import { run } from '@/lib/db';
 import { createInitiative } from '@/lib/db/initiatives';
-import { createNote } from '@/lib/db/agent-notes';
+import { createNote, listNotes } from '@/lib/db/agent-notes';
+import { buildAuditPrompt } from './audit-prompt';
 import { runSurveyor, buildFallbackManifest } from './audit-survey';
 import {
   __setSendChatClientForTests,
@@ -198,6 +199,218 @@ test('runSurveyor: dispatch ok but no manifest note → dispatchOutcome no-manif
 
   assert.equal(result.dispatchOutcome, 'no-manifest');
   assert.equal(result.manifest, null);
+});
+
+test('runSurveyor (Phase 5): no prior synthesis → manifest has previous_synthesis_run_group_id null + briefing renders "no prior audit"', async () => {
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Delta root no prior' });
+  const child = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'Child A',
+    parent_initiative_id: root.id,
+  });
+
+  __setSendChatClientForTests(
+    stubClient({
+      beforeReply: () => {
+        createNote({
+          workspace_id: ws,
+          agent_id: null,
+          initiative_id: root.id,
+          scope_key: `initiative-${root.id}:audit-survey:1`,
+          role: 'auditor',
+          run_group_id: uuidv4(),
+          kind: 'audit_manifest',
+          audience: 'pm',
+          importance: 1,
+          // Surveyor agent (hallucinated) emits a non-null id; we expect
+          // the orchestrator to overwrite it back to null since no prior
+          // synthesis exists in the DB.
+          body: JSON.stringify({
+            version: 1,
+            root_initiative_id: root.id,
+            attempt: 1,
+            previous_synthesis_run_group_id: 'hallucinated-id',
+            summary: 'no prior',
+            nodes: [
+              {
+                initiative_id: child.id,
+                title: child.title,
+                current_status: 'in_progress',
+                hypothesis: 'needs-deep-dive',
+                confidence: 'medium',
+                investigation_prompt: 'go look',
+                scoped_evidence_hints: [],
+                skip: false,
+              },
+            ],
+            cross_cutting_questions: [],
+          }),
+        });
+      },
+    }),
+  );
+
+  const result = await runSurveyor({
+    rootId: root.id,
+    workspaceId: ws,
+    attempt: 1,
+    runner: fakeRunner(),
+    parentRunId: null,
+  });
+
+  assert.equal(result.dispatchOutcome, 'ok');
+  assert.equal(result.manifest!.previous_synthesis_run_group_id, null);
+
+  // Cross-check: rendering buildAuditPrompt with priorSynthesis=null
+  // surfaces the "(no prior audit synthesis on this root …)" line.
+  const briefing = buildAuditPrompt({
+    initiative: root,
+    tasks: [],
+    childInitiatives: [],
+    priorFindings: [],
+    childFindings: [],
+    mode: 'survey',
+    surveyInput: {
+      rootId: root.id,
+      attempt: 1,
+      descendants: [
+        { id: child.id, title: child.title, kind: 'story', status: 'in_progress', parent_initiative_id: root.id },
+      ],
+      gitActivity: null,
+      priorSynthesis: null,
+    },
+  });
+  assert.match(briefing, /## Prior audit/);
+  assert.match(briefing, /no prior audit synthesis/);
+  assert.match(briefing, /previous_synthesis_run_group_id: null/);
+});
+
+test('runSurveyor (Phase 5): prior synthesis present → manifest carries run_group_id; briefing surfaces sentinel + delta-skip guidance', async () => {
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Delta root with prior' });
+  const child = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'Child B',
+    parent_initiative_id: root.id,
+  });
+
+  // Plant a valid prior audit_synthesis note on the root.
+  const priorRunGroupId = uuidv4();
+  const priorSynthesisBody = {
+    version: 1,
+    root_initiative_id: root.id,
+    attempt: 1,
+    completion_sentinel: 'Phase 4 cutover ships and surveyor delta-runs are validated.',
+    epic_proposals: [],
+    cross_node_proposals: [],
+  };
+  createNote({
+    workspace_id: ws,
+    agent_id: null,
+    initiative_id: root.id,
+    scope_key: `initiative-${root.id}:audit-synthesis:0`,
+    role: 'auditor',
+    run_group_id: priorRunGroupId,
+    kind: 'audit_synthesis',
+    audience: 'pm',
+    importance: 1,
+    body: JSON.stringify(priorSynthesisBody),
+  });
+
+  __setSendChatClientForTests(
+    stubClient({
+      beforeReply: () => {
+        createNote({
+          workspace_id: ws,
+          agent_id: null,
+          initiative_id: root.id,
+          scope_key: `initiative-${root.id}:audit-survey:1`,
+          role: 'auditor',
+          run_group_id: uuidv4(),
+          kind: 'audit_manifest',
+          audience: 'pm',
+          importance: 1,
+          // Even if the agent emits the wrong id, the orchestrator
+          // should overwrite to the truth.
+          body: JSON.stringify({
+            version: 1,
+            root_initiative_id: root.id,
+            attempt: 1,
+            previous_synthesis_run_group_id: 'wrong-id',
+            summary: 'with prior',
+            nodes: [
+              {
+                initiative_id: child.id,
+                title: child.title,
+                current_status: 'in_progress',
+                hypothesis: 'likely-done',
+                confidence: 'high',
+                investigation_prompt: 'unchanged since prior',
+                scoped_evidence_hints: [],
+                skip: true,
+              },
+            ],
+            cross_cutting_questions: [],
+          }),
+        });
+      },
+    }),
+  );
+
+  const result = await runSurveyor({
+    rootId: root.id,
+    workspaceId: ws,
+    attempt: 1,
+    runner: fakeRunner(),
+    parentRunId: null,
+  });
+
+  assert.equal(result.dispatchOutcome, 'ok');
+  assert.equal(
+    result.manifest!.previous_synthesis_run_group_id,
+    priorRunGroupId,
+    'orchestrator overwrites previous_synthesis_run_group_id with the DB-truth',
+  );
+
+  // Briefing rendering — pull the same priorSynthesis the surveyor saw.
+  const priorNote = listNotes({
+    initiative_id: root.id,
+    kinds: ['audit_synthesis'],
+    limit: 1,
+    order: 'desc',
+  })[0];
+  assert.ok(priorNote);
+  const briefing = buildAuditPrompt({
+    initiative: root,
+    tasks: [],
+    childInitiatives: [],
+    priorFindings: [],
+    childFindings: [],
+    mode: 'survey',
+    surveyInput: {
+      rootId: root.id,
+      attempt: 1,
+      descendants: [
+        { id: child.id, title: child.title, kind: 'story', status: 'in_progress', parent_initiative_id: root.id },
+      ],
+      gitActivity: null,
+      priorSynthesis: {
+        created_at: priorNote.created_at,
+        run_group_id: priorNote.run_group_id,
+        completion_sentinel: priorSynthesisBody.completion_sentinel,
+      },
+    },
+  });
+  assert.match(briefing, /## Prior audit/);
+  assert.match(briefing, /A prior audit completed at /);
+  assert.match(briefing, /Last sentinel:/);
+  assert.match(briefing, /Phase 4 cutover ships/);
+  assert.match(briefing, /delta baseline/);
+  assert.match(briefing, /skip: true/);
+  assert.ok(briefing.includes(priorNote.run_group_id), 'briefing tells the agent the exact run_group_id to emit');
 });
 
 test('buildFallbackManifest: every descendant skip:false, hypothesis needs-deep-dive', () => {

--- a/src/lib/agents/audit-survey.ts
+++ b/src/lib/agents/audit-survey.ts
@@ -17,6 +17,7 @@ import {
   validateAuditNoteBody,
   type AuditManifestBody,
   type AuditManifestNode,
+  type AuditSynthesisBody,
 } from '@/lib/agents/audit-proposals/schemas';
 import type { Agent } from '@/lib/types';
 
@@ -102,19 +103,50 @@ export function buildFallbackManifest(
 }
 
 /**
- * Look up the most recent prior `audit_synthesis` note on the root —
- * used for delta runs in Phase 5. Phase 2 doesn't change behavior on
- * this read, but threads it through so the briefing renders the prior
- * if/when one exists.
+ * Compact summary of the most recent prior `audit_synthesis` note on
+ * the root, surfaced into the surveyor briefing for delta runs.
+ *
+ * Spec: specs/subtree-audit-proposals-spec.md §7, §10 Phase 5.
  */
-function loadPriorSynthesis(rootId: string): string | null {
+export interface PriorSynthesisRef {
+  /** Note row's `created_at` — the timestamp of the prior audit. */
+  created_at: string;
+  /** Note row's `run_group_id` — surfaced as `previous_synthesis_run_group_id`. */
+  run_group_id: string;
+  /** Synthesis body's `completion_sentinel` (1-line "we're done if…" string). */
+  completion_sentinel: string;
+}
+
+/**
+ * Look up the most recent prior `audit_synthesis` note on the root and
+ * decode the `completion_sentinel` for delta-run framing. Returns null
+ * if no prior synthesis exists OR the prior note's body fails to
+ * validate (corrupt / pre-schema). Failure logs but doesn't throw —
+ * we'd rather degrade to a full re-audit than crash the run.
+ */
+function loadPriorSynthesisRef(rootId: string): PriorSynthesisRef | null {
   const rows = listNotes({
     initiative_id: rootId,
     kinds: ['audit_synthesis'],
     limit: 1,
     order: 'desc',
   });
-  return rows[0]?.body ?? null;
+  const note = rows[0];
+  if (!note) return null;
+  const parsed = validateAuditNoteBody('audit_synthesis', note.body);
+  if (!parsed.ok) {
+    console.warn(
+      `[audit-survey] prior audit_synthesis note ${note.id} on ${rootId} ` +
+        `did not validate (${parsed.error}); treating as no prior audit.`,
+    );
+    return null;
+  }
+  const body = parsed.parsed as AuditSynthesisBody;
+  return {
+    created_at: note.created_at,
+    run_group_id: note.run_group_id,
+    completion_sentinel: body.completion_sentinel,
+  };
 }
 
 /**
@@ -183,7 +215,7 @@ export async function runSurveyor(input: RunSurveyorInput): Promise<SurveyorResu
     }
   }
 
-  const priorSynthesisBody = loadPriorSynthesis(rootId);
+  const priorSynthesis = loadPriorSynthesisRef(rootId);
 
   const triggerBody = buildAuditPrompt({
     initiative: root,
@@ -198,7 +230,7 @@ export async function runSurveyor(input: RunSurveyorInput): Promise<SurveyorResu
       attempt,
       descendants,
       gitActivity: gitActivity ?? null,
-      priorSynthesisBody,
+      priorSynthesis,
     },
   });
 
@@ -249,8 +281,16 @@ export async function runSurveyor(input: RunSurveyorInput): Promise<SurveyorResu
       errorMessage: `surveyor manifest body did not validate: ${parsed.error}`,
     };
   }
+  const manifest = parsed.parsed as AuditManifestBody;
+  // Phase 5: source-of-truth for the prior-synthesis link is the DB,
+  // not whatever the surveyor wrote into its body. The briefing tells
+  // the agent the right value to emit; we overwrite here defensively
+  // so a hallucinated null still gets corrected for downstream
+  // consumers (the synthesizer briefing surfaces this id).
+  manifest.previous_synthesis_run_group_id =
+    priorSynthesis?.run_group_id ?? null;
   return {
-    manifest: parsed.parsed as AuditManifestBody,
+    manifest,
     surveyorNoteId: fresh.noteId,
     dispatchOutcome: 'ok',
   };

--- a/src/lib/agents/subtree-audit.test.ts
+++ b/src/lib/agents/subtree-audit.test.ts
@@ -881,3 +881,153 @@ test('runSubtreeAudit (Phase 4): L3 failure → no synthetic fallback, root outc
   assert.match(rootOutcome!.error ?? '', /synthesis no-synthesis/);
   assert.match(rootOutcome!.error ?? '', /ghost-walked/);
 });
+
+test('runSubtreeAudit (Phase 5): delta skip — node dispatched on run 1, skipped on run 2', async () => {
+  __setSendChatClientForTests(stubClient());
+  const ws = freshWorkspace();
+  const root = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Delta epic' });
+  const node1 = createInitiative({
+    workspace_id: ws,
+    kind: 'story',
+    title: 'Node 1',
+    parent_initiative_id: root.id,
+  });
+
+  // Run 1: surveyor reports needs-deep-dive / not skipped → node1 is
+  // dispatched. Plant a synthesis note at the end of run 1 so run 2
+  // sees a delta baseline.
+  const surveyorRun1 = async (): Promise<SurveyorResult> => ({
+    manifest: {
+      version: 1,
+      root_initiative_id: root.id,
+      attempt: 1,
+      previous_synthesis_run_group_id: null,
+      summary: 'first run',
+      nodes: [
+        {
+          initiative_id: node1.id,
+          title: node1.title,
+          current_status: 'in_progress',
+          hypothesis: 'needs-deep-dive',
+          confidence: 'medium',
+          investigation_prompt: 'first audit',
+          scoped_evidence_hints: [],
+          skip: false,
+        },
+      ],
+      cross_cutting_questions: [],
+    },
+    surveyorNoteId: null,
+    dispatchOutcome: 'ok',
+  });
+
+  const r1 = await runSubtreeAudit({
+    rootId: root.id,
+    workspaceId: ws,
+    guidance: null,
+    perNodeTimeoutMs: 10_000,
+    subtreeConcurrency: 2,
+    runner: fakeRunner(),
+    mode: 'subtree-proposal',
+    surveyorOverride: surveyorRun1,
+    synthesizerOverride: noopSynthesizer,
+  });
+
+  // Run 1: node1 was dispatched (an agent_runs child row exists).
+  const run1Children = queryAll<{ id: string }>(
+    `SELECT id FROM agent_runs WHERE workspace_id = ? AND initiative_id = ? AND parent_run_id = ?`,
+    [ws, node1.id, r1.parentRunId],
+  );
+  assert.equal(run1Children.length, 1, 'run 1: node1 dispatched');
+
+  // Plant a valid prior synthesis on the root (simulates L3 having
+  // landed at the end of run 1). The Phase 5 surveyor read should pick
+  // this up on run 2.
+  createNote({
+    workspace_id: ws,
+    agent_id: null,
+    initiative_id: root.id,
+    scope_key: `initiative-${root.id}:audit-synthesis:1`,
+    role: 'auditor',
+    run_group_id: uuidv4(),
+    kind: 'audit_synthesis',
+    audience: 'pm',
+    importance: 1,
+    body: JSON.stringify({
+      version: 1,
+      root_initiative_id: root.id,
+      attempt: 1,
+      completion_sentinel: 'Delta epic done.',
+      epic_proposals: [],
+      cross_node_proposals: [],
+    }),
+  });
+
+  // Run 2: surveyor reports skip:true / high — simulating "nothing
+  // changed since the prior audit", which the Phase 5 briefing
+  // explicitly authorizes when a prior synthesis exists.
+  const surveyorRun2 = async (): Promise<SurveyorResult> => ({
+    manifest: {
+      version: 1,
+      root_initiative_id: root.id,
+      attempt: 2,
+      previous_synthesis_run_group_id: null, // overwritten by orchestrator anyway
+      summary: 'second run, nothing changed',
+      nodes: [
+        {
+          initiative_id: node1.id,
+          title: node1.title,
+          current_status: 'in_progress',
+          hypothesis: 'likely-done',
+          confidence: 'high',
+          investigation_prompt: 'unchanged since prior audit',
+          scoped_evidence_hints: [],
+          skip: true,
+        },
+      ],
+      cross_cutting_questions: [],
+    },
+    surveyorNoteId: null,
+    dispatchOutcome: 'ok',
+  });
+
+  const r2 = await runSubtreeAudit({
+    rootId: root.id,
+    workspaceId: ws,
+    guidance: null,
+    perNodeTimeoutMs: 10_000,
+    subtreeConcurrency: 2,
+    runner: fakeRunner(),
+    mode: 'subtree-proposal',
+    surveyorOverride: surveyorRun2,
+    synthesizerOverride: noopSynthesizer,
+  });
+
+  // Run 2: node1 should NOT have a new agent_runs child row under r2's
+  // parent (manifest-skip → synthetic keep, no dispatch).
+  const run2Children = queryAll<{ id: string }>(
+    `SELECT id FROM agent_runs WHERE workspace_id = ? AND initiative_id = ? AND parent_run_id = ?`,
+    [ws, node1.id, r2.parentRunId],
+  );
+  assert.equal(run2Children.length, 0, 'run 2: node1 skipped (no new dispatch)');
+
+  // A synthetic keep audit_proposal landed for node1 on run 2.
+  const proposals = listNotes({
+    initiative_id: node1.id,
+    kinds: ['audit_proposal'],
+    limit: 5,
+  });
+  // At least one keep proposal — the run 2 synthetic keep. (Run 1's
+  // dispatch may or may not have produced a real proposal via the
+  // stub, which doesn't matter for this assertion.)
+  const synthKeep = proposals
+    .map((p) => JSON.parse(p.body))
+    .find((b) => b.proposed_action === 'keep' && b.confidence === 'high');
+  assert.ok(synthKeep, 'run 2 emitted a synthetic high-confidence keep proposal');
+
+  // Per-node outcome is recorded with the manifest-skip marker.
+  const skipOutcome = r2.perNodeOutcomes.find((o) => o.initiativeId === node1.id);
+  assert.ok(skipOutcome);
+  assert.equal(skipOutcome!.status, 'ok');
+  assert.match(skipOutcome!.note ?? '', /manifest-skip/);
+});


### PR DESCRIPTION
## Summary
Phase 5 of [spec #284](https://github.com/smb209/mission-control/pull/284). L1 surveyor reads the most recent `audit_synthesis` note on the root before dispatching and threads its context into the briefing so the auditor emits a *delta* manifest — `skip: true && confidence: 'high'` on unchanged nodes. The orchestrator's existing Phase-2 manifest filter then skips those nodes (synthetic keep proposal), cutting L2 fan-out cost on healthy epics audited frequently.

Stacks on [#285](https://github.com/smb209/mission-control/pull/285), [#286](https://github.com/smb209/mission-control/pull/286), [#287](https://github.com/smb209/mission-control/pull/287), [#288](https://github.com/smb209/mission-control/pull/288) — all merged.

## Changes
- **`audit-survey.ts`** — `loadPriorSynthesisRef` validates the prior synthesis body via `validateAuditNoteBody` and returns `{ created_at, run_group_id, completion_sentinel }`. Threads typed `priorSynthesis` into the `mode: 'survey'` briefing. **After the manifest is parsed back from the surveyor's note, the orchestrator defensively overwrites `previous_synthesis_run_group_id` with the DB truth** — guards against the auditor hallucinating a UUID.
- **`audit-prompt.ts`** — `mode: 'survey'` branch always renders a `## Prior audit` section.
  - **With prior**: date + completion sentinel + explicit delta-skip guidance ("set skip:true && confidence:'high' for unchanged nodes; when in doubt, do not skip") + the exact `run_group_id` to emit.
  - **Without prior**: "(no prior audit synthesis on this root — investigate every node freshly)" + null instruction.
- **Source of truth = DB, not the agent.** The note row in the DB is unchanged (still contains whatever the agent wrote); only the `AuditManifestBody` flowing through `runSubtreeAudit` is corrected. Defense in depth so a hallucinated UUID doesn't leak into the synthesizer briefing.

## Spec deviations (documented; subagent report)
- **`previous_synthesis_run_group_id` overwrite** is orchestrator-side. Spec §7 didn't specify whether the value should come from the agent or the orchestrator; I picked the safer option. Documented inline.
- **`loadPriorSynthesisRef`** treats Zod-validation failure on the prior note's body as "no prior audit" (logs + returns null). Per spec's "handle gracefully" guidance.
- **No git-log integration** (per §3.1 + §9.2 q2 — surveyor relies on MC state alone in v1; per-node activity heuristics deferred until we have run data).

## Test plan
- [x] `yarn test`: **926 pass, 1 fail**. Single fail is the pre-existing `schedule-runner: produces a brief and advances run_count`.
- [x] `yarn run tsc --noEmit`: only 3 pre-existing errors remain.
- [x] Three new tests:
  - `runSurveyor` no-prior: manifest carries `previous_synthesis_run_group_id: null`; briefing renders the no-prior message.
  - `runSurveyor` prior-present: plants a real `audit_synthesis` note; asserts orchestrator overwrites manifest's `previous_synthesis_run_group_id` with the DB id even when the agent hallucinates; briefing surfaces sentinel + delta guidance.
  - `runSubtreeAudit` delta-skip end-to-end: runs the audit twice on the same subtree, plants synthesis between runs; node dispatched on run 1, skipped (synthetic keep, no `agent_runs` child) on run 2.
- N/A: preview-verify (no UI surface; pure orchestrator + briefing wiring).

## What this PR does NOT do
- L1 git-log integration / per-node activity heuristics — deferred per §9.2 q2 until we have run data.
- Downweighting repeat-rejected proposals — that's an L4 (proposal queue UI) concern.
- Operator proposal queue UI — Phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)