### PR TITLE
fix(ui): pin the Sections fold to the top in single-pane layouts

### DIFF
--- a/src/components/shell/PageWithRails.tsx
+++ b/src/components/shell/PageWithRails.tsx
@@ -261,11 +261,20 @@ export function PageWithRails({
 
           <main className={clsx('flex-1 min-w-0', mainMaxWidth, 'mx-auto lg:mx-0')}>
             {leftRail && (
-              <details className="lg:hidden mb-4 rounded-lg border border-mc-border/60 bg-mc-bg-secondary">
+              // Below the lg breakpoint the dedicated left aside is
+              // hidden; this <details> is the fallback nav. Pin it to
+              // the top of the viewport (just under the page header at
+              // top-0 / z-20) so the operator can collapse/expand the
+              // tree-controls panel without scrolling back up. Backdrop
+              // blur keeps content scrolling underneath legible without
+              // leaking through the toggle.
+              <details className="lg:hidden mb-4 rounded-lg border border-mc-border/60 bg-mc-bg-secondary/95 backdrop-blur-sm sticky top-[4.5rem] z-10">
                 <summary className="px-3 py-2 text-xs uppercase tracking-wide text-mc-text-secondary cursor-pointer">
                   Sections
                 </summary>
-                <div className="p-3 border-t border-mc-border/60">{leftRail}</div>
+                <div className="p-3 border-t border-mc-border/60 max-h-[calc(100vh-9rem)] overflow-y-auto">
+                  {leftRail}
+                </div>
               </details>
             )}
             {children}


### PR DESCRIPTION
## Summary
Below the `lg` breakpoint (1024px) the dedicated left aside is hidden and the left-rail content folds into a `<details>` at the top of the main content area. Operator asked: pin this so it stays accessible without scrolling back to the top of the page.

## Changes (`src/components/shell/PageWithRails.tsx`)
- `sticky top-[4.5rem] z-10` anchors the fold just under the page header (which sits at `top-0 z-20`).
- `bg-mc-bg-secondary/95 backdrop-blur-sm` keeps content scrolling underneath legible without leaking through the toggle.
- Inner panel gets `max-h-[calc(100vh-9rem)] overflow-y-auto` so the expanded panel (search + tree) scrolls within itself rather than overflowing the viewport.

Affects every `PageWithRails`-rendered surface in single-pane mode (Initiatives, Workspace settings, etc.).

## Test plan
- [x] `yarn run tsc --noEmit`: only the 3 pre-existing errors remain.
- [x] **Preview-verify** at 700×900 on `/initiatives`: scrolled the page; SECTIONS toggle stays pinned at the top with content scrolling underneath; expand/collapse the toggle still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)