### PR TITLE
feat(initiatives): vocab refresh, investigate presets, theme split, PM context fixes

### DIFF
--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -846,7 +846,7 @@ function InitiativeRow({
   const isStory = node.kind === 'story';
   const isContainer = node.kind !== 'story';
   const hasParent = !!node.parent_initiative_id;
-  const isDecomposable = node.kind === 'epic' || node.kind === 'milestone';
+  const isDecomposable = node.kind === 'theme' || node.kind === 'milestone' || node.kind === 'epic';
 
   // Direct + total descendant counts for the collapsed-children summary.
   // useMemo keeps the recursion off the render hot path; node identity
@@ -869,7 +869,7 @@ function InitiativeRow({
     ...(isDecomposable
       ? [
           {
-            label: 'Decompose with PM',
+            label: 'Split with PM',
             icon: <Network className="w-3.5 h-3.5" />,
             onClick: () => onDecompose(node),
           },
@@ -1530,7 +1530,7 @@ export function EditDrawer({
             className="px-3 py-2 rounded border border-mc-accent/50 text-mc-accent text-sm inline-flex items-center gap-1 disabled:opacity-50"
             title="Ask the PM agent to suggest description / complexity / window / dependencies"
           >
-            <Sparkles className="w-3.5 h-3.5" /> Plan with PM
+            <Sparkles className="w-3.5 h-3.5" /> Enrich with PM
           </button>
           <button
             onClick={onClose}

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -1771,7 +1771,7 @@ function ApplyPlanToInitiativeModal({
         <header className="p-4 border-b border-mc-border">
           <h2 className="text-lg font-semibold">Apply PM suggestions to an initiative</h2>
           <p className="text-xs text-mc-text-secondary mt-1">
-            Plan with PM produces an advisory proposal. Pick which initiative these suggestions
+            Enrich with PM produces an advisory proposal. Pick which initiative these suggestions
             should land on — the server will patch its fields and create the suggested
             dependencies in one go.
           </p>

--- a/src/app/api/pm/decompose-initiative/route.ts
+++ b/src/app/api/pm/decompose-initiative/route.ts
@@ -52,10 +52,10 @@ export async function POST(request: NextRequest) {
     if (!parent) {
       return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
     }
-    if (parent.kind !== 'epic' && parent.kind !== 'milestone') {
+    if (parent.kind !== 'theme' && parent.kind !== 'milestone' && parent.kind !== 'epic') {
       return NextResponse.json(
         {
-          error: `Decompose only supported for epic/milestone parents (got "${parent.kind}")`,
+          error: `Split only supported for theme/milestone/epic parents (got "${parent.kind}")`,
         },
         { status: 400 },
       );
@@ -113,8 +113,16 @@ export async function POST(request: NextRequest) {
       agent_prompt:
         `Decompose initiative ${parent.id} ("${parent.title}", kind=${parent.kind}) ` +
         `into 3-7 child initiatives.` +
+        (parent.description ? ` Parent description: ${parent.description}` : '') +
         (parsed.data.hint ? ` Operator hint: ${parsed.data.hint}.` : '') +
-        ` Call \`propose_changes\` (trigger_kind='decompose_initiative') with one ` +
+        ` Before composing, call read_notes({ initiative_id: "${parent.id}", audience: 'pm', min_importance: 2, limit: 5 }) ` +
+        `to ingest any recent audit findings; if any are returned, reference one or two explicitly in impact_md ` +
+        `(e.g. \`Per audit on YYYY-MM-DD: "<short quoted finding>"\`). See SOUL.md "Ingest recent audit findings".\n\n` +
+        `Pick child_kind based on the parent's kind: theme parents split into ` +
+        `milestones; milestone parents split into epics (or stories for thin slices); ` +
+        `epic parents split into stories (or smaller epics for genuinely large scope). ` +
+        `Never propose theme as child_kind. ` +
+        `Call \`propose_changes\` (trigger_kind='decompose_initiative') with one ` +
         `\`create_child_initiative\` diff per child. Pre-wire each child to depend on the ` +
         `prior sibling using placeholder ids \`$0\`, \`$1\`, etc. See your SOUL.md. ` +
         `Output discipline: tool call FIRST, then a single-line \`Proposal {id}.\` reply — ` +
@@ -129,7 +137,7 @@ export async function POST(request: NextRequest) {
       postPmChatMessage({
         workspace_id: parent.workspace_id,
         role: 'user',
-        content: `Decompose: "${parent.title}"` + (parsed.data.hint ? ` (hint: ${parsed.data.hint})` : ''),
+        content: `Split: "${parent.title}"` + (parsed.data.hint ? ` (hint: ${parsed.data.hint})` : ''),
       });
       postPmChatMessage({
         workspace_id: parent.workspace_id,

--- a/src/app/api/pm/decompose-story/route.ts
+++ b/src/app/api/pm/decompose-story/route.ts
@@ -112,8 +112,13 @@ export async function POST(request: NextRequest) {
       agent_prompt:
         `Decompose story ${parent.id} ("${parent.title}") into a small set of ` +
         `draft TASKS (not initiatives) that an implementer can pick up directly.` +
+        (parent.description ? ` Story description: ${parent.description}` : '') +
         (parsed.data.hint ? ` Operator hint: ${parsed.data.hint}.` : '') +
-        ` Call \`propose_changes\` with trigger_kind='decompose_story' and one ` +
+        ` Before composing, call read_notes({ initiative_id: "${parent.id}", audience: 'pm', min_importance: 2, limit: 5 }) ` +
+        `to ingest any recent audit findings; if any are returned, reference one or two explicitly in impact_md ` +
+        `(e.g. \`Per audit on YYYY-MM-DD: "<short quoted finding>"\`) and let them inform task scope. ` +
+        `See SOUL.md "Ingest recent audit findings".\n\n` +
+        `Call \`propose_changes\` with trigger_kind='decompose_story' and one ` +
         `\`create_task_under_initiative\` diff per task, all targeting initiative_id='${parent.id}'. ` +
         `Each task should be focused enough to land in a single PR. ` +
         `Output discipline: tool call FIRST, then a single-line \`Proposal {id}.\` reply — ` +
@@ -126,7 +131,7 @@ export async function POST(request: NextRequest) {
         workspace_id: parent.workspace_id,
         role: 'user',
         content:
-          `Decompose story to tasks: "${parent.title}"` +
+          `Create tasks: "${parent.title}"` +
           (parsed.data.hint ? ` (hint: ${parsed.data.hint})` : ''),
       });
       postPmChatMessage({

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -182,7 +182,7 @@ export async function POST(request: NextRequest) {
       postPmChatMessage({
         workspace_id: parsed.data.workspace_id,
         role: 'user',
-        content: `Plan with PM: "${parsed.data.draft.title}"`,
+        content: `Enrich: "${parsed.data.draft.title}"`,
       });
       postPmChatMessage({
         workspace_id: parsed.data.workspace_id,

--- a/src/components/DecomposeStoryToTasksModal.tsx
+++ b/src/components/DecomposeStoryToTasksModal.tsx
@@ -267,7 +267,7 @@ export default function DecomposeStoryToTasksModal({
   };
 
   const displayMd = impactMd.replace(/<!--pm-plan-suggestions[\s\S]*?-->/g, '').trim();
-  const headerLabel = agentLabel ? `Decompose with ${agentLabel}` : 'Decompose to tasks';
+  const headerLabel = agentLabel ? `Create tasks with ${agentLabel}` : 'Create tasks';
 
   return (
     <div
@@ -275,7 +275,7 @@ export default function DecomposeStoryToTasksModal({
       onClick={onClose}
       role="dialog"
       aria-modal="true"
-      aria-label="Decompose story into tasks"
+      aria-label="Create tasks from story"
     >
       <div
         className="bg-mc-bg-secondary border border-mc-border rounded-lg w-full max-w-5xl h-[88vh] flex flex-col text-mc-text"

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -44,7 +44,7 @@ interface ChildDiff {
   parent_initiative_id: string;
   title: string;
   description?: string | null;
-  child_kind: 'epic' | 'story';
+  child_kind: 'milestone' | 'epic' | 'story';
   complexity?: 'S' | 'M' | 'L' | 'XL' | null;
   estimated_effort_hours?: number | null;
   sort_order?: number;
@@ -277,6 +277,10 @@ export default function DecomposeWithPmModal({
   };
 
   const addChild = () => {
+    const defaultChildKind: 'milestone' | 'epic' | 'story' =
+      initiative.kind === 'theme' ? 'milestone'
+      : initiative.kind === 'milestone' ? 'epic'
+      : 'story';
     setChildren(prev => [
       ...prev,
       {
@@ -284,7 +288,7 @@ export default function DecomposeWithPmModal({
         parent_initiative_id: initiative.id,
         title: 'New child',
         description: null,
-        child_kind: 'story',
+        child_kind: defaultChildKind,
         complexity: 'M',
       },
     ]);
@@ -299,7 +303,7 @@ export default function DecomposeWithPmModal({
       onClick={onClose}
       role="dialog"
       aria-modal="true"
-      aria-label="Decompose initiative with PM"
+      aria-label="Split initiative with PM"
     >
       <div
         className="bg-mc-bg-secondary border border-mc-border rounded-lg w-full max-w-5xl h-[88vh] flex flex-col text-mc-text"
@@ -308,7 +312,7 @@ export default function DecomposeWithPmModal({
         <header className="flex items-center justify-between px-5 py-3 border-b border-mc-border">
           <div className="flex items-center gap-2">
             <Sparkles className="w-4 h-4 text-mc-accent" />
-            <h2 className="text-lg font-semibold">Decompose &ldquo;{initiative.title}&rdquo;</h2>
+            <h2 className="text-lg font-semibold">Split &ldquo;{initiative.title}&rdquo;</h2>
           </div>
           <button
             onClick={onClose}
@@ -403,12 +407,13 @@ export default function DecomposeWithPmModal({
                           </div>
                           <select
                             value={c.child_kind}
-                            onChange={e => updateChild(i, { child_kind: e.target.value as 'epic' | 'story' })}
+                            onChange={e => updateChild(i, { child_kind: e.target.value as 'milestone' | 'epic' | 'story' })}
                             className="px-2 py-1 rounded bg-mc-bg-secondary border border-mc-border text-xs"
                             aria-label="Child kind"
                           >
                             <option value="story">story</option>
                             <option value="epic">epic</option>
+                            <option value="milestone">milestone</option>
                           </select>
                           <input
                             type="text"

--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -715,28 +715,28 @@ export function InitiativeDetailView({
               icon={<Sparkles className="w-3.5 h-3.5" />}
               onClick={() => openPlanPanel()}
               onClickWithGuidance={(g) => openPlanPanel(g)}
-              guidanceLabel="What should the PM focus the plan on?"
+              guidanceLabel="What should the PM focus the enrichment on?"
               guidancePlaceholder={`e.g. "size for v1 only — defer fertility/pregnancy features"
 or "treat memory + checklist as MVP, exclude dashboard widgets"`}
-              guidanceCta="Plan with guidance"
-              title={hasDraftProposal ? 'Resolve the existing draft proposal first' : 'Plan with PM — proposes refined description / sizing / window'}
+              guidanceCta="Enrich with guidance"
+              title={hasDraftProposal ? 'Resolve the existing draft proposal first' : 'Enrich with PM — proposes refined description / sizing / window'}
               disabled={hasDraftProposal}
             >
-              Plan
+              Enrich
             </SplitToolbarButton>
-            {(initiative.kind === 'epic' || initiative.kind === 'milestone') && (
+            {(initiative.kind === 'theme' || initiative.kind === 'milestone' || initiative.kind === 'epic') && (
               <SplitToolbarButton
                 icon={<Sparkles className="w-3.5 h-3.5" />}
                 onClick={() => openDecompose()}
                 onClickWithGuidance={(g) => openDecompose(g)}
-                guidanceLabel="How should the PM slice this?"
+                guidanceLabel="How should the PM split this?"
                 guidancePlaceholder={`e.g. "split by frontend / backend / data"
 or "carve out the onboarding flow as its own story first"`}
-                guidanceCta="Decompose with guidance"
-                title={hasDraftDecomposeProposal ? 'Resolve the existing draft decomposition first' : 'Decompose with PM — propose 3-7 child initiatives'}
+                guidanceCta="Split with guidance"
+                title={hasDraftDecomposeProposal ? 'Resolve the existing draft split first' : 'Split with PM — propose 3-7 child initiatives'}
                 disabled={hasDraftDecomposeProposal}
               >
-                Decompose
+                Split
               </SplitToolbarButton>
             )}
             {initiative.kind === 'story' && (
@@ -747,9 +747,9 @@ or "carve out the onboarding flow as its own story first"`}
                   setDecomposeStoryAgent({ id, label });
                   setShowDecomposeStoryModal(true);
                 }}
-                title="Break this story into draft tasks"
+                title="Create draft tasks from this story"
               >
-                Decompose to tasks
+                Create tasks
               </DecomposerAgentPicker>
             )}
             <InvestigatePicker
@@ -1012,7 +1012,7 @@ or "carve out the onboarding flow as its own story first"`}
         <Section id="tasks" title={`Tasks (${tasks.length})`}>
           {tasks.length === 0 ? (
             <p className="text-sm text-mc-text-secondary">
-              No tasks yet. {initiative.kind === 'story' ? 'Use “Promote to task” to create one.' : ''}
+              No tasks yet. {initiative.kind === 'story' ? 'Use “Use as task” to create one directly, or “Create tasks” for an agent-drafted set.' : ''}
             </p>
           ) : (
             <div className="space-y-3">
@@ -1436,7 +1436,7 @@ function OverflowMenu({
               just omit it). */}
           {isStory && (
             <MenuItem icon={<Plus className="w-3.5 h-3.5" />} onClick={wrap(onPromote)}>
-              Promote to task
+              Use as task
             </MenuItem>
           )}
           <MenuItem icon={<MoveRight className="w-3.5 h-3.5" />} onClick={wrap(onMove)}>
@@ -1724,11 +1724,12 @@ function PromoteToTaskModal({
         className="bg-mc-bg-secondary border border-mc-border rounded-lg p-6 w-full max-w-lg text-mc-text"
         onClick={e => e.stopPropagation()}
       >
-        <h2 className="text-lg font-semibold mb-4">Promote story to task draft</h2>
+        <h2 className="text-lg font-semibold mb-4">Use story as task</h2>
         <p className="text-sm text-mc-text-secondary mb-4">
-          Creates one task in <code>status=draft</code>, linked to this initiative.
-          The draft lives on the task board's Draft column until you explicitly
-          promote it to the execution queue.
+          Creates one task in <code>status=draft</code>, linked to this initiative,
+          using this story's title and description directly (no agent). The draft
+          lives on the task board's Draft column until you explicitly promote it
+          to the execution queue.
         </p>
         {existingDraftCount + existingActiveCount > 0 && (
           <div className="mb-4 p-3 rounded bg-amber-500/10 border border-amber-500/30 text-amber-200 text-sm">
@@ -1742,7 +1743,7 @@ function PromoteToTaskModal({
               : existingDraftCount > 0
                 ? ` (draft${existingDraftCount === 1 ? '' : 's'})`
                 : ` (active)`}
-            . Promote anyway only if you genuinely need another parallel task.
+            . Create another only if you genuinely need a parallel task.
           </div>
         )}
         <div className="space-y-3">
@@ -1776,7 +1777,7 @@ function PromoteToTaskModal({
               disabled={submitting || !title.trim()}
               className="px-3 py-2 rounded bg-mc-accent text-white disabled:opacity-50 text-sm"
             >
-              Promote to draft
+              Create draft task
             </button>
           </div>
         </div>

--- a/src/components/InvestigateModal.tsx
+++ b/src/components/InvestigateModal.tsx
@@ -215,6 +215,35 @@ type Reaudit = 'fresh' | 'build_on';
 
 const GUIDANCE_MAX = 2000;
 
+interface GuidancePreset {
+  id: string;
+  label: string;
+  text: string;
+}
+
+const GUIDANCE_PRESETS: GuidancePreset[] = [
+  {
+    id: 'progress',
+    label: 'Progress / status',
+    text: "Assess actual progress vs intended scope. What's complete, what's in-flight, what's blocked. Cite specific files/PRs/tasks where possible.",
+  },
+  {
+    id: 'mental-model',
+    label: 'Mental model',
+    text: "Map the relevant files, modules, and call sites for this initiative. I'm preparing for detailed planning — focus on architecture and surface area, not gaps.",
+  },
+  {
+    id: 'risks',
+    label: 'Risks / unknowns',
+    text: 'Identify risks, underspecified areas, and likely failure modes. Flag anything that should be resolved before implementation starts.',
+  },
+  {
+    id: 'scope',
+    label: 'Scope check',
+    text: 'Is this initiative still the right shape? Too big, too small, overlapping with siblings? Recommend split/merge/reparent if warranted.',
+  },
+];
+
 interface DispatchResult {
   mode: 'narrow' | 'subtree-proposal';
   scope_key?: string;
@@ -544,6 +573,36 @@ export default function InvestigateModal({
             </label>
           </fieldset>
           )}
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs uppercase tracking-wide text-mc-text-secondary/80">
+              Presets
+            </span>
+            <div className="flex flex-wrap gap-1.5">
+              {GUIDANCE_PRESETS.map((preset) => {
+                const active = guidance.trim() === preset.text;
+                return (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    onClick={() => setGuidance(active ? '' : preset.text)}
+                    className={`px-2 py-1 rounded-full border text-xs transition-colors ${
+                      active
+                        ? 'bg-mc-accent/20 border-mc-accent/60 text-mc-text'
+                        : 'border-mc-border text-mc-text-secondary hover:bg-mc-bg hover:text-mc-text'
+                    }`}
+                  >
+                    {preset.label}
+                  </button>
+                );
+              })}
+            </div>
+            {mode === 'subtree-proposal' && (
+              <span className="text-[10px] text-mc-text-secondary/70 leading-snug">
+                Same guidance is sent to every node in the subtree.
+              </span>
+            )}
+          </div>
 
           <label className="flex flex-col gap-1">
             <span className="text-xs uppercase tracking-wide text-mc-text-secondary/80">

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -302,7 +302,7 @@ export default function PlanWithPmPanel({
     <aside
       className="border border-mc-accent/30 rounded-lg bg-mc-bg p-4 mt-4"
       role="region"
-      aria-label="Plan with PM suggestions"
+      aria-label="Enrich with PM suggestions"
     >
       <header className="flex items-center gap-2 mb-3">
         <Sparkles className="w-4 h-4 text-mc-accent" />

--- a/src/components/inline/DecomposerAgentPicker.tsx
+++ b/src/components/inline/DecomposerAgentPicker.tsx
@@ -73,7 +73,7 @@ export function DecomposerAgentPicker({
         }}
         disabled={disabled || noneAvailable}
         title={noneAvailable ? 'No decomposer agents available in this workspace' : title}
-        className="inline-flex items-center gap-1.5 text-xs px-2 py-1.5 rounded-l border border-mc-border border-r-0 text-mc-accent hover:bg-mc-accent/10 hover:border-mc-accent/40 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-l border border-r-0 border-mc-accent/40 text-mc-accent bg-mc-accent/5 hover:bg-mc-accent/10 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {icon}
         <span>{children}</span>
@@ -83,7 +83,7 @@ export function DecomposerAgentPicker({
         aria-label="Choose decomposer agent"
         onClick={() => setOpen(o => !o)}
         disabled={disabled || noneAvailable}
-        className="inline-flex items-center px-1.5 py-1.5 rounded-r border border-mc-border text-mc-accent hover:bg-mc-accent/10 hover:border-mc-accent/40 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="inline-flex items-center px-1.5 rounded-r border border-mc-accent/40 text-mc-accent bg-mc-accent/5 hover:bg-mc-accent/10 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <ChevronDown className="w-3.5 h-3.5" />
       </button>
@@ -93,7 +93,7 @@ export function DecomposerAgentPicker({
           role="menu"
         >
           <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-mc-text-secondary/70">
-            Decompose with…
+            Agent
           </div>
           {agents.length === 0 ? (
             <div className="px-2 py-2 text-xs text-mc-text-secondary">

--- a/src/lib/agents/pm-agent.ts
+++ b/src/lib/agents/pm-agent.ts
@@ -339,6 +339,13 @@ export function synthesizeDecompose(
   const baseDesc = parent.description?.trim() ?? '';
   const hintBlock = hint ? `\n\n_Operator hint: ${hint.trim()}_` : '';
 
+  // Default child_kind is one tier below the parent: theme→milestone,
+  // milestone→epic, epic→story. Theme is never proposed as a child.
+  const childKind: 'milestone' | 'epic' | 'story' =
+    parent.kind === 'theme' ? 'milestone'
+    : parent.kind === 'milestone' ? 'epic'
+    : 'story';
+
   const changes: PmDiff[] = [];
   for (let i = 0; i < titles.length; i++) {
     const t = titles[i];
@@ -354,7 +361,7 @@ export function synthesizeDecompose(
         `${t} for parent initiative "${x}".` +
         (baseDesc ? `\n\nParent context:\n${baseDesc}` : '') +
         hintBlock,
-      child_kind: 'story',
+      child_kind: childKind,
       complexity: 'M',
       sort_order: i,
       depends_on_initiative_ids: deps,

--- a/src/lib/agents/pm-decompose.test.ts
+++ b/src/lib/agents/pm-decompose.test.ts
@@ -153,9 +153,9 @@ test('acceptProposal: create_child_initiative inserts children with audit + dep 
   }
 });
 
-test('acceptProposal: rejects create_child_initiative with theme/milestone child_kind', () => {
+test('acceptProposal: rejects create_child_initiative with theme child_kind (milestone now allowed)', () => {
   const ws = freshWorkspace();
-  const parent = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Parent' });
+  const parent = createInitiative({ workspace_id: ws, kind: 'theme', title: 'Parent' });
 
   assert.throws(
     () =>
@@ -166,10 +166,10 @@ test('acceptProposal: rejects create_child_initiative with theme/milestone child
         impact_md: 'x',
         proposed_changes: [
           {
-            // @ts-expect-error testing the validation path
             kind: 'create_child_initiative',
             parent_initiative_id: parent.id,
             title: 'Bad theme child',
+            // @ts-expect-error testing the validation path — theme is the only forbidden child_kind
             child_kind: 'theme',
           },
         ],

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -133,12 +133,12 @@ export type PmDiff =
       // can carry placeholder ids (`$0`, `$1`, …) that point to other
       // siblings created in the SAME accept call (resolved post-insert) or
       // real ids for existing initiatives. `child_kind` is constrained to
-      // {epic, story} — themes/milestones are operator-driven only.
+      // {milestone, epic, story} — themes are operator-driven only.
       kind: 'create_child_initiative';
       parent_initiative_id: string;
       title: string;
       description?: string | null;
-      child_kind: 'epic' | 'story';
+      child_kind: 'milestone' | 'epic' | 'story';
       complexity?: 'S' | 'M' | 'L' | 'XL' | null;
       estimated_effort_hours?: number | null;
       sort_order?: number;
@@ -440,11 +440,12 @@ export function validateProposedChanges(
         if (!c.title || typeof c.title !== 'string') {
           errors.push(`changes[${i}]: title required`);
         }
-        // Hard-coded allowlist for child_kind — themes/milestones are
-        // operator-driven and never proposed by the PM.
-        if (c.child_kind !== 'epic' && c.child_kind !== 'story') {
+        // Hard-coded allowlist for child_kind — themes are
+        // operator-driven and never proposed by the PM. Milestones are
+        // permitted so a theme parent can be split into milestones.
+        if (c.child_kind !== 'milestone' && c.child_kind !== 'epic' && c.child_kind !== 'story') {
           errors.push(
-            `changes[${i}]: child_kind must be 'epic' or 'story' (got '${c.child_kind}')`,
+            `changes[${i}]: child_kind must be 'milestone', 'epic', or 'story' (got '${c.child_kind}')`,
           );
         }
         if (c.complexity != null && !['S', 'M', 'L', 'XL'].includes(c.complexity)) {

--- a/src/lib/mcp/shared.ts
+++ b/src/lib/mcp/shared.ts
@@ -275,7 +275,7 @@ export const DiffSchema = z.discriminatedUnion('kind', [
     parent_initiative_id: z.string().min(1),
     title: z.string().min(1),
     description: z.string().nullish(),
-    child_kind: z.enum(['epic', 'story']),
+    child_kind: z.enum(['milestone', 'epic', 'story']),
     complexity: z.enum(['S', 'M', 'L', 'XL']).nullish(),
     estimated_effort_hours: z.number().nullish(),
     sort_order: z.number().optional(),


### PR DESCRIPTION
## Summary

- **Vocab refresh** for the initiative detail page CTAs to clarify intent: Plan → **Enrich**, Decompose → **Split**, Decompose to tasks → **Create tasks**, Promote to task → **Use as task**, picker header "Decompose with…" → **Agent**.
- **Investigate presets** — chip row above the Guidance textarea (Progress / Mental model / Risks / Scope check) that prefill canned guidance, with a subtree-mode hint that the same guidance fans out to every node.
- **PM context fixes** — Split (epic/milestone) and Create tasks (story) prompts now pass the parent description and direct the agent to ingest recent audit notes (`read_notes` with `audience='pm'`, `min_importance=2`), matching the pattern Enrich already used.
- **Theme parents can Split** — `child_kind` allowlist widened to `{milestone, epic, story}`; theme is still forbidden as a child. Synth fallback and agent prompt pick the right child tier per parent. Edit modal's kind picker offers all three.

## Changes

- Rename AI CTAs and tooltips across `InitiativeDetailView`, `initiatives/page.tsx`, `pm/page.tsx`, the Plan/Decompose/DecomposeStoryToTasks modals, and `DecomposerAgentPicker`. Style `Create tasks` to match `Enrich`/`Investigate`.
- Add preset chip row to `InvestigateModal`.
- Update `decompose-initiative` and `decompose-story` agent prompts; gate `decompose-initiative` route to allow theme parents.
- Widen `child_kind` enums in `pm-proposals.ts` (validation + types) and `shared.ts` (zod). Update synth fallback in `pm-agent.ts` to pick child_kind one tier below parent.
- Update `pm-decompose.test.ts` to reflect that only `theme` is now forbidden as a child.

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `yarn test` passes for all modified slices (1 pre-existing failure unrelated to this change: `schedule-runner: produces a brief and advances run_count`, fails on main without these edits).
- [x] Preview verified end-to-end:
  - Story page shows **Enrich / Create tasks / Investigate**, picker header reads "AGENT" → "PM"
  - Epic page shows **Enrich / Split / Investigate**
  - Theme page shows **Enrich / Split / Investigate** (new)
  - Investigate modal: preset chips toggle correctly, fill/clear the textarea, no console errors
  - Overflow menu: "Use as task" present on stories with the no-agent copy in the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)