### PR TITLE
feat(research-loop): slice 2 — suggest pipeline initiative scoping

### DIFF
--- a/specs/initiative-research-loop-build-plan.md
+++ b/specs/initiative-research-loop-build-plan.md
@@ -1,0 +1,188 @@
+---
+name: Initiative Research Loop — Build Plan
+description: Slice plan + design decisions for shipping the initiative-scoped research loop on top of briefs
+status: draft
+spec: specs/initiative-research-loop.md
+---
+
+# Initiative Research Loop — Build Plan
+
+Status: draft · Owner: smb209 · Date: 2026-05-09
+Spec: [specs/initiative-research-loop.md](initiative-research-loop.md)
+
+This is the build-plan companion to the spec. It commits to slices, files-touched, and the load-bearing design calls. Operator OKs this doc *before* any code lands; per-slice unit tests + preview verification are the per-PR contract; full validation runs against the stacked branch tip per [specs/long-unattended-feature-dev.md](long-unattended-feature-dev.md).
+
+## Audit (current state, verified 2026-05-09)
+
+- `briefs` table — `src/lib/db/migrations.ts` migration 075 (line 4133+). Columns today: `id, workspace_id, agent_run_id, topic_id, template, title, prompt, requested_by, source_ref, result_md, citations_json, error_md, created_at, updated_at`. **Already has** `source_ref TEXT` — used by rerun (`src/app/api/briefs/[id]/rerun/route.ts:43`) to write `brief:<original_id>` linking a rerun back to its source brief. **Missing:** `initiative_id`, `summary`.
+- `briefs` DAO — `src/lib/db/briefs.ts`, `createBriefWithRun()` at line 119. `BriefInput` at line 111 already accepts `source_ref`.
+- Suggest pipeline — `src/lib/research/suggest.ts`, `buildSuggestPrompt(kind, ctx)` at line 154. `gatherWorkspaceContext()` is workspace-wide. API caller is `POST /api/research/suggestions` (`generateSuggestions`).
+- Brief run / completion — `src/lib/research/run-brief.ts`. Completion path writes `result_md` + transitions agent_run via DAO `markComplete`.
+- agent_notes — `src/lib/db/agent-notes.ts:208` `listNotes(filter)`. Schema (migrations 065 + 067) supports `kind: 'discovery'`, `audience`, `importance: 0|1|2`, `archived_at`/`archived_reason`, `source` is **not** a first-class column — instead `source` shape from spec needs to map to existing fields. Verified columns: `id, workspace_id, agent_id, task_id, initiative_id, scope_key, role, run_group_id, kind, audience, body, attached_files, importance, consumed_by_stages, archived_at, archived_reason, created_at, pm_proposal_ids`. **Gap vs spec:** there's no `source_kind` / `source_id` column on `agent_notes`. We'll either (a) add one in this feature's migration, or (b) embed `{type, id}` in `body_md` via a parseable marker. See Decision 4.
+- Decompose / refine context — confirmed: `src/app/api/pm/decompose-initiative/route.ts:118` and `src/app/api/pm/plan-initiative/route.ts:157` already prompt PM to call `read_notes({initiative_id, audience: 'pm', min_importance: 2, limit: 5})`. Auto-notes at importance 2 / audience 'pm' will land here with zero changes.
+- MCP groups — `src/lib/mcp/groups/{core,crud,pm,read,work}.ts`. **No `research` group today.** `read_notes` lives in `core.ts:554`. New `read_brief` tool will go in `read.ts` (read-only role-agnostic), not `core.ts` (which is the heavy human-facing toolset).
+- InitiativeDetailView — `src/components/InitiativeDetailView.tsx` (~1300 lines). Description and Children are clearly separated; insertion point obvious.
+- Brief progress / SSE — confirmed **no SSE channel for brief progress today**. The brief detail page at `src/app/(app)/research/briefs/[id]/page.tsx` polls/refreshes server-side. The Research section on the initiative page will use the same pattern (server-rendered with revalidation, optionally SWR-style refresh on a timer) — **no new SSE channel in v1**.
+- Rerun semantics — verified: rerun creates a **new brief row** with `source_ref: brief:<original_id>`. Originals stay. The new brief has its own `result_md` + `agent_run`. This shapes Decision 3.
+- Suggestions UI — `src/components/research/SuggestPickerDrawer.tsx` is the existing queue surface; it filters by workspace today.
+
+## Design decisions
+
+### D1. `briefs.summary` generation strategy
+
+**Choice:** "first sentence of `result_md`, max 160 chars" at brief completion. Computed in JS with a small extractor (`/^(.*?[.!?])\s/`). No LLM call.
+
+- **Why:** zero added cost / latency / failure mode. Spec already names this as the v1 default. If indexes look noisy after dogfood, swap to LLM 1-liner in a follow-up.
+- **Reversible:** yes — column is a single string, regenerable from `result_md` any time.
+
+### D2. Auto-note `source` representation
+
+The spec writes `source: { type: 'brief', id }` on the note. `agent_notes` has no `source_kind`/`source_id` column today.
+
+**Choice:** add `source_kind TEXT` and `source_ref TEXT` columns to `agent_notes` in this feature's migration. Indexed `(source_kind, source_ref)` for the dedupe lookup.
+
+- **Why over body-marker:** clean dedupe + future "rerun replaces" + cheap to query. The cost is a 2-column migration; the benefit is the rerun-replace path is a single SQL `UPDATE` instead of a body parse. Notes rail rendering can read `source_kind='brief'` to render a "View brief" affordance cleanly.
+- **Why not reuse existing `attached_files`:** wrong semantics — that's a JSON list of filesystem paths.
+- **Reversible:** columns are nullable and net-additive; existing notes stay null.
+
+### D3. Rerun ↔ auto-note semantics
+
+Rerun creates a **new brief row** with `source_ref: brief:<original_id>`. The original brief (and its auto-note) still exists. Two questions:
+1. Does the rerun's auto-note replace the original's, or stack alongside?
+2. Is "replace" via in-place update or soft-delete + insert?
+
+**Choice:** when a brief with non-null `briefs.source_ref` (i.e. it's a rerun) completes, find any existing **non-archived** `agent_notes` with `source_kind='brief'` and `source_ref` pointing at the chain root, **soft-delete** them (`archived_at = now`, `archived_reason = 'superseded_by_rerun'`), then insert a new note for the new brief.
+
+- **Why soft-delete over in-place update:** preserves audit trail in the `agent_notes` table; `archived_reason` makes the relationship explicit. Notes rail already filters out `archived_at IS NOT NULL`, so the UI is clean.
+- **Why "chain root":** if the rerun is itself rerun, we want to walk back to the original to find every prior auto-note. Trivial recursive lookup.
+- **Reversible:** yes — `archived_at` is a flag; un-archiving brings back the prior note.
+
+### D4. New MCP tool placement
+
+**Choice:** `read_brief({ brief_id })` lives in `src/lib/mcp/groups/read.ts`. Returns the shape from the spec.
+
+- **Why `read.ts`:** it's the read-only group available to all roles. No need to invent a `research` group for a single tool.
+- **Future:** if we add `list_briefs_for_initiative`, that probably belongs here too. Don't pre-invent the group.
+
+### D5. UI fetch for the Research section
+
+**Choice:** server-rendered list of briefs scoped by `initiative_id` on the initiative detail page. In-progress briefs render with the existing `agent_runs.status` (queued / running / complete / failed), refreshed via the same revalidation pattern the page already uses. **No new SSE channel.**
+
+- **Why:** matches existing `/research` hub. SSE for brief progress is a worthwhile follow-up but out of scope for the loop's correctness.
+- **Reversible:** yes — adding SSE later doesn't break server-rendered fallback.
+
+### D6. Migration scope
+
+Single migration adds: `briefs.initiative_id` (FK + index), `briefs.summary`, `agent_notes.source_kind`, `agent_notes.source_ref`, index on `(source_kind, source_ref)`.
+
+- **Why one migration:** atomic; no slice can land partial state.
+- **Cost:** ~30 lines in `migrations.ts`; backfills are no-ops.
+
+## Slice plan
+
+Each slice is one stacked PR. Branch base for slice N = slice N-1's branch (per [specs/long-unattended-feature-dev.md](long-unattended-feature-dev.md)). Retarget children to `main` before merging the parent.
+
+### Slice 1 — DB migration + DAO surface
+
+**Branch:** `feat/research-loop-1-migration` (off `main`)
+
+**Files:**
+- `src/lib/db/migrations.ts` — new migration: `briefs.initiative_id`, `briefs.summary`, `agent_notes.source_kind`, `agent_notes.source_ref`, indexes.
+- `src/lib/db/briefs.ts` — extend `BriefInput`, `BriefRow`, `createBriefWithRun()` to accept `initiative_id` and write/read it. Add `summary` to row shape.
+- `src/lib/db/agent-notes.ts` — extend insert/list to accept `source_kind` / `source_ref`; add `findBySource(source_kind, source_ref)` helper for the rerun dedupe path.
+- Tests: extend `src/lib/db/briefs.test.ts` and `src/lib/db/agent-notes.test.ts` (paths exist) — schema round-trip + new filter.
+
+**Testable after this slice:** DAO unit tests pass; `yarn test` green for DB layer.
+
+**Dependencies:** none.
+
+### Slice 2 — Suggest pipeline carries initiative scope
+
+**Branch:** `feat/research-loop-2-suggest` (off slice 1)
+
+**Files:**
+- `src/lib/research/suggest.ts` — add `initiativeId?: string` to options. New `gatherInitiativeContext(initiativeId)` that returns `{ initiative, parents, recent_pm_notes, prior_briefs_index: [{id, title, summary}] }`. Branch in `buildSuggestPrompt` to use it instead of workspace context.
+- `src/app/api/research/suggestions/route.ts` — accept `{ initiative_id }` body field, thread through. List endpoint accepts `?initiative_id=` query.
+- `src/lib/db/research-suggestions.ts` — `payload_json.initiative_id` so accept-flow propagates it onto the brief. (verify the DAO; may already be JSON-blob-passthrough)
+- Tests: extend `src/lib/research/suggest.test.ts` — assert prompt contains initiative-scoped block when set.
+
+**Testable after this slice:** suggest works against an initiative end-to-end; produced suggestions carry `initiative_id`.
+
+### Slice 3 — Brief dispatch + auto-note + rerun replace
+
+**Branch:** `feat/research-loop-3-autonote` (off slice 2)
+
+**Files:**
+- `src/lib/research/run-brief.ts` — accept `initiative_id` in dispatch helpers; persist on row (already covered by slice 1 DAO change). At completion: if `initiative_id` non-null, compute `summary`, write `agent_notes` row with `kind: 'discovery'`, `audience: 'pm'`, `importance: 2`, `source_kind: 'brief'`, `source_ref: <brief_id>`. If brief has `source_ref` (it's a rerun), walk back to chain root, soft-delete prior auto-notes for that root.
+- `src/app/api/research/suggestions/[id]/accept/route.ts` (or wherever accept lives) — pass through `initiative_id` from the suggestion payload onto the dispatched brief.
+- `src/app/api/briefs/[id]/rerun/route.ts` — copy `initiative_id` from original to rerun.
+- Tests: `src/lib/research/run-brief.test.ts` — extend with the auto-note assertion (one note written, idempotent on second completion of same brief, replace on rerun).
+
+**Testable after this slice:** end-to-end: suggest → accept → run → complete → note appears via `read_notes`. Refine + decompose context loads now include the auto-note with no changes.
+
+### Slice 4 — `read_brief` MCP tool
+
+**Branch:** `feat/research-loop-4-read-brief` (off slice 3)
+
+**Files:**
+- `src/lib/mcp/groups/read.ts` — register `read_brief({ brief_id })`. Returns `{ id, title, prompt, result_md, citations, status, completed_at, initiative_id, summary }`.
+- Schema test: add a sibling `read.schema.test.ts` if a pattern exists, otherwise extend whatever schema test covers `read.ts`.
+- Tests: integration smoke (`yarn mcp:smoke`) — verify the tool is discoverable.
+
+**Testable after this slice:** PM and researcher roles can fetch full brief bodies during refine / iterative research.
+
+### Slice 5 — InitiativeDetailView Research section + suggest UI scope
+
+**Branch:** `feat/research-loop-5-ui` (off slice 4)
+
+**Files:**
+- `src/components/InitiativeDetailView.tsx` — new `<ResearchSection>` between Description and Children. Loads `briefs.where(initiative_id = X)` server-side. Header has `Suggest research` and `New brief` buttons.
+- `src/components/research/InitiativeResearchSection.tsx` (new) — list of brief rows with status badges + "View" link.
+- `src/components/research/SuggestPickerDrawer.tsx` — accept optional `initiativeId` prop; filter listed suggestions by it.
+- `src/components/research/RunBriefDrawer.tsx` — accept optional `initiativeId`; post it to brief create.
+- `src/app/api/initiatives/[id]/briefs/route.ts` (new) — GET endpoint listing briefs for an initiative (or extend `/api/briefs?initiative_id=` if that's the existing pattern).
+- Tests: component smoke; preview-verify in validation phase.
+
+**Testable after this slice:** full UI loop. Operator can drive the entire sequence from the initiative page. This is the slice that the validation test plan exercises end-to-end.
+
+## Test strategy summary
+
+| Slice | Unit tests added | Validation scenarios that become exercisable |
+|---|---|---|
+| 1 | DAO round-trip, source-ref filter | none yet (DB only) |
+| 2 | Suggest prompt content w/ initiative | R-S1 (suggest scoped to initiative) |
+| 3 | Auto-note write + rerun replace | R-S2 (note appears post-completion), R-S3 (rerun replaces note), R-S4 (decompose context includes auto-note) |
+| 4 | MCP smoke | R-S5 (researcher fetches prior brief body) |
+| 5 | Component smoke | R-S6 (full UI loop), R-S7 (decompose proposal references research) |
+
+Validation directory ([initiative-research-loop-validation/](initiative-research-loop-validation/)) holds the concrete scenarios.
+
+## Open questions for operator
+
+1. **Slice-3 auto-note's link** — the spec writes `[Full brief](${briefUrl})` in `body_md`. Confirmed brief detail page lives at `/research/briefs/[id]/page.tsx` so URL is `/research/briefs/<id>`. Going with that unless you say otherwise.
+2. **Brief rerun edge case** — if the *original* brief has `initiative_id = X` but the rerun is dispatched from a context where that's lost (shouldn't happen but worth nailing), the rerun copies `initiative_id` from the original. Confirmed this is what the rerun route does in slice 3.
+3. **`agent_notes.source_kind` / `source_ref`** — adding these columns is a small but real schema expansion. If you'd rather embed source-tracking in `body_md` to avoid the migration, say so and I'll switch. Default is the migration.
+
+None of these block writing the validation skeleton. Calling them out so they're not surprises.
+
+## Out of scope (named explicitly)
+
+- Phase tracking + heartbeat on briefs (autopilot lift, deferred).
+- Cost / token tracking on briefs (deferred).
+- Hierarchical context rollup (parent initiative refine sees child briefs).
+- Brief deletion → auto-note cascade UI prompt (defer until briefs are deletable from the UI).
+- LLM-generated `summary` (defer until first-sentence proves noisy).
+- New SSE channel for brief progress.
+- Workspace-level "research watch" auto-loop.
+
+## Cost ceiling
+
+Per `project_openclaw_model.md`: real-agent dispatches use `spark-lb/agent`, self-hosted, no budget concern. Validation runs ~7 scenarios × ~5 min each ≈ 35 min of agent time. **HMR-runaway watchdog** (per `project_research_hmr_runaway.md`): pre-check 01 confirms pending-brief queue is empty before any dispatch; abort-if-not.
+
+## Slice merge order
+
+Per `feedback_stacked_pr_merges.md`:
+1. Each slice PR opens against the prior slice's branch (`--base feat/research-loop-N-…`).
+2. Before merging slice 1, retarget slice 2's base to `main`. Repeat down the stack.
+3. `--delete-branch` only after children are retargeted.
+4. All PRs target the fork (`smb209/mission-control`), explicit `--repo` per `feedback_pr_target_fork.md`.

--- a/specs/initiative-research-loop-validation/00-baseline-observations.md
+++ b/specs/initiative-research-loop-validation/00-baseline-observations.md
@@ -1,0 +1,37 @@
+# 00 — Baseline observations
+
+Captured 2026-05-09, before any slice merges. Re-read before validation runs to confirm the substrate hasn't shifted.
+
+## Schema state
+
+- `briefs` table — migration 075 (`src/lib/db/migrations.ts:4133+`). Columns: `id, workspace_id, agent_run_id, topic_id, template, title, prompt, requested_by, source_ref, result_md, citations_json, error_md, created_at, updated_at`.
+  - **Missing:** `initiative_id`, `summary`. Slice 1 adds both.
+- `agent_notes` table — supports `kind: 'discovery'`, `audience`, `importance: 0|1|2`, `archived_at` (migrations 065 + 067).
+  - **Missing:** `source_kind`, `source_ref`. Slice 1 adds both.
+
+## API + lib state
+
+- Suggest pipeline workspace-only: `src/lib/research/suggest.ts:154` (`buildSuggestPrompt(kind, ctx)`), `gatherWorkspaceContext` is the only context gatherer.
+- Brief completion has **no** auto-note path: `src/lib/research/run-brief.ts` writes `result_md`, transitions agent_run, returns. No write to `agent_notes`.
+- Decompose / refine **already** prompts PM to call `read_notes({ initiative_id, audience: 'pm', min_importance: 2, limit: 5 })`:
+  - `src/app/api/pm/decompose-initiative/route.ts:118`
+  - `src/app/api/pm/plan-initiative/route.ts:157`
+- Rerun route (`src/app/api/briefs/[id]/rerun/route.ts:43`) creates a **new brief row** with `source_ref: brief:<original_id>` (not an in-place rerun).
+- No `read_brief` MCP tool. `read.ts` has no brief-fetching tool today.
+
+## UI state
+
+- `/roadmap` ships timeline shell + recompute (separate spec — roadmap-navigation-polish).
+- `/initiatives/[id]` renders Description + Children, no Research section.
+- `/research` hub renders SuggestPickerDrawer / RunBriefDrawer / ResearchSideRail; suggestions filter by workspace only.
+- No SSE channel for brief progress. Brief detail page (`src/app/(app)/research/briefs/[id]/page.tsx`) is server-rendered.
+
+## Environment
+
+- Dev DB at `:4010`, prod at `:4001` per `project_dev_prod_db_split.md`. Validation runs against dev.
+- Default agent: `spark-lb/agent`.
+- Pending-brief queue: **must be empty before validation**; check pre-run.
+
+## Open issues / known unrelated breakage
+
+To be filled in during pre-check 01 from `yarn test` baseline. Anything failing pre-feature-branch gets listed here so we don't blame the feature for it.

--- a/specs/initiative-research-loop-validation/01-pre-check-initialization.md
+++ b/specs/initiative-research-loop-validation/01-pre-check-initialization.md
@@ -1,0 +1,84 @@
+# 01 — Pre-check initialization
+
+Destructive runbook. Run to a clean baseline before each test-plan execution. **Halt on any unexpected output.**
+
+## P0. Repo state
+
+```bash
+git status                       # clean working tree
+git rev-parse --abbrev-ref HEAD  # on feat/research-loop-5-ui (or whichever tip)
+```
+
+Expect: `working tree clean`, branch is the stack tip (slice 5).
+
+## P1. Dev DB reset + migration apply
+
+```bash
+yarn dev:stop || true            # ensure no dev server holding the DB
+yarn db:backup                   # safety net
+yarn db:reset                    # wipe dev DB
+yarn db:migrate                  # apply migrations including the slice-1 add
+```
+
+Expect: migration 0NN (whatever number slice 1 lands as) listed as applied. Failure here = halt + investigate before any agent dispatch.
+
+## P2. Confirm schema additions are live
+
+```bash
+sqlite3 $(node -e 'console.log(require("./src/lib/db/path").DATABASE_PATH)') \
+  "SELECT name FROM pragma_table_info('briefs') WHERE name IN ('initiative_id','summary');"
+sqlite3 $(node -e 'console.log(require("./src/lib/db/path").DATABASE_PATH)') \
+  "SELECT name FROM pragma_table_info('agent_notes') WHERE name IN ('source_kind','source_ref');"
+```
+
+Expect both queries to list the four new columns. If empty, migration didn't take — halt.
+
+## P3. HMR runaway guard
+
+```bash
+sqlite3 $DB_PATH "SELECT COUNT(*) FROM briefs b JOIN agent_runs r ON b.agent_run_id = r.id WHERE r.status IN ('queued','running');"
+```
+
+Expect `0`. **If non-zero**, dispatch is in progress — abort, investigate per `project_research_hmr_runaway.md`. Do not start the dev server until the queue is drained.
+
+## P4. Dev server cold start
+
+```bash
+yarn dev:start                   # background on :4010
+yarn dev:status                  # confirm pid + recent log
+```
+
+Expect: server up, no compile errors in tail of log. **A clean restart is mandatory** between any code edit to `src/lib/research/run-brief.ts`, `suggest.ts`, or any dispatcher and the first dispatch of a validation run.
+
+## P5. Targeted test slice baseline
+
+```bash
+yarn test src/lib/db/briefs.test.ts \
+          src/lib/db/agent-notes.test.ts \
+          src/lib/research/suggest.test.ts \
+          src/lib/research/run-brief.test.ts
+```
+
+Expect all green. **Pre-existing failures elsewhere in `yarn test`** get listed in `00-baseline-observations.md` and the verdict doc — never silently worked around per CLAUDE.md.
+
+## P6. Workspace + initiative seed
+
+Create a single throwaway initiative through the UI or DAO that the test plan acts on:
+
+- Title: `[VALIDATION] Theme: how to model X`
+- Description: 2 sentences, intentionally fuzzy so there's room for research to add value.
+- Status: `proposed` (or whatever the default exploratory status is).
+
+Capture the `initiative_id` to `/tmp/mc-validation/research-loop/seed.txt`. All scenarios reference it.
+
+## P7. MCP smoke
+
+```bash
+yarn mcp:smoke
+```
+
+Expect green. The new `read_brief` tool should be discoverable; the smoke run is enough to catch a broken registration.
+
+## Halt-on-failure
+
+Any halt in P0–P7 means the validation run does not start. Surface the halt to the operator with the failing command output verbatim.

--- a/specs/initiative-research-loop-validation/02-test-plan.md
+++ b/specs/initiative-research-loop-validation/02-test-plan.md
@@ -1,0 +1,119 @@
+# 02 — Test plan
+
+7 scenarios. Each is independent given pre-check 01 was run cleanly. Capture path: `/tmp/mc-validation/research-loop/<scenario_id>/`.
+
+All real-agent dispatches use `spark-lb/agent`. Time budget per scenario: ~5 min agent time.
+
+---
+
+## R-S1. Suggest scoped to initiative produces initiative-relevant candidates
+
+**Setup:** seed initiative from pre-check P6. No prior briefs.
+
+**Action:** From the initiative detail page, click **Suggest research**. (Or POST `/api/research/suggestions { initiative_id }`.)
+
+**Observation:**
+- `research_suggestions` rows appear with `payload_json.initiative_id = <seed_id>`.
+- 3–5 candidates produced.
+- The PM prompt (capture from agent transcript) contains the initiative title + description + status (not workspace-wide context).
+- Capture: full transcript → `R-S1/transcript.json`; suggestions list → `R-S1/suggestions.json`.
+
+---
+
+## R-S2. Accepted brief writes one auto-note on completion
+
+**Setup:** R-S1 completed; pick one suggestion.
+
+**Action:** Accept the suggestion from the SuggestPickerDrawer. Brief dispatches.
+
+**Observation:**
+- Brief row created with `initiative_id = <seed_id>` and `source_ref = NULL`.
+- Brief completes (`agent_runs.status = 'complete'`, `briefs.result_md` non-empty).
+- `briefs.summary` populated, ≤160 chars.
+- **Exactly one** `agent_notes` row appears with: `kind='discovery'`, `audience='pm'`, `importance=2`, `initiative_id=<seed_id>`, `source_kind='brief'`, `source_ref=<brief_id>`, `archived_at IS NULL`, body containing brief title and a ≤600-char excerpt.
+- Capture: brief row, agent_run row, agent_notes row → `R-S2/db_state.json`.
+
+---
+
+## R-S3. Rerun replaces the prior auto-note (soft-delete + insert)
+
+**Setup:** R-S2 completed.
+
+**Action:** POST `/api/briefs/<R-S2 brief_id>/rerun`. New brief row created with `source_ref='brief:<R-S2 brief_id>'`. Wait for completion.
+
+**Observation:**
+- New brief row has `initiative_id = <seed_id>`, copied from the original.
+- The R-S2 auto-note now has `archived_at` set, `archived_reason='superseded_by_rerun'`.
+- A new auto-note exists with `source_ref=<rerun brief_id>`, not archived.
+- `read_notes({ initiative_id, audience: 'pm', min_importance: 2 })` returns the rerun's note, not the archived one.
+- Capture: pre/post agent_notes snapshot → `R-S3/notes_diff.json`.
+
+---
+
+## R-S4. Decompose context loads the auto-note with no further changes
+
+**Setup:** R-S2 completed (R-S3 not required for this scenario).
+
+**Action:** From the initiative, dispatch `decompose_initiative` via the existing PM flow.
+
+**Observation:**
+- Capture the PM agent's transcript. The transcript shows `read_notes` being called with `audience: 'pm', min_importance: 2`, and the auto-note appears in the response.
+- The proposal output (in `agent_proposals` or wherever the PM writes its draft) references content from the brief — verify by grepping the proposal `impact_md` / `rationale` for a phrase from the brief's `summary`.
+- Capture: PM transcript + final proposal row → `R-S4/`.
+
+---
+
+## R-S5. Researcher fetches a prior brief's full body via `read_brief`
+
+**Setup:** R-S2 brief exists with non-trivial `result_md`.
+
+**Action:** Dispatch a second research suggestion → brief on the same initiative. The new brief's PM prompt references prior briefs by `{id, title, summary}`. Inspect the researcher's tool calls.
+
+**Observation:**
+- Researcher (or PM, depending on who's reading priors) calls `read_brief({ brief_id: <R-S2 brief_id> })` at least once.
+- Response shape matches: `{ id, title, prompt, result_md, citations, status, completed_at, initiative_id, summary }`.
+- Capture: tool call + response → `R-S5/read_brief_call.json`.
+
+If the agent doesn't naturally call `read_brief` (it's not strictly required by the prompt), this scenario falls back to a direct MCP smoke probe: invoke `read_brief` with the known id and assert the response shape. Note in results which mode was used.
+
+---
+
+## R-S6. Full UI loop end-to-end
+
+**Setup:** fresh seed initiative (pre-check rerun, or new initiative via UI).
+
+**Action:** preview-driven. From the initiative detail page:
+1. **Suggest research** → drawer opens with initiative-scoped suggestions.
+2. Accept one → brief appears in the new Research section with `running` status.
+3. Wait for completion → status flips to `complete`, citation count visible.
+4. Open notes rail → auto-note visible with "View brief" affordance.
+5. Click **Decompose with PM** → new proposal appears that references the research finding.
+
+**Observation:**
+- Each step verifiable in `preview_snapshot` / `preview_screenshot`.
+- No console errors in `preview_console_logs` across the run.
+- No 4xx/5xx in `preview_network` for `/api/briefs`, `/api/research/suggestions`, `/api/pm/decompose-initiative`.
+- Capture: screenshots per step → `R-S6/step-N.png`; final notes rail → `R-S6/notes-rail.png`.
+
+---
+
+## R-S7. Decompose proposal demonstrably uses the research finding
+
+**Setup:** R-S6 completed through step 5.
+
+**Action:** Inspect the resulting proposal.
+
+**Observation:**
+- Proposal `impact_md` / `rationale` quotes or paraphrases something specific from the brief's `result_md` — not just generic boilerplate.
+- This is the qualitative gate: a human (or this agent) reads the proposal and confirms the research changed the output. Subjective but the most important gate.
+- Capture: proposal row + brief `result_md` → `R-S7/comparison.md` with the specific phrase callouts.
+
+---
+
+## Capture conventions
+
+- All scenario directories under `/tmp/mc-validation/research-loop/`.
+- `db_state.json` files use `sqlite3 -json` output.
+- Transcripts are the raw `agent_runs.transcript_md` or equivalent.
+- Screenshots are PNG from `preview_screenshot`.
+- Each scenario folder has a `notes.md` for any anomalies observed during the run.

--- a/specs/initiative-research-loop-validation/03-validation-criteria.md
+++ b/specs/initiative-research-loop-validation/03-validation-criteria.md
@@ -1,0 +1,72 @@
+# 03 — Validation criteria
+
+Pass/fail gates per scenario (AND-ed within a scenario). Plus global gates that apply across the whole run. A milestone passes only if **all** gates pass.
+
+`FLAKE` policy: re-run the affected scenario 3×, pass if ≥ 2/3 succeed. Flake is logged in the verdict.
+
+## Per-scenario gates
+
+### R-S1 — Suggest scoped to initiative
+
+- [ ] G1.1 `research_suggestions` rows have `payload_json.initiative_id = <seed_id>`.
+- [ ] G1.2 3–5 candidates produced (not 0, not >5).
+- [ ] G1.3 PM prompt contains the seed initiative's title and at least one phrase from its description.
+- [ ] G1.4 PM prompt does **not** contain workspace-wide context blocks (other initiatives, blocked tasks at workspace scope).
+
+### R-S2 — Auto-note on completion
+
+- [ ] G2.1 Brief row has `initiative_id = <seed_id>`, `summary` non-empty and ≤160 chars.
+- [ ] G2.2 Exactly one agent_notes row matches `(initiative_id=<seed_id>, source_kind='brief', source_ref=<brief_id>)`.
+- [ ] G2.3 Auto-note has `kind='discovery'`, `audience='pm'`, `importance=2`, `archived_at IS NULL`.
+- [ ] G2.4 Auto-note `body` contains the brief title and an excerpt of `result_md` no longer than 600 chars (excluding the title + link footer).
+- [ ] G2.5 No auto-note is written for any other initiative.
+
+### R-S3 — Rerun replace
+
+- [ ] G3.1 New brief row has `initiative_id = <seed_id>`, `source_ref='brief:<original_id>'`.
+- [ ] G3.2 Original auto-note is now `archived_at` non-null with `archived_reason='superseded_by_rerun'`.
+- [ ] G3.3 A new auto-note exists for the rerun, not archived.
+- [ ] G3.4 `read_notes({initiative_id, audience:'pm', min_importance:2})` returns the rerun's note, not the archived one.
+- [ ] G3.5 Total non-archived auto-notes for this initiative = 1.
+
+### R-S4 — Decompose context loads auto-note
+
+- [ ] G4.1 PM transcript shows a `read_notes` call with `min_importance:2, audience:'pm'`.
+- [ ] G4.2 Response to that call includes the auto-note body.
+- [ ] G4.3 Final proposal row exists.
+- [ ] G4.4 Proposal `impact_md` or `rationale` contains a phrase traceable to the brief's `summary` or first 200 chars of `result_md`. (Substring match, case-insensitive, ≥6 consecutive words.)
+
+### R-S5 — `read_brief` discoverability + shape
+
+- [ ] G5.1 If invoked by an agent: tool call captured with correct `brief_id`. Else direct MCP probe used and noted.
+- [ ] G5.2 Response includes all keys: `id, title, prompt, result_md, citations, status, completed_at, initiative_id, summary`.
+- [ ] G5.3 No `null` for `result_md` (the brief is complete).
+
+### R-S6 — Full UI loop
+
+- [ ] G6.1 Preview screenshots captured for steps 1–5; each shows the expected state.
+- [ ] G6.2 No errors in `preview_console_logs` across the run.
+- [ ] G6.3 No 4xx/5xx in `preview_network` for the listed endpoints.
+- [ ] G6.4 Notes rail renders the auto-note with a working "View brief" link.
+
+### R-S7 — Proposal references research (qualitative)
+
+- [ ] G7.1 Reviewer (this agent) writes a 1–2 sentence claim in the comparison.md identifying which phrase in the proposal traces back to the brief.
+- [ ] G7.2 The traceable phrase is concrete (a fact, a number, a named pattern), not generic ("we should research more" doesn't count).
+
+## Global gates
+
+- [ ] GG.1 Every slice's per-PR test slice (`yarn test <files>`) is green at the stack tip.
+- [ ] GG.2 `yarn mcp:smoke` is green at the stack tip.
+- [ ] GG.3 `yarn typecheck` (or whatever the project uses — `yarn build` if no separate typecheck) is green.
+- [ ] GG.4 No new entries in dev server log matching `/error|unhandled|EADDR|ECONNREFUSED/i` introduced during the run.
+- [ ] GG.5 Pending-brief queue is empty at the end of the run (no orphan dispatches still in flight).
+- [ ] GG.6 No more than 1 brief was dispatched per scenario (HMR runaway smoke).
+- [ ] GG.7 Pre-existing test failures, if any, are listed verbatim in the verdict doc per CLAUDE.md.
+
+## Verdict mapping
+
+- **GREEN** — all per-scenario gates + all global gates pass. Ready to merge.
+- **YELLOW** — global gates pass; one or more scenario gates fail but the failure is well-understood and documented. Operator decides.
+- **BLOCKED** — pre-check 01 halted; validation didn't run.
+- **RED** — global gate failure, or scenario failure that points to a wrong design call. Stop, surface, do not merge.

--- a/specs/initiative-research-loop-validation/04-e2e-run-results.md
+++ b/specs/initiative-research-loop-validation/04-e2e-run-results.md
@@ -1,0 +1,49 @@
+# 04 — E2E run results
+
+> Written during/after the validation run. Single document the operator reads to decide "ship it."
+
+## Verdict
+
+_pending — to be filled in after the run_
+
+One of: **GREEN** / **YELLOW** / **BLOCKED** / **RED** (per `03-validation-criteria.md`).
+
+One-paragraph summary: what passed, what failed, and what the operator should do next.
+
+## Per-scenario results
+
+| ID | Scenario | Result | Evidence |
+|---|---|---|---|
+| R-S1 | Suggest scoped to initiative | _pending_ | `/tmp/mc-validation/research-loop/R-S1/` |
+| R-S2 | Auto-note on completion | _pending_ | `R-S2/` |
+| R-S3 | Rerun replace | _pending_ | `R-S3/` |
+| R-S4 | Decompose context loads auto-note | _pending_ | `R-S4/` |
+| R-S5 | `read_brief` discoverability | _pending_ | `R-S5/` |
+| R-S6 | Full UI loop | _pending_ | `R-S6/` |
+| R-S7 | Proposal references research | _pending_ | `R-S7/` |
+
+## Global gates
+
+| ID | Gate | Result | Note |
+|---|---|---|---|
+| GG.1 | per-PR test slices green | _pending_ | |
+| GG.2 | `yarn mcp:smoke` | _pending_ | |
+| GG.3 | typecheck / build | _pending_ | |
+| GG.4 | no new error log entries | _pending_ | |
+| GG.5 | queue empty at end | _pending_ | |
+| GG.6 | ≤ 1 dispatch per scenario | _pending_ | |
+| GG.7 | pre-existing failures listed | _pending_ | |
+
+## Pre-existing test failures (if any)
+
+_To be filled in from `yarn test` baseline. File + reason. Per CLAUDE.md, listed not silenced._
+
+## Anomalies / flakes
+
+_Per scenario, any retries or unexpected observations._
+
+## Next steps
+
+_If GREEN: merge order per `feedback_stacked_pr_merges.md`._
+_If YELLOW: itemized list of accepted defects + follow-up tickets._
+_If RED/BLOCKED: what to fix before re-running._

--- a/specs/initiative-research-loop-validation/README.md
+++ b/specs/initiative-research-loop-validation/README.md
@@ -1,0 +1,13 @@
+# Initiative Research Loop — Validation
+
+Per [specs/long-unattended-feature-dev.md](../long-unattended-feature-dev.md). Run order:
+
+1. [00-baseline-observations.md](00-baseline-observations.md) — captured before any slice merges.
+2. [01-pre-check-initialization.md](01-pre-check-initialization.md) — destructive runbook to reach known-good baseline before each test-plan execution.
+3. [02-test-plan.md](02-test-plan.md) — the 7 scenarios.
+4. [03-validation-criteria.md](03-validation-criteria.md) — pass/fail gates.
+5. [04-e2e-run-results.md](04-e2e-run-results.md) — verdict + evidence; written during/after the run.
+
+All real-agent dispatches use `spark-lb/agent` per `project_openclaw_model.md` memory. Capture path for transcripts: `/tmp/mc-validation/research-loop/<scenario_id>/`.
+
+**HMR runaway guard** (per `project_research_hmr_runaway.md`): pre-check 01 verifies the pending-brief queue is empty and the dev server has been cleanly restarted since the last dispatch-code edit. Abort-if-not.

--- a/specs/initiative-research-loop.md
+++ b/specs/initiative-research-loop.md
@@ -1,0 +1,194 @@
+# Initiative Research Loop — Spec (Draft)
+
+Couple the existing PM brief/topic research system to initiatives so an operator can iterate **research → refine → research → decompose** against a single high-level goal, with each round feeding the next round's context.
+
+## Operator intent
+
+> "I have a theme. Help me figure out what we should actually do — research the space, refine the framing as we learn, then break it into milestones."
+
+The loop is operator-driven, not autonomous. Each step produces evidence the operator reviews; the operator decides whether to run another brief, refine the description, or move to decompose.
+
+## Why on top of briefs (not autopilot)
+
+Decided in conversation 2026-05-09. Briefs already have: citations with snippets, markdown output that flows through the notes rail, topic grouping, rerun, recurring schedules, gateway retry resilience. Autopilot is product-scoped, JSON-sectioned, swipe-ranked — wrong shape for arbitrary initiatives. See [research-area.md](research-area.md) for the brief/topic substrate.
+
+## The loop
+
+```
+                ┌──────────────────────────────────────┐
+                │  Initiative (theme)                  │
+                │  description + existing notes        │
+                └──────────────────────────────────────┘
+                                 │
+                                 ▼
+                  ┌──────────────────────────┐
+                  │ Suggest research          │  PM agent reads initiative
+                  │ (operator-triggered)      │  + prior briefs + notes,
+                  └──────────────────────────┘  proposes 3–5 candidate briefs
+                                 │
+                                 ▼
+                  ┌──────────────────────────┐
+                  │ Operator picks / edits   │
+                  └──────────────────────────┘
+                                 │
+                                 ▼
+                  ┌──────────────────────────┐
+                  │ Brief executes           │  researcher dispatch
+                  │ initiative_id = <X>      │  → result_md + citations
+                  └──────────────────────────┘
+                                 │
+                                 ▼
+                  ┌──────────────────────────┐
+                  │ Auto-note on initiative  │  kind: 'discovery'
+                  │ (link + excerpt)         │  body: brief title +
+                  └──────────────────────────┘  result excerpt
+                                 │
+                                 ▼
+              ┌─────────────────────────────────────┐
+              │ Operator reviews. Three exits:      │
+              │  (a) refine description, then loop  │
+              │  (b) suggest more research, loop    │
+              │  (c) Decompose with PM              │
+              └─────────────────────────────────────┘
+```
+
+`refine` and `decompose` already pull `agent_notes` for the initiative (`min_importance: 2, limit: 5, audience: 'pm'`). Auto-noting brief completions means the loop closes without touching those endpoints.
+
+## Architecture
+
+### DB changes (one migration)
+
+```ts
+// migrations.ts — new migration
+ALTER TABLE briefs ADD COLUMN initiative_id TEXT
+  REFERENCES initiatives(id) ON DELETE SET NULL;
+ALTER TABLE briefs ADD COLUMN summary TEXT;  -- one-liner for index views
+CREATE INDEX briefs_initiative_id_idx ON briefs(initiative_id);
+```
+
+`summary` is populated at completion time from the first sentence of `result_md` (max 160 chars). It feeds the suggest prompt's prior-briefs index and the Research section list view.
+
+`topics.linked_initiatives` (already in the research-area spec, may not be implemented yet) stays optional and orthogonal — a topic *can* span initiatives. The brief is the per-initiative unit.
+
+No changes to `agent_notes` schema. We use `kind: 'discovery'` with structured body.
+
+### Suggest endpoint extension
+
+`src/lib/research/suggest.ts:154` (`buildSuggestPrompt`) already gathers workspace context. Add optional `initiative_id` scoping:
+
+```ts
+// suggest.ts
+export type SuggestOptions = {
+  workspaceId: string;
+  initiativeId?: string;  // NEW
+  // ...existing
+};
+```
+
+When `initiativeId` is set:
+- Replace workspace-wide context block with **initiative-scoped** context: initiative title/description/status, parent chain, recent agent_notes (`audience: 'pm', limit: 10`), and a **lightweight index** of prior briefs where `initiative_id = ?` — just `{ id, title, summary }` per brief, not the full body. The PM can call `read_brief({ brief_id })` (see "New MCP tool" below) to pull a full prior brief if it looks relevant.
+- Prompt instructs PM to propose briefs that *advance this specific initiative* — fill gaps in current understanding, validate assumptions in the description, surface unknowns blocking decomposition.
+- Generated `research_suggestions` rows carry `payload_json.initiative_id` so accept-flow knows to set it on the brief.
+
+API: extend `POST /api/research/suggestions` to accept `{ initiative_id?: string }`. List/filter endpoints get an `initiative_id` query param.
+
+### Brief dispatch carries initiative_id
+
+`src/lib/research/run-brief.ts` — `createBriefWithRun()` accepts `initiative_id` and persists it on the brief row. No change to the agent prompt itself; the initiative context shows up via the brief's own `prompt` field, which the suggest step composed.
+
+### Auto-note on brief completion
+
+Where briefs transition to `complete` (run-brief.ts around line 290–340 in the completion handler), if `brief.initiative_id` is non-null, write an `agent_notes` row:
+
+```ts
+{
+  initiative_id: brief.initiative_id,
+  kind: 'discovery',
+  audience: 'pm',
+  importance: 2,                    // visible to refine/decompose default filter
+  body_md: `**Research: ${brief.title}**\n\n${excerpt(brief.result_md, 600)}\n\n[Full brief](${briefUrl})`,
+  source: { type: 'brief', id: brief.id },
+  created_at: now,
+}
+```
+
+Notes:
+- `importance: 2` is the threshold `decompose_initiative` uses (`min_importance: 2`). Anything lower wouldn't appear in the context.
+- Excerpt is the first ~600 chars of `result_md`, not the full body — full body stays one click away. Refine/decompose contexts have token budgets; we don't want a single brief to crowd them out.
+- `source` block lets the notes rail render a "View brief" affordance and lets us dedupe if the brief is rerun.
+
+### Brief rerun semantics
+
+If a brief is rerun (`POST /api/briefs/[id]/rerun`), the new run *replaces* the prior auto-note rather than stacking. Find by `source.type='brief' AND source.id=<brief_id>` and update in place, or soft-delete the old and insert the new. **Open question:** soft-delete + new = preserves history in notes rail; in-place update = cleaner UI. Default to in-place; revisit if operators want to compare runs.
+
+### UI surface
+
+Initiative detail page (`src/components/InitiativeDetailView.tsx`) gets a new section between **Description** and **Children**:
+
+**Research** section
+- List of briefs where `initiative_id = <this>` ordered by `created_at desc`.
+- Each row: title, status badge, completion date, citation count, "View" link.
+- Header buttons:
+  - **Suggest research** → calls `POST /api/research/suggestions { initiative_id }`. Returns to a modal/drawer where operator multi-selects suggestions, edits prompts, accepts.
+  - **New brief** → free-form prompt entry, dispatches directly with `initiative_id` set.
+- In-progress briefs render with the same progress signal as `/research` hub (subscribe to brief_progress events).
+
+The notes rail keeps showing the auto-notes alongside other discoveries. The Research section is the canonical view; the rail is the synthesis surface that `refine`/`decompose` see.
+
+### Suggest UX inside initiative
+
+Reuse the existing suggestions queue UI (`/research` hub) but filter to `initiative_id = <this>`. Suggestions for an initiative don't pollute the workspace-wide suggestions feed — they're scoped.
+
+## Lift from autopilot (deferred, not in this spec)
+
+Two ideas worth lifting later, neither required for the loop to work:
+
+1. **Phase tracking with heartbeat** on briefs (autopilot's `current_phase` + `last_heartbeat` pattern from `research_cycles`). Briefs currently lean on `agent_runs.status`; for long iterative loops a finer-grained phase column gives better UI feedback. **Defer until** operators complain about "running for 4 minutes" being opaque.
+2. **Cost/token tracking per brief** (autopilot calls `recordCostEvent` per cycle). A research → refine → research cycle could quietly burn budget. **Defer until** there's a cost concern; track it as a row-level addition to `briefs` when the time comes.
+
+Neither blocks v1.
+
+## Migration & rollout
+
+1. **Migration** — add `briefs.initiative_id` column + index. Backfill is a no-op (existing briefs stay null).
+2. **Suggest extension** — `initiativeId` is optional; existing workspace-scoped suggest path is unchanged. Behind no flag.
+3. **Auto-note on completion** — only fires when `initiative_id` is non-null, so no impact on existing one-shot briefs.
+4. **UI section** — new component, no existing surface modified.
+
+No flag needed; net-additive everywhere except the suggest prompt builder, which has a clean branch on `initiativeId`.
+
+## Test plan
+
+- **Unit / integration**
+  - `suggest.ts` with `initiativeId` produces prompt with initiative-scoped context block; without it falls back to workspace context.
+  - Brief completion writes one `agent_notes` row with `kind: 'discovery'`, `importance: 2`, `source.type='brief'`, when and only when `initiative_id` is set.
+  - Brief rerun replaces (not duplicates) the prior auto-note.
+  - `decompose_initiative` and `refine` context loads include the auto-note (verify via `read_notes` in their existing flows — should require zero changes).
+- **Preview-verify**
+  - Create a theme initiative with a 2-sentence description.
+  - Click **Suggest research** → 3–5 candidates appear scoped to the initiative.
+  - Accept one → brief runs → completion writes a note visible in notes rail.
+  - Run **Decompose with PM** → confirm proposal `impact_md` references the research finding.
+- **MCP smoke** — `yarn mcp:smoke` should pass; no MCP tool surface changes in v1.
+
+## Out of scope (named for clarity)
+
+- Workspace seeding from autopilot ideation — captured in conversation 2026-05-09, deferred.
+- A "research watch" auto-loop that fires briefs on its own when an initiative changes status — interesting but the operator-driven loop ships first.
+- Replacing autopilot's product-scoped research with the brief system — eventual direction, not part of this work.
+- Hierarchical context (rolling up child-initiative briefs into a parent's refine context) — solvable later via the same `read_notes` channel; out for v1.
+
+## Resolved decisions (from review)
+
+1. **Auto-note importance** — `2`. Matches `decompose_initiative`'s default filter so research lands in context without crowding higher-priority signals. Revisit after dogfood.
+2. **Auto-note `audience`** — `'pm'`. Single audience; the rail already renders PM-audience notes for human review.
+3. **Prior briefs in suggest context** — pass **only** `{ id, title, one_line_summary }` per prior brief, not the result_md. The PM (and the researcher it dispatches) can pull the full body via a new MCP tool when relevant. Keeps the suggest prompt small and lets the researcher decide which prior briefs are worth fetching.
+4. **Brief deletion ↔ auto-note** — no DB cascade. When a brief with `initiative_id` is deleted, surface a follow-up UI prompt: "This brief has 1 note attached to <Initiative>. Delete the note too?" Operator decides per-case. Defer implementation until briefs are deletable from the UI.
+
+## New MCP tool (researchers + PM)
+
+`read_brief({ brief_id })` — returns `{ id, title, prompt, result_md, citations, status, completed_at, initiative_id }`.
+
+Belongs in the `research` MCP group (or `core` if there isn't one yet — check `src/lib/mcp/groups/`). Available to any role; primary callers are `researcher` (when investigating an initiative with prior briefs) and `pm` (during refine/decompose if a brief excerpt in a note isn't enough).
+
+The `one_line_summary` field used in suggest context comes from the existing `briefs.title` plus a new `briefs.summary` column populated at completion time — first sentence of `result_md` or an LLM-generated 1-liner. Open: which generation strategy. Defaulting to "first sentence, max 160 chars" for v1; LLM-summarize if that proves noisy.

--- a/src/app/api/research/suggestions/route.ts
+++ b/src/app/api/research/suggestions/route.ts
@@ -15,6 +15,10 @@ const ALLOWED_STATUSES: SuggestionStatus[] = ['pending', 'accepted', 'rejected',
 const PostSchema = z.object({
   workspace_id: z.string().min(1),
   kind: z.enum(['topic', 'brief']),
+  /** When set, scope the dispatch to a specific initiative — the PM
+   *  gets initiative-scoped context and brief suggestions carry
+   *  `payload.initiative_id`. */
+  initiative_id: z.string().min(1).optional(),
 });
 
 /**
@@ -36,9 +40,11 @@ export async function GET(request: NextRequest) {
     if (statusParam && !ALLOWED_STATUSES.includes(statusParam as SuggestionStatus)) {
       return NextResponse.json({ error: `status must be one of: ${ALLOWED_STATUSES.join(', ')}` }, { status: 400 });
     }
+    const initiativeIdParam = searchParams.get('initiative_id') || undefined;
     return NextResponse.json(listSuggestions(workspaceId, {
       kind: (kindParam as SuggestionKind | null) ?? undefined,
       status: statusParam as SuggestionStatus,
+      initiative_id: initiativeIdParam,
     }));
   } catch (error) {
     console.error('Failed to list research_suggestions:', error);
@@ -65,6 +71,7 @@ export async function POST(request: NextRequest) {
     const result = await generateSuggestions({
       workspace_id: parsed.data.workspace_id,
       kind: parsed.data.kind,
+      initiative_id: parsed.data.initiative_id,
     });
     if (result.state === 'rejected') {
       return NextResponse.json(

--- a/src/lib/db/agent-notes.test.ts
+++ b/src/lib/db/agent-notes.test.ts
@@ -338,3 +338,38 @@ test('listNotes: workspace deletion cascades agent_notes (FK)', () => {
   );
   assert.equal(after?.n, 0);
 });
+
+test('createNote: persists source_kind / source_ref and findNotesBySource scopes by archived_at', async () => {
+  const { findNotesBySource, archiveNote } = await import('./agent-notes');
+  const ws = freshWorkspace();
+  const briefId = `brief-${uuidv4().slice(0, 8)}`;
+
+  const a = createNote(
+    baseInput(ws, {
+      body: 'auto-note from brief A',
+      source_kind: 'brief',
+      source_ref: briefId,
+    }),
+  );
+  assert.equal(a.source_kind, 'brief');
+  assert.equal(a.source_ref, briefId);
+
+  // A second note with a different source_ref is not picked up.
+  createNote(baseInput(ws, { body: 'unrelated', source_kind: 'brief', source_ref: 'other-brief' }));
+
+  const found = findNotesBySource('brief', briefId);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].id, a.id);
+
+  // Archived notes are excluded by default and included on opt-in.
+  archiveNote(a.id, 'superseded_by_rerun');
+  assert.equal(findNotesBySource('brief', briefId).length, 0);
+  assert.equal(findNotesBySource('brief', briefId, { include_archived: true }).length, 1);
+});
+
+test('createNote: source_kind / source_ref default to null', () => {
+  const ws = freshWorkspace();
+  const note = createNote(baseInput(ws, { body: 'no source' }));
+  assert.equal(note.source_kind, null);
+  assert.equal(note.source_ref, null);
+});

--- a/src/lib/db/agent-notes.ts
+++ b/src/lib/db/agent-notes.ts
@@ -81,6 +81,11 @@ export interface AgentNote {
    *  from this note via the Ask-PM-from-notes flow. Multiple ids are
    *  possible because the operator can re-ask on the same note. */
   pm_proposal_ids: string | null;
+  /** Upstream entity that produced this note. E.g. {kind:'brief', ref:<id>}
+   *  for auto-notes written when an initiative-scoped brief completes.
+   *  See specs/initiative-research-loop-build-plan.md §D2. */
+  source_kind: string | null;
+  source_ref: string | null;
 }
 
 /** Maximum body length per note. Sized to fit a full multi-section
@@ -105,6 +110,11 @@ export interface CreateNoteInput {
   body: string;
   attached_files?: ReadonlyArray<string> | null;
   importance?: NoteImportance;
+  /** Optional upstream entity producing this note. Both fields must be
+   *  set together or both null. Used by `findNoteBySource` for dedupe
+   *  paths (e.g. brief-rerun replaces prior auto-note). */
+  source_kind?: string | null;
+  source_ref?: string | null;
 }
 
 export class AgentNoteValidationError extends Error {
@@ -146,8 +156,9 @@ export function createNote(input: CreateNoteInput): AgentNote {
        id, workspace_id, agent_id, task_id, initiative_id,
        scope_key, role, run_group_id, kind, audience, body,
        attached_files, importance, consumed_by_stages,
-       archived_at, archived_reason, created_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, datetime('now'))`,
+       archived_at, archived_reason, created_at,
+       source_kind, source_ref
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, datetime('now'), ?, ?)`,
     [
       id,
       input.workspace_id,
@@ -162,6 +173,8 @@ export function createNote(input: CreateNoteInput): AgentNote {
       input.body,
       attachedJson,
       importance,
+      input.source_kind ?? null,
+      input.source_ref ?? null,
     ],
   );
 
@@ -277,6 +290,29 @@ export function listNotes(filter: ListNotesFilter): AgentNote[] {
 
 export function getNote(noteId: string): AgentNote | null {
   return queryOne<AgentNote>(`SELECT * FROM agent_notes WHERE id = ?`, [noteId]) ?? null;
+}
+
+/**
+ * Look up notes by their upstream source. Returns non-archived rows
+ * by default (set `include_archived` to fetch the full history). Used
+ * by the brief-rerun auto-note path: when a rerun completes, find the
+ * non-archived auto-note for the chain root and soft-delete it before
+ * inserting the new one.
+ */
+export function findNotesBySource(
+  source_kind: string,
+  source_ref: string,
+  opts: { include_archived?: boolean } = {},
+): AgentNote[] {
+  const where: string[] = ['source_kind = ?', 'source_ref = ?'];
+  const args: unknown[] = [source_kind, source_ref];
+  if (!opts.include_archived) {
+    where.push('archived_at IS NULL');
+  }
+  return queryAll<AgentNote>(
+    `SELECT * FROM agent_notes WHERE ${where.join(' AND ')} ORDER BY created_at ASC`,
+    args,
+  );
 }
 
 // ─── Mutate ─────────────────────────────────────────────────────────

--- a/src/lib/db/briefs.test.ts
+++ b/src/lib/db/briefs.test.ts
@@ -245,3 +245,56 @@ test('deleteBrief: returns false for unknown id', async () => {
   const { deleteBrief } = await import('./briefs');
   assert.equal(deleteBrief('does-not-exist'), false);
 });
+
+test('createBriefWithRun: persists initiative_id when provided', async () => {
+  const { findBriefChainRoot, setBriefSummary } = await import('./briefs');
+  const ws = freshWorkspace();
+  // Seed an initiative in this workspace.
+  const initId = `init-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT INTO initiatives (id, workspace_id, kind, title, status, sort_order, created_at, updated_at)
+     VALUES (?, ?, 'theme', 'Test theme', 'planned', 0, datetime('now'), datetime('now'))`,
+    [initId, ws],
+  );
+
+  const { brief } = createBriefWithRun(baseInput(ws, { initiative_id: initId }));
+  assert.equal(brief.initiative_id, initId);
+  assert.equal(brief.summary, null);
+  assert.equal(brief.source_ref, null);
+
+  // Round-trip through getBrief.
+  assert.equal(getBrief(brief.id)?.initiative_id, initId);
+
+  // setBriefSummary persists.
+  const updated = setBriefSummary(brief.id, 'WebGPU is broadly supported.');
+  assert.equal(updated?.summary, 'WebGPU is broadly supported.');
+
+  // Listing by initiative finds it.
+  const byInit = listBriefs(ws, { initiative_id: initId });
+  assert.equal(byInit.length, 1);
+  assert.equal(byInit[0].id, brief.id);
+
+  // Initiative-less briefs don't bleed into the filtered list.
+  const { brief: other } = createBriefWithRun(baseInput(ws));
+  assert.equal(other.initiative_id, null);
+  assert.equal(listBriefs(ws, { initiative_id: initId }).length, 1);
+
+  // ON DELETE SET NULL: deleting the initiative nulls out the FK.
+  run(`DELETE FROM initiatives WHERE id = ?`, [initId]);
+  assert.equal(getBrief(brief.id)?.initiative_id, null);
+
+  // Chain root walk: a brief with no source_ref returns itself.
+  assert.equal(findBriefChainRoot(brief.id), brief.id);
+});
+
+test('findBriefChainRoot: walks source_ref chain back to the original', async () => {
+  const { findBriefChainRoot } = await import('./briefs');
+  const ws = freshWorkspace();
+  const original = createBriefWithRun(baseInput(ws));
+  const rerun1 = createBriefWithRun(baseInput(ws, { source_ref: `brief:${original.brief.id}` }));
+  const rerun2 = createBriefWithRun(baseInput(ws, { source_ref: `brief:${rerun1.brief.id}` }));
+
+  assert.equal(findBriefChainRoot(rerun2.brief.id), original.brief.id);
+  assert.equal(findBriefChainRoot(rerun1.brief.id), original.brief.id);
+  assert.equal(findBriefChainRoot(original.brief.id), original.brief.id);
+});

--- a/src/lib/db/briefs.ts
+++ b/src/lib/db/briefs.ts
@@ -37,6 +37,7 @@ export interface Brief {
   workspace_id: string;
   agent_run_id: string;
   topic_id: string | null;
+  initiative_id: string | null;
   template: BriefTemplate;
   title: string;
   prompt: string;
@@ -44,6 +45,8 @@ export interface Brief {
   result_md: string | null;
   citations: BriefCitation[];
   error_md: string | null;
+  summary: string | null;
+  source_ref: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -53,13 +56,16 @@ interface BriefRow {
   workspace_id: string;
   agent_run_id: string;
   topic_id: string | null;
+  initiative_id: string | null;
   template: BriefTemplate;
   title: string;
   prompt: string;
   requested_by: string;
+  source_ref: string | null;
   result_md: string | null;
   citations_json: string | null;
   error_md: string | null;
+  summary: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -88,6 +94,7 @@ function rowToBrief(row: BriefRow): Brief {
     workspace_id: row.workspace_id,
     agent_run_id: row.agent_run_id,
     topic_id: row.topic_id,
+    initiative_id: row.initiative_id,
     template: row.template,
     title: row.title,
     prompt: row.prompt,
@@ -95,6 +102,8 @@ function rowToBrief(row: BriefRow): Brief {
     result_md: row.result_md,
     citations: parseCitations(row.citations_json),
     error_md: row.error_md,
+    summary: row.summary,
+    source_ref: row.source_ref,
     created_at: row.created_at,
     updated_at: row.updated_at,
   };
@@ -106,6 +115,7 @@ export interface CreateBriefInput {
   title: string;
   prompt: string;
   topic_id?: string | null;
+  initiative_id?: string | null;
   requested_by?: string;
   source_kind?: AgentRunSourceKind;
   source_ref?: string | null;
@@ -154,18 +164,20 @@ export function createBriefWithRun(input: CreateBriefInput): CreateBriefResult {
     const id = uuidv4();
     run(
       `INSERT INTO briefs (
-         id, workspace_id, agent_run_id, topic_id, template,
-         title, prompt, requested_by, created_at, updated_at
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+         id, workspace_id, agent_run_id, topic_id, initiative_id, template,
+         title, prompt, requested_by, source_ref, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
       [
         id,
         input.workspace_id,
         agent_run.id,
         input.topic_id ?? null,
+        input.initiative_id ?? null,
         input.template,
         input.title.trim(),
         input.prompt,
         input.requested_by ?? 'manual',
+        input.source_ref ?? null,
       ],
     );
     const row = queryOne<BriefRow>(`SELECT * FROM briefs WHERE id = ?`, [id]);
@@ -186,6 +198,7 @@ export function getBriefByAgentRun(agentRunId: string): Brief | null {
 
 export interface ListBriefsOptions {
   topic_id?: string;
+  initiative_id?: string;
   limit?: number;
 }
 
@@ -195,6 +208,10 @@ export function listBriefs(workspaceId: string, opts: ListBriefsOptions = {}): B
   if (opts.topic_id) {
     where.push('topic_id = ?');
     params.push(opts.topic_id);
+  }
+  if (opts.initiative_id) {
+    where.push('initiative_id = ?');
+    params.push(opts.initiative_id);
   }
   const limit = Math.min(opts.limit ?? 100, 500);
   const rows = queryAll<BriefRow>(
@@ -258,4 +275,48 @@ export function setBriefError(id: string, errorMd: string): Brief | null {
     [errorMd, id],
   );
   return getBrief(id);
+}
+
+/**
+ * Persist the one-line `summary` for a brief. Computed at completion
+ * time (slice 3 — see specs/initiative-research-loop-build-plan.md D1)
+ * from the first sentence of `result_md`, capped at 160 chars.
+ */
+export function setBriefSummary(id: string, summary: string): Brief | null {
+  const current = getBrief(id);
+  if (!current) return null;
+  run(
+    `UPDATE briefs SET summary = ?, updated_at = datetime('now') WHERE id = ?`,
+    [summary, id],
+  );
+  return getBrief(id);
+}
+
+/**
+ * Walk `briefs.source_ref` (`brief:<id>`) backwards to the chain root
+ * — the original brief that hasn't itself been re-run. Used by the
+ * auto-note rerun-replace path so we soft-delete the prior auto-note
+ * regardless of how many reruns deep we are.
+ *
+ * Cycle-safe via a 32-step ceiling — that's more reruns than will ever
+ * realistically happen on a single brief; if we hit the ceiling we
+ * just return the latest seen id rather than loop forever.
+ */
+export function findBriefChainRoot(id: string): string {
+  const SEEN_LIMIT = 32;
+  const seen = new Set<string>();
+  let cursor = id;
+  for (let i = 0; i < SEEN_LIMIT; i++) {
+    if (seen.has(cursor)) return cursor;
+    seen.add(cursor);
+    const row = queryOne<{ source_ref: string | null }>(
+      `SELECT source_ref FROM briefs WHERE id = ?`,
+      [cursor],
+    );
+    if (!row || !row.source_ref) return cursor;
+    const m = /^brief:(.+)$/.exec(row.source_ref);
+    if (!m) return cursor;
+    cursor = m[1];
+  }
+  return cursor;
 }

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4610,6 +4610,51 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    id: '089',
+    name: 'initiative_research_loop',
+    up: (db) => {
+      // Substrate for the initiative research loop (specs/initiative-research-loop.md):
+      //   - briefs.initiative_id: lets a brief belong to an initiative so refine/decompose
+      //     pull its result into context via the existing read_notes channel.
+      //   - briefs.summary: one-liner populated at completion time, used in the suggest
+      //     prompt's "prior briefs" index so the PM doesn't have to re-read each body.
+      //   - agent_notes.source_kind / source_ref: track the upstream entity that produced
+      //     a note (e.g. {brief, <id>}) so a brief rerun can soft-archive its prior auto-note
+      //     instead of stacking duplicates. Indexed for the rerun lookup path.
+      // All columns are nullable; existing rows are unaffected.
+
+      const briefCols = db.prepare(`PRAGMA table_info(briefs)`).all() as Array<{ name: string }>;
+      if (!briefCols.some((c) => c.name === 'initiative_id')) {
+        db.exec(`ALTER TABLE briefs ADD COLUMN initiative_id TEXT REFERENCES initiatives(id) ON DELETE SET NULL`);
+        console.log('[Migration 089] briefs.initiative_id added.');
+      }
+      if (!briefCols.some((c) => c.name === 'summary')) {
+        db.exec(`ALTER TABLE briefs ADD COLUMN summary TEXT`);
+        console.log('[Migration 089] briefs.summary added.');
+      }
+      // source_ref denormalized onto briefs so chain-walk during a rerun
+      // is a single-table lookup instead of a join through agent_runs.
+      // Format: "brief:<original_id>". Stored on the corresponding
+      // agent_run.source_ref too — that column was the previous home.
+      if (!briefCols.some((c) => c.name === 'source_ref')) {
+        db.exec(`ALTER TABLE briefs ADD COLUMN source_ref TEXT`);
+        console.log('[Migration 089] briefs.source_ref added.');
+      }
+      db.exec(`CREATE INDEX IF NOT EXISTS briefs_initiative_id_idx ON briefs(initiative_id) WHERE initiative_id IS NOT NULL`);
+
+      const noteCols = db.prepare(`PRAGMA table_info(agent_notes)`).all() as Array<{ name: string }>;
+      if (!noteCols.some((c) => c.name === 'source_kind')) {
+        db.exec(`ALTER TABLE agent_notes ADD COLUMN source_kind TEXT`);
+        console.log('[Migration 089] agent_notes.source_kind added.');
+      }
+      if (!noteCols.some((c) => c.name === 'source_ref')) {
+        db.exec(`ALTER TABLE agent_notes ADD COLUMN source_ref TEXT`);
+        console.log('[Migration 089] agent_notes.source_ref added.');
+      }
+      db.exec(`CREATE INDEX IF NOT EXISTS agent_notes_source_idx ON agent_notes(source_kind, source_ref) WHERE source_kind IS NOT NULL`);
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/research-suggestions.ts
+++ b/src/lib/db/research-suggestions.ts
@@ -31,6 +31,9 @@ export interface BriefSuggestionPayload {
   title: string;
   prompt: string;
   topic_id?: string | null;
+  /** When set, the accepted brief will be dispatched with this
+   *  `initiative_id`. Slice 2 of the initiative research loop. */
+  initiative_id?: string | null;
   template: 'general_brief';
 }
 
@@ -166,6 +169,11 @@ export interface ListSuggestionsOptions {
   kind?: SuggestionKind;
   status?: SuggestionStatus;
   source_run_id?: string;
+  /** When set, restrict to suggestions whose `payload_json` references
+   *  this initiative_id (matched as a JSON-string substring). Used by
+   *  the InitiativeDetailView Research section so initiative-scoped
+   *  suggestions don't pollute the workspace-wide queue. */
+  initiative_id?: string;
   limit?: number;
 }
 
@@ -186,6 +194,14 @@ export function listSuggestions(
   if (opts.source_run_id) {
     where.push('source_run_id = ?');
     params.push(opts.source_run_id);
+  }
+  if (opts.initiative_id) {
+    // payload_json is JSON; match the value as a string. We accept the
+    // false-positive risk on a payload that mentions the id elsewhere
+    // (the JSON shape is small and dedicated, and the alternative is
+    // a generated column / json_extract which adds schema cost).
+    where.push(`payload_json LIKE ?`);
+    params.push(`%"initiative_id":"${opts.initiative_id}"%`);
   }
   const limit = Math.min(opts.limit ?? 100, 500);
   const rows = queryAll<SuggestionRow>(

--- a/src/lib/research/suggest.test.ts
+++ b/src/lib/research/suggest.test.ts
@@ -229,3 +229,127 @@ test('generateSuggestions: returns failed when PM reply has no JSON', async () =
   assert.equal(result.state, 'failed');
   assert.match(result.reason ?? '', /JSON/i);
 });
+
+// ─── Initiative-scoped context (slice 2 of initiative research loop) ──
+
+import { gatherInitiativeContext, buildInitiativeSuggestPrompt } from './suggest';
+import { createBriefWithRun, setBriefSummary } from '@/lib/db/briefs';
+import { createNote } from '@/lib/db/agent-notes';
+import { markComplete, markRunning } from "@/lib/db/agent-runs";
+
+function seedInitiative(workspaceId: string, overrides: { parent?: string; description?: string } = {}): string {
+  const id = `init-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT INTO initiatives (id, workspace_id, parent_initiative_id, kind, title, description, status, sort_order, created_at, updated_at)
+     VALUES (?, ?, ?, 'theme', 'Test theme', ?, 'planned', 0, datetime('now'), datetime('now'))`,
+    [id, workspaceId, overrides.parent ?? null, overrides.description ?? 'A theme to research.'],
+  );
+  return id;
+}
+
+test('gatherInitiativeContext: returns null for foreign workspace', () => {
+  const ws = freshWorkspace();
+  const other = freshWorkspace();
+  const initId = seedInitiative(ws);
+  const ctx = gatherInitiativeContext(other, initId);
+  assert.equal(ctx, null);
+});
+
+test('gatherInitiativeContext: parent chain + recent PM notes + prior briefs index', () => {
+  const ws = freshWorkspace();
+  const root = seedInitiative(ws, { description: 'root theme' });
+  const child = seedInitiative(ws, { parent: root, description: 'child' });
+
+  // Add a PM-audience note above the importance threshold.
+  createNote({
+    workspace_id: ws,
+    agent_id: null,
+    initiative_id: child,
+    scope_key: 'agent:test:ws:none:builder:1',
+    role: 'builder',
+    run_group_id: 'rg-1',
+    kind: 'discovery',
+    audience: 'pm',
+    body: 'A discovery worth surfacing',
+    importance: 2,
+  });
+  // Importance-0 note is filtered out (gather uses min_importance: 1).
+  createNote({
+    workspace_id: ws,
+    agent_id: null,
+    initiative_id: child,
+    scope_key: 'agent:test:ws:none:builder:1',
+    role: 'builder',
+    run_group_id: 'rg-1',
+    kind: 'observation',
+    audience: 'pm',
+    body: 'low signal',
+    importance: 0,
+  });
+
+  // A prior brief on this initiative, completed.
+  const { brief, agent_run } = createBriefWithRun({
+    workspace_id: ws,
+    template: 'general_brief',
+    title: 'Prior brief',
+    prompt: 'What is X?',
+    initiative_id: child,
+  });
+  markRunning(agent_run.id);
+  markComplete(agent_run.id);
+  setBriefSummary(brief.id, 'X is well-understood and mature.');
+
+  const ctx = gatherInitiativeContext(ws, child);
+  assert.ok(ctx, 'context should be present');
+  assert.equal(ctx!.initiative.id, child);
+  assert.equal(ctx!.parent_chain.length, 1);
+  assert.equal(ctx!.parent_chain[0].id, root);
+
+  assert.equal(ctx!.recent_notes.length, 1);
+  assert.equal(ctx!.recent_notes[0].body, 'A discovery worth surfacing');
+
+  assert.equal(ctx!.prior_briefs.length, 1);
+  assert.equal(ctx!.prior_briefs[0].id, brief.id);
+  assert.equal(ctx!.prior_briefs[0].summary, 'X is well-understood and mature.');
+  assert.equal(ctx!.prior_briefs[0].status, 'complete');
+});
+
+test('buildInitiativeSuggestPrompt: prompt body is initiative-scoped, not workspace-scoped', () => {
+  const ws = freshWorkspace();
+  const initId = seedInitiative(ws, { description: 'unique-marker-string' });
+  const ctx = gatherInitiativeContext(ws, initId);
+  assert.ok(ctx);
+  const prompt = buildInitiativeSuggestPrompt('brief', ctx!);
+  assert.match(prompt, /initiative-scoped/);
+  assert.match(prompt, /unique-marker-string/);
+  // Workspace-scoped buckets should NOT appear in this prompt.
+  assert.doesNotMatch(prompt, /Tasks needing attention/);
+});
+
+test('generateSuggestions: rejects unknown initiative_id', async () => {
+  const ws = freshWorkspace();
+  ensurePm(ws);
+  const result = await generateSuggestions({ workspace_id: ws, kind: 'brief', initiative_id: 'does-not-exist' });
+  assert.equal(result.state, 'rejected');
+  assert.match(result.reason ?? '', /not found/);
+});
+
+test('generateSuggestions: stamps initiative_id onto brief suggestion payloads', async () => {
+  const ws = freshWorkspace();
+  ensurePm(ws);
+  const initId = seedInitiative(ws);
+  __setSendChatClientForTests(makeStubClient(
+    `\`\`\`json
+{ "suggestions": [{ "title": "T1", "prompt": "?", "topic_id": null, "rationale": "r" }] }
+\`\`\``,
+  ));
+  const result = await generateSuggestions({ workspace_id: ws, kind: 'brief', initiative_id: initId });
+  assert.equal(result.state, 'ok');
+  assert.equal(result.suggestions.length, 1);
+  const payload = result.suggestions[0].payload as { initiative_id?: string };
+  assert.equal(payload.initiative_id, initId);
+  // listSuggestions filter by initiative_id finds it.
+  const filtered = listSuggestions(ws, { initiative_id: initId, status: 'pending' });
+  assert.equal(filtered.length, 1);
+  assert.equal(filtered[0].id, result.suggestions[0].id);
+});

--- a/src/lib/research/suggest.ts
+++ b/src/lib/research/suggest.ts
@@ -21,7 +21,8 @@ import { dispatchScope } from '@/lib/agents/dispatch-scope';
 import { getPmAgent } from '@/lib/agents/pm-resolver';
 import { listTopics } from '@/lib/db/topics';
 import { listBriefs } from '@/lib/db/briefs';
-import { listInitiatives } from '@/lib/db/initiatives';
+import { listNotes } from '@/lib/db/agent-notes';
+import { getInitiative, listInitiatives } from '@/lib/db/initiatives';
 import {
   createSuggestion,
   dismissPendingForWorkspaceKind,
@@ -30,6 +31,7 @@ import {
   type TopicSuggestionPayload,
   type BriefSuggestionPayload,
 } from '@/lib/db/research-suggestions';
+import type { Initiative } from '@/lib/db/initiatives';
 import { extractReplyText } from '@/lib/research/run-brief';
 import type { ChatEvent } from '@/lib/openclaw/send-chat';
 
@@ -40,6 +42,15 @@ export interface SuggestOptions {
   workspace_id: string;
   /** Either 'topic' or 'brief'. recurring_brief is reserved (phase 2). */
   kind: 'topic' | 'brief';
+  /**
+   * When set, scope the suggest pipeline to a single initiative. The PM
+   * gets initiative-specific context (title/description/parent chain +
+   * recent PM-audience notes + index of prior briefs on this initiative)
+   * instead of the workspace-wide snapshot. Generated `brief` suggestions
+   * carry `payload.initiative_id` so accept-flow propagates it onto the
+   * dispatched brief. See specs/initiative-research-loop.md.
+   */
+  initiative_id?: string;
   timeoutMs?: number;
 }
 
@@ -90,12 +101,44 @@ interface WorkspaceContext {
   topics: TopicSummary[];
 }
 
+interface PriorBriefIndexEntry {
+  id: string;
+  title: string;
+  summary: string | null;
+  status: string;
+}
+
+interface InitiativeNoteSummary {
+  kind: string;
+  importance: number;
+  body: string;
+  created_at: string;
+}
+
+interface InitiativeContext {
+  initiative: InitiativeSummary;
+  /** Root → leaf, this initiative last. Empty when initiative is a root. */
+  parent_chain: InitiativeSummary[];
+  recent_notes: InitiativeNoteSummary[];
+  /** {id, title, summary} per prior brief on this initiative. The PM
+   *  fetches full bodies via `read_brief` (slice 4) when a summary
+   *  hints at relevance. */
+  prior_briefs: PriorBriefIndexEntry[];
+  /** Existing topics in the same workspace — passed through so the
+   *  PM can still anchor a `brief` suggestion to a topic if it fits. */
+  topics: TopicSummary[];
+}
+
 /** Cap how much we feed the PM. Beyond a few dozen rows the prompt
  *  bloats and the PM's signal-to-noise drops. Tune on real usage. */
 const MAX_INITIATIVES = 30;
 const MAX_TASKS_PER_BUCKET = 15;
 const MAX_BRIEFS = 20;
 const MAX_TOPICS = 30;
+const MAX_NOTES_PER_INITIATIVE = 10;
+const MAX_PARENT_CHAIN = 4;
+const MAX_PRIOR_BRIEFS_INDEX = 25;
+const NOTE_BODY_TRUNCATE = 400;
 
 export function gatherWorkspaceContext(workspaceId: string): WorkspaceContext {
   const initiatives = listInitiatives({ workspace_id: workspaceId })
@@ -149,6 +192,200 @@ export function gatherWorkspaceContext(workspaceId: string): WorkspaceContext {
       description: t.description,
     })),
   };
+}
+
+function toSummary(i: Initiative | InitiativeSummary): InitiativeSummary {
+  return {
+    id: i.id,
+    kind: i.kind,
+    title: i.title,
+    status: i.status,
+    description: 'description' in i ? i.description ?? null : null,
+    target_end: 'target_end' in i ? i.target_end ?? null : null,
+  };
+}
+
+/**
+ * Gather initiative-scoped context for the suggest prompt: the
+ * initiative itself + its parent chain (so the PM understands where
+ * it sits in the roadmap), recent PM-audience notes (`importance≥1`
+ * so the PM sees discoveries/blockers but not pure observations), and
+ * a lightweight `{id,title,summary}` index of prior briefs scoped to
+ * this initiative. Workspace topics pass through so the PM can anchor
+ * a brief to a topic if one fits.
+ *
+ * Returns `null` when the initiative isn't found in this workspace —
+ * caller should fall back to workspace-scoped context.
+ */
+export function gatherInitiativeContext(
+  workspace_id: string,
+  initiative_id: string,
+): InitiativeContext | null {
+  const initiative = getInitiative(initiative_id);
+  if (!initiative || initiative.workspace_id !== workspace_id) return null;
+
+  // Walk the parent chain (oldest ancestor first).
+  const chain: InitiativeSummary[] = [];
+  let cursor = initiative.parent_initiative_id;
+  let steps = 0;
+  while (cursor && steps < MAX_PARENT_CHAIN) {
+    const parent = getInitiative(cursor);
+    if (!parent) break;
+    chain.unshift(toSummary(parent));
+    cursor = parent.parent_initiative_id;
+    steps++;
+  }
+
+  const notes = listNotes({
+    workspace_id,
+    initiative_id,
+    audience: 'pm',
+    min_importance: 1,
+    limit: MAX_NOTES_PER_INITIATIVE,
+    order: 'desc',
+  });
+  const recent_notes: InitiativeNoteSummary[] = notes.map(n => ({
+    kind: n.kind,
+    importance: n.importance,
+    body: n.body.length > NOTE_BODY_TRUNCATE
+      ? `${n.body.slice(0, NOTE_BODY_TRUNCATE)}…`
+      : n.body,
+    created_at: n.created_at,
+  }));
+
+  const prior = listBriefs(workspace_id, {
+    initiative_id,
+    limit: MAX_PRIOR_BRIEFS_INDEX,
+  });
+  // Pull each brief's status from agent_runs in a single batched
+  // lookup so the PM can see which prior briefs actually completed.
+  const runIds = prior.map(b => b.agent_run_id).filter(Boolean);
+  const statuses = new Map<string, string>();
+  if (runIds.length > 0) {
+    const placeholders = runIds.map(() => '?').join(',');
+    const rows = queryAll<{ id: string; status: string }>(
+      `SELECT id, status FROM agent_runs WHERE id IN (${placeholders})`,
+      runIds,
+    );
+    for (const r of rows) statuses.set(r.id, r.status);
+  }
+  const prior_briefs: PriorBriefIndexEntry[] = prior.map(b => ({
+    id: b.id,
+    title: b.title,
+    summary: b.summary,
+    status: statuses.get(b.agent_run_id) ?? 'unknown',
+  }));
+
+  const topics = listTopics(workspace_id).slice(0, MAX_TOPICS);
+
+  return {
+    initiative: toSummary(initiative),
+    parent_chain: chain,
+    recent_notes,
+    prior_briefs,
+    topics: topics.map(t => ({ id: t.id, name: t.name, description: t.description })),
+  };
+}
+
+/** Initiative-scoped variant of `buildSuggestPrompt`. Composed onto
+ *  the same reply-format footer so the parser stays unchanged. */
+export function buildInitiativeSuggestPrompt(
+  kind: 'topic' | 'brief',
+  ctx: InitiativeContext,
+): string {
+  const sections: string[] = [];
+  sections.push(
+    `# Research suggestion request — initiative-scoped`,
+    `\nYou are being asked to propose up to ${MAX_SUGGESTIONS_PER_RUN} candidate ` +
+    `**research ${kind === 'topic' ? 'topics' : 'briefs'}** that *advance this specific initiative*: ` +
+    `fill gaps in the current understanding, validate assumptions in the description, or surface ` +
+    `unknowns blocking decomposition into milestones/epics.\n` +
+    `\n**This is NOT a Mission Control task.** Do NOT call \`register_deliverable\` / ` +
+    `\`update_task_status\` / \`log_activity\` / \`propose_changes\`. Reply with the JSON block ` +
+    `specified at the bottom of this prompt and nothing else after it.`,
+  );
+
+  // Parent chain → root...→ this. Helps the PM see where this sits.
+  if (ctx.parent_chain.length > 0) {
+    sections.push(
+      `## Parent chain`,
+      ctx.parent_chain
+        .map((p, i) => `${'  '.repeat(i)}- **${p.kind}** \`${p.status}\` — ${p.title}`)
+        .join('\n'),
+    );
+  }
+
+  const i = ctx.initiative;
+  sections.push(
+    `## This initiative`,
+    `- **${i.kind}** \`${i.status}\` — ${i.title}` +
+      (i.description ? `\n- description: ${i.description.slice(0, 1500)}` : '') +
+      (i.target_end ? `\n- target_end: ${i.target_end}` : ''),
+  );
+
+  if (ctx.recent_notes.length > 0) {
+    sections.push(
+      `## Recent PM-audience notes (importance ≥ 1)`,
+      ctx.recent_notes
+        .map(n => `- (${n.kind}, importance ${n.importance}) ${n.body}`)
+        .join('\n'),
+    );
+  }
+
+  if (ctx.prior_briefs.length > 0) {
+    sections.push(
+      `## Prior briefs on this initiative (${ctx.prior_briefs.length})`,
+      ctx.prior_briefs
+        .map(b => `- \`${b.id}\` [${b.status}] **${b.title}**` + (b.summary ? ` — ${b.summary}` : ''))
+        .join('\n'),
+      `\n_Use \`read_brief({brief_id})\` to fetch the full body of any prior brief if a summary hints ` +
+      `it might be directly relevant. Avoid duplicating prior briefs._`,
+    );
+  } else {
+    sections.push(`## Prior briefs on this initiative\n\n_(none yet — open territory)_`);
+  }
+
+  if (ctx.topics.length > 0) {
+    sections.push(
+      `## Existing workspace topics (you may anchor a brief to one if it fits)`,
+      ctx.topics.map(t => `- \`${t.id}\` **${t.name}** — ${t.description.slice(0, 200) || '(no description)'}`).join('\n'),
+    );
+  }
+
+  sections.push(
+    `## Reply format`,
+    `\nReply with a single fenced JSON code block (\`\`\`json … \`\`\`) and nothing else after it. ` +
+    `Shape:\n` +
+    (kind === 'topic'
+      ? `\n\`\`\`json
+{
+  "suggestions": [
+    {
+      "name": "Short topic name (≤ 80 chars)",
+      "description": "Why this topic matters; what we'd track over time (1–3 sentences).",
+      "tags": ["short", "tags"],
+      "rationale": "1 sentence: WHY you suggested this, referencing this initiative's specific gaps."
+    }
+  ]
+}
+\`\`\`\n`
+      : `\n\`\`\`json
+{
+  "suggestions": [
+    {
+      "title": "Short brief title (≤ 100 chars)",
+      "prompt": "Specific research question. Be precise about scope, depth, and what would make the answer useful for this initiative.",
+      "topic_id": null,
+      "rationale": "1 sentence: WHY you suggested this, referencing this initiative's specific gaps."
+    }
+  ]
+}
+\`\`\`\n` +
+        `If a brief naturally belongs to one of the existing topics above, set \`topic_id\` to that topic's id; otherwise leave null.\n`),
+    `\nReturn between 1 and ${MAX_SUGGESTIONS_PER_RUN} candidates. Quality over quantity.`,
+  );
+
+  return sections.join('\n\n');
 }
 
 export function buildSuggestPrompt(
@@ -358,9 +595,29 @@ export async function generateSuggestions(opts: SuggestOptions): Promise<Suggest
     };
   }
 
-  const ctx = gatherWorkspaceContext(opts.workspace_id);
-  const triggerBody = buildSuggestPrompt(opts.kind, ctx);
-  const validTopicIds = new Set(ctx.topics.map(t => t.id));
+  let triggerBody: string;
+  let validTopicIds: Set<string>;
+  let initiativeCtx: InitiativeContext | null = null;
+  let sessionTag: string;
+
+  if (opts.initiative_id) {
+    initiativeCtx = gatherInitiativeContext(opts.workspace_id, opts.initiative_id);
+    if (!initiativeCtx) {
+      return {
+        state: 'rejected',
+        reason: `Initiative ${opts.initiative_id} not found in this workspace.`,
+        suggestions: [],
+      };
+    }
+    triggerBody = buildInitiativeSuggestPrompt(opts.kind, initiativeCtx);
+    validTopicIds = new Set(initiativeCtx.topics.map(t => t.id));
+    sessionTag = `init-${opts.initiative_id.slice(0, 8)}`;
+  } else {
+    const ctx = gatherWorkspaceContext(opts.workspace_id);
+    triggerBody = buildSuggestPrompt(opts.kind, ctx);
+    validTopicIds = new Set(ctx.topics.map(t => t.id));
+    sessionTag = 'workspace';
+  }
 
   let result;
   try {
@@ -368,7 +625,7 @@ export async function generateSuggestions(opts: SuggestOptions): Promise<Suggest
       workspace_id: opts.workspace_id,
       role: 'pm',
       agent: pm,
-      session_suffix: `research-suggest-${opts.kind}-${Date.now()}`,
+      session_suffix: `research-suggest-${opts.kind}-${sessionTag}-${Date.now()}`,
       trigger_body: triggerBody,
       timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
       attempt_strategy: 'fresh',
@@ -414,17 +671,25 @@ export async function generateSuggestions(opts: SuggestOptions): Promise<Suggest
   }
 
   // Dismiss any prior pending suggestions of this kind so the picker
-  // shows only the latest batch.
+  // shows only the latest batch. (Workspace-wide; initiative-scoped
+  // dismissal is coarser than ideal but matches the existing UX —
+  // suggestions queue is workspace-wide.)
   dismissPendingForWorkspaceKind(opts.workspace_id, opts.kind);
 
-  const inserted = candidates.map(c =>
-    createSuggestion({
+  const inserted = candidates.map(c => {
+    // For brief suggestions in initiative-scoped mode, stamp the
+    // initiative_id onto the payload so accept-flow propagates it.
+    let payload = c.payload;
+    if (opts.initiative_id && opts.kind === 'brief') {
+      payload = { ...(payload as BriefSuggestionPayload), initiative_id: opts.initiative_id };
+    }
+    return createSuggestion({
       workspace_id: opts.workspace_id,
       kind: opts.kind as SuggestionKind,
-      payload: c.payload,
+      payload,
       rationale: c.rationale,
-    }),
-  );
+    });
+  });
 
   return { state: 'ok', suggestions: inserted, raw: body };
 }


### PR DESCRIPTION
## Summary

Slice 2 of the [initiative research loop](https://github.com/smb209/mission-control/blob/feat/research-loop-2-suggest/specs/initiative-research-loop.md). **Stacked on [#314](https://github.com/smb209/mission-control/pull/314)** — base will be retargeted to `main` before merging the parent (per [feedback_stacked_pr_merges.md](https://github.com/smb209/mission-control/blob/feat/research-loop-2-suggest/specs/initiative-research-loop-build-plan.md#slice-merge-order)).

When the operator triggers Suggest from an initiative, the PM gets initiative-scoped context instead of the workspace-wide snapshot, and any `brief` suggestions it returns carry `payload.initiative_id` so the accepted brief gets dispatched correctly. Slice 3 will consume that field and write the auto-note on completion.

## Changes

**`src/lib/research/suggest.ts`:**
- `SuggestOptions.initiative_id?: string` (new). When set:
  - `gatherInitiativeContext()` returns initiative title/description/parent-chain (≤4 deep), recent PM-audience notes (`importance ≥ 1`, ≤10, body truncated to 400 chars), and a `{id, title, summary, status}` index of prior briefs scoped to this initiative (≤25). Topics still pass through.
  - `buildInitiativeSuggestPrompt()` emits an initiative-scoped prompt asking the PM to advance THIS initiative — fill gaps, validate assumptions, surface unknowns blocking decomposition. Reply format unchanged so the parser is shared.
  - `generateSuggestions()` stamps `payload.initiative_id` onto each `brief` suggestion so accept-flow can propagate it onto the dispatched brief.

**`src/lib/db/research-suggestions.ts`:**
- `BriefSuggestionPayload.initiative_id?: string | null` (new field).
- `listSuggestions({ initiative_id })` filter via LIKE on `payload_json`. False-positive risk accepted for the small dedicated payload shape.

**`src/app/api/research/suggestions/route.ts`:**
- `POST` accepts optional `initiative_id` in the body, threads through to `generateSuggestions`.
- `GET ?initiative_id=` filters the queue.

## Out of scope (deferred to later slices)

- Slice 3: brief dispatch carries `initiative_id`; auto-note on completion; rerun-replace path.
- Slice 4: `read_brief` MCP tool (the suggest prompt instructs the PM to call it but the tool isn't registered yet — slice 3 / 4 PRs ship together with the rest of the stack).
- Slice 5: UI surface in `InitiativeDetailView`.

## Test plan

- [x] `yarn tsc --noEmit -p tsconfig.json` — clean.
- [x] `yarn test src/lib/research/suggest.test.ts` — 5 new tests green:
  - `gatherInitiativeContext: returns null for foreign workspace`
  - `gatherInitiativeContext: parent chain + recent PM notes + prior briefs index`
  - `buildInitiativeSuggestPrompt: prompt body is initiative-scoped, not workspace-scoped`
  - `generateSuggestions: rejects unknown initiative_id`
  - `generateSuggestions: stamps initiative_id onto brief suggestion payloads`
- [x] Full `yarn test` — **939/940 pass**. Same pre-existing `schedule-runner` failure as slice 1 baseline (`src/lib/research/eval/schedule-runner.test.ts → schedule-runner: produces a brief and advances run_count`).

## Risk

Net-additive on every surface. The workspace-scoped `generateSuggestions` path is unchanged when `initiative_id` is absent. PM reply parsing is shared between the two prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)