### PR TITLE
fix(ui): bigger tree-chevron tap targets + textarea size match

### DIFF
--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -909,9 +909,12 @@ function InitiativeRow({
           aria-label={childrenExpanded ? 'Collapse subtree' : 'Expand subtree'}
           aria-expanded={childrenExpanded}
           disabled={directChildrenCount === 0}
-          className="p-0.5 mt-0.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text disabled:opacity-30 disabled:hover:bg-transparent shrink-0"
+          // ~32px tap target — was a 14px chevron + p-0.5 padding, which
+          // was easy to miss especially on touchpads. Now p-1.5 +
+          // larger 18px chevron lands at ~30×30px hit area.
+          className="p-1.5 mt-0.5 rounded hover:bg-mc-bg text-mc-text-secondary hover:text-mc-text disabled:opacity-30 disabled:hover:bg-transparent shrink-0"
         >
-          {childrenExpanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+          {childrenExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
         </button>
         <button
           type="button"

--- a/src/components/inline/InlineEdit.tsx
+++ b/src/components/inline/InlineEdit.tsx
@@ -290,8 +290,12 @@ export function InlineTextarea({
           disabled={saving}
           className={
             textareaClassName ??
+            // Default editor matches the rendered display size. Non-mono
+            // content lands at text-sm (14px) so the textarea doesn't
+            // jump to the browser's 16px body default the moment you
+            // click into a description; mono fields stay at text-xs.
             `w-full px-3 py-2 rounded bg-mc-bg border border-mc-accent/60 text-mc-text outline-none resize-y ${
-              mono ? 'font-mono text-xs' : ''
+              mono ? 'font-mono text-xs' : 'text-sm'
             }`
           }
         />


### PR DESCRIPTION
## Summary
Two related fixes for tap-target / type-size consistency.

### Tree chevrons
Operator flagged that the expand/collapse chevrons on the initiative tree were hard to hit. They were ~18×18px (`p-0.5` padding + 14px icon). Bumped to ~28×28px (`p-1.5` + 16px icon) — verified `getBoundingClientRect()` reads `28×28`.

### InlineTextarea editor size
The non-mono editor branch lacked an explicit font-size, so it defaulted to the browser body (16px). Clicking into a Description textarea visually jumped 14→16→14 between display, edit, and save. Default is now `text-sm` (14px) so the editor matches its rendered display. Mono branch (status check, SOUL/USER/AGENTS, etc.) unchanged at `text-xs`.

## Test plan
- [x] `yarn run tsc --noEmit`: only the 3 pre-existing errors remain.
- [x] **Preview-verify** at narrow 700×900: chevron buttons measurably 28×28; tree expand/collapse feels noticeably easier to hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)