### PR TITLE
fix(ui): expand metadata grid to fill horizontal space

### DIFF
--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -783,9 +783,9 @@ or "carve out the onboarding flow as its own story first"`}
             up vertically and the strip reads as a structured table
             instead of the prior wrap-anywhere flex chain.
           */}
-          <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-1 text-xs">
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-1 text-sm">
             <div>
-              <div className="text-[10px] uppercase tracking-wide text-mc-text-secondary/70 mb-1">
+              <div className="text-xs uppercase tracking-wide text-mc-text-secondary/70 mb-1.5">
                 Schedule
               </div>
               <MetaRow label="target start">
@@ -811,7 +811,7 @@ or "carve out the onboarding flow as its own story first"`}
               </MetaRow>
             </div>
             <div>
-              <div className="text-[10px] uppercase tracking-wide text-mc-text-secondary/70 mb-1">
+              <div className="text-xs uppercase tracking-wide text-mc-text-secondary/70 mb-1.5">
                 Sizing
               </div>
               <MetaRow label="owner">
@@ -1483,8 +1483,8 @@ function OverflowMenu({
  */
 function MetaRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div className="flex items-baseline gap-2 py-0.5">
-      <span className="uppercase tracking-wide text-[10px] text-mc-text-secondary/70 w-20 shrink-0">
+    <div className="flex items-baseline gap-3 py-1">
+      <span className="uppercase tracking-wide text-xs text-mc-text-secondary/70 w-24 shrink-0">
         {label}
       </span>
       <span className="text-mc-text min-w-0">{children}</span>


### PR DESCRIPTION
## Summary
Operator flagged that the schedule/sizing block stayed single-column at narrow viewports — leaving the right half of the card empty — and that the labels + values were noticeably smaller than the surrounding chrome.

## Changes
- **Lower the 2-col breakpoint** from `md` (768px) to `sm` (640px). The right pane on the planning-tree split layout is wide enough to fit two columns at typical operator window sizes.
- **Value font**: `text-xs` (12px) → `text-sm` (14px) — matches Description body, Children list, etc. The metadata now reads as a peer block, not ancillary fine-print.
- **Field labels**: `text-[10px]` → `text-xs` (12px); label column `w-20` → `w-24` so labels breathe at the new size without crowding values.
- **Group headers** (SCHEDULE / SIZING): `text-[10px]` → `text-xs` with `mb-1.5` for the new scale.
- **MetaRow rhythm**: `py-0.5 gap-2` → `py-1 gap-3` so values don't visually pile up at the bumped size.

## Test plan
- [x] `yarn run tsc --noEmit`: only the 3 pre-existing errors remain.
- [x] **Preview-verify** at narrow 700×900: SCHEDULE | SIZING grid now sits side-by-side with values clearly readable; no wasted right-half space; metadata reads at the same scale as Description body and Children list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)