### PR TITLE
fix(ui): solid backgrounds on the Sections fold + inner tree toolbar

### DIFF
--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -469,7 +469,15 @@ export default function InitiativesPage() {
   const trimmedSearch = search.trim();
   const leftRail = (
     <div className="text-sm flex flex-col h-full">
-      <div className="sticky top-0 z-10 -mt-1 pt-1 pb-2 bg-mc-bg/95 backdrop-blur-sm space-y-2 mb-1">
+      {/* Solid background, no /95 + backdrop-blur — translucent let
+          scrolling content read through the New / Search / filter row
+          and the operator flagged it as visually weird. The bg colour
+          differs by context: at >=lg the leftRail sits in a desktop
+          aside with the page background; below lg it sits inside the
+          PageWithRails <details> fold which uses bg-mc-bg-secondary,
+          so the inner toolbar matches its parent surface in either
+          context. */}
+      <div className="sticky top-0 z-10 -mt-1 pt-1 pb-2 bg-mc-bg-secondary lg:bg-mc-bg space-y-2 mb-1">
         {/* Primary action — full-width so it doesn't fight the tree
             rows for attention. */}
         <button

--- a/src/components/shell/PageWithRails.tsx
+++ b/src/components/shell/PageWithRails.tsx
@@ -265,10 +265,11 @@ export function PageWithRails({
               // hidden; this <details> is the fallback nav. Pin it to
               // the top of the viewport (just under the page header at
               // top-0 / z-20) so the operator can collapse/expand the
-              // tree-controls panel without scrolling back up. Backdrop
-              // blur keeps content scrolling underneath legible without
-              // leaking through the toggle.
-              <details className="lg:hidden mb-4 rounded-lg border border-mc-border/60 bg-mc-bg-secondary/95 backdrop-blur-sm sticky top-[4.5rem] z-10">
+              // tree-controls panel without scrolling back up. Solid
+              // background — translucent + backdrop-blur let scrolling
+              // content read THROUGH the toggle, which the operator
+              // (correctly) called out as visually weird.
+              <details className="lg:hidden mb-4 rounded-lg border border-mc-border/60 bg-mc-bg-secondary sticky top-[4.5rem] z-10">
                 <summary className="px-3 py-2 text-xs uppercase tracking-wide text-mc-text-secondary cursor-pointer">
                   Sections
                 </summary>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1030,6 +1030,7 @@ export type SSEEventType =
   | 'rollcall_entry_updated'
   | 'agent_pinged'
   | 'pm_proposal_replaced'
+  | 'pm_proposal_deleted'
   | 'pm_proposal_dispatch_state_changed'
   | 'agent_note_created'
   | 'agent_note_consumed'


### PR DESCRIPTION
## Summary
Operator flagged that with the new sticky Sections fold, the New initiative button, search field, and filter row inside the leftRail let scrolling content read THROUGH them — translucent backgrounds + backdrop-blur weren't enough to fully hide content scrolling underneath.

## Fix
- **`PageWithRails` `<details>` fold**: drop `bg-mc-bg-secondary/95 backdrop-blur-sm`, use solid `bg-mc-bg-secondary`.
- **Initiatives `leftRail` inner sticky toolbar**: was `bg-mc-bg/95 backdrop-blur-sm`. Now `bg-mc-bg-secondary lg:bg-mc-bg` — at narrow widths it matches the fold's `bg-mc-bg-secondary` surface; at desktop (≥lg) it matches the page-bg surface of the desktop aside. Both contexts read as one continuous solid panel.
- **Drive-by**: added `'pm_proposal_deleted'` to the `SSEEventType` union in `src/lib/types.ts` — fixes a long-standing pre-existing TS error at `src/app/api/pm/proposals/[id]/route.ts:55` where the value was already being emitted but missing from the type.

## Test plan
- [x] `yarn run tsc --noEmit`: down from 3 pre-existing errors to 2 (only the unrelated `pm-decompose.test.ts` ones remain).
- [x] **Preview-verify** at narrow 700×900 on `/initiatives`: scroll the page, no bleed-through on the SECTIONS fold or the inner controls; panel reads as one solid surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)