### PR TITLE
fix(ui): unpin .mc-md font-size so markdown matches surrounding chrome

### DIFF
--- a/src/app/deliverables/[id]/view/page.tsx
+++ b/src/app/deliverables/[id]/view/page.tsx
@@ -114,8 +114,9 @@ export default function DeliverableViewPage({ params }: { params: Promise<{ id: 
           </div>
         )}
 
+        {/* Dedicated viewer — read at a comfortable content size. */}
         {!state.error && state.content !== undefined && looksMarkdown && (
-          <article className="mc-md">
+          <article className="mc-md text-[15px]">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{state.content}</ReactMarkdown>
           </article>
         )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -196,11 +196,14 @@ body {
   box-shadow: 0 0 10px var(--mc-accent-green), 0 0 20px var(--mc-accent-green);
 }
 
-/* Markdown viewer typography (deliverables/[id]/view). Scoped so it doesn't
-   bleed into other markdown surfaces; styled with mc-* tokens. */
+/* Markdown typography. Sets headings / lists / blockquotes / code styling
+   but intentionally does NOT pin font-size — it inherits from the parent
+   so call sites can pick a size that matches their surrounding chrome
+   (text-xs for compact panels, text-sm for content blocks, text-base for
+   the dedicated deliverables viewer). All heading sizes are em-based so
+   they scale relative to whatever the parent sets. */
 .mc-md {
   color: var(--mc-text);
-  font-size: 15px;
   line-height: 1.65;
 }
 .mc-md > :first-child { margin-top: 0; }

--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -926,7 +926,7 @@ or "carve out the onboarding flow as its own story first"`}
               // Render the saved value as markdown so links, lists, and
               // headings show up. Editing falls back to the raw textarea.
               renderDisplay={v => (
-                <div className="mc-md text-mc-text">
+                <div className="mc-md text-sm text-mc-text">
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{v}</ReactMarkdown>
                 </div>
               )}


### PR DESCRIPTION
## Summary
The global `.mc-md` class hardcoded `font-size: 15px`, which was bigger than every Tailwind `text-xs` (12px) / `text-sm` (14px) chrome element on the same page. Markdown bodies (description, status check, PM chat, settings preview) read as visually heavier than the rest of the surface, with `.mc-md`'s class-level specificity overriding any Tailwind size utility on the same div.

## Fix
Drop the `font-size` declaration from `.mc-md`. Headings remain em-based so they scale relative to whatever size the parent picks. Each call site now drives its own size with an explicit Tailwind class — most already had a class that's now actually effective:

| call site | size now | was effectively (mc-md override) |
|---|---|---|
| Initiative detail — Description | `text-sm` (14px) | 15px |
| Initiative detail — Status check | `text-xs` (12px) | 15px |
| PM page — chat content | `text-sm` (14px) | 15px |
| PM page — draft preview | `text-xs` (12px) | 15px |
| Workspace settings — agent prompt preview | `text-xs` (12px) | 15px |
| Deliverables `/view` page | `text-[15px]` (preserved) | 15px |

`.mc-md` is now what its comment originally claimed: a typography *shape* (headings / lists / blockquotes / code styling), not a sizing rule.

## Test plan
- [x] `yarn run tsc --noEmit`: only the 3 pre-existing errors remain.
- [x] **Preview-verify** at narrow 700×900 on the alert-dialog epic — Description body now sits at 14px, clearly distinct from both the h2 section header above and the field labels (TARGET START / COMMITTED / etc.) it shares the page with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)