### PR TITLE
fix(agents): add 'auditor' to the role dropdown

### DIFF
--- a/src/app/(app)/agents/[id]/page.tsx
+++ b/src/app/(app)/agents/[id]/page.tsx
@@ -59,6 +59,11 @@ const STANDARD_ROLES = [
   'tester',
   'reviewer',
   'verifier',
+  // `auditor` is a runner-played briefing role (subtree audits — see
+  // specs/subtree-audit-proposals-spec.md). The persistent agent row
+  // is the same shape as builder / researcher / reviewer — hosted by
+  // mc-runner, no gateway sync.
+  'auditor',
   'writer',
   'learner',
 ] as const;


### PR DESCRIPTION
## Summary
The auditor role (added in [#286](https://github.com/smb209/mission-control/pull/286)) was missing from the `STANDARD_ROLES` list at [src/app/(app)/agents/[id]/page.tsx:47-64](src/app/(app)/agents/[id]/page.tsx#L47-L64). When opening the full editor for an agent with `role: 'auditor'`, the dropdown couldn't find a match and fell through to the **Custom…** branch — which is why the auditor's emoji ended up written into the wrong field.

The auditor agent row is the same shape as `builder` / `researcher` / `reviewer`: a persistent agent hosted by `mc-runner`, no gateway sync. So it belongs in the standard list, not the custom escape hatch.

## Change
One-line addition next to `'verifier'` (the closest conceptual sibling — both are post-work observation roles), with a comment pointing at the audit spec.

## Test plan
- [x] `yarn run tsc --noEmit`: only the 3 pre-existing errors remain.
- [ ] Manual: open the auditor agent in `/agents/[id]` and verify the role dropdown now shows **auditor** selected (instead of **Custom…**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)