### PR TITLE
fix(ui): shift toolbar icons left + bump section headers

### DIFF
--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -759,9 +759,12 @@ or "carve out the onboarding flow as its own story first"`}
                 setShowInvestigateModal(true);
               }}
             />
-            {/* Secondary icon strip + overflow — pinned right at desktop,
-                wraps below at narrow via flex-wrap on the parent. */}
-            <div className="ml-auto flex flex-wrap items-center gap-1.5">
+            {/* Secondary icon strip + overflow — sits adjacent to the
+                primary CTAs (no `ml-auto` push), so the cluster reads
+                as one continuous toolbar instead of two parties at
+                opposite ends of the room. Wraps below at narrow via
+                flex-wrap on the parent. */}
+            <div className="flex flex-wrap items-center gap-1.5">
               <IconButton
                 ariaLabel="Promote to task"
                 title={
@@ -906,11 +909,11 @@ or "carve out the onboarding flow as its own story first"`}
             </div>
           </div>
 
-          {/* Description — the largest editable surface */}
-          <div id="description" className="mt-5 scroll-mt-20">
-            <div className="uppercase tracking-wide text-[10px] text-mc-text-secondary/70 mb-1">
-              Description
-            </div>
+          {/* Description — the largest editable surface. Header
+              sized to match the Section component so the eye can
+              chunk these as page sections, not as field labels. */}
+          <div id="description" className="mt-6 scroll-mt-20">
+            <h2 className="font-medium text-mc-text mb-2">Description</h2>
             <InlineTextarea
               value={initiative.description ?? ''}
               onSave={next =>
@@ -931,10 +934,8 @@ or "carve out the onboarding flow as its own story first"`}
             />
           </div>
 
-          <div id="status-check" className="mt-4 scroll-mt-20">
-            <div className="uppercase tracking-wide text-[10px] text-mc-text-secondary/70 mb-1">
-              Status check
-            </div>
+          <div id="status-check" className="mt-6 scroll-mt-20">
+            <h2 className="font-medium text-mc-text mb-2">Status check</h2>
             <div className="p-3 rounded border border-mc-border/60 bg-mc-bg">
               <InlineTextarea
                 value={initiative.status_check_md ?? ''}


### PR DESCRIPTION
## Summary
Two follow-on polish items after the Direction-1 toolbar landed in [#295](https://github.com/smb209/mission-control/pull/295):

1. **Toolbar icon cluster shifts left** instead of pinning to the right edge. The `ml-auto` on the secondary cluster wrapper made it read as two parties at opposite ends of the room; left-adjacent reads as a single continuous toolbar at any width.
2. **Description / Status-check headers bumped** from `text-[10px] uppercase tracking-wide` (which made them visually identical to TARGET START / COMMITTED / etc. field labels) to `<h2 font-medium text-mc-text>` matching the `Section` component used by Children / Tasks / Activity / Notes.

## Visual hierarchy now

- **Page sections** (Description, Status check, Children, Tasks, Activity, Notes, Audit Proposals…) → `h2 font-medium`, mixed case.
- **Sub-group labels inside the metadata grid** (SCHEDULE, SIZING) → small uppercase, kept as-is for compact subgroup framing.
- **Individual field labels** (TARGET START, COMMITTED, OWNER, COMPLEXITY, EFFORT) → small uppercase, same-as-before.

## Test plan
- [x] `yarn run tsc --noEmit`: only the 3 pre-existing errors remain.
- [x] **Preview-verify** at narrow 700×900: icon strip + ⋯ overflow now sits on row 2 left-aligned; "Description" appears as a proper page-section heading clearly distinct from SCHEDULE / SIZING / field labels above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)