### PR TITLE
fix(ui): render status pill on every initiative card

### DIFF
--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -103,14 +103,25 @@ const KIND_BADGE: Record<Kind, string> = {
 };
 
 /**
- * Pills next to the kind badge surface notable statuses on the tree
- * row at a glance. `planned` and `in_progress` are intentionally
- * omitted — they're the boring default and would clutter every row;
- * the title/kind already convey "this is a thing being worked on".
- * `cancelled` had its own pill before this map landed; we fold it in
- * here for consistency and keep the existing red treatment.
+ * Pills next to the kind badge surface the status of every node on
+ * the tree row at a glance. Originally `planned` / `in_progress` were
+ * omitted (treated as the boring default), but operators consistently
+ * read the absence of a pill as "I haven't yet figured out the status"
+ * rather than "this is the default" — so every status gets a pill now,
+ * with the boring defaults rendered in muted neutral chrome so they
+ * don't shout.
  */
-const STATUS_BADGE: Partial<Record<Status, { label: string; className: string; tooltip: string }>> = {
+const STATUS_BADGE: Record<Status, { label: string; className: string; tooltip: string }> = {
+  planned: {
+    label: 'planned',
+    className: 'bg-mc-bg-tertiary text-mc-text-secondary border border-mc-border',
+    tooltip: 'Planned — not started yet',
+  },
+  in_progress: {
+    label: 'in progress',
+    className: 'bg-blue-500/15 text-blue-300 border border-blue-500/30',
+    tooltip: 'In progress',
+  },
   done: {
     label: 'done',
     className: 'bg-green-500/15 text-green-300 border border-green-500/30',
@@ -914,14 +925,12 @@ function InitiativeRow({
             <span className={`px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wide ${KIND_BADGE[node.kind]}`}>
               {node.kind}
             </span>
-            {STATUS_BADGE[node.status] && (
-              <span
-                className={`text-[10px] uppercase tracking-wide px-1 py-0.5 rounded ${STATUS_BADGE[node.status]!.className}`}
-                title={STATUS_BADGE[node.status]!.tooltip}
-              >
-                {STATUS_BADGE[node.status]!.label}
-              </span>
-            )}
+            <span
+              className={`text-[10px] uppercase tracking-wide px-1 py-0.5 rounded ${STATUS_BADGE[node.status].className}`}
+              title={STATUS_BADGE[node.status].tooltip}
+            >
+              {STATUS_BADGE[node.status].label}
+            </span>
             {!childrenExpanded && directChildrenCount > 0 && (
               <span
                 className="text-[10px] text-mc-text-secondary/80"

--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -1019,7 +1019,11 @@ or "carve out the onboarding flow as its own story first"`}
                       {c.title}
                     </Link>
                   )}
-                  <span className="text-xs text-mc-text-secondary ml-auto">{c.status}</span>
+                  <span
+                    className={`ml-auto text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${STATUS_PILL[c.status].className}`}
+                  >
+                    {STATUS_PILL[c.status].label}
+                  </span>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
The planning tree at `/initiatives` and the **Children** list inside an initiative detail both rendered status pills only for `done` / `cancelled` / `blocked` / `at_risk` and left `planned` / `in_progress` as either bare text or nothing. Operators read the absent pill as "no status set" rather than "this is the default."

## Changes
- **`src/app/(app)/initiatives/page.tsx`** — `STATUS_BADGE` map made total (was `Partial<Record<Status, …>>`); `planned` + `in_progress` added. `planned` uses the muted neutral chrome so it doesn't shout; `in_progress` gets the blue treatment matching the `STATUS_PILL` map already used on the detail view. The conditional render at the call site simplifies to an unconditional render now that every status has an entry.
- **`src/components/InitiativeDetailView.tsx`** — the Children list's trailing `<span>{c.status}</span>` plain-text render replaced with the existing `STATUS_PILL` styling so child cards match the rest of the detail surface.

## Test plan
- [x] `yarn run tsc --noEmit`: only the 3 pre-existing errors remain.
- [x] **Preview-verify** on `/initiatives`: every node in the planning tree (THEME / EPIC / STORY at every depth) now has a kind pill **plus** a status pill — `PLANNED` (muted neutral), `IN PROGRESS` (blue), `DONE` (green), `CANCELLED` (red), `BLOCKED` (red), `AT RISK` (amber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)