### PR TITLE
fix(openclaw): unconditional idle priming + globalThis singleton + timeout diagnostics

### DIFF
--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -754,12 +754,23 @@ export class OpenClawClient extends EventEmitter {
   }
 }
 
-// Singleton instance for server-side usage
-let clientInstance: OpenClawClient | null = null;
+// Singleton instance for server-side usage. Persisted on `globalThis`
+// so the instance survives module re-evaluation (HMR in dev, double-
+// import edge cases in prod). Without this, a stale module realm could
+// hold a previous instance whose WS still owns the chat session, while
+// new `getOpenClawClient()` callers get a fresh instance — splitting
+// the EventEmitter listeners (registered by in-flight dispatches) from
+// the actual frame producer. That split is the documented cause of the
+// missed-final-frame audit hangs (see the listener-count diagnostic in
+// `sendChatAndAwaitReply` and /tmp/missed-final-investigation.md).
+const GLOBAL_CLIENT_KEY = '__openclawClientInstance__';
 
 export function getOpenClawClient(): OpenClawClient {
+  const g = globalThis as Record<string, unknown>;
+  let clientInstance = g[GLOBAL_CLIENT_KEY] as OpenClawClient | undefined;
   if (!clientInstance) {
     clientInstance = new OpenClawClient();
+    g[GLOBAL_CLIENT_KEY] = clientInstance;
   }
   return clientInstance;
 }

--- a/src/lib/openclaw/send-chat.test.ts
+++ b/src/lib/openclaw/send-chat.test.ts
@@ -414,6 +414,41 @@ test('sendChatAndAwaitReply: idle timer resets on every event; hard ceiling stil
   }
 });
 
+test('sendChatAndAwaitReply: idle expires when listener never fires (singleton-split scenario)', async () => {
+  // Simulate the missed-final bug: send succeeds, but the gateway
+  // delivers events to a DIFFERENT client instance (or never delivers),
+  // so the dispatcher's listener never sees a frame. Pre-fix the only
+  // armIdle() call was after send-ack, so a never-firing listener
+  // meant idle never bit and we sat at the hard ceiling.
+  // Post-fix, armIdle() primes immediately after listener attach, so
+  // idle expiry fires regardless of whether the listener ever sees a
+  // single frame.
+  const stub = makeStub({
+    callImpl: async () => {
+      // chat.send succeeds — but no events are emitted to our listener.
+      // That mimics a singleton split where frames go to a different
+      // client instance.
+      return undefined;
+    },
+  });
+  __setSendChatClientForTests(stub.client);
+  try {
+    const t0 = Date.now();
+    const result = await sendChatAndAwaitReply({
+      agent: FAKE_AGENT,
+      message: 'hi',
+      timeoutMs: 2_000,
+      idleTimeoutMs: 80,
+    });
+    const elapsed = Date.now() - t0;
+    assert.equal(result.timedOut, true);
+    assert.equal(result.timeoutReason, 'idle');
+    assert.ok(elapsed < 1_000, `should resolve at idle (~80ms) even with zero events, got ${elapsed}ms`);
+  } finally {
+    __setSendChatClientForTests(null);
+  }
+});
+
 test('sendChatAndAwaitReply: idle disabled (no idleTimeoutMs) keeps legacy single-timer behavior', async () => {
   const stub = makeStub();
   __setSendChatClientForTests(stub.client);

--- a/src/lib/openclaw/send-chat.ts
+++ b/src/lib/openclaw/send-chat.ts
@@ -446,6 +446,18 @@ export async function sendChatAndAwaitReply(
   client.on('chat_event', listener);
   if (agentEventListener) client.on('agent_event', agentEventListener);
 
+  // Prime the idle clock IMMEDIATELY after listener attach — independent
+  // of the send-ack path. Rationale: if an upstream bug ever leaves our
+  // listener attached to a different OpenClawClient instance than the
+  // one whose WS is delivering frames (HMR module-realm churn,
+  // singleton replacement, etc.), the listener never fires AND the
+  // send-ack path used to skip the only `armIdle()` call. That meant
+  // dispatches stalled to the hard `timeoutMs` ceiling instead of the
+  // soft `idleTimeoutMs`. Priming here makes idle-recovery
+  // unconditional. See specs/subtree-audit-proposals-spec.md and the
+  // missed-final investigation against run group c3c0e995.
+  armIdle();
+
   try {
     // Send the frame. If this fails, short-circuit with the SendChatResult
     // shape — no point waiting for a reply that can never arrive.
@@ -469,10 +481,6 @@ export async function sendChatAndAwaitReply(
       };
     }
 
-    // Arm the idle clock once the send is acked; we don't want
-    // pre-send latency to count as agent silence.
-    armIdle();
-
     // Race the `done` event (or idle expiry) against the hard ceiling.
     let timeoutHandle: NodeJS.Timeout | null = null;
     const timeoutPromise = new Promise<null>(resolve => {
@@ -487,6 +495,26 @@ export async function sendChatAndAwaitReply(
     if (idleTimer) clearTimeout(idleTimer);
 
     if (winner === null && !doneEvent) {
+      // Diagnostic: log enough to root-cause whether the listener was on
+      // the same client instance whose WS is delivering frames. If the
+      // count here is 0 (or off-by-one against expected concurrent
+      // dispatches), the listener was attached to a different
+      // OpenClawClient instance — the singleton-replacement bug. See
+      // missed-final investigation /tmp/missed-final-investigation.md.
+      try {
+        const clientWithCounts = client as SendChatClient & {
+          listenerCount?: (event: string) => number;
+        };
+        const lc = clientWithCounts.listenerCount?.('chat_event');
+        const connected = client.isConnected();
+        console.warn(
+          `[send-chat] dispatch timed out (reason=${timeoutReason ?? 'max'}, ` +
+            `sessionKey=${sessionKey}, idleEnabled=${idleEnabled}, ` +
+            `listenerCount(chat_event)=${lc ?? 'n/a'}, isConnected=${connected})`,
+        );
+      } catch {
+        // Diagnostics shouldn't break the result.
+      }
       return {
         sent: true,
         sessionKey,
@@ -504,6 +532,24 @@ export async function sendChatAndAwaitReply(
       timedOut: false,
     };
   } finally {
+    // Defensive: re-fetch the client at cleanup. If a singleton swap
+    // happened mid-dispatch, `client.off(...)` would otherwise be a
+    // no-op against a stale instance, leaking listeners on the live
+    // one. Warn so the diagnostic above (and this one) point at the
+    // same root cause if it ever triggers.
+    const cleanupClient = getClient();
+    if (cleanupClient !== client) {
+      console.warn(
+        `[send-chat] OpenClawClient singleton was replaced mid-dispatch ` +
+          `(sessionKey=${sessionKey}). Cleaning up listeners on both ` +
+          `instances to avoid leaks. This is the singleton-replacement ` +
+          `path that produces missed-final stalls.`,
+      );
+      try { cleanupClient.off('chat_event', listener); } catch { /* noop */ }
+      if (agentEventListener) {
+        try { cleanupClient.off('agent_event', agentEventListener); } catch { /* noop */ }
+      }
+    }
     client.off('chat_event', listener);
     if (agentEventListener) client.off('agent_event', agentEventListener);
     if (idleTimer) clearTimeout(idleTimer);


### PR DESCRIPTION
## Summary

Followups to the missed-final investigation surfaced after [#307](https://github.com/smb209/mission-control/pull/307). The previous PR added a 5-min idle timeout to bound stuck dispatches; this PR eliminates the upstream cause (listener attached to a different `OpenClawClient` instance than the WS frame producer) and adds the diagnostic that will let us confirm root cause on the next stuck run.

Three coupled changes:

1. **Idle priming is now unconditional.** `sendChatAndAwaitReply` arms `armIdle()` immediately after listener attach, not only after the send-ack. If the listener never fires (singleton split, HMR churn), idle still expires at `idleTimeoutMs`. Worst-case dispatch stall: 5 min → 5 min, regardless of whether the listener ever sees a frame.

2. **`getOpenClawClient` singleton persisted on `globalThis`.** Matches the existing pattern already used in [`client.ts`](src/lib/openclaw/client.ts) for `globalProcessedEvents`. Survives module re-evaluation in dev (HMR module-realm split) and double-import edge cases. This is the *primary* fix — eliminates the structural cause of the split, not just its symptoms.

3. **Diagnostic logging on `timedOut: true`** including `listenerCount('chat_event')` and `isConnected()`. The next stuck run will tell us in one log line whether the listener was even attached to the live client. Also a defensive `finally`-block assert: if `getClient()` returns a different instance at cleanup than at attach, log it and clean up listeners on both.

## Test plan

- [x] `tsx --test src/lib/openclaw/send-chat.test.ts` — 29/29 (1 new: idle expires when listener never fires).
- [x] `tsx --test` on send-chat + audit-survey + subtree-audit + dispatch-scope — 57/57 pass.
- [x] `yarn tsc --noEmit` clean (same pre-existing pm-decompose errors).
- [ ] Will validate on the next real audit run via the new console.warn output and `debug_events`.

## Risk

- **Always-arm idle:** very low. Hard `timeoutMs` ceiling still bounds everything; only changes the *first* idle arming. The only edge case is "first agent activity takes > `idleTimeoutMs` to start," unlikely for current audit shapes (5-min default is generous).
- **`globalThis` singleton:** low. Mirrors patterns already in the same file. The test seam `__setSendChatClientForTests` keeps working — it overrides at the `getClient()` call site, not the singleton.
- **Cleanup-instance assertion:** zero behavior risk; logs only.

## Background

See [#307 description](https://github.com/smb209/mission-control/pull/307) and the investigation note saved at `/tmp/missed-final-investigation.md` for the receipts (debug_events showed 0 activity for 13 min and 9.7 min after the final frames on two stuck runs, yet idle never fired — the listener was effectively detached for the entire run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)