### PR TITLE
fix(pm/refine): block double-submit + drop orphan child on per-branch failure

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -114,6 +114,11 @@ export default function PmChatPage() {
   // operator out forever. See specs/pm-chat-prompt.md PR A §4.
   const [awaitingAgent, setAwaitingAgent] = useState<{ since: number; userMessageCount: number } | null>(null);
   const [refining, setRefining] = useState<string | null>(null);
+  // Separate in-flight flag from the "which input is open" state so we
+  // can disable Send + ignore Enter while a refine POST is awaiting. A
+  // double-fire (button + Enter, or browser auto-submit) would otherwise
+  // call refineProposal twice and create two child drafts.
+  const [refineSubmitting, setRefineSubmitting] = useState(false);
   const [refineText, setRefineText] = useState('');
   const [runningStandup, setRunningStandup] = useState(false);
   const [standupBanner, setStandupBanner] = useState<string | null>(null);
@@ -616,6 +621,8 @@ export default function PmChatPage() {
 
   const onRefineSubmit = async (parentId: string) => {
     if (!refineText.trim()) return;
+    if (refineSubmitting) return;
+    setRefineSubmitting(true);
     try {
       const res = await fetch(`/api/pm/proposals/${parentId}/refine`, {
         method: 'POST',
@@ -629,6 +636,8 @@ export default function PmChatPage() {
       await loadRecent();
     } catch (err) {
       setError((err as Error).message);
+    } finally {
+      setRefineSubmitting(false);
     }
   };
 
@@ -875,6 +884,7 @@ export default function PmChatPage() {
                   onReject={onReject}
                   refining={refining}
                   refineText={refineText}
+                  refineSubmitting={refineSubmitting}
                   onRefineStart={(id) => { setRefining(id); setRefineText(''); }}
                   onRefineCancel={() => { setRefining(null); setRefineText(''); }}
                   onRefineSubmit={onRefineSubmit}
@@ -1154,6 +1164,9 @@ interface ChatMessageRowProps {
   onReject: (id: string) => void;
   refining: string | null;
   refineText: string;
+  /** True while a refine POST is in flight — disables Send + suppresses
+   *  Enter so a double-fire can't create two child drafts. */
+  refineSubmitting: boolean;
   onRefineStart: (id: string) => void;
   onRefineCancel: () => void;
   onRefineSubmit: (id: string) => void;
@@ -1174,6 +1187,7 @@ function ChatMessageRow({
   onReject,
   refining,
   refineText,
+  refineSubmitting,
   onRefineStart,
   onRefineCancel,
   onRefineSubmit,
@@ -1320,21 +1334,25 @@ function ChatMessageRow({
                   value={refineText}
                   onChange={e => onRefineTextChange(e.target.value)}
                   onKeyDown={e => {
+                    if (refineSubmitting) return;
                     if (e.key === 'Enter') { e.preventDefault(); onRefineSubmit(proposal.id); }
                     if (e.key === 'Escape') { onRefineCancel(); }
                   }}
                   placeholder="Add a constraint (e.g. don't slip launch)"
-                  className="flex-1 bg-mc-bg border border-mc-border rounded-sm px-2 py-1 text-xs focus:outline-hidden focus:border-mc-accent"
+                  disabled={refineSubmitting}
+                  className="flex-1 bg-mc-bg border border-mc-border rounded-sm px-2 py-1 text-xs focus:outline-hidden focus:border-mc-accent disabled:opacity-60"
                 />
                 <button
                   type="button"
                   onClick={() => onRefineSubmit(proposal.id)}
-                  className="text-xs px-2 py-1 bg-mc-accent text-mc-bg rounded-sm hover:bg-mc-accent/90"
-                >Send</button>
+                  disabled={refineSubmitting}
+                  className="text-xs px-2 py-1 bg-mc-accent text-mc-bg rounded-sm hover:bg-mc-accent/90 disabled:opacity-50 disabled:hover:bg-mc-accent"
+                >{refineSubmitting ? 'Sending…' : 'Send'}</button>
                 <button
                   type="button"
                   onClick={onRefineCancel}
-                  className="text-xs px-2 py-1 text-mc-text-secondary hover:text-mc-text"
+                  disabled={refineSubmitting}
+                  className="text-xs px-2 py-1 text-mc-text-secondary hover:text-mc-text disabled:opacity-50"
                 >Cancel</button>
               </>
             ) : (() => {

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -128,6 +128,11 @@ export default function ProposalDetailPage({
 
   const refine = async () => {
     if (!proposal || !refineText.trim()) return;
+    // Belt-and-suspenders: input.disabled blocks Enter on most browsers
+    // but stale state can still let a second invocation through. Guarding
+    // here ensures refineProposal can't be called twice for one click +
+    // create two child drafts.
+    if (refining) return;
     setRefining(true);
     setRefineErr(null);
     try {

--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -81,6 +81,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     let newChanges: unknown[];
     let newPlanSuggestions: unknown = null;
 
+    // If anything in the per-branch work below throws (gateway timeout,
+    // synth blowup, etc.) we'd otherwise leave `child` as a draft row with
+    // impact_md='_(refining…)_' that's indistinguishable from a real
+    // proposal in the UI. Catch + delete so the operator sees nothing
+    // rather than a permanently-stalled placeholder.
+    try {
     if (parent.trigger_kind === 'plan_initiative') {
       const ctx = parseTriggerContext(parent.trigger_text);
       // When trigger_text is old free-text format, extract the title from
@@ -357,6 +363,21 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     const refreshed = getProposal(child.id)!;
     return NextResponse.json({ proposal: refreshed }, { status: 201 });
+    } catch (innerErr) {
+      // Per-branch failure (gateway timeout, synth blowup, agent crash).
+      // Drop the placeholder child rather than leaving a `_(refining…)_`
+      // ghost in the operator's view, then re-throw to the outer handler.
+      try {
+        const { run: del } = await import('@/lib/db');
+        del('DELETE FROM pm_proposals WHERE id = ?', [child.id]);
+      } catch (cleanupErr) {
+        console.warn(
+          '[refine] orphan child cleanup failed:',
+          (cleanupErr as Error).message,
+        );
+      }
+      throw innerErr;
+    }
   } catch (err) {
     if (err instanceof PmProposalValidationError) {
       return NextResponse.json({ error: err.message, hints: err.hints }, { status: 400 });


### PR DESCRIPTION
## Summary

Operator reported a single Refine click producing two draft proposals.

- **Root cause #1 — no in-flight guard.** The inline-card refine handler in `/pm` chat had no submit-in-flight flag. A second click on Send (or Enter pressed before the first POST returned) called `refineProposal` twice and created two child drafts. The standalone `/pm/proposals/[id]` page had a `disabled={refining}` flag but no early-return guard, so stale focus + Enter could still slip a second call through.
- **Root cause #2 — orphan placeholder on per-branch failure.** When the dispatch inside any refine branch threw mid-flight (gateway timeout, synth blowup), the placeholder child created by `refineProposal` was left in the DB with `impact_md='_(refining…)_'` and rendered as a permanently-stalled card.

## Changes

- `src/app/(app)/pm/page.tsx` — new `refineSubmitting` state separate from `refining` (which tracks _which_ proposal's input is open). `onRefineSubmit` early-exits when already in flight; Send button + input disabled; Enter suppressed via the keydown handler.
- `src/app/(app)/pm/proposals/[id]/page.tsx` — belt-and-suspenders `if (refining) return` early-exit at the top of `refine()`.
- `src/app/api/pm/proposals/[id]/refine/route.ts` — wrap the per-branch work in try/catch. On failure, delete the placeholder child created by `refineProposal` before re-throwing, so the operator sees nothing rather than a stalled row.

## Test plan

- [x] `yarn tsc --noEmit` clean
- [ ] Smoke: rapidly click Send twice on a Refine input — verify only one new draft is created
- [ ] Smoke: trigger a refine while gateway is down — verify no `_(refining…)_` row is left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)