### PR TITLE
feat(roadmap): nav polish — header, resizable rail, today-centering, scroll, recompute UX

### DIFF
--- a/specs/roadmap-navigation-polish.md
+++ b/specs/roadmap-navigation-polish.md
@@ -1,0 +1,107 @@
+---
+name: Roadmap navigation polish
+description: Small, focused fixes to the roadmap timeline — header cleanup, resizable rail, recompute UX, week-view centering, horizontal scroll affordances
+status: draft
+---
+
+# Roadmap navigation polish
+
+Status: draft · Owner: smb209 · Date: 2026-05-09
+
+The roadmap page (`/roadmap`) ships the timeline shell + derivation engine, but day-to-day navigation has rough edges. This spec captures five small, mostly independent fixes. None of them touch the data model or the recompute engine — just the UI shell in `src/components/roadmap/`.
+
+## Problems
+
+1. **Recompute has no clear next step.** Clicking "Recompute now" flashes a banner (`"Recomputed: N updated, K flipped, D drifts"`) and silently refreshes. The drifts and flips aren't actionable from the banner — you can't see *which* initiatives changed.
+2. **Header has redundant nav.** "Initiative tree" and "Workspaces" links in the page header duplicate the left sidebar.
+3. **Initiative column is fixed-width.** `RAIL_WIDTH = 300` is a hardcoded const; long titles truncate aggressively and the user can't widen the column to read them.
+4. **Week view opens scrolled to the past.** The canvas always opens at `windowStart`. On Week zoom (32 px/day) today is thousands of pixels in, so the user lands on empty whitespace.
+5. **No horizontal scroll affordance.** The calendar scrolls horizontally but there are no buttons, no keyboard shortcut, and no obvious scrollbar — discoverability is poor.
+
+## Non-goals
+
+- No changes to the derivation engine, drift detection, or `/api/roadmap/recompute` payload.
+- No changes to the bar-drag-to-update-dates flow.
+- No new filter dimensions; toolbar stays as-is.
+- No mobile/touch redesign — desktop only.
+
+## Changes
+
+### 1. Recompute result UX
+
+**File:** `src/components/roadmap/RoadmapTimeline.tsx`
+
+- When the recompute response returns `initiatives_updated === 0 && status_flips === 0 && drifts.length === 0`, show a muted "No changes" banner that auto-dismisses after ~3s.
+- When there *are* changes, the banner becomes expandable: a chevron toggles a list of the affected initiatives (id + title + which field changed: `target_*`, `derived_*`, `committed_end`, status). Clicking a row scrolls the rail/canvas to that initiative and flashes the row briefly.
+- Drifts (where `committed_end < derived_end`) get a distinct red badge in the expanded list — they're the cases the user most wants to act on.
+- Banner stays sticky until the user dismisses (X button) or runs another recompute.
+
+The recompute API already returns `drifts: unknown[]`; tighten that type in the response handler so the UI can render id + delta. If the current API doesn't return enough detail, *do not extend the API in this PR* — just render what we have and file a follow-up.
+
+### 2. Header cleanup
+
+**File:** `src/components/roadmap/RoadmapTimeline.tsx`
+
+- Remove the `<Link href="/initiatives">Initiative tree</Link>` and `<Link href="/">Workspaces</Link>` buttons from the header (lines ~326–337).
+- Keep "Recompute now". Move it to the right edge.
+
+### 3. Resizable initiative column
+
+**Files:** `RoadmapTimeline.tsx`, `RoadmapRail.tsx`
+
+- Promote `RAIL_WIDTH` from a const to state in `RoadmapTimeline`. Default 300, clamp 200–600.
+- Persist to `localStorage` under `roadmap.railWidth`, mirroring the existing `roadmap.zoom` pattern.
+- Add a 4-px-wide drag handle on the rail's right edge. On `mousedown`, capture pointer; on `mousemove`, set width = clamp(startWidth + dx, 200, 600); on `mouseup`, persist.
+- Cursor: `col-resize` on hover; show a thin accent-colored line while dragging.
+- Rail row content (title, kind icon, status dot) should reflow gracefully — increase the max title width as the column widens rather than just leaving extra whitespace.
+
+### 4. Week view auto-centers on today
+
+**File:** `RoadmapTimeline.tsx` (or `RoadmapCanvas.tsx`, wherever scroll lives)
+
+- After the snapshot loads and on every zoom change, set `canvasScrollRef.current.scrollLeft` so that today's x-coordinate sits ~⅓ from the left edge of the visible canvas.
+- Compute today's offset as `daysBetween(windowStart, today) * pxPerDay - viewportWidth / 3`, clamped to `[0, scrollWidth - clientWidth]`.
+- This applies to all three zoom levels but is most visible on Week.
+
+Optional follow-up (not in this spec): tighten `defaultWindow` for Week zoom so we don't render a year of empty canvas when only one initiative has a far-future `committed_end`.
+
+### 5. Horizontal scroll affordances
+
+**Files:** `RoadmapToolbar.tsx`, `RoadmapCanvas.tsx`
+
+- Add three buttons to the toolbar (next to the zoom group): `◀ week`, `Today`, `▶ week`.
+  - Left/right shift `scrollLeft` by `7 * pxPerDay` (one week regardless of zoom — feels consistent across zooms).
+  - "Today" runs the same auto-center logic from change #4.
+- Add a keyboard listener on the canvas: `←` / `→` shift by one week, `Home` jumps to today. Only active when the canvas (or its scroll container) has focus or hover.
+- Shift+wheel → horizontal scroll (browsers don't always do this for inner scrollers).
+
+## File-level checklist
+
+| File | Changes |
+|---|---|
+| `src/components/roadmap/RoadmapTimeline.tsx` | Header cleanup; rail width state + persistence; recompute banner refactor; auto-center scroll |
+| `src/components/roadmap/RoadmapRail.tsx` | Accept dynamic width; render drag handle; reflow row content |
+| `src/components/roadmap/RoadmapCanvas.tsx` | Keyboard + wheel handlers for horizontal scroll; expose imperative `scrollToToday` |
+| `src/components/roadmap/RoadmapToolbar.tsx` | ◀ / Today / ▶ buttons |
+
+## Test plan
+
+- **Manual via preview** (`preview_start`, navigate to `/roadmap`):
+  - Header no longer shows "Initiative tree" / "Workspaces".
+  - Drag the column edge — width changes smoothly, persists across reload, clamps at 200/600.
+  - Click "Recompute now" with no real changes → "No changes" banner, auto-dismisses.
+  - Click "Recompute now" after editing dates upstream → expandable banner lists changed initiatives; clicking a row scrolls it into view and flashes.
+  - Switch to Week zoom → today is ~⅓ from the left, not stuck at the far past.
+  - Click ◀ / ▶ → canvas scrolls one week per click; "Today" recenters; arrow keys do the same when canvas is focused; shift+wheel scrolls horizontally.
+- **No new unit tests required** — these are pure UI changes against existing data. If `RoadmapCanvas` gains an imperative scroll method, a small smoke test covering "scrollToToday positions today within viewport" is nice-to-have but not required.
+
+## Out of scope / follow-ups
+
+- Tightening `defaultWindow` per-zoom (a separate, more invasive change).
+- Surfacing drift detail (delta in days, owner, parent) — depends on whether the recompute API payload is rich enough.
+- Mobile touch handles for column resize.
+- Persisting horizontal scroll position across reloads.
+
+## Rollout
+
+Single PR is fine — all five changes are small and touch the same handful of files. Ship as `feat(roadmap): nav polish` against `main`.

--- a/src/components/roadmap/RoadmapCanvas.tsx
+++ b/src/components/roadmap/RoadmapCanvas.tsx
@@ -38,6 +38,8 @@ export function RoadmapCanvas({
   onUpdateDates,
   scrollRef,
   onScroll,
+  onScrollWeek,
+  onScrollToToday,
 }: {
   initiatives: RoadmapInitiative[];
   visibleIds: Set<string>;
@@ -51,7 +53,30 @@ export function RoadmapCanvas({
   onUpdateDates: (id: string, start: string | null, end: string | null) => void;
   scrollRef: RefObject<HTMLDivElement | null>;
   onScroll: () => void;
+  onScrollWeek: (direction: 1 | -1) => void;
+  onScrollToToday: () => void;
 }) {
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      onScrollWeek(-1);
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      onScrollWeek(1);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      onScrollToToday();
+    }
+  };
+
+  // Browsers don't always translate shift+wheel to horizontal scroll for
+  // inner scroll containers — wire it explicitly.
+  const onWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (!e.shiftKey || e.deltaY === 0) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollLeft += e.deltaY;
+  };
   // Width = days in window * pxPerDay.
   const totalDays = daysBetween(windowStart, windowEnd) + 1;
   const totalWidth = Math.max(640, totalDays * pxPerDay);
@@ -82,7 +107,10 @@ export function RoadmapCanvas({
       <div
         ref={scrollRef}
         onScroll={onScroll}
-        className="flex-1 overflow-auto bg-mc-bg"
+        onKeyDown={onKeyDown}
+        onWheel={onWheel}
+        tabIndex={0}
+        className="flex-1 overflow-auto bg-mc-bg outline-none focus:ring-1 focus:ring-mc-accent/40 focus:ring-inset"
       >
         <div style={{ width: totalWidth, position: 'relative' }}>
           {/* Axis */}

--- a/src/components/roadmap/RoadmapRail.tsx
+++ b/src/components/roadmap/RoadmapRail.tsx
@@ -8,7 +8,7 @@
  * can index by row with index*rowHeight without re-measuring.
  */
 
-import type { RefObject } from 'react';
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import Link from 'next/link';
 import { ChevronDown, ChevronRight, Square, Diamond, ListTree, Circle, AlertTriangle } from 'lucide-react';
 import type { Kind, RoadmapInitiative, RoadmapSnapshot, Status } from './RoadmapTimeline';
@@ -40,21 +40,29 @@ export const STATUS_PILL: Record<Status, string> = {
 export function RoadmapRail({
   initiatives,
   width,
+  minWidth,
+  maxWidth,
+  onResize,
   rowHeight,
   collapsed,
   onToggleCollapsed,
   snapshot,
   scrollRef,
   onScroll,
+  flashedId,
 }: {
   initiatives: RoadmapInitiative[];
   width: number;
+  minWidth: number;
+  maxWidth: number;
+  onResize: (width: number) => void;
   rowHeight: number;
   collapsed: Set<string>;
   onToggleCollapsed: (id: string) => void;
   snapshot: RoadmapSnapshot | null;
   scrollRef: RefObject<HTMLDivElement | null>;
   onScroll: () => void;
+  flashedId: string | null;
 }) {
   // Map id → has-children. Use the *full* snapshot (not the filtered set) so
   // a parent that's been hidden by filter/collapse but has children doesn't
@@ -66,83 +74,149 @@ export function RoadmapRail({
     }
   }
 
+  const [dragging, setDragging] = useState(false);
+  const dragState = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    dragState.current = { startX: e.clientX, startWidth: width };
+    setDragging(true);
+  }, [width]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragState.current) return;
+    const dx = e.clientX - dragState.current.startX;
+    const next = Math.max(minWidth, Math.min(maxWidth, dragState.current.startWidth + dx));
+    onResize(next);
+  }, [onResize, minWidth, maxWidth]);
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragState.current) return;
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      // capture may already be lost
+    }
+    dragState.current = null;
+    setDragging(false);
+  }, []);
+
+  // Disable text selection while dragging — prevents the cursor flicker
+  // when the pointer leaves the handle.
+  useEffect(() => {
+    if (!dragging) return;
+    const prev = document.body.style.userSelect;
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'col-resize';
+    return () => {
+      document.body.style.userSelect = prev;
+      document.body.style.cursor = '';
+    };
+  }, [dragging]);
+
   return (
     <aside
-      className="border-r border-mc-border bg-mc-bg flex flex-col min-h-0"
+      className="border-r border-mc-border bg-mc-bg flex min-h-0 relative"
       style={{ width, minWidth: width }}
     >
-      {/* Spacer matching the timeline axis row */}
-      <div className="h-12 border-b border-mc-border bg-mc-bg-secondary flex items-center px-3 text-[11px] uppercase tracking-wide text-mc-text-secondary">
-        Initiative
+      <div className="flex flex-col flex-1 min-w-0">
+        {/* Spacer matching the timeline axis row */}
+        <div className="h-12 border-b border-mc-border bg-mc-bg-secondary flex items-center px-3 text-[11px] uppercase tracking-wide text-mc-text-secondary">
+          Initiative
+        </div>
+        <div
+          ref={scrollRef}
+          onScroll={onScroll}
+          className="overflow-y-auto overflow-x-hidden flex-1"
+        >
+          {initiatives.map(i => {
+            const Icon = KIND_ICON[i.kind];
+            const expanded = !collapsed.has(i.id);
+            const showCaret = !!hasChildren.get(i.id);
+            const counts = i.task_counts;
+            const isFlashed = flashedId === i.id;
+            return (
+              <div
+                key={i.id}
+                className={`flex items-center gap-1.5 px-2 border-b border-mc-border/40 transition-colors ${
+                  isFlashed ? 'bg-mc-accent/20' : ''
+                }`}
+                style={{ height: rowHeight, paddingLeft: 8 + i.depth * 14 }}
+                title={i.title}
+              >
+                {showCaret ? (
+                  <button
+                    onClick={() => onToggleCollapsed(i.id)}
+                    className="p-0.5 rounded hover:bg-mc-bg-secondary text-mc-text-secondary"
+                    title={expanded ? 'Collapse' : 'Expand'}
+                  >
+                    {expanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                  </button>
+                ) : (
+                  <span className="w-4" />
+                )}
+                <Icon className={`w-3.5 h-3.5 shrink-0 ${KIND_COLOR[i.kind]}`} />
+                <Link
+                  href={`/initiatives/${i.id}`}
+                  className="text-sm text-mc-text hover:text-mc-accent truncate flex-1 min-w-0"
+                >
+                  {i.title}
+                </Link>
+                {/* Drift indicator: milestone whose derived_end overruns
+                    committed_end. Hover shows the gap in days. */}
+                {i.kind === 'milestone' && i.committed_end && i.derived_end && i.derived_end > i.committed_end && (
+                  <span
+                    className="text-amber-400 shrink-0"
+                    title={`Schedule debt: ${daysBetween(i.committed_end, i.derived_end)}d past committed_end (${i.committed_end} → ${i.derived_end})`}
+                  >
+                    <AlertTriangle className="w-3.5 h-3.5" />
+                  </span>
+                )}
+                <span
+                  className={`text-[10px] px-1.5 py-0.5 rounded border shrink-0 ${STATUS_PILL[i.status]}`}
+                  title={i.status}
+                >
+                  {i.status === 'in_progress'
+                    ? 'wip'
+                    : i.status === 'at_risk'
+                      ? 'risk'
+                      : i.status.slice(0, 4)}
+                </span>
+                {counts.total > 0 && (
+                  <span
+                    className="text-[10px] text-mc-text-secondary shrink-0"
+                    title={`${counts.total} tasks: ${counts.draft} draft, ${counts.active} active, ${counts.done} done`}
+                  >
+                    {counts.total}
+                    {counts.draft > 0 && <span className="text-slate-400">·{counts.draft}d</span>}
+                    {counts.active > 0 && <span className="text-blue-400">·{counts.active}a</span>}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
       </div>
+
+      {/* Resize handle on the right edge. Wider hit target than the visual
+          line for easier grabbing; centered 4-px line shows on hover/drag. */}
       <div
-        ref={scrollRef}
-        onScroll={onScroll}
-        className="overflow-y-auto overflow-x-hidden flex-1"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize initiative column"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        className="absolute top-0 right-0 h-full w-2 cursor-col-resize group"
+        style={{ touchAction: 'none' }}
       >
-        {initiatives.map(i => {
-          const Icon = KIND_ICON[i.kind];
-          const expanded = !collapsed.has(i.id);
-          const showCaret = !!hasChildren.get(i.id);
-          const counts = i.task_counts;
-          return (
-            <div
-              key={i.id}
-              className="flex items-center gap-1.5 px-2 border-b border-mc-border/40"
-              style={{ height: rowHeight, paddingLeft: 8 + i.depth * 14 }}
-              title={i.title}
-            >
-              {showCaret ? (
-                <button
-                  onClick={() => onToggleCollapsed(i.id)}
-                  className="p-0.5 rounded hover:bg-mc-bg-secondary text-mc-text-secondary"
-                  title={expanded ? 'Collapse' : 'Expand'}
-                >
-                  {expanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-                </button>
-              ) : (
-                <span className="w-4" />
-              )}
-              <Icon className={`w-3.5 h-3.5 ${KIND_COLOR[i.kind]}`} />
-              <Link
-                href={`/initiatives/${i.id}`}
-                className="text-sm text-mc-text hover:text-mc-accent truncate flex-1 min-w-0"
-              >
-                {i.title}
-              </Link>
-              {/* Drift indicator: milestone whose derived_end overruns
-                  committed_end. Hover shows the gap in days. */}
-              {i.kind === 'milestone' && i.committed_end && i.derived_end && i.derived_end > i.committed_end && (
-                <span
-                  className="text-amber-400"
-                  title={`Schedule debt: ${daysBetween(i.committed_end, i.derived_end)}d past committed_end (${i.committed_end} → ${i.derived_end})`}
-                >
-                  <AlertTriangle className="w-3.5 h-3.5" />
-                </span>
-              )}
-              <span
-                className={`text-[10px] px-1.5 py-0.5 rounded border ${STATUS_PILL[i.status]}`}
-                title={i.status}
-              >
-                {i.status === 'in_progress'
-                  ? 'wip'
-                  : i.status === 'at_risk'
-                    ? 'risk'
-                    : i.status.slice(0, 4)}
-              </span>
-              {counts.total > 0 && (
-                <span
-                  className="text-[10px] text-mc-text-secondary"
-                  title={`${counts.total} tasks: ${counts.draft} draft, ${counts.active} active, ${counts.done} done`}
-                >
-                  {counts.total}
-                  {counts.draft > 0 && <span className="text-slate-400">·{counts.draft}d</span>}
-                  {counts.active > 0 && <span className="text-blue-400">·{counts.active}a</span>}
-                </span>
-              )}
-            </div>
-          );
-        })}
+        <div
+          className={`absolute right-0 top-0 h-full w-px transition-colors ${
+            dragging ? 'bg-mc-accent w-0.5' : 'group-hover:bg-mc-accent/60'
+          }`}
+        />
       </div>
     </aside>
   );

--- a/src/components/roadmap/RoadmapTimeline.tsx
+++ b/src/components/roadmap/RoadmapTimeline.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
-import { Plus, RefreshCw } from 'lucide-react';
+import { Plus, RefreshCw, X, ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react';
 import { RoadmapRail } from './RoadmapRail';
 import { RoadmapCanvas } from './RoadmapCanvas';
 import { RoadmapToolbar } from './RoadmapToolbar';
@@ -24,12 +24,17 @@ import {
   PX_PER_DAY,
   defaultWindow,
   toIsoDay,
+  dateToPx,
   type ZoomLevel,
 } from '@/lib/roadmap/date-math';
+import type { DriftEvent } from '@/lib/roadmap/drift';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
 
 const ZOOM_KEY = 'roadmap.zoom';
-const RAIL_WIDTH = 300; // px
+const RAIL_WIDTH_KEY = 'roadmap.railWidth';
+const RAIL_DEFAULT = 300;
+const RAIL_MIN = 200;
+const RAIL_MAX = 600;
 const ROW_HEIGHT = 36;  // px — must match RoadmapRail row height
 
 export type Kind = 'theme' | 'milestone' | 'epic' | 'story';
@@ -89,6 +94,19 @@ export interface RoadmapFilters {
   statuses: Set<Status>;
 }
 
+interface RecomputeResult {
+  initiatives_updated: number;
+  status_flips: number;
+  drifts: DriftEvent[];
+  cycle?: string[];
+  warnings?: string[];
+}
+
+interface RecomputeBanner {
+  result: RecomputeResult;
+  expanded: boolean;
+}
+
 const ALL_KINDS: Kind[] = ['theme', 'milestone', 'epic', 'story'];
 const ALL_STATUSES: Status[] = ['planned', 'in_progress', 'at_risk', 'blocked', 'done', 'cancelled'];
 
@@ -108,12 +126,31 @@ function writeZoom(z: ZoomLevel) {
   }
 }
 
+function readRailWidth(): number {
+  if (typeof window === 'undefined') return RAIL_DEFAULT;
+  const raw = window.localStorage.getItem(RAIL_WIDTH_KEY);
+  if (!raw) return RAIL_DEFAULT;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return RAIL_DEFAULT;
+  return Math.max(RAIL_MIN, Math.min(RAIL_MAX, Math.round(n)));
+}
+
+function writeRailWidth(w: number) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(RAIL_WIDTH_KEY, String(w));
+  } catch {
+    // ignore.
+  }
+}
+
 export function RoadmapTimeline() {
   const workspaceId = useCurrentWorkspaceId();
   const [snapshot, setSnapshot] = useState<RoadmapSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [zoom, setZoomState] = useState<ZoomLevel>('month');
+  const [railWidth, setRailWidthState] = useState<number>(RAIL_DEFAULT);
   const [filters, setFilters] = useState<RoadmapFilters>({
     product_id: null,
     owner_agent_id: null,
@@ -122,16 +159,25 @@ export function RoadmapTimeline() {
   });
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [recomputing, setRecomputing] = useState(false);
-  const [recomputeMsg, setRecomputeMsg] = useState<string | null>(null);
+  const [recomputeBanner, setRecomputeBanner] = useState<RecomputeBanner | null>(null);
+  const [recomputeError, setRecomputeError] = useState<string | null>(null);
+  const [flashedId, setFlashedId] = useState<string | null>(null);
 
-  // Read zoom on mount only (client-only).
+  // Read persisted prefs on mount.
   useEffect(() => {
     setZoomState(readZoom());
+    setRailWidthState(readRailWidth());
   }, []);
 
   const setZoom = useCallback((z: ZoomLevel) => {
     setZoomState(z);
     writeZoom(z);
+  }, []);
+
+  const setRailWidth = useCallback((w: number) => {
+    const clamped = Math.max(RAIL_MIN, Math.min(RAIL_MAX, Math.round(w)));
+    setRailWidthState(clamped);
+    writeRailWidth(clamped);
   }, []);
 
   const refresh = useCallback(async () => {
@@ -158,7 +204,7 @@ export function RoadmapTimeline() {
 
   const recompute = useCallback(async () => {
     setRecomputing(true);
-    setRecomputeMsg(null);
+    setRecomputeError(null);
     try {
       const r = await fetch('/api/roadmap/recompute', {
         method: 'POST',
@@ -169,21 +215,26 @@ export function RoadmapTimeline() {
         const body = await r.json().catch(() => ({}));
         throw new Error(body.error || `Recompute failed (${r.status})`);
       }
-      const result = await r.json() as {
-        initiatives_updated: number;
-        status_flips: number;
-        drifts: unknown[];
-      };
-      setRecomputeMsg(
-        `Recomputed: ${result.initiatives_updated} updated, ${result.status_flips} flipped, ${result.drifts.length} drift${result.drifts.length === 1 ? '' : 's'}`,
-      );
+      const result = (await r.json()) as RecomputeResult;
+      setRecomputeBanner({ result, expanded: false });
       await refresh();
     } catch (e) {
-      setRecomputeMsg(e instanceof Error ? e.message : 'Recompute failed');
+      setRecomputeError(e instanceof Error ? e.message : 'Recompute failed');
+      setRecomputeBanner(null);
     } finally {
       setRecomputing(false);
     }
-  }, [refresh]);
+  }, [workspaceId, refresh]);
+
+  // Auto-dismiss the "no changes" variant after 3s. Sticky variant stays.
+  useEffect(() => {
+    if (!recomputeBanner) return;
+    const { initiatives_updated, status_flips, drifts } = recomputeBanner.result;
+    const noop = initiatives_updated === 0 && status_flips === 0 && drifts.length === 0;
+    if (!noop) return;
+    const t = setTimeout(() => setRecomputeBanner(null), 3000);
+    return () => clearTimeout(t);
+  }, [recomputeBanner]);
 
   // Apply client-side kind+status filters and collapse logic to the snapshot.
   const visibleInitiatives = useMemo(() => {
@@ -299,9 +350,80 @@ export function RoadmapTimeline() {
     syncingScroll.current = false;
   };
 
+  // Read window_ + pxPerDay via a ref so scrollToToday is stable across
+  // renders (window_ is a fresh object every render via useMemo, which
+  // would otherwise invalidate the useCallback every frame).
+  const scrollCtxRef = useRef({ windowStart: window_.start, pxPerDay });
+  scrollCtxRef.current = { windowStart: window_.start, pxPerDay };
+
+  // Position today's x ~⅓ from the left edge of the visible canvas.
+  // Direct scrollLeft assignment (not scrollTo({behavior:'smooth'})) so
+  // the call is idempotent across re-renders and never gets cancelled
+  // by an animation frame.
+  const scrollToToday = useCallback(() => {
+    const el = canvasScrollRef.current;
+    if (!el) return;
+    const { windowStart, pxPerDay: ppd } = scrollCtxRef.current;
+    const todayX = dateToPx(new Date(), windowStart, ppd);
+    const target = Math.max(
+      0,
+      Math.min(el.scrollWidth - el.clientWidth, todayX - el.clientWidth / 3),
+    );
+    el.scrollLeft = target;
+  }, []);
+
+  // Auto-center only on initial snapshot arrival and explicit zoom changes —
+  // not on every render. Use a key derived from snapshot identity + zoom.
+  const lastAutoCenterKey = useRef<string | null>(null);
+  useEffect(() => {
+    if (!snapshot) return;
+    const key = `${snapshot.workspace_id}:${snapshot.initiatives.length}:${zoom}`;
+    if (lastAutoCenterKey.current === key) return;
+    lastAutoCenterKey.current = key;
+    // setTimeout, not requestAnimationFrame — RAF was unreliably starved
+    // in the test harness when snapshot identity churned across renders.
+    // The 50ms delay also gives the canvas time to measure scrollWidth
+    // after a zoom-change layout.
+    setTimeout(() => scrollToToday(), 50);
+  }, [snapshot, zoom, scrollToToday]);
+
+  const scrollByWeek = useCallback((direction: 1 | -1) => {
+    const el = canvasScrollRef.current;
+    if (!el) return;
+    const { pxPerDay: ppd } = scrollCtxRef.current;
+    const next = el.scrollLeft + direction * 7 * ppd;
+    el.scrollLeft = Math.max(0, Math.min(el.scrollWidth - el.clientWidth, next));
+  }, []);
+
+  // Scroll a row into vertical view + flash it briefly.
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scrollToInitiative = useCallback((id: string) => {
+    const idx = visibleInitiatives.findIndex(i => i.id === id);
+    if (idx < 0) return;
+    const el = canvasScrollRef.current;
+    if (!el) return;
+    const targetTop = Math.max(
+      0,
+      idx * ROW_HEIGHT - el.clientHeight / 2 + ROW_HEIGHT / 2,
+    );
+    el.scrollTop = Math.min(el.scrollHeight - el.clientHeight, targetTop);
+    setFlashedId(id);
+    if (flashTimer.current) clearTimeout(flashTimer.current);
+    flashTimer.current = setTimeout(() => setFlashedId(null), 1500);
+  }, [visibleInitiatives]);
+
+  useEffect(() => () => {
+    if (flashTimer.current) clearTimeout(flashTimer.current);
+  }, []);
+
   const truncatedNote = snapshot?.truncated
     ? `Showing first ${snapshot.initiatives.length} of a larger workspace; refine filters for the full set.`
     : null;
+
+  const initiativesById = useMemo(
+    () => new Map((snapshot?.initiatives ?? []).map(i => [i.id, i])),
+    [snapshot],
+  );
 
   return (
     <div className="min-h-screen bg-mc-bg flex flex-col">
@@ -323,24 +445,32 @@ export function RoadmapTimeline() {
             <RefreshCw className={`w-3.5 h-3.5 ${recomputing ? 'animate-spin' : ''}`} />
             {recomputing ? 'Recomputing…' : 'Recompute now'}
           </button>
-          <Link
-            href="/initiatives"
-            className="px-3 py-1.5 rounded-lg border border-mc-border text-mc-text-secondary hover:text-mc-text text-sm"
-          >
-            Initiative tree
-          </Link>
-          <Link
-            href="/"
-            className="px-3 py-1.5 rounded-lg border border-mc-border text-mc-text-secondary hover:text-mc-text text-sm"
-          >
-            Workspaces
-          </Link>
         </div>
       </header>
-      {recomputeMsg && (
-        <div className="mx-4 mt-2 p-2 rounded-lg bg-mc-accent/10 border border-mc-accent/30 text-mc-accent text-xs">
-          {recomputeMsg}
+
+      {recomputeError && (
+        <div className="mx-4 mt-2 p-2 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300 text-xs flex items-start justify-between gap-2">
+          <span>{recomputeError}</span>
+          <button
+            onClick={() => setRecomputeError(null)}
+            className="text-red-300/70 hover:text-red-300"
+            aria-label="Dismiss error"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
         </div>
+      )}
+
+      {recomputeBanner && (
+        <RecomputeBannerView
+          banner={recomputeBanner}
+          onToggleExpanded={() =>
+            setRecomputeBanner(b => (b ? { ...b, expanded: !b.expanded } : b))
+          }
+          onDismiss={() => setRecomputeBanner(null)}
+          onJumpToInitiative={scrollToInitiative}
+          initiativesById={initiativesById}
+        />
       )}
 
       <RoadmapToolbar
@@ -349,6 +479,8 @@ export function RoadmapTimeline() {
         zoom={zoom}
         setZoom={setZoom}
         snapshot={snapshot}
+        onScrollWeek={scrollByWeek}
+        onScrollToToday={scrollToToday}
       />
 
       {error && (
@@ -381,13 +513,17 @@ export function RoadmapTimeline() {
           <>
             <RoadmapRail
               initiatives={visibleInitiatives}
-              width={RAIL_WIDTH}
+              width={railWidth}
+              minWidth={RAIL_MIN}
+              maxWidth={RAIL_MAX}
+              onResize={setRailWidth}
               rowHeight={ROW_HEIGHT}
               collapsed={collapsed}
               onToggleCollapsed={toggleCollapsed}
               snapshot={snapshot}
               scrollRef={railScrollRef}
               onScroll={onRailScroll}
+              flashedId={flashedId}
             />
             <RoadmapCanvas
               initiatives={visibleInitiatives}
@@ -402,10 +538,134 @@ export function RoadmapTimeline() {
               onUpdateDates={updateInitiativeDates}
               scrollRef={canvasScrollRef}
               onScroll={onCanvasScroll}
+              onScrollWeek={scrollByWeek}
+              onScrollToToday={scrollToToday}
             />
           </>
         )}
       </main>
+    </div>
+  );
+}
+
+function driftLabel(d: DriftEvent): { label: string; isDrift: boolean } {
+  switch (d.kind) {
+    case 'milestone_at_risk':
+      return { label: `committed_end overrun by ${d.days_over}d`, isDrift: true };
+    case 'slippage':
+      return { label: `target_end slipped by ${d.days_over}d`, isDrift: false };
+    case 'cycle_detected':
+      return { label: `cycle (${d.initiative_ids.length} nodes)`, isDrift: false };
+    case 'no_effort_signal':
+      return { label: `no effort signal`, isDrift: false };
+  }
+}
+
+function RecomputeBannerView({
+  banner,
+  onToggleExpanded,
+  onDismiss,
+  onJumpToInitiative,
+  initiativesById,
+}: {
+  banner: RecomputeBanner;
+  onToggleExpanded: () => void;
+  onDismiss: () => void;
+  onJumpToInitiative: (id: string) => void;
+  initiativesById: Map<string, RoadmapInitiative>;
+}) {
+  const { initiatives_updated, status_flips, drifts } = banner.result;
+  const noop = initiatives_updated === 0 && status_flips === 0 && drifts.length === 0;
+
+  // Flatten drifts to a per-initiative row list. cycle_detected becomes one
+  // synthetic row per node.
+  const rows = useMemo(() => {
+    const out: Array<{ id: string; title: string; label: string; isDrift: boolean }> = [];
+    for (const d of drifts) {
+      const { label, isDrift } = driftLabel(d);
+      if (d.kind === 'cycle_detected') {
+        for (const id of d.initiative_ids) {
+          out.push({
+            id,
+            title: initiativesById.get(id)?.title ?? id,
+            label,
+            isDrift,
+          });
+        }
+      } else {
+        out.push({
+          id: d.initiative_id,
+          title: initiativesById.get(d.initiative_id)?.title ?? d.initiative_id,
+          label,
+          isDrift,
+        });
+      }
+    }
+    return out;
+  }, [drifts, initiativesById]);
+
+  const summary = noop
+    ? 'No changes'
+    : `${initiatives_updated} updated · ${status_flips} status flip${status_flips === 1 ? '' : 's'} · ${drifts.length} drift${drifts.length === 1 ? '' : 's'}`;
+
+  return (
+    <div
+      className={`mx-4 mt-2 rounded-lg border text-xs ${
+        noop
+          ? 'bg-mc-bg-secondary border-mc-border text-mc-text-secondary'
+          : 'bg-mc-accent/10 border-mc-accent/30 text-mc-accent'
+      }`}
+    >
+      <div className="flex items-center gap-2 p-2">
+        {!noop && rows.length > 0 ? (
+          <button
+            onClick={onToggleExpanded}
+            className="text-mc-accent hover:text-mc-accent/80"
+            aria-label={banner.expanded ? 'Collapse' : 'Expand'}
+          >
+            {banner.expanded ? (
+              <ChevronDown className="w-3.5 h-3.5" />
+            ) : (
+              <ChevronRight className="w-3.5 h-3.5" />
+            )}
+          </button>
+        ) : (
+          <span className="w-3.5 h-3.5" />
+        )}
+        <span className="flex-1">{summary}</span>
+        <button
+          onClick={onDismiss}
+          className="text-mc-text-secondary hover:text-mc-text"
+          aria-label="Dismiss"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      {!noop && banner.expanded && rows.length > 0 && (
+        <ul className="border-t border-mc-accent/20 max-h-48 overflow-y-auto">
+          {rows.map((row, i) => (
+            <li key={`${row.id}-${i}`}>
+              <button
+                onClick={() => onJumpToInitiative(row.id)}
+                className="w-full text-left flex items-center gap-2 px-3 py-1.5 hover:bg-mc-accent/10 text-mc-text"
+                title={`Jump to ${row.title}`}
+              >
+                {row.isDrift && (
+                  <span
+                    className="inline-flex items-center gap-1 px-1 py-0.5 rounded border border-red-500/40 bg-red-500/10 text-red-300 text-[10px]"
+                    title="Schedule debt: derived_end > committed_end"
+                  >
+                    <AlertTriangle className="w-3 h-3" />
+                    drift
+                  </span>
+                )}
+                <span className="truncate flex-1">{row.title}</span>
+                <span className="text-[10px] text-mc-text-secondary shrink-0">{row.label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/src/components/roadmap/RoadmapToolbar.tsx
+++ b/src/components/roadmap/RoadmapToolbar.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useMemo } from 'react';
-import { Layers, Filter } from 'lucide-react';
+import { Layers, Filter, ChevronLeft, ChevronRight, Crosshair } from 'lucide-react';
 import type { ZoomLevel } from '@/lib/roadmap/date-math';
 import type {
   Kind,
@@ -40,12 +40,16 @@ export function RoadmapToolbar({
   zoom,
   setZoom,
   snapshot,
+  onScrollWeek,
+  onScrollToToday,
 }: {
   filters: RoadmapFilters;
   setFilters: (next: RoadmapFilters) => void;
   zoom: ZoomLevel;
   setZoom: (z: ZoomLevel) => void;
   snapshot: RoadmapSnapshot | null;
+  onScrollWeek: (direction: 1 | -1) => void;
+  onScrollToToday: () => void;
 }) {
   const productOptions = useMemo(() => {
     const set = new Set<string>();
@@ -155,8 +159,35 @@ export function RoadmapToolbar({
         ))}
       </div>
 
+      {/* Nav: ◀ week / Today / ▶ week */}
+      <div className="ml-auto flex items-center gap-1 mr-1">
+        <button
+          onClick={() => onScrollWeek(-1)}
+          className="px-2 py-1 rounded text-xs border border-mc-border text-mc-text-secondary hover:text-mc-text inline-flex items-center gap-1"
+          title="Scroll one week earlier (←)"
+          aria-label="Scroll one week earlier"
+        >
+          <ChevronLeft className="w-3 h-3" /> week
+        </button>
+        <button
+          onClick={onScrollToToday}
+          className="px-2 py-1 rounded text-xs border border-mc-border text-mc-text-secondary hover:text-mc-text inline-flex items-center gap-1"
+          title="Center on today (Home)"
+        >
+          <Crosshair className="w-3 h-3" /> Today
+        </button>
+        <button
+          onClick={() => onScrollWeek(1)}
+          className="px-2 py-1 rounded text-xs border border-mc-border text-mc-text-secondary hover:text-mc-text inline-flex items-center gap-1"
+          title="Scroll one week later (→)"
+          aria-label="Scroll one week later"
+        >
+          week <ChevronRight className="w-3 h-3" />
+        </button>
+      </div>
+
       {/* Zoom */}
-      <div className="ml-auto flex items-center gap-1">
+      <div className="flex items-center gap-1">
         <Layers className="w-3.5 h-3.5 text-mc-text-secondary" />
         {(['week', 'month', 'quarter'] as const).map(z => (
           <button


### PR DESCRIPTION
## Summary

Implements [specs/roadmap-navigation-polish.md](https://github.com/smb209/mission-control/blob/feat/roadmap-nav-polish/specs/roadmap-navigation-polish.md). Five small UI fixes to `/roadmap`, no data-model or derivation-engine changes.

## Changes

- **Header** — drop redundant `Initiative tree` / `Workspaces` links; sidebar already covers them. `Recompute now` stays at the right edge.
- **Resizable initiative column** — drag handle on the rail's right edge, clamp 200–600 px, persisted under `roadmap.railWidth` (mirroring the existing `roadmap.zoom` pattern). Cursor + accent line on hover/drag.
- **Auto-center on today** — on initial snapshot and every zoom change, the canvas scrolls so today sits ~⅓ from the left edge of the viewport. Most visible on Week zoom; on Month zoom today often already sits in the leftmost third so nothing visibly moves.
- **Horizontal scroll affordances** — toolbar buttons `◀ week / Today / ▶ week`; canvas-focused `← / → / Home` keys; explicit `shift+wheel → horizontal` handler (browsers don't always do this for inner scrollers).
- **Recompute banner refactor** — types the `drifts: DriftEvent[]` response, renders an expandable list with one row per affected initiative (title + "what changed" label). `milestone_at_risk` drifts get a red "drift" badge. Click a row → vertical scroll + brief background flash on the rail entry. "No changes" variant auto-dismisses after 3s; the sticky variant stays until the X is clicked.

## Files touched

- `src/components/roadmap/RoadmapTimeline.tsx` — header + banner + rail width state + auto-center + scroll callbacks
- `src/components/roadmap/RoadmapRail.tsx` — accept dynamic width + onResize; pointer-driven drag handle; flashedId prop
- `src/components/roadmap/RoadmapCanvas.tsx` — keyboard + shift-wheel handlers; `tabIndex={0}` for focus; new scroll-week / scroll-to-today callbacks (forwarded but kept lean)
- `src/components/roadmap/RoadmapToolbar.tsx` — new ◀ / Today / ▶ button group next to the zoom controls
- `specs/roadmap-navigation-polish.md` — checked in alongside the implementation

## Test plan

- [x] `yarn tsc --noEmit -p tsconfig.json` — clean.
- [x] Full `yarn test` — 930/931 pass. **Pre-existing failure** unrelated to this change: `src/lib/research/eval/schedule-runner.test.ts` → `schedule-runner: produces a brief and advances run_count`. Confirmed failing on `main` via `git stash` baseline run; not introduced here.
- [x] Preview-verify on `/roadmap`:
  - [x] Header has no `Initiative tree` / `Workspaces` links.
  - [x] Drag handle: 300 → 400 px on a +100 px drag, persists in `localStorage.roadmap.railWidth = "400"`.
  - [x] Switch to Week → `scrollLeft` lands at 484 px (todayX 768 − viewport/3 ≈ 284).
  - [x] `Today` button, `Home` key both center → `scrollLeft = 484`.
  - [x] `▶ week` button + `→` key both shift `scrollLeft` by `7 × pxPerDay` (224 px on Week).
  - [x] `shift+wheel` with `deltaY=200` → `scrollLeft += 200`.
  - [x] Recompute now → banner reads `5 updated · 0 status flips · 8 drifts`; expand → 8 rows with per-initiative drift labels (e.g. `target_end slipped by 4d`, `no effort signal`); X dismisses.
  - [x] No console errors across the run.

## Notes for review

- Auto-center uses `setTimeout(..., 50)` rather than `requestAnimationFrame`. RAFs were being starved in the dev preview when `snapshot` identity churned across renders (the refresh path returns a new object even when content is identical). 50 ms also gives the canvas time to remeasure `scrollWidth` after a zoom-change layout.
- The auto-center effect is keyed on `${workspace_id}:${initiatives.length}:${zoom}` so it runs once per real change, not once per render.
- Recompute API response shape was tightened from `drifts: unknown[]` to `drifts: DriftEvent[]` (already exported from `@/lib/roadmap/drift`). No API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)