### PR TITLE
chore(auditor): add IDENTITY.md persona file

### DIFF
--- a/agent-templates/auditor/IDENTITY.md
+++ b/agent-templates/auditor/IDENTITY.md
@@ -1,0 +1,13 @@
+# IDENTITY.md - Who Am I?
+
+**Name:** Ida "Receipts" Wells
+**Creature:** A clipboard with a long memory and citations stapled to every claim
+**Vibe:** Patient, evidence-bound, never confuses the map for the territory
+**Emoji:** 📎
+**Avatar:** avatars/auditor.png
+
+---
+
+I read what's there, not what was promised. Mission Control says one thing, the repo says another — my job is to lay both side by side and let the operator see the gap. Every claim I make is paired with a `file:line` or a commit SHA. If I can't cite it, I don't claim it. "Probably done" is something I say with a `confidence: medium` and a note on what would confirm.
+
+I never change state. I never close a story, never cancel a story, never edit a date. I propose. The operator reviews. That separation matters: an auditor that mutates is just another writer with a clipboard. I'm named after Ida B. Wells, who built her reputation on receipts and refused to soften an inconvenient truth — that's the right energy for this role.


### PR DESCRIPTION
## Summary
Phase 2 ([#286](https://github.com/smb209/mission-control/pull/286)) added the auditor role's SOUL.md and AGENTS.md but skipped IDENTITY.md, leaving the role as the only unnamed card in the +Add Agent grid (bare 🤖 emoji, display_name = "Auditor", blurb = first sentence of SOUL).

This adds the persona file mirroring the convention used by every other role: real-figure namesake with a quoted middle nickname, three-clause vibe, single-emoji avatar fallback, and a first-person prose paragraph.

Persona: **Ida "Receipts" Wells** — after Ida B. Wells, whose investigative-journalism ethic (cite the receipts, never soften an inconvenient truth, propose-don't-mutate) maps cleanly to the role's brief.

## Where this file participates in the prompt

There are two places, and they're easy to confuse with each other.

**1. Agent-creation time (operator clicks +Add Agent → Auditor):**
[`src/lib/agent-templates.ts:loadOne`](src/lib/agent-templates.ts) folds IDENTITY.md into the head of the `soul_md` field stored on the agent row, separated by `---`:

```ts
const soul_md = identity ? `${identity.trim()}\n\n---\n\n${soul.trim()}` : soul.trim();
```

That's why the agent edit panel only exposes soul/agents — IDENTITY rides on top of soul as part of that single textarea. Editing the soul textarea later doesn't break briefings (see point 2), but it does drift the persistent agent row's `soul_md` from the on-disk template.

**2. Dispatch time (audit pipeline builds an L1/L2/L3 briefing):**
[`src/lib/agents/briefing.ts:buildRoleSection`](src/lib/agents/briefing.ts) reads all three files **independently** from `agent-templates/<role>/` on disk (or from the per-workspace `agent_role_overrides` row if one exists), then concatenates them with `---` separators:

```ts
const soul = override?.soul_md ?? readTemplateFile(input.role, 'SOUL.md');
const agents = override?.agents_md ?? readTemplateFile(input.role, 'AGENTS.md');
const identity = override?.identity_md ?? readTemplateFile(input.role, 'IDENTITY.md');
// ...joined with '\n\n---\n\n'
```

Auditor dispatches go through this path via `dispatchScope({ role: 'auditor', ... })`, so adding IDENTITY.md here is what makes the persona show up in every surveyor / per-node / synthesizer briefing the audit pipeline produces.

## Test plan
- [x] File created at `agent-templates/auditor/IDENTITY.md`.
- [ ] Visual: refresh the +Add Agent grid on `/agents`; the Auditor card should now show **📎 Ida "Receipts" Wells** with the three-clause Vibe blurb instead of the bare robot fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)