### PR TITLE
fix(pm,mcp): defensive take_note backfill, richer refine, broaden refine UI

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -1306,7 +1306,11 @@ function ChatMessageRow({
               : undefined
           }
         />
-        {proposal.status === 'draft' && (
+        {proposal.status !== 'accepted' && (
+          // Refine is allowed on draft, superseded, and rejected — the DB
+          // only blocks accepted (refineProposal at pm-proposals.ts).
+          // Accept/Reject still gated to status === 'draft' below since
+          // those mutate state that's already moved on for non-drafts.
           <div className="px-3 py-2 border-t border-amber-500/30 bg-amber-500/5 flex flex-wrap items-center gap-2">
             {refining === proposal.id ? (
               <>
@@ -1338,6 +1342,7 @@ function ChatMessageRow({
               const sel = selectedIndexes.size;
               const allSelected = sel === total;
               const noneSelected = sel === 0;
+              const isDraft = proposal.status === 'draft';
               const applyLabel = decomposeLocked
                 ? 'Apply all'
                 : allSelected
@@ -1354,7 +1359,7 @@ function ChatMessageRow({
                   >
                     <RefreshCw className="w-3 h-3" /> Refine
                   </button>
-                  {!decomposeLocked && (
+                  {isDraft && !decomposeLocked && (
                     <>
                       <button
                         type="button"
@@ -1380,30 +1385,33 @@ function ChatMessageRow({
                   )}
                   {/* Apply: when all selected, hits /accept with no
                       filter (back-compat). When none, hits /reject.
-                      Otherwise, /accept with accepted_indexes. */}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (noneSelected) {
-                        onReject(proposal.id);
-                        return;
-                      }
-                      const indexes = Array.from(selectedIndexes).sort(
-                        (a, b) => a - b,
-                      );
-                      onAccept(
-                        proposal,
-                        allSelected ? undefined : { accepted_indexes: indexes },
-                      );
-                    }}
-                    className={`text-xs px-2 py-1 rounded-sm flex items-center gap-1 ${
-                      noneSelected
-                        ? 'bg-red-500/20 border border-red-500/40 text-red-200 hover:bg-red-500/30'
-                        : 'bg-emerald-500/20 border border-emerald-500/40 text-emerald-200 hover:bg-emerald-500/30'
-                    }`}
-                  >
-                    <Check className="w-3 h-3" /> {applyLabel}
-                  </button>
+                      Otherwise, /accept with accepted_indexes. Hidden for
+                      non-draft proposals — those have already moved on. */}
+                  {isDraft && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (noneSelected) {
+                          onReject(proposal.id);
+                          return;
+                        }
+                        const indexes = Array.from(selectedIndexes).sort(
+                          (a, b) => a - b,
+                        );
+                        onAccept(
+                          proposal,
+                          allSelected ? undefined : { accepted_indexes: indexes },
+                        );
+                      }}
+                      className={`text-xs px-2 py-1 rounded-sm flex items-center gap-1 ${
+                        noneSelected
+                          ? 'bg-red-500/20 border border-red-500/40 text-red-200 hover:bg-red-500/30'
+                          : 'bg-emerald-500/20 border border-emerald-500/40 text-emerald-200 hover:bg-emerald-500/30'
+                      }`}
+                    >
+                      <Check className="w-3 h-3" /> {applyLabel}
+                    </button>
+                  )}
                 </>
               );
             })()}

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -245,7 +245,11 @@ export default function ProposalDetailPage({
               )}
 
               {/* Actions */}
-              {proposal.status === 'draft' && (
+              {proposal.status !== 'accepted' && (
+                // Refine is allowed on draft, superseded, and rejected —
+                // the DB only blocks accepted (refineProposal in
+                // pm-proposals.ts). Accept/Reject still gated to draft
+                // below since those mutate state that's already moved on.
                 <div className="px-4 py-3 bg-amber-500/5 flex flex-wrap items-center gap-2">
                   {showRefineInput ? (
                     <>
@@ -290,22 +294,26 @@ export default function ProposalDetailPage({
                       >
                         <RefreshCw className="w-3 h-3" /> Refine
                       </button>
-                      <button
-                        type="button"
-                        onClick={accept}
-                        disabled={acting !== null}
-                        className="text-xs px-2 py-1 bg-emerald-500/20 border border-emerald-500/40 text-emerald-200 rounded-sm hover:bg-emerald-500/30 flex items-center gap-1 disabled:opacity-50"
-                      >
-                        <Check className="w-3 h-3" /> {acting === 'accept' ? 'Accepting…' : 'Accept'}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={reject}
-                        disabled={acting !== null}
-                        className="text-xs px-2 py-1 bg-red-500/20 border border-red-500/40 text-red-200 rounded-sm hover:bg-red-500/30 flex items-center gap-1 disabled:opacity-50"
-                      >
-                        <X className="w-3 h-3" /> {acting === 'reject' ? 'Rejecting…' : 'Reject'}
-                      </button>
+                      {proposal.status === 'draft' && (
+                        <>
+                          <button
+                            type="button"
+                            onClick={accept}
+                            disabled={acting !== null}
+                            className="text-xs px-2 py-1 bg-emerald-500/20 border border-emerald-500/40 text-emerald-200 rounded-sm hover:bg-emerald-500/30 flex items-center gap-1 disabled:opacity-50"
+                          >
+                            <Check className="w-3 h-3" /> {acting === 'accept' ? 'Accepting…' : 'Accept'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={reject}
+                            disabled={acting !== null}
+                            className="text-xs px-2 py-1 bg-red-500/20 border border-red-500/40 text-red-200 rounded-sm hover:bg-red-500/30 flex items-center gap-1 disabled:opacity-50"
+                          >
+                            <X className="w-3 h-3" /> {acting === 'reject' ? 'Rejecting…' : 'Reject'}
+                          </button>
+                        </>
+                      )}
                     </>
                   )}
                 </div>

--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -13,7 +13,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getProposal, refineProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
 import { dispatchPm, dispatchPmSynthesized } from '@/lib/agents/pm-dispatch';
-import { synthesizePlanInitiative, synthesizeDecompose } from '@/lib/agents/pm-agent';
+import {
+  synthesizePlanInitiative,
+  synthesizeDecompose,
+  synthesizeStoryToTasks,
+} from '@/lib/agents/pm-agent';
 import { getRoadmapSnapshot } from '@/lib/db/roadmap';
 import { getInitiative } from '@/lib/db/initiatives';
 import { parseSuggestionsFromImpactMd } from '@/lib/pm/planSuggestionsSidecar';
@@ -148,8 +152,26 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       // the synth placeholder, and (if the named agent responded) a
       // separate agent row that supersedes it. Refine has its own
       // pre-allocated child row to copy content onto, so both transient
-      // rows are cleaned up.
+      // rows are cleaned up — but first re-key any chat-message rows
+      // that referenced them, otherwise the /pm chat's structured card
+      // lookup misses and falls back to plain markdown.
       const { run: del } = await import('@/lib/db');
+      if (settled.final.id !== child.id) {
+        del(
+          `UPDATE agent_chat_messages
+              SET metadata = json_set(metadata, '$.proposal_id', ?)
+            WHERE json_extract(metadata, '$.proposal_id') = ?`,
+          [child.id, settled.final.id],
+        );
+      }
+      if (dispatch.proposal.id !== child.id && dispatch.proposal.id !== settled.final.id) {
+        del(
+          `UPDATE agent_chat_messages
+              SET metadata = json_set(metadata, '$.proposal_id', ?)
+            WHERE json_extract(metadata, '$.proposal_id') = ?`,
+          [child.id, dispatch.proposal.id],
+        );
+      }
       if (dispatch.proposal.id !== child.id) {
         del('DELETE FROM pm_proposals WHERE id = ?', [dispatch.proposal.id]);
       }
@@ -177,6 +199,86 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       const synth = synthesizeDecompose(init, combinedHint.trim());
       newImpactMd = synth.impact_md;
       newChanges = synth.changes;
+    } else if (parent.trigger_kind === 'decompose_story') {
+      // Story-aware refine. Mirrors the decompose_story dispatch: synth
+      // floor via `synthesizeStoryToTasks`, then routes the LLM through
+      // `dispatchPmSynthesized` with an agent_prompt that explicitly
+      // hands the prior proposal's impact_md + proposed_changes to the
+      // PM so it can preserve the original detail rather than re-deriving
+      // a generic single task. Without this branch the refine fell into
+      // the disruption-analysis fallback and dropped all the per-task
+      // context (file paths, line numbers, classifications).
+      const ctx = parseTriggerContext(parent.trigger_text);
+      const initiativeId = ctx?.initiative_id as string | undefined;
+      const story = initiativeId ? getInitiative(initiativeId) : undefined;
+      if (!story) {
+        return NextResponse.json(
+          { error: 'Original story no longer exists; cannot refine' },
+          { status: 400 },
+        );
+      }
+      const combinedHint =
+        ((ctx?.hint as string | null) ?? '') +
+        (ctx?.hint ? '\n' : '') +
+        `Refine: ${parsed.data.additional_constraint}`;
+      const synth = synthesizeStoryToTasks(story, combinedHint.trim());
+
+      const dispatch = dispatchPmSynthesized({
+        workspace_id: parent.workspace_id,
+        trigger_text: child.trigger_text,
+        trigger_kind: 'decompose_story',
+        target_initiative_id: story.id,
+        timeoutMs: 120_000,
+        synth: { impact_md: synth.impact_md, changes: synth.changes },
+        agent_prompt:
+          `Refine the task decomposition for story ${story.id} ("${story.title}").\n\n` +
+          `Operator refinement request: "${parsed.data.additional_constraint}"\n\n` +
+          `### Prior proposal — preserve relevant detail\n` +
+          `Impact summary:\n${parent.impact_md}\n\n` +
+          `Prior proposed_changes (verbatim JSON):\n` +
+          `\`\`\`json\n${JSON.stringify(parent.proposed_changes, null, 2)}\n\`\`\`\n\n` +
+          `Apply the operator's refinement to that prior proposal — keep file ` +
+          `paths, line numbers, classifications, and any specific call-site detail ` +
+          `the prior tasks captured. Don't re-derive from scratch unless the ` +
+          `refinement explicitly asks to.\n\n` +
+          `Call \`propose_changes\` with trigger_kind='decompose_story' and one ` +
+          `\`create_task_under_initiative\` diff per task, all targeting ` +
+          `initiative_id='${story.id}'. Output discipline: tool call FIRST, then ` +
+          `a single-line \`Proposal {id}.\` reply — no freeform summary (the ` +
+          `operator UI discards it).`,
+      });
+      const settled = await dispatch.completion;
+      newImpactMd = settled.final.impact_md;
+      newChanges = settled.final.proposed_changes;
+
+      const { run: del } = await import('@/lib/db');
+      // Re-key chat messages that were posted against the transient
+      // dispatch rows so the structured task-card render in /pm chat
+      // resolves to the surviving `child.id` row. Without this the
+      // chat falls back to plain markdown because the proposal_id
+      // metadata points at a row we're about to delete.
+      if (settled.final.id !== child.id) {
+        del(
+          `UPDATE agent_chat_messages
+              SET metadata = json_set(metadata, '$.proposal_id', ?)
+            WHERE json_extract(metadata, '$.proposal_id') = ?`,
+          [child.id, settled.final.id],
+        );
+      }
+      if (dispatch.proposal.id !== child.id && dispatch.proposal.id !== settled.final.id) {
+        del(
+          `UPDATE agent_chat_messages
+              SET metadata = json_set(metadata, '$.proposal_id', ?)
+            WHERE json_extract(metadata, '$.proposal_id') = ?`,
+          [child.id, dispatch.proposal.id],
+        );
+      }
+      if (dispatch.proposal.id !== child.id) {
+        del('DELETE FROM pm_proposals WHERE id = ?', [dispatch.proposal.id]);
+      }
+      if (settled.final.id !== dispatch.proposal.id && settled.final.id !== child.id) {
+        del('DELETE FROM pm_proposals WHERE id = ?', [settled.final.id]);
+      }
     } else {
       // Default disruption-analysis path. We borrow dispatchPm's
       // synthesizer and patch the result onto the pre-allocated child
@@ -189,10 +291,21 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       // trigger that combines the original parent context with the
       // operator's new constraint, plus an explicit "use propose_changes"
       // instruction so the agent stays on the right tool.
+      // Hand the agent the parent's impact_md + proposed_changes so it
+      // can preserve specific detail (file paths, line numbers, prior
+      // rationale) when applying the operator's refinement, rather than
+      // re-deriving generic content from the bare trigger_text.
       const cleanTrigger =
         `Operator refinement of an earlier ${parent.trigger_kind} proposal.\n\n` +
         `Original context:\n${(parent.trigger_text || '').replace(/\n*\[refine\][\s\S]*$/, '').trim()}\n\n` +
+        `### Prior proposal — preserve relevant detail\n` +
+        `Impact summary:\n${parent.impact_md}\n\n` +
+        `Prior proposed_changes (verbatim JSON):\n` +
+        `\`\`\`json\n${JSON.stringify(parent.proposed_changes, null, 2)}\n\`\`\`\n\n` +
         `New constraint to incorporate: ${parsed.data.additional_constraint}\n\n` +
+        `Apply the operator's refinement to that prior proposal — keep file paths, ` +
+        `line numbers, and any specific detail the prior changes captured. Don't ` +
+        `re-derive from scratch unless the refinement explicitly asks to.\n\n` +
         `Respond by calling \`propose_changes\` with an updated impact_md + diff list. ` +
         `Do NOT call \`refine_proposal\` — that's an operator-only tool and would create a dispatch loop.`;
       const synthesized = dispatchPm({
@@ -207,6 +320,26 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       newImpactMd = settled.final.impact_md;
       newChanges = settled.final.proposed_changes;
       const { run } = await import('@/lib/db');
+      // Re-key chat messages off the transient rows onto child.id BEFORE
+      // deleting them — otherwise the /pm chat's structured proposal
+      // card lookup misses (id no longer exists) and falls back to plain
+      // markdown rendering.
+      if (settled.final.id !== child.id) {
+        run(
+          `UPDATE agent_chat_messages
+              SET metadata = json_set(metadata, '$.proposal_id', ?)
+            WHERE json_extract(metadata, '$.proposal_id') = ?`,
+          [child.id, settled.final.id],
+        );
+      }
+      if (synthesized.proposal.id !== child.id && synthesized.proposal.id !== settled.final.id) {
+        run(
+          `UPDATE agent_chat_messages
+              SET metadata = json_set(metadata, '$.proposal_id', ?)
+            WHERE json_extract(metadata, '$.proposal_id') = ?`,
+          [child.id, synthesized.proposal.id],
+        );
+      }
       // Clean up both the placeholder and (if separate) the agent's row.
       if (synthesized.proposal.id !== child.id) {
         run(`DELETE FROM pm_proposals WHERE id = ?`, [synthesized.proposal.id]);

--- a/src/lib/db/agent-notes.ts
+++ b/src/lib/db/agent-notes.ts
@@ -83,8 +83,12 @@ export interface AgentNote {
   pm_proposal_ids: string | null;
 }
 
-/** Maximum body length per note (matches the role-soul guidance). */
-export const NOTE_BODY_MAX = 3000;
+/** Maximum body length per note. Sized to fit a full multi-section
+ *  audit observation (6 sections w/ file paths + commit shas) without
+ *  forcing the agent into a truncate-and-retry loop, which empirically
+ *  causes it to drop other required fields across attempts. The prompt
+ *  still asks for tight notes; this is a ceiling, not a target. */
+export const NOTE_BODY_MAX = 8000;
 
 // ─── Create ─────────────────────────────────────────────────────────
 

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -547,6 +547,50 @@ export interface CreateProposalInput {
   reverts_proposal_id?: string | null;
 }
 
+/**
+ * Walk the proposed changes and return the single initiative_id they
+ * all converge on, if any. Used by `createProposal` to auto-populate
+ * `target_initiative_id` so list-view affordances ("this initiative
+ * has a pending PM proposal") can do an indexed lookup instead of
+ * scanning the JSON blob.
+ *
+ * Strict by design: every diff must contribute the same initiative id.
+ * A single initiative-agnostic diff (add_availability, remove_dependency,
+ * reorder_initiatives, set_task_status) means the proposal isn't really
+ * "about" one initiative, and we don't want to auto-link it — the FK is
+ * `ON DELETE CASCADE`, so a wrong link can vaporize a multi-purpose
+ * proposal when an unrelated initiative is deleted.
+ */
+export function inferTargetInitiativeId(changes: PmDiff[]): string | null {
+  if (changes.length === 0) return null;
+  const ids = new Set<string>();
+  for (const c of changes) {
+    let id: string | undefined;
+    switch (c.kind) {
+      case 'shift_initiative_target':
+      case 'set_initiative_status':
+      case 'add_dependency':
+      case 'update_status_check':
+      case 'create_task_under_initiative':
+        id = c.initiative_id;
+        break;
+      case 'create_child_initiative':
+        id = c.parent_initiative_id;
+        break;
+      default:
+        // Initiative-agnostic kind (add_availability, remove_dependency,
+        // reorder_initiatives, set_task_status) — bail out, proposal
+        // stays untargeted.
+        return null;
+    }
+    // Placeholder ids ($N) reference siblings created in the same
+    // proposal; they don't anchor the target.
+    if (!id || id.startsWith('$')) return null;
+    ids.add(id);
+  }
+  return ids.size === 1 ? [...ids][0] : null;
+}
+
 export function createProposal(input: CreateProposalInput): PmProposal {
   if (!input.workspace_id) throw new PmProposalValidationError('workspace_id required');
   if (!input.trigger_text) throw new PmProposalValidationError('trigger_text required');
@@ -566,6 +610,12 @@ export function createProposal(input: CreateProposalInput): PmProposal {
     );
   }
 
+  // Fall back to inferring a single-initiative target from the diff so
+  // the initiative list can render a "pending PM proposal" chip without
+  // scanning the proposed_changes JSON. Caller-supplied value wins.
+  const resolvedTargetId =
+    input.target_initiative_id ?? inferTargetInitiativeId(input.proposed_changes ?? []);
+
   const id = uuidv4();
   const now = new Date().toISOString();
   run(
@@ -582,7 +632,7 @@ export function createProposal(input: CreateProposalInput): PmProposal {
       JSON.stringify(input.proposed_changes ?? []),
       input.plan_suggestions != null ? JSON.stringify(input.plan_suggestions) : null,
       input.parent_proposal_id ?? null,
-      input.target_initiative_id ?? null,
+      resolvedTargetId,
       input.dispatch_state ?? 'agent_complete',
       input.reverts_proposal_id ?? null,
       now,

--- a/src/lib/mcp/groups/core.ts
+++ b/src/lib/mcp/groups/core.ts
@@ -468,11 +468,25 @@ export function registerCoreTools(server: McpServer): void {
           }
         }
 
+        // Defensive backfill: agents under tight validation pressure
+        // (body-cap retries, missing-field cascades) sometimes drop
+        // initiative_id / task_id across attempts even when the prompt
+        // told them to set it. The scope_key is canonically formed as
+        // `initiative-<uuid>:…` or `task-<uuid>:…`, so we can recover
+        // the link without re-prompting. Without this, the note writes
+        // with NULL fk and disappears from the initiative/task UI even
+        // though the audit succeeded. See May 9 audit:2 incident.
+        const scopeMatch = /^(initiative|task)-([0-9a-f-]{36}):/i.exec(args.scope_key);
+        const scopeInitiativeId =
+          scopeMatch && scopeMatch[1].toLowerCase() === 'initiative' ? scopeMatch[2] : null;
+        const scopeTaskId =
+          scopeMatch && scopeMatch[1].toLowerCase() === 'task' ? scopeMatch[2] : null;
+
         const note = createNote({
           workspace_id: deriveWorkspaceFromAgent(args.agent_id),
           agent_id: args.agent_id,
-          task_id: args.task_id ?? null,
-          initiative_id: args.initiative_id ?? null,
+          task_id: args.task_id ?? scopeTaskId ?? null,
+          initiative_id: args.initiative_id ?? scopeInitiativeId ?? null,
           scope_key: args.scope_key,
           role: args.role,
           run_group_id: args.run_group_id,


### PR DESCRIPTION
## Summary

Five surgical fixes surfaced by exercising the audit → decompose → refine loop on a real story.

- **`take_note` backfills `initiative_id` / `task_id` from `scope_key`** when the agent drops them across validation retries. The audit prompt asked for `initiative_id`, but under the 3000-char body cap the agent truncate-and-retried and lost fields each pass. Without the backfill the observation wrote with NULL fk and disappeared from the initiative UI even though the audit run succeeded.
- **`NOTE_BODY_MAX` raised 3000 → 8000.** Audit observations legitimately need the room (6 sections + commit shas + file paths); the prior cap forced the retry loop above. Prompt unchanged so agents don't read it as license to be more verbose.
- **`createProposal` infers `target_initiative_id`** when every proposed change anchors on the same initiative. Powers the "pending PM proposal" chip on initiative cards without scanning JSON. Strict: a single initiative-agnostic diff (`add_availability`, etc.) bails — the FK is `ON DELETE CASCADE`, so a wrong link can vaporize a multi-purpose proposal.
- **`/pm/proposals/[id]/refine` rebuild:** new `decompose_story` branch (mirrors `decompose_initiative`), enriched `cleanTrigger` handing the refining agent the parent's `impact_md` + `proposed_changes` JSON, and chat-message rekey before deleting transient dispatch rows. Without these the refine on a `decompose_story` dropped all the per-task detail (file paths, line numbers, classifications) and the structured task-card render in /pm chat fell back to plain markdown because the `proposal_id` metadata pointed at a deleted row.
- **Refine UI gate broadened** from `status === 'draft'` to `status !== 'accepted'`. The DB already allowed refining superseded/rejected (`refineProposal` only blocks accepted); only the UI was over-restrictive. Accept/Reject buttons stay draft-only since those mutate state that has moved on.

## Changes

- `src/lib/mcp/groups/core.ts` — scope_key parse + fk backfill in `take_note` handler
- `src/lib/db/agent-notes.ts` — `NOTE_BODY_MAX` 3000 → 8000
- `src/lib/db/pm-proposals.ts` — new `inferTargetInitiativeId` + `createProposal` auto-set
- `src/app/api/pm/proposals/[id]/refine/route.ts` — `decompose_story` branch, parent-detail in `cleanTrigger`, chat re-key in three branches
- `src/app/(app)/pm/page.tsx` + `pm/proposals/[id]/page.tsx` — refine action surfaces on non-accepted

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `yarn test` 930/931 pass (the one failure is the pre-existing `schedule-runner` test unrelated to these changes; same failure on `main` pre-PR)
- [ ] Smoke: run `decompose_story` on a story, refine the resulting draft with a "consolidate to N tasks" constraint — verify chat renders structured `NEW TASK` cards (not plain markdown), and proposed tasks preserve file paths / line numbers from the original
- [ ] Smoke: navigate to a superseded proposal in `/pm` — verify the Refine button is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)