### PR TITLE
feat(review-robust): slice 2 — convoy-subtask evidence gate

### DIFF
--- a/specs/review-stage-robustness-build-plan.md
+++ b/specs/review-stage-robustness-build-plan.md
@@ -1,0 +1,210 @@
+---
+name: Review-Stage Robustness — Build Plan
+description: Slice plan + design decisions for closing the review-stage stall pattern (roster gate, self-review interlock, soft-lock, SLA)
+status: draft
+spec: specs/review-stage-robustness-spec.md
+---
+
+# Review-Stage Robustness — Build Plan
+
+Status: draft · Owner: smb209 · Date: 2026-05-09
+Spec: [specs/review-stage-robustness-spec.md](review-stage-robustness-spec.md)
+
+Companion to the spec. Commits to slices, files-touched, and load-bearing design calls. Per [specs/long-unattended-feature-dev.md](long-unattended-feature-dev.md): operator OKs build plan + validation skeleton; per-slice unit tests are the per-PR contract; full real-agent validation runs against the stack tip before merge.
+
+## Audit (verified 2026-05-09)
+
+- **`transitionTaskStatus`** — [src/lib/services/task-status.ts:74-208](src/lib/services/task-status.ts:74). Single chokepoint for all status moves (HTTP PATCH + MCP `update_task_status` + `update_subtask`). Returns a discriminated `{ ok, code }`. Already enforces evidence gate, terminal guard, fail-backwards reason, `taskCanBeDone`. Adding new gates here is the right shape.
+- **`checkStageEvidence`** — [src/lib/task-governance.ts:50-140](src/lib/task-governance.ts:50). Strict path enforces `STAGE_REQUIRED_EVIDENCE` once any `task_evidence` row exists; legacy path falls back to `deliverableCount + activityCount`. Convoy-subtask early-return at line 113-115 (`if (task?.convoy_id) return { ok: true }`) is the load-bearing gap for FM4.
+- **Authz** — [src/lib/authz/agent-task.ts:42-166](src/lib/authz/agent-task.ts:42). `AuthzError` already has typed `code`. `agent_not_coordinator` is thrown by `assertAgentCanActOnTask(..., 'delegate' | 'status')`. The MCP layer at [src/lib/mcp/groups/work.ts:1047-1052](src/lib/mcp/groups/work.ts:1047) calls `assertAgentCanActOnTask` directly and lets the error propagate as plain text.
+- **Stall detection** — [src/lib/stall-detection.ts:54-130](src/lib/stall-detection.ts:54). One global threshold (`STALL_DETECTION_MINUTES`, default 30). Marks `status_reason = 'stalled_no_activity (...)'` and notifies coordinator/webhook. **Does not bounce or transition.** Has `coordinator_stalled` / `coordinator_missing` fallback paths we can reuse for review-SLA escalation.
+- **Dispatch entry points** — [src/app/api/tasks/[id]/dispatch/route.ts](src/app/api/tasks/[id]/dispatch/route.ts) (HTTP), [src/lib/convoy.ts](src/lib/convoy.ts) `dispatchReadyConvoySubtasks`, [src/lib/workflow-engine.ts](src/lib/workflow-engine.ts) `drainQueue`. Three call sites; the gate (Slice 0) needs to slot in front of all three. Existing `pickDynamicAgent` + `resolveBriefingRole` give us role lookup primitives.
+- **`task_roles`** — schema has `(task_id, role, agent_id)`. Today's prod data only carries `role='builder'`; `coordinator` and `reviewer` rows are never written even though `assertAgentCanActOnTask` reads `coordinator` rows.
+- **`spawn_subtask`** — [src/lib/mcp/groups/work.ts:988-1230](src/lib/mcp/groups/work.ts:988). Already does the auth check first thing; clean place to intercept the `agent_not_coordinator` denial.
+- **`tasks` schema** — additive columns are cheap; existing migrations (`is_failed` was added similarly in PR 2 of autonomous-flow-tightening). New `locked_for_completion` is a one-column migration.
+- **`convoy_subtasks` schema** — has `acceptance_criteria` (JSON) and `expected_deliverables` (JSON) already. Adding `required_evidence_gates` JSON is parallel.
+- **Agent role pool** — `getRunnerAgent`, `getPmAgent`, gateway-id-derived role via `resolveBriefingRole` give us the means to enumerate workspace agents by role.
+
+## Design decisions
+
+### D1. Required-roles derivation for the roster gate
+
+**Choice:** rule-based, not configured.
+- Convoy subtask: `[suggested_role, 'reviewer']`.
+- Workflow-template task: union of `required_role` across stages, defaulting `reviewer` if any stage is `review`.
+- Plain task: `['builder', 'reviewer']` (the standard ladder).
+- Convoy parent: union of all child requirements.
+
+**Why:** every task's lifecycle is already encoded in workflow_template or convoy structure; we don't need a new declaration surface. Reversible via a single function — swap the rules without schema changes.
+
+### D2. "Available" agent definition
+
+**Choice:** `disabled = 0 AND status != 'offline' AND role matches required role (via column or gateway-id derivation)`.
+
+**Why over "ever-existed":** dispatch fires the worker right now; the gate has to reflect now. An offline reviewer is not a reviewer for this dispatch. False-positive failures ("you're missing X") are operator-actionable; false-negative passes recreate the stall pattern.
+
+### D3. Soft-lock storage
+
+**Choice:** new column `tasks.locked_for_completion INTEGER NOT NULL DEFAULT 0`.
+
+**Why over a `task_locks` side table:** the lock is 1:1 with the task and read on every mutating MCP call; an indexed boolean column is simpler and faster than a join. Reversible — column is additive.
+
+### D4. Self-review interlock placement
+
+**Choice:** at the top of the `newStatus === 'review'` branch in `transitionTaskStatus`, before the evidence gate.
+
+**Why:** earliest cheap rejection. Tests get a deterministic error code (`self_review_blocked`) regardless of evidence state.
+
+### D5. Per-stage stall thresholds
+
+**Choice:** introduce `STALL_DETECTION_MINUTES_REVIEW` (default 20m). Other stages keep the global default.
+
+**Why:** review's only legitimate work is reviewer evaluation; 20m is generous for that. Other stages have wider variance (in-progress can legitimately be slow). Keeps the env surface minimal.
+
+### D6. Auto-bounce mechanics for stalled review
+
+**Choice:** at 1× threshold, log `reviewer_stalled` activity + mailbox-ping the reviewer. At 2× threshold, transition `review → assigned` with `is_failed=1, status_reason='Failed: reviewer unresponsive (idle Xm)'`. Convoy-aware: also notify the coordinator if the parent is `convoy_active`.
+
+**Why two-stage:** matches the existing throttle/notify cadence in `stall-detection.ts`. One-shot bounce is too aggressive (real reviewers can be 25m late); never-bounce is the current bug.
+
+### D7. `escalate_to_parent` shape
+
+**Choice:** new MCP tool with args `{ task_id, agent_id, reason }`. Behavior:
+- Walk parent chain: convoy parent if exists; else operator (top-level).
+- Write `task_activities` row on parent: `activity_type='escalation'`.
+- Set parent `status_reason='child_escalated:<reason>'`; if parent is operator (top-level), flip task to `needs_user_input` and write to operator mailbox.
+- Bounce child: `review/assigned/in_progress → assigned, is_failed=1`. Clear `locked_for_completion` on child.
+- Idempotent: a second call within 60s returns the same parent ack.
+
+**Why:** matches existing fail-backwards semantics; `is_failed` already triggers fixer logic downstream. No new bounce primitive.
+
+## Slice plan
+
+Each slice = one stacked PR. Branch base for slice N = slice N-1's branch. Per [feedback_stacked_pr_merges.md](file:///Users/snappytwo/.claude/projects/-Users-snappytwo-snappytwo-sandbox-mission-control/memory/feedback_stacked_pr_merges.md): retarget children to `main` before merging the parent. All PRs target `smb209/mission-control` with explicit `--repo`.
+
+### Slice 0 — Pre-dispatch workspace-roster gate
+
+**Branch:** `feat/review-robust-0-roster-gate` (off `main`)
+
+**Files:**
+- `src/lib/dispatch/roster-gate.ts` (new) — `requiredRolesForTask(taskId)`, `validateWorkspaceRoster(workspaceId, requiredRoles)`, `enforceRosterGate(taskId)` orchestrator.
+- `src/app/api/tasks/[id]/dispatch/route.ts` — invoke gate before any side effects.
+- `src/lib/convoy.ts` — invoke gate inside `dispatchReadyConvoySubtasks` per child.
+- `src/lib/workflow-engine.ts` — invoke gate inside `drainQueue`.
+- `src/lib/mailbox.ts` — reuse for operator ping (no schema change).
+- Tests: `src/lib/dispatch/roster-gate.test.ts` (new) — required-roles derivation; available-agent rules; gate pass/fail; mailbox row written on fail.
+
+**Feature flag:** `MC_ROSTER_GATE` (default `0` for one cycle, then default-on after backfill).
+
+**Testable after this slice:** dispatch refuses tasks in workspaces missing required roles; existing dispatches with full roster behave identically.
+
+### Slice 1 — Self-review interlock + reviewer-required gate
+
+**Branch:** `feat/review-robust-1-self-review` (off slice 0)
+
+**Files:**
+- `src/lib/services/task-status.ts` — extend result `code` enum (`self_review_blocked`, `reviewer_required`); enforce both at top of `→ review` branch.
+- `src/lib/services/task-status.test.ts` — three new cases.
+- `src/lib/task-governance.ts` — add `pickReviewerForTask(taskId, workspaceId, excludeAgentId)` mirroring `ensureFixerExists`. Writes `task_roles` row on auto-pick.
+- `src/app/api/tasks/[id]/route.ts` + MCP tool error-mapping — surface new codes to callers (HTTP 422, MCP `structuredContent.error`).
+
+**Feature flag:** `MC_REVIEW_STRICT_GATING` (default `0` for one cycle).
+
+**Testable after this slice:** completer cannot transition own task to review; tasks lacking a reviewer either auto-pick or reject with actionable error.
+
+### Slice 2 — Convoy-subtask evidence gate
+
+**Branch:** `feat/review-robust-2-subtask-evidence` (off slice 1)
+
+**Files:**
+- `src/lib/db/migrations.ts` — add `convoy_subtasks.required_evidence_gates TEXT` (JSON array).
+- `src/lib/convoy.ts` — write `required_evidence_gates: ['test_full']` (default for review-bound subtasks) into `spawnDelegationSubtask`. Read on dispatch.
+- `src/lib/task-governance.ts` — replace the `if (task?.convoy_id) return { ok: true }` early-return with: skip *spec reconciliation* but enforce `STAGE_REQUIRED_EVIDENCE` plus per-subtask `required_evidence_gates` if set.
+- `src/lib/task-governance.test.ts` — extend with subtask cases.
+
+**No feature flag** — additive default; legacy subtasks (no required_evidence_gates set) keep current behavior.
+
+**Testable after this slice:** convoy subtask cannot reach `review` without `test_full` evidence; legacy subtasks unaffected.
+
+### Slice 3 — Capability-denial soft-lock + `escalate_to_parent`
+
+**Branch:** `feat/review-robust-3-soft-lock` (off slice 2)
+
+**Files:**
+- `src/lib/db/migrations.ts` — `tasks.locked_for_completion INTEGER NOT NULL DEFAULT 0`.
+- `src/lib/authz/agent-task.ts` — `lockTaskForCompletion(taskId, reason)` helper; honored by `assertAgentCanActOnTask` for actions in `('status', 'register_deliverable', 'submit_evidence')` — denies if locked.
+- `src/lib/mcp/groups/work.ts` — `spawn_subtask` and other coordinator-only tools: catch `AuthzError(code='agent_not_coordinator')`, set lock, return `next_action: 'escalate_to_parent'` shape.
+- `src/lib/mcp/groups/work.ts` — register `escalate_to_parent` tool.
+- `src/lib/mcp/mcp.test.ts` — add tool to discovery test.
+- `src/app/api/mcp/pm/route.ts` — register tool.
+- Tests: capability-denial → lock set → register_deliverable rejected → escalate_to_parent clears lock and bounces.
+
+**Testable after this slice:** the original incident (`92b7b092`) replays with a clean escalation instead of a stall.
+
+### Slice 4 — Review SLA + auto-bounce
+
+**Branch:** `feat/review-robust-4-review-sla` (off slice 3)
+
+**Files:**
+- `src/lib/stall-detection.ts` — per-stage threshold helper; review-specific bounce path.
+- `src/lib/agent-health.ts` — feed bounced rows back into the activity stream.
+- `src/lib/stall-detection.test.ts` — review stall + bounce + coordinator notify cases.
+- `scripts/audit-review-stalls.ts` (new) — one-shot operator backfill: list `status='review'` rows with no reviewer / no evidence.
+- `package.json` — script entry.
+
+**Feature flag:** `MC_REVIEW_AUTOBOUNCE` (default `0`; flip after operator runs the audit script).
+
+**Testable after this slice:** review tasks idle past threshold get bounced; coordinator pinged.
+
+### Slice 5 — Role-doc + ops-doc updates
+
+**Branch:** `feat/review-robust-5-docs` (off slice 4)
+
+**Files:**
+- `src/lib/agents/pm-soul.md` — add escalation paragraph.
+- `src/lib/agents/builder-soul.md` (create if absent; otherwise extend).
+- `docs/REVIEW_STAGE_PROTOCOL.md` (new) — operator-facing runbook for the four feature flags + audit script.
+
+Pure docs slice; no code change.
+
+## Test strategy summary
+
+| Slice | Unit tests added | Validation scenarios that become exercisable |
+|---|---|---|
+| 0 | Required-roles derivation; available-agent matrix; gate pass/fail | RR-S1 (dispatch refused on missing reviewer), RR-S2 (full roster passes) |
+| 1 | Self-review block; reviewer auto-pick; reviewer-required reject | RR-S3 (completer ≠ reviewer enforced) |
+| 2 | Subtask evidence-gate strict path | RR-S4 (subtask cannot reach review without test_full) |
+| 3 | Soft-lock; escalate_to_parent; tool blocks | RR-S5 (full incident replay — agent_not_coordinator → escalation, not stall) |
+| 4 | Review-SLA bounce; per-stage threshold | RR-S6 (stale review auto-bounces; coordinator pinged) |
+| 5 | none | Doc lint only |
+
+Validation scenarios live in [review-stage-robustness-validation/02-test-plan.md](review-stage-robustness-validation/02-test-plan.md).
+
+## Open questions for operator
+
+1. **Default for `MC_ROSTER_GATE`** — ship Slice 0 default-off so the first dogfood pass shows the count of tasks that *would* have been refused, then flip default-on in a follow-up? Or default-on immediately given backup safety net? Current plan: default-off for one cycle.
+2. **`escalate_to_parent` for top-level tasks** — confirmed in Decisions section to flip task to `needs_user_input` + mailbox-ping the operator. Alternative: also create a high-priority `task_notes` row visible in the UI rail. Going with mailbox + needs_user_input unless you say otherwise.
+3. **Cleanup of in-flight stalls before flag-flips** — Slice 4's `scripts/audit-review-stalls.ts` lists candidates but does not auto-clean. If you want auto-cleanup behind a separate flag, name it now.
+
+None of these block writing the validation skeleton; called out so they're not surprises.
+
+## Out of scope
+
+- New evidence gates beyond `build_fast` / `test_full` / `review_static`. Existing set is sufficient for review-stage correctness.
+- New roles. Builder / Tester / Reviewer / PM / Coordinator stay as-is.
+- Workflow-template UI changes. Roster gate reads existing templates; doesn't redesign them.
+- Reviewer agent prompts. Extending the soul-prompt for reviewer behavior is a separate concern — this feature only ensures one *exists* and is *assigned*.
+- Multi-workspace agent borrowing. If a workspace lacks a role, operator onboards locally; cross-workspace role resolution is a deferred design.
+
+## Cost ceiling
+
+Per [project_openclaw_model.md](file:///Users/snappytwo/.claude/projects/-Users-snappytwo-snappytwo-sandbox-mission-control/memory/project_openclaw_model.md): real-agent dispatches use `spark-lb/agent`, self-hosted, no budget concern. Validation run is ~6 scenarios × ~5 min each ≈ 30 min of agent time, plus one full incident replay (RR-S5) at ~10 min.
+
+**HMR-runaway watchdog** (per [project_research_hmr_runaway.md](file:///Users/snappytwo/.claude/projects/-Users-snappytwo-snappytwo-sandbox-mission-control/memory/project_research_hmr_runaway.md)): pre-check 01 confirms no editing of dispatch code while validation runs. Restart cleanly between scenarios.
+
+## Slice merge order
+
+1. Each slice PR opens against the prior slice's branch (`--base feat/review-robust-N-…`).
+2. Before merging slice 0, retarget slice 1's base to `main`. Repeat down the stack.
+3. `--delete-branch` only after children are retargeted.
+4. All PRs target the fork (`smb209/mission-control`), explicit `--repo`.

--- a/specs/review-stage-robustness-spec.md
+++ b/specs/review-stage-robustness-spec.md
@@ -1,0 +1,208 @@
+# Review-Stage Robustness
+
+Status: draft
+Owner: smb209
+Date: 2026-05-09
+Trigger: recurring stall pattern observed across multiple convoys, most recently task `92b7b092` ("Implement alert() replacements…"). The PM hit `agent_not_coordinator` trying to spawn a builder, silently re-roled, did the work itself, marked complete → review, and stalled there with no evidence rows and no reviewer assigned.
+
+## Goal
+
+Make the path from `assigned → review → done` self-policing. Today the `review` status is a parking lot: any agent can land a task there with zero evidence, no reviewer assigned, and the only signal that something is wrong is a "stalled" badge that paints but doesn't act. Close all three holes (capability-denial swallowing, toothless review stage, cosmetic stall detection) so a misbehaving or under-tooled agent can't strand work.
+
+## Non-goals
+
+- Adding new agent roles. Builder / Reviewer / Tester / PM stay as-is.
+- Re-doing evidence gates. `submit_evidence` and `task_evidence` already exist; this spec wires them in tighter.
+- Changing OpenClaw worker semantics. All changes are MC-side: state machine, MCP tool surface, stall handler, role docs.
+- Rewriting authz. We extend the existing `assertAgentCanActOnTask` but don't restructure it.
+
+## Core principle: capability denials are control-flow, not advisory
+
+When a tool returns `agent_not_coordinator` (or any structured denial), the agent must not be free to "decide" to do the work itself. The system either:
+1. Forces the bounce-back via a structured response the agent can't ignore (the only useful next-tool is `escalate_to_parent` / `fail_task`), or
+2. Performs the rerouting itself (auto-reassign, auto-spawn under a coordinator-capable agent).
+
+Today the error is text and the agent prompt picks the path. That's the same anti-pattern as "ask an agent a yes/no question about its own work" from `autonomous-flow-tightening-spec.md` — replace agent judgment with rails.
+
+## Failure modes (from post-mortem of task 92b7b092)
+
+| FM | One-line | Ground truth |
+|----|----------|--------------|
+| FM1 | `agent_not_coordinator` is swallowable text — agent silently switches role | [src/lib/authz/agent-task.ts:148-160](src/lib/authz/agent-task.ts:148), [src/lib/mcp/groups/work.ts:1047-1052](src/lib/mcp/groups/work.ts:1047) |
+| FM2 | `transitionTaskStatus → review` accepts any caller; no reviewer is required or assigned | [src/lib/services/task-status.ts:74-208](src/lib/services/task-status.ts:74) |
+| FM3 | Self-review allowed: completer == reviewer is permitted | (no check exists) |
+| FM4 | Convoy-subtask path bypasses the strict evidence gate | [src/lib/task-governance.ts:113-115](src/lib/task-governance.ts:113) (`if (task?.convoy_id) return { ok: true }`) — exactly the case our incident hit |
+| FM5 | `stalled_no_activity` is purely cosmetic for `review` — scanner sets `status_reason` but never bounces or escalates | [src/lib/stall-detection.ts:54-130](src/lib/stall-detection.ts:54) |
+| FM6 | No SLA on time-in-review. A subtask in `review` with no reviewer can sit there indefinitely | (no timer exists) |
+| FM7 | `task_roles` only knows `coordinator` / `builder` — no `reviewer` row, so the system can't pick one to assign | `sqlite> SELECT DISTINCT role FROM task_roles;` → `builder` only |
+| FM8 | Dispatch fires even when the workspace can't field every role the task will need (no reviewer, no coordinator, no tester). The shortage is discovered mid-flight, by which time work is in progress and rollback is expensive | [src/app/api/tasks/[id]/dispatch/route.ts](src/app/api/tasks/[id]/dispatch/route.ts), [src/lib/convoy.ts](src/lib/convoy.ts) `dispatchReadyConvoySubtasks` |
+
+## Design
+
+### A. Capability denials become forced bounces (FM1)
+
+`spawn_subtask` and friends already throw `AuthzError` with a typed `code`. Two changes:
+
+1. **At the MCP transport layer** (`src/lib/mcp/groups/work.ts`), catch `AuthzError` for the coordinator-only family and rewrite the response so the `structuredContent.next_action` field names a single allowed continuation:
+
+   ```jsonc
+   {
+     "isError": true,
+     "structuredContent": {
+       "error": "agent_not_coordinator",
+       "next_action": "escalate_to_parent",
+       "next_action_args_hint": { "reason": "<why I can't dispatch this myself>" },
+       "blocked_tools": ["register_deliverable", "update_task_status"]
+     }
+   }
+   ```
+
+   Adding `blocked_tools` is advisory metadata (the rails in B/C below do the actual blocking).
+
+2. **Add a server-side soft-lock**: when an agent receives a coordinator-only denial on task T, set `tasks.locked_for_completion = 1` for T. While the lock is set, `update_task_status` and `register_deliverable` from that agent return a hard error pointing at `escalate_to_parent`. The lock is cleared when the task is reassigned or the parent acknowledges the escalation.
+
+   New column: `tasks.locked_for_completion INTEGER NOT NULL DEFAULT 0`. Migration is additive, defaults to off, no backfill needed.
+
+3. **`escalate_to_parent` MCP tool** (new). Writes a parent-task activity with `activity_type='escalation'`, flips the parent's `status_reason` to `child_escalated:<reason>`, and bounces the child to `assigned` with `is_failed=1`. Ada (or whoever the parent's coordinator is) sees the escalation in the next inbox poll.
+
+### B. Review stage requires a reviewer at transition time (FM2, FM7)
+
+In `transitionTaskStatus`, when `newStatus === 'review'`:
+
+1. Require either:
+   - A `task_roles` row with `role='reviewer'` for this task, OR
+   - An auto-pickable reviewer agent in the workspace (mirrors `ensureFixerExists`: pick by role, online, not the completer).
+2. If neither exists, fail with `code='reviewer_required'` and a hint: "no reviewer agent available — operator must add one or call escalate_to_parent".
+3. If auto-picked, write the `task_roles` row inline so subsequent transitions are deterministic.
+
+### C. Self-review interlock (FM3)
+
+When `newStatus === 'review'`:
+- The transitioning agent (`actingAgentId`) cannot equal `tasks.assigned_agent_id` UNLESS a separate `task_roles[role='reviewer']` row exists with a different `agent_id`.
+- This is enforced in `transitionTaskStatus` next to the existing evidence gate, returning `code='self_review_blocked'`.
+
+This is the cheapest invariant in the whole spec and would have caught our incident even with FM1 unfixed.
+
+### D. Convoy-subtask evidence gate (FM4)
+
+The current bypass at `task-governance.ts:113-115` was added because subtasks don't carry the parent's `planning_spec`. The bypass is too broad — it skips even the baseline `deliverableCount > 0 && activityCount > 0` check.
+
+Fix: convoy-subtasks still skip *spec reconciliation* (correct, they don't own the spec), but they pass through the strict-mode evidence gate (`STAGE_REQUIRED_EVIDENCE[review]: ['test_full']`) once the dispatcher prescribes commands. Subtasks get evidence requirements from `convoy_subtasks.acceptance_criteria` — extend the schema with an optional `required_evidence_gates: ['build_fast', 'test_full']` JSON field, default `['test_full']` for review-bound subtasks.
+
+### E. Review SLA → action, not just badge (FM5, FM6)
+
+Extend `scanStalledTasks` (and the per-stage timer in `agent-health.ts`) with:
+
+- **Per-stage thresholds.** Today there's one `STALL_DETECTION_MINUTES`. Add `STALL_DETECTION_MINUTES_REVIEW` (default 20m) — review should be tighter than `in_progress` because the only legitimate work is reviewer evaluation.
+- **Action, not paint.** When a `review` task crosses threshold:
+  1. If a reviewer is assigned but inactive: log `reviewer_stalled`, send a mailbox ping, and after 2× threshold auto-bounce to `assigned` with `is_failed=1, status_reason='Failed: reviewer unresponsive'`.
+  2. If no reviewer is assigned (only possible if A/B were bypassed by an older flow): bounce immediately and surface as `status='needs_user_input'`.
+- **Convoy-aware escalation.** If the parent is `convoy_active` and a child stalls in `review`, ping the convoy coordinator (Ada in our case) — the existing `notifyCoordinator` path is the right hook.
+
+### F. Role docs (FM1)
+
+PM and builder soul-prompts get a one-paragraph addition: when you receive `agent_not_coordinator` (or any `next_action: escalate_to_parent`), your only valid next call is `escalate_to_parent`. Doing the work yourself is a protocol violation.
+
+This is a belt-and-braces redundant rail — A.2's soft-lock makes it impossible at the system level — but worth keeping aligned.
+
+## Decisions (formerly open questions)
+
+- **`escalate_to_parent` works for non-convoy tasks too.** Operator is the implicit parent for top-level tasks: tool flips the task to `needs_user_input` and writes a mailbox row to the workspace's default operator agent (or the activity feed if none). One code path, two equally valid parents — mirrors the existing `coordinator_missing` fallback in `stall-detection.ts:262-274`.
+- **Soft-lock and `is_failed` are orthogonal.** Lock describes agent agency (you cannot advance this task; only `escalate_to_parent` is legal). Flag describes stage outcome (the work was rejected). Both can be set in one incident; lock clears on reassign/escalation-ack, flag clears on next forward transition. No precedence puzzle.
+- **Soft-lock blocks all forward-only mutations on the locked task** for the locked agent: `update_task_status`, `register_deliverable`, `submit_evidence`. Read-only tools (`get_task`, `read_brief`) stay open so the agent can craft a clean escalation message. Rationale: a denied agent dropping deliverables creates exactly the artifact set that bypasses the legacy evidence gate.
+- **Single-agent-workspace reviewer fallback is moot** once the pre-dispatch roster gate (Slice 0) lands — the task never reaches `assigned`. Slice 1's auto-pick stays as defense-in-depth, not the load-bearing rail.
+
+## Implementation slices
+
+Each slice is a stacked PR. All target `smb209/mission-control`, base on the prior slice.
+
+### Slice 0 — Pre-dispatch workspace-roster gate
+
+**Goal**: refuse to dispatch a task whose downstream stages need roles the workspace can't currently fill. Converts the recurring "mid-flight stall because no reviewer/no coordinator existed" failure into a one-time, operator-actionable error at dispatch time.
+
+Files: `src/lib/dispatch/roster-gate.ts` (new), `src/app/api/tasks/[id]/dispatch/route.ts`, `src/lib/convoy.ts` (`dispatchReadyConvoySubtasks`), `src/lib/workflow-engine.ts` (`drainQueue`).
+
+1. **`requiredRolesForTask(taskId): RoleName[]`** — derive the role set:
+   - If the task has a `workflow_template_id`, walk its stages and collect every `required_role`.
+   - If the task is a convoy subtask, return `[suggested_role, 'reviewer']` (review stage will need one).
+   - If neither, default to `['builder', 'reviewer']` for the standard `assigned → in_progress → review → done` ladder.
+   - For convoy parents (`status='convoy_active'`), union across all child rows.
+
+2. **`validateWorkspaceRoster(workspaceId, requiredRoles): { ok: true } | { ok: false, missing: RoleName[] }`** — an "available" agent is `status != 'offline' AND disabled = 0` and has a matching `role` (or gateway-id-derived role per `resolveBriefingRole`).
+
+3. **At every dispatch entry point** (HTTP route, convoy auto-dispatch, workflow drain), call the gate before any side effects. On failure:
+   - Flip the task to `needs_user_input` with `status_reason='roster_incomplete: <missing>'`.
+   - Log a `roster_incomplete` activity row carrying the missing roles in metadata.
+   - Send a mailbox row to the operator (or workspace default agent) with the actionable text: "workspace `<id>` is missing role(s) X — onboard or enable an agent and call dispatch again".
+   - Return a structured error to the caller; do **not** fire the OpenClaw worker.
+
+4. **Feature flag**: `MC_ROSTER_GATE=1` (off for one cycle so we can backfill-audit existing workspaces, then default-on).
+
+5. **Tests**: workspace with builder but no reviewer rejects at dispatch; workspace with offline reviewer rejects; workspace with full roster passes; convoy parent gate unions across children correctly.
+
+This slice is upstream of everything else: it removes the precondition for most of the failure modes (FM2, FM7, partly FM1 where the missing role is `coordinator`).
+
+### Slice 1 — Self-review interlock + reviewer-required gate
+
+Files: `src/lib/services/task-status.ts`, `src/lib/services/services.test.ts`.
+- Add `code: 'self_review_blocked' | 'reviewer_required'` to the result enum.
+- Enforce both at the start of `newStatus === 'review'` branch.
+- Add `task_roles` reviewer auto-pick helper next to `ensureFixerExists`.
+- Tests: completer ≠ reviewer; missing reviewer rejects; auto-pick writes `task_roles`.
+
+Smallest, lowest-risk change. Lands the highest-leverage invariant (C) and unblocks B.
+
+### Slice 2 — Convoy-subtask evidence gate
+
+Files: `src/lib/task-governance.ts`, `src/lib/db/schema.ts` (add `convoy_subtasks.required_evidence_gates`), `src/lib/convoy.ts` (read it on dispatch).
+- Migration: additive, default `['test_full']`.
+- Update the `if (task?.convoy_id) return { ok: true }` early-return: keep skipping spec reconciliation, but enforce strict-mode gates from `required_evidence_gates`.
+- Tests: subtask without `test_full` evidence is rejected at `review`; legacy subtasks (no required_evidence_gates set) keep working.
+
+### Slice 3 — Capability-denial soft-lock + escalate_to_parent
+
+Files: `src/lib/authz/agent-task.ts`, `src/lib/mcp/groups/work.ts`, `src/lib/db/schema.ts` (`tasks.locked_for_completion`), `src/app/api/mcp/pm/route.ts`.
+- Migration: additive column, default 0.
+- New MCP tool `escalate_to_parent` (≈80 LOC).
+- `spawn_subtask` and `delegate`-class denials set the lock + return `next_action`.
+- `update_task_status` and `register_deliverable` honor the lock with `'task_locked_pending_escalation'`.
+- Tests: PM hits `agent_not_coordinator`, lock gets set, `update_task_status` rejects, `escalate_to_parent` clears lock and bounces.
+
+### Slice 4 — Review SLA + convoy-aware escalation
+
+Files: `src/lib/stall-detection.ts`, `src/lib/agent-health.ts`, env schema.
+- New `STALL_DETECTION_MINUTES_REVIEW` env (default 20).
+- Auto-bounce logic + reviewer-stalled mailbox ping.
+- Tests: stalled review → bounced; reviewer stalled → mailbox row written to coordinator.
+
+### Slice 5 — Role-doc updates + ops doc
+
+Files: `src/lib/agents/pm-soul.md`, `src/lib/agents/builder-soul.md` (create if missing), `docs/REVIEW_STAGE_PROTOCOL.md`.
+- One paragraph each. Pure docs slice; no code change. Goes last so the soul-prompt references the now-existing tools.
+
+## Verification
+
+Per CLAUDE.md "Spec-First" workflow:
+
+1. **Unit tests** at slice boundaries (above).
+2. **MCP integration** (`yarn mcp:integration`) covering: agent_not_coordinator → soft-lock → escalate_to_parent.
+3. **Real-agent dogfood**: re-run an alert-replacement-style task on the dev stack (`:4010`) — assigned PM, no builder available — and verify the system either auto-spawns under the orchestrator or bounces back instead of stalling. Capture the evidence in `specs/review-stage-robustness-validation/`.
+4. **Backfill check** before merging slice 4: count current tasks in `review` with no reviewer assigned and no `task_evidence`. They'll auto-bounce on first scan after deploy. List them in the PR description so the operator isn't surprised.
+
+## Rollout
+
+- Each slice ships with a feature flag where it could affect in-flight work:
+  - Slice 1: `MC_REVIEW_STRICT_GATING=1` (off by default for one cycle, then default-on).
+  - Slice 4: `MC_REVIEW_AUTOBOUNCE=1` (off by default; flip after operator reviews backfill list).
+- Slices 2, 3, 5 are safe to land default-on.
+- One-shot backfill script (`scripts/audit-review-stalls.ts`) prints in-flight `review` rows with no reviewer / no evidence so operator can clean up before flipping `MC_REVIEW_AUTOBOUNCE`.
+
+## Open questions
+
+- **Q1.** Should the roster gate (Slice 0) also re-check at the start of `convoy_active → review` transitions, or is dispatch-time enough? Lean: dispatch-time only. Re-checking on every transition risks blocking legitimate work if an agent goes offline mid-flow; that case is the SLA's job (Slice 4), not the gate's.
+- **Q2.** Workflow templates with conditional stages (e.g. `testing` only fires if `task.has_tests`) — does `requiredRolesForTask` over-collect? Probably yes for the first cut. Acceptable: false-positive failures at dispatch ("you don't have a tester, even though this task may not need one") are operator-actionable, whereas false negatives recreate the original failure mode. Re-evaluate after a week of dogfood.
+
+## References
+
+- Recurring incident exemplars: task `92b7b092-a7b6-4542-ba41-b1bdb95860db` (this spec's trigger), prior PR #111 post-mortem in [autonomous-flow-tightening-spec.md](specs/autonomous-flow-tightening-spec.md).
+- Adjacent specs: [coordinator-delegation-via-convoy-spec.md](specs/coordinator-delegation-via-convoy-spec.md) (built `spawn_subtask`/`update_subtask`), [agent-health-overhaul-spec.md](specs/agent-health-overhaul-spec.md) (heartbeat + stall infrastructure this builds on).

--- a/specs/review-stage-robustness-validation/00-baseline-observations.md
+++ b/specs/review-stage-robustness-validation/00-baseline-observations.md
@@ -1,0 +1,39 @@
+# 00 · Baseline Observations
+
+Read-only snapshot captured 2026-05-09, before any feature slice lands. Used as the diff target for post-slice runs.
+
+## Repo state
+- Branch: `main` at `483d5de Replace window.alert with app dialogs/toasts`.
+- Working tree clean apart from this feature's spec/build-plan/validation skeleton.
+
+## Recurring incident — example task
+- `tasks.id = 92b7b092-a7b6-4542-ba41-b1bdb95860db` ("Implement alert() replacements…").
+  - `status = review`, `assigned_agent_id = 8e52f6688339f2eb7a5330f4cce875f9` (MC PM).
+  - `task_evidence` rows: **0**.
+  - `task_roles` rows: **0** (no reviewer assigned).
+  - Activity trail: `agent_not_coordinator` denial → "I'll do it myself" → 4× `register_deliverable` → `update_task_status → review` → stalled.
+  - Parent `be51f229-…` `convoy_active`, `status_reason='stalled_no_activity (idle 62m)'`.
+
+## DB-level invariants today
+- `SELECT DISTINCT role FROM task_roles;` → `builder` only. No `coordinator` or `reviewer` rows in dev DB.
+- `tasks.locked_for_completion` column does not exist.
+- `convoy_subtasks.required_evidence_gates` column does not exist.
+- `STAGE_REQUIRED_EVIDENCE` map ([src/lib/task-governance.ts:43-48](../../src/lib/task-governance.ts:43)): `testing → ['build_fast']`, `review → ['test_full']`, others empty. Convoy-subtask early-return at line 113-115 bypasses this entirely for subtasks.
+- Stall detection: single global `STALL_DETECTION_MINUTES` (default 30). No review-specific threshold. Scanner sets `status_reason` but never transitions.
+
+## Reviewer-stranded review tasks (pre-feature snapshot)
+
+```sql
+SELECT id, title, datetime(updated_at)
+FROM tasks
+WHERE status = 'review'
+  AND id NOT IN (SELECT task_id FROM task_roles WHERE role = 'reviewer')
+  AND id NOT IN (SELECT task_id FROM task_evidence)
+ORDER BY updated_at DESC LIMIT 10;
+```
+
+To be re-run as part of pre-check 01 each iteration; counts inserted into 04 results doc.
+
+## MCP tool surface (pre-feature)
+- `spawn_subtask` exists. `escalate_to_parent` does **not**.
+- `update_task_status`, `register_deliverable`, `submit_evidence` honor authz but no soft-lock concept.

--- a/specs/review-stage-robustness-validation/01-pre-check-initialization.md
+++ b/specs/review-stage-robustness-validation/01-pre-check-initialization.md
@@ -1,0 +1,65 @@
+# 01 · Pre-Check / Initialization
+
+Destructive runbook to reach a known-good baseline before each test-plan run. **Halt on any unexpected output.**
+
+## Step 0 · Repo
+```sh
+git status -s
+git branch --show-current
+```
+Expected: clean working tree (or only validation `04` edits); branch starts with `feat/review-robust-`.
+
+## Step 1 · Dev DB reset
+```sh
+yarn db:backup        # rolling backup
+yarn db:reset         # nuke + re-migrate dev DB
+yarn db:sync-agents   # repopulate openclaw roster
+```
+Expected: no migration errors; agent count > 0.
+
+## Step 2 · Roster check
+Confirm dev workspace has at minimum one builder, one reviewer, one PM/coordinator agent online.
+
+```sh
+sqlite3 mission-control.db "
+  SELECT role, COUNT(*) FROM agents
+  WHERE workspace_id = 'default' AND COALESCE(disabled,0)=0 AND status != 'offline'
+  GROUP BY role;
+"
+```
+Expected: at least `builder ≥ 1`, `reviewer ≥ 1`, `pm ≥ 1` (or equivalent gateway-id-derivable rows). If reviewer missing, onboard one before continuing.
+
+## Step 3 · Queue depth (HMR-runaway watchdog)
+```sh
+sqlite3 mission-control.db "SELECT COUNT(*) FROM agent_runs WHERE status IN ('queued','running');"
+```
+Expected: ≤ 5. If higher, restart dev server cleanly and wait for drain.
+
+## Step 4 · Dev server restart
+```sh
+# /dev-restart  (skill)
+yarn dev:status   # confirm :4010 listening
+```
+Expected: dev server up; `/api/health` returns 200.
+
+## Step 5 · Targeted-suite baseline
+```sh
+yarn test --runInBand src/lib/services/task-status.test.ts \
+                     src/lib/task-governance.test.ts \
+                     src/lib/dispatch/roster-gate.test.ts \
+                     src/lib/stall-detection.test.ts
+```
+Expected: all green. Pre-existing failures elsewhere are listed in `04-e2e-run-results.md` per CLAUDE.md.
+
+## Step 6 · Capture dir
+```sh
+mkdir -p /tmp/mc-validation/review-robust
+ls /tmp/mc-validation/review-robust   # should be empty for first scenario
+```
+
+## Step 7 · Feature flags (per scenario, enabled selectively)
+- `MC_ROSTER_GATE` — Slice 0 scenarios.
+- `MC_REVIEW_STRICT_GATING` — Slice 1 scenarios.
+- `MC_REVIEW_AUTOBOUNCE` — Slice 4 scenarios.
+
+Set as env vars before `yarn dev` boots; scenario doc names which.

--- a/specs/review-stage-robustness-validation/02-test-plan.md
+++ b/specs/review-stage-robustness-validation/02-test-plan.md
@@ -1,0 +1,144 @@
+# 02 · Test Plan
+
+Six concrete scenarios. Each lands a different slice's failure-mode coverage. All real-agent dispatches use `spark-lb/agent`. Captures at `/tmp/mc-validation/review-robust/<scenario_id>/`.
+
+Time budget: ~5 min real-agent time per scenario. RR-S5 (full incident replay) is ~10 min.
+
+---
+
+## RR-S1 · Dispatch refused on missing reviewer (Slice 0)
+
+**Setup**
+- Workspace `rr-s1-test` (fresh) seeded with one builder + one PM. **No reviewer.**
+- `MC_ROSTER_GATE=1`.
+- Plain task created via API, status `inbox`.
+
+**Action**
+- `POST /api/tasks/<id>/dispatch`.
+
+**Observation**
+- HTTP 422 with structured error containing `code: 'roster_incomplete'`, `missing: ['reviewer']`.
+- Task status flips to `needs_user_input`, `status_reason='roster_incomplete: reviewer'`.
+- `task_activities` row `activity_type='roster_incomplete'`, metadata includes `missing`.
+- Mailbox row written to operator (or workspace default agent).
+- **No** OpenClaw worker dispatched (check `agent_runs` table).
+
+**Capture:** dispatch request/response, task row, activity row, mailbox row.
+
+---
+
+## RR-S2 · Full roster passes (Slice 0 regression)
+
+**Setup**
+- Workspace with builder + reviewer + PM all online.
+- `MC_ROSTER_GATE=1`.
+- Plain task created.
+
+**Action**
+- `POST /api/tasks/<id>/dispatch`.
+
+**Observation**
+- HTTP 200; task transitions to `assigned`.
+- OpenClaw worker dispatched (check `agent_runs` row created).
+- No `roster_incomplete` activity.
+
+**Capture:** dispatch response, agent_runs row.
+
+---
+
+## RR-S3 · Self-review block + reviewer auto-pick (Slice 1)
+
+**Setup**
+- Task assigned to builder agent A, in `in_progress`.
+- `MC_REVIEW_STRICT_GATING=1`.
+- Reviewer agent B online in same workspace.
+
+**Action**
+- Builder A submits `test_full` evidence and calls `update_task_status({status:'review'})`.
+
+**Observation**
+- Transition succeeds (A ≠ B; auto-picked B as reviewer).
+- `task_roles` row written: `(task_id, 'reviewer', B.id)`.
+
+**Action 2**
+- Workspace reduced to A only (B disabled). New task assigned to A. A submits evidence and calls `update_task_status({status:'review'})`.
+
+**Observation 2**
+- Transition rejected with `code: 'self_review_blocked'` (no other agent to auto-pick → falls through to self-review check).
+
+**Capture:** both transition responses, `task_roles` row.
+
+---
+
+## RR-S4 · Subtask cannot reach review without `test_full` (Slice 2)
+
+**Setup**
+- Convoy parent + one subtask spawned via `spawn_subtask`. Subtask carries `required_evidence_gates: ['test_full']`.
+- `MC_REVIEW_STRICT_GATING=1`.
+
+**Action**
+- Subtask agent registers deliverables but does **not** submit `test_full`. Calls `update_task_status({status:'review'})`.
+
+**Observation**
+- Transition rejected with `code: 'evidence_gate'`, message naming `test_full`.
+- Task remains in `in_progress`.
+
+**Action 2**
+- Submit `test_full` (passing). Re-call `update_task_status`.
+
+**Observation 2**
+- Transition succeeds.
+
+**Capture:** rejection response, evidence rows.
+
+---
+
+## RR-S5 · Full incident replay — `agent_not_coordinator` → escalation, not stall (Slice 3)
+
+This is the headline scenario: the original task `92b7b092` failure mode, replayed against the patched stack.
+
+**Setup**
+- Convoy parent assigned to coordinator C; subtask assigned to PM agent P (not a coordinator on this task).
+- `MC_REVIEW_STRICT_GATING=1` (just for the lock to be honored against subsequent mutations).
+
+**Action**
+- P calls `spawn_subtask` to delegate to a builder.
+
+**Observation**
+- Tool returns `isError: true, structuredContent: { error: 'agent_not_coordinator', next_action: 'escalate_to_parent' }`.
+- `tasks.locked_for_completion = 1` for P's task.
+- P attempts `register_deliverable` → rejected with `error: 'task_locked_pending_escalation'`.
+- P calls `escalate_to_parent({ task_id, reason: 'I cannot delegate; redecompose' })`.
+- Parent gets activity row `activity_type='escalation'`, mailbox row to coordinator C.
+- Child bounces to `assigned`, `is_failed = 1`, `locked_for_completion = 0`.
+
+**Capture:** full transcript of P's MCP calls; parent + child task rows before/after.
+
+**Time budget:** 10 min (longer than other scenarios because of the multi-step interaction).
+
+---
+
+## RR-S6 · Stale review auto-bounces; coordinator pinged (Slice 4)
+
+**Setup**
+- Task `T` in `review`, reviewer `R` assigned, parent `P` `convoy_active` with coordinator `C`.
+- `MC_REVIEW_AUTOBOUNCE=1`, `STALL_DETECTION_MINUTES_REVIEW=1` (1 min for test acceleration).
+- Backdate `T.updated_at` and last activity to 3 minutes ago.
+
+**Action**
+- Run `POST /api/tasks/scan-stalls` (or wait for scheduled run).
+
+**Observation**
+- First scan (≥ 1× threshold): `task_activities` row `reviewer_stalled`; mailbox row to `R`.
+- Second scan (≥ 2× threshold): `T` transitions `review → assigned`, `is_failed = 1`, `status_reason='Failed: reviewer unresponsive (idle 3m)'`. Coordinator `C` mailbox-pinged.
+
+**Capture:** scan response payloads, both activity rows, mailbox rows, task transitions.
+
+---
+
+## Globals (apply to every scenario)
+
+- No unhandled SSE errors during the run (`preview_console_logs` clean).
+- No worker dispatched on a refused gate (any `agent_runs` row appearing on a refused task is a global fail).
+- Pre-existing test failures listed in `04-e2e-run-results.md`, not silently ignored.
+- Each scenario writes its capture dir before passing to the next.

--- a/specs/review-stage-robustness-validation/03-validation-criteria.md
+++ b/specs/review-stage-robustness-validation/03-validation-criteria.md
@@ -1,0 +1,61 @@
+# 03 · Validation Criteria
+
+Per-scenario gates (AND-ed within a scenario). Plus globals applied across the run. A milestone is GREEN only if all gates pass.
+
+`FLAKE` policy: re-run 3×; passes if ≥ 2/3.
+
+## Per-scenario gates
+
+### RR-S1 — Dispatch refused on missing reviewer
+- **G1.1** HTTP 422 returned.
+- **G1.2** Response body has `code: 'roster_incomplete'` and `missing: ['reviewer']` (or superset).
+- **G1.3** Task status flipped to `needs_user_input`.
+- **G1.4** `task_activities` row with `activity_type='roster_incomplete'` exists.
+- **G1.5** Operator mailbox row exists for this task.
+- **G1.6** No `agent_runs` row created for this task.
+
+### RR-S2 — Full roster passes
+- **G2.1** HTTP 200.
+- **G2.2** Task status `assigned`.
+- **G2.3** `agent_runs` row exists (`status` in `queued|running`).
+- **G2.4** No `roster_incomplete` activity row.
+
+### RR-S3 — Self-review block + auto-pick
+- **G3.1** First action succeeds (A ≠ B auto-pick path).
+- **G3.2** `task_roles` row inserted with `role='reviewer'`, `agent_id != A.id`.
+- **G3.3** Second action returns `code: 'self_review_blocked'`.
+- **G3.4** Task remains in `in_progress` after rejection.
+
+### RR-S4 — Subtask evidence gate
+- **G4.1** First action returns `code: 'evidence_gate'` mentioning `test_full`.
+- **G4.2** Task remains in `in_progress`.
+- **G4.3** Second action (with evidence) succeeds; status transitions to `review`.
+
+### RR-S5 — Full incident replay
+- **G5.1** `spawn_subtask` returns `next_action: 'escalate_to_parent'` on denial.
+- **G5.2** `tasks.locked_for_completion = 1` immediately after denial.
+- **G5.3** `register_deliverable` while locked returns `error: 'task_locked_pending_escalation'`.
+- **G5.4** `escalate_to_parent` returns success; parent activity `activity_type='escalation'` written; mailbox row to coordinator.
+- **G5.5** Child bounces: `status='assigned'`, `is_failed=1`, `locked_for_completion=0`.
+- **G5.6** No `register_deliverable` rows accepted between denial and escalation.
+
+### RR-S6 — Review SLA auto-bounce
+- **G6.1** First scan writes `reviewer_stalled` activity + reviewer mailbox row; task remains in `review`.
+- **G6.2** Second scan transitions `review → assigned`, `is_failed=1`.
+- **G6.3** `status_reason` matches `^Failed: reviewer unresponsive`.
+- **G6.4** Coordinator mailbox row written.
+
+## Global gates (apply across the run)
+
+- **GG-1** No unhandled errors in `preview_console_logs` for the duration of any scenario.
+- **GG-2** Targeted-suite (`yarn test` slice from pre-check 01 step 5) green.
+- **GG-3** No worker dispatched on a refused gate (cross-cuts G1.6).
+- **GG-4** Pre-existing failures (if any) are listed in `04-e2e-run-results.md` with file + reason — not silently skipped.
+- **GG-5** Backfill audit (`scripts/audit-review-stalls.ts`) was run before flipping `MC_REVIEW_AUTOBOUNCE`; results pasted into `04`.
+
+## Verdict mapping
+
+- **GREEN** — all per-scenario gates AND all globals pass.
+- **YELLOW** — a non-load-bearing gate fails (e.g. mailbox-row text mismatch but transition correct). Documented; ship-eligible with operator OK.
+- **BLOCKED** — environmental failure (DB locked, port collision) blocks scenario execution. Re-run after fix.
+- **RED** — a load-bearing gate fails (G1.1, G5.5, etc.). Stop, file the failure mode, fix, re-run.

--- a/specs/review-stage-robustness-validation/04-e2e-run-results.md
+++ b/specs/review-stage-robustness-validation/04-e2e-run-results.md
@@ -1,0 +1,41 @@
+# 04 · End-to-End Run Results
+
+Written during/after the validation run against the stack tip. The single document the operator reads to decide "ship it."
+
+## Verdict
+
+**Status:** _PENDING_ (scaffolding only; no run yet)
+
+Will be set to one of: GREEN / YELLOW / BLOCKED / RED.
+
+## Summary
+
+_(One paragraph after the run: what was exercised, what passed, what didn't. Specific row counts and key evidence.)_
+
+## Per-scenario results
+
+| Scenario | Slice | Result | Evidence |
+|---|---|---|---|
+| RR-S1 — Dispatch refused on missing reviewer | 0 | _PENDING_ | _path_ |
+| RR-S2 — Full roster passes | 0 | _PENDING_ | _path_ |
+| RR-S3 — Self-review block + auto-pick | 1 | _PENDING_ | _path_ |
+| RR-S4 — Subtask evidence gate | 2 | _PENDING_ | _path_ |
+| RR-S5 — Full incident replay | 3 | _PENDING_ | _path_ |
+| RR-S6 — Review SLA auto-bounce | 4 | _PENDING_ | _path_ |
+
+## Pre-existing test failures
+
+_(Listed here per CLAUDE.md so they're not silently masked. File + reason each.)_
+
+## Backfill audit (Slice 4)
+
+_(Output of `scripts/audit-review-stalls.ts` before `MC_REVIEW_AUTOBOUNCE` is flipped on. Counts of `review`-status tasks with no reviewer / no evidence.)_
+
+## Open issues surfaced during the run
+
+_(Anything noticed in passing — not part of the gate set, but worth flagging for follow-up.)_
+
+## Sign-off
+
+_Operator review_: ___
+_Date_: ___

--- a/specs/review-stage-robustness-validation/README.md
+++ b/specs/review-stage-robustness-validation/README.md
@@ -1,0 +1,18 @@
+# Review-Stage Robustness — Validation
+
+Validation skeleton for the [Review-Stage Robustness](../review-stage-robustness-spec.md) feature stack. Per the [long-unattended-feature-dev contract](../long-unattended-feature-dev.md), the operator reads `04-e2e-run-results.md` (verdict + evidence) instead of every intermediate diff.
+
+## Read order
+
+1. [`00-baseline-observations.md`](00-baseline-observations.md) — state of the dev DB + relevant rows before any slice lands.
+2. [`01-pre-check-initialization.md`](01-pre-check-initialization.md) — destructive runbook to reach a known-good baseline before each test-plan run.
+3. [`02-test-plan.md`](02-test-plan.md) — concrete RR-S* scenarios with setup / action / observation / capture path.
+4. [`03-validation-criteria.md`](03-validation-criteria.md) — per-scenario gates + globals.
+5. [`04-e2e-run-results.md`](04-e2e-run-results.md) — written during/after runs. Verdict (GREEN / YELLOW / BLOCKED / RED) + per-scenario evidence pointers.
+
+## Conventions
+
+- Real-agent dispatches use `spark-lb/agent` per [project_openclaw_model.md](../../memory/project_openclaw_model.md).
+- Captures live at `/tmp/mc-validation/review-robust/<scenario_id>/`.
+- Dev DB at `:4010` is fully separate from prod at `:4001` per [project_dev_prod_db_split.md](../../memory/project_dev_prod_db_split.md). Wipes are routine.
+- HMR runaway: pre-check 01 confirms pending-brief queue is empty before any dispatch; restart cleanly between scenarios per [project_research_hmr_runaway.md](../../memory/project_research_hmr_runaway.md).

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -14,6 +14,7 @@ import { getRelevantKnowledge, formatKnowledgeForDispatch } from '@/lib/learner'
 import { getTaskWorkflow } from '@/lib/workflow-engine';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { pickDynamicAgent } from '@/lib/task-governance';
+import { enforceRosterGate } from '@/lib/dispatch/roster-gate';
 import { buildCheckpointContext, saveCheckpoint, getLatestCheckpoint } from '@/lib/checkpoint';
 import { clearStallFlag } from '@/lib/stall-detection';
 import { logDebugEvent } from '@/lib/debug-log';
@@ -111,6 +112,26 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     if (!task) {
       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    }
+
+    // Pre-dispatch roster gate (Slice 0 of review-stage-robustness).
+    // Refuses to dispatch when the workspace can't field every role the
+    // task will need across its lifecycle. On failure, the gate has
+    // already flipped the task to `needs_user_input` and pinged the
+    // operator — we just translate the structured result to HTTP.
+    // No-op when MC_ROSTER_GATE != '1'.
+    const rosterGate = await enforceRosterGate(id);
+    if (!rosterGate.ok) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: rosterGate.message,
+          code: rosterGate.code,
+          missing: rosterGate.missing,
+          available_by_role: rosterGate.availableByRole,
+        },
+        { status: 422 },
+      );
     }
 
     let assignedAgentId = task.assigned_agent_id;

--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -17,7 +17,8 @@ export type ServerActivityType =
   | 'stall_notified'   // stall scanner messaged coordinator / webhook
   | 'stall_recovered'  // coordinator / dispatch clears a stall flag
   | 'coordinator_stalled'   // convoy coordinator itself can't be reached
-  | 'coordinator_missing';  // convoy has no live coordinator
+  | 'coordinator_missing'   // convoy has no live coordinator
+  | 'roster_incomplete';    // pre-dispatch roster gate refused: workspace missing required role(s)
 
 interface LogActivityInput {
   taskId: string;

--- a/src/lib/convoy.ts
+++ b/src/lib/convoy.ts
@@ -606,13 +606,19 @@ export function spawnDelegationSubtask(input: SpawnDelegationInput): SpawnDelega
     const dueAt = new Date(Date.now() + input.expectedDurationMinutes * 60_000).toISOString();
 
     const subtaskId = uuidv4();
+    // Slice 2 of review-stage-robustness: every spawned subtask gets a
+    // default required_evidence_gates of ['test_full'] so the strict-mode
+    // evidence gate fires for review transitions. Legacy subtasks (no
+    // row updated) keep the bypass; new subtasks must produce real
+    // test evidence to enter review.
+    const defaultRequiredGates = JSON.stringify(['test_full']);
     run(
       `INSERT INTO convoy_subtasks (
          id, convoy_id, task_id, sort_order, depends_on, suggested_role,
          slice, expected_deliverables, acceptance_criteria,
          expected_duration_minutes, checkin_interval_minutes,
-         dispatched_at, due_at, deliverables_registered_count, created_at
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+         dispatched_at, due_at, deliverables_registered_count, required_evidence_gates, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`,
       [
         subtaskId,
         convoy.id,
@@ -629,6 +635,7 @@ export function spawnDelegationSubtask(input: SpawnDelegationInput): SpawnDelega
         input.checkinIntervalMinutes,
         now,
         dueAt,
+        defaultRequiredGates,
         now,
       ]
     );

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4671,6 +4671,21 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    id: '091',
+    name: 'convoy_subtasks_required_evidence_gates',
+    up: (db) => {
+      // Slice 2 of review-stage-robustness. Closes the convoy-subtask
+      // evidence-gate bypass: subtasks now declare which evidence gates
+      // they must satisfy to enter review. JSON array (e.g. ["test_full"]).
+      // Null/missing keeps the legacy bypass intact for in-flight rows.
+      const cols = db.prepare(`PRAGMA table_info(convoy_subtasks)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'required_evidence_gates')) {
+        db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN required_evidence_gates TEXT`);
+        console.log('[Migration 091] convoy_subtasks.required_evidence_gates added.');
+      }
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/dispatch/roster-gate.test.ts
+++ b/src/lib/dispatch/roster-gate.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for the pre-dispatch workspace-roster gate (Slice 0).
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { run, queryOne } from '@/lib/db';
+import {
+  enforceRosterGate,
+  requiredRolesForTask,
+  validateWorkspaceRoster,
+  type RosterRole,
+} from './roster-gate';
+
+function seedWorkspace(id: string): void {
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at, updated_at)
+     VALUES (?, ?, ?, datetime('now'), datetime('now'))`,
+    [id, id, id],
+  );
+}
+
+function freshWorkspace(): string {
+  const id = `ws-${crypto.randomUUID().slice(0, 8)}`;
+  seedWorkspace(id);
+  return id;
+}
+
+function seedAgent(opts: {
+  id?: string;
+  workspace?: string;
+  role?: string | null;
+  gateway?: string | null;
+  status?: string;
+  isActive?: number;
+  isPm?: number;
+  isMaster?: number;
+} = {}): string {
+  const id = opts.id ?? crypto.randomUUID();
+  run(
+    `INSERT INTO agents (id, name, role, gateway_agent_id, workspace_id, status, is_active, is_pm, is_master, created_at, updated_at)
+     VALUES (?, 'A', ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+    [
+      id,
+      // role is NOT NULL in schema. Empty string lets the gateway-id-derivation path fire.
+      opts.role ?? '',
+      opts.gateway ?? null,
+      opts.workspace ?? 'default',
+      opts.status ?? 'standby',
+      opts.isActive ?? 1,
+      opts.isPm ?? 0,
+      opts.isMaster ?? 0,
+    ],
+  );
+  return id;
+}
+
+function seedTask(opts: {
+  id?: string;
+  workspace?: string;
+  status?: string;
+  assigned?: string | null;
+  convoyId?: string | null;
+  isSubtask?: number;
+  workflowTemplateId?: string | null;
+} = {}): string {
+  const id = opts.id ?? crypto.randomUUID();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, assigned_agent_id, convoy_id, is_subtask, workflow_template_id, created_at, updated_at)
+     VALUES (?, 'T', ?, 'normal', ?, 'default', ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+    [
+      id,
+      opts.status ?? 'inbox',
+      opts.workspace ?? 'default',
+      opts.assigned ?? null,
+      opts.convoyId ?? null,
+      opts.isSubtask ?? 0,
+      opts.workflowTemplateId ?? null,
+    ],
+  );
+  return id;
+}
+
+function seedConvoySubtask(taskId: string, convoyId: string, suggestedRole: string): void {
+  run(
+    `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, suggested_role, slice, created_at)
+     VALUES (?, ?, ?, 0, ?, 'test slice', datetime('now'))`,
+    [crypto.randomUUID(), convoyId, taskId, suggestedRole],
+  );
+}
+
+function seedConvoy(id: string, workspace = 'default'): { parentTaskId: string } {
+  // convoys.parent_task_id is NOT NULL — create a parent task first.
+  const parentTaskId = seedTask({ workspace, status: 'convoy_active' });
+  run(
+    `INSERT INTO convoys (id, parent_task_id, name, status, created_at, updated_at)
+     VALUES (?, ?, 'test convoy', 'active', datetime('now'), datetime('now'))`,
+    [id, parentTaskId],
+  );
+  return { parentTaskId };
+}
+
+function setEnv(key: string, value: string | undefined): () => void {
+  const prior = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  return () => {
+    if (prior === undefined) delete process.env[key];
+    else process.env[key] = prior;
+  };
+}
+
+// ─── requiredRolesForTask ─────────────────────────────────────────────
+
+test('requiredRolesForTask: plain task defaults to builder + reviewer', () => {
+  const task = seedTask();
+  const roles = requiredRolesForTask(task);
+  assert.deepEqual([...roles].sort(), ['builder', 'reviewer']);
+});
+
+test('requiredRolesForTask: convoy subtask uses suggested_role + reviewer', () => {
+  const convoyId = crypto.randomUUID();
+  seedConvoy(convoyId);
+  const task = seedTask({ convoyId, isSubtask: 1 });
+  seedConvoySubtask(task, convoyId, 'tester');
+  const roles = requiredRolesForTask(task);
+  assert.deepEqual([...roles].sort(), ['reviewer', 'tester']);
+});
+
+test('requiredRolesForTask: convoy subtask with unknown suggested_role falls back to builder', () => {
+  const convoyId = crypto.randomUUID();
+  seedConvoy(convoyId);
+  const task = seedTask({ convoyId, isSubtask: 1 });
+  seedConvoySubtask(task, convoyId, 'wizard'); // not a known role
+  const roles = requiredRolesForTask(task);
+  assert.deepEqual([...roles].sort(), ['builder', 'reviewer']);
+});
+
+test('requiredRolesForTask: workflow-template task unions stage roles', () => {
+  const tplId = crypto.randomUUID();
+  run(
+    `INSERT INTO workflow_templates (id, workspace_id, name, stages, created_at, updated_at)
+     VALUES (?, 'default', 'Std', ?, datetime('now'), datetime('now'))`,
+    [
+      tplId,
+      JSON.stringify([
+        { id: 'build', label: 'Build', role: 'builder', status: 'in_progress' },
+        { id: 'test', label: 'Test', role: 'tester', status: 'testing' },
+        { id: 'review', label: 'Review', role: 'reviewer', status: 'review' },
+      ]),
+    ],
+  );
+  const task = seedTask({ workflowTemplateId: tplId });
+  const roles = requiredRolesForTask(task);
+  assert.deepEqual([...roles].sort(), ['builder', 'reviewer', 'tester']);
+});
+
+test('requiredRolesForTask: malformed template falls back to default ladder', () => {
+  const tplId = crypto.randomUUID();
+  run(
+    `INSERT INTO workflow_templates (id, workspace_id, name, stages, created_at, updated_at)
+     VALUES (?, 'default', 'Bad', 'not-json', datetime('now'), datetime('now'))`,
+    [tplId],
+  );
+  const task = seedTask({ workflowTemplateId: tplId });
+  const roles = requiredRolesForTask(task);
+  assert.deepEqual([...roles].sort(), ['builder', 'reviewer']);
+});
+
+// ─── validateWorkspaceRoster ──────────────────────────────────────────
+
+test('validateWorkspaceRoster: passes when each role has an online active agent', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: 'builder', status: 'standby' });
+  seedAgent({ workspace: ws, role: 'reviewer', status: 'standby' });
+  const result = validateWorkspaceRoster(ws, ['builder', 'reviewer']);
+  assert.equal(result.ok, true);
+});
+
+test('validateWorkspaceRoster: fails when reviewer absent', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: 'builder', status: 'standby' });
+  const result = validateWorkspaceRoster(ws, ['builder', 'reviewer']);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.deepEqual(result.missing, ['reviewer']);
+    assert.equal(result.availableByRole.builder, 1);
+  }
+});
+
+test('validateWorkspaceRoster: offline agent does not satisfy', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: 'reviewer', status: 'offline' });
+  const result = validateWorkspaceRoster(ws, ['reviewer']);
+  assert.equal(result.ok, false);
+});
+
+test('validateWorkspaceRoster: is_active = 0 does not satisfy', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: 'reviewer', status: 'standby', isActive: 0 });
+  const result = validateWorkspaceRoster(ws, ['reviewer']);
+  assert.equal(result.ok, false);
+});
+
+test('validateWorkspaceRoster: gateway-id derivation provides role when role column null', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: null, gateway: 'mc-reviewer-dev', status: 'standby' });
+  const result = validateWorkspaceRoster(ws, ['reviewer']);
+  assert.equal(result.ok, true);
+});
+
+test('validateWorkspaceRoster: cross-workspace agent does not satisfy', () => {
+  const wsA = freshWorkspace();
+  const wsB = freshWorkspace();
+  seedAgent({ workspace: wsB, role: 'reviewer', status: 'standby' });
+  const result = validateWorkspaceRoster(wsA, ['reviewer']);
+  assert.equal(result.ok, false);
+});
+
+// ─── enforceRosterGate ────────────────────────────────────────────────
+
+test('enforceRosterGate: no-op when MC_ROSTER_GATE != "1"', async () => {
+  const restore = setEnv('MC_ROSTER_GATE', undefined);
+  try {
+    const ws = freshWorkspace();
+    const task = seedTask({ workspace: ws }); // no agents exist
+    const result = await enforceRosterGate(task);
+    assert.equal(result.ok, true);
+    // Task was NOT touched.
+    const row = queryOne<{ status: string }>('SELECT status FROM tasks WHERE id = ?', [task]);
+    assert.equal(row?.status, 'inbox');
+  } finally {
+    restore();
+  }
+});
+
+test('enforceRosterGate: blocks when reviewer missing and flips status + writes activity', async () => {
+  const restore = setEnv('MC_ROSTER_GATE', '1');
+  try {
+    const ws = freshWorkspace();
+    seedAgent({ workspace: ws, role: 'builder', status: 'standby' });
+    // No reviewer.
+    const task = seedTask({ workspace: ws });
+    const result = await enforceRosterGate(task);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.code, 'roster_incomplete');
+      assert.deepEqual(result.missing, ['reviewer']);
+    }
+    const row = queryOne<{ status: string; status_reason: string | null }>(
+      'SELECT status, status_reason FROM tasks WHERE id = ?',
+      [task],
+    );
+    assert.equal(row?.status, 'needs_user_input');
+    assert.match(row?.status_reason ?? '', /^roster_incomplete:/);
+    const activity = queryOne<{ activity_type: string }>(
+      `SELECT activity_type FROM task_activities WHERE task_id = ? ORDER BY created_at DESC LIMIT 1`,
+      [task],
+    );
+    assert.equal(activity?.activity_type, 'roster_incomplete');
+  } finally {
+    restore();
+  }
+});
+
+test('enforceRosterGate: passes when full roster available — task untouched', async () => {
+  const restore = setEnv('MC_ROSTER_GATE', '1');
+  try {
+    const ws = freshWorkspace();
+    seedAgent({ workspace: ws, role: 'builder', status: 'standby' });
+    seedAgent({ workspace: ws, role: 'reviewer', status: 'standby' });
+    const task = seedTask({ workspace: ws });
+    const result = await enforceRosterGate(task);
+    assert.equal(result.ok, true);
+    const row = queryOne<{ status: string }>('SELECT status FROM tasks WHERE id = ?', [task]);
+    assert.equal(row?.status, 'inbox'); // not changed
+  } finally {
+    restore();
+  }
+});
+
+test('enforceRosterGate: writes mailbox row to workspace PM when present', async () => {
+  const restore = setEnv('MC_ROSTER_GATE', '1');
+  try {
+    const ws = freshWorkspace();
+    const pmId = seedAgent({
+      workspace: ws,
+      role: 'pm',
+      gateway: 'mc-pm-test-dev',
+      status: 'standby',
+      isPm: 1,
+      isMaster: 1,
+    });
+    // No builder, no reviewer.
+    const task = seedTask({ workspace: ws });
+    const result = await enforceRosterGate(task);
+    assert.equal(result.ok, false);
+    const mail = queryOne<{ from_agent_id: string; to_agent_id: string; subject: string | null }>(
+      `SELECT from_agent_id, to_agent_id, subject FROM agent_mailbox WHERE task_id = ? ORDER BY created_at DESC LIMIT 1`,
+      [task],
+    );
+    assert.equal(mail?.to_agent_id, pmId);
+    assert.match(mail?.subject ?? '', /Roster incomplete/);
+  } finally {
+    restore();
+  }
+});
+
+test('enforceRosterGate: missing roles list reflects multiple deficits', async () => {
+  const restore = setEnv('MC_ROSTER_GATE', '1');
+  try {
+    const ws = freshWorkspace();
+    // Empty workspace.
+    const task = seedTask({ workspace: ws });
+    const result = await enforceRosterGate(task);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      const missing = result.missing as RosterRole[];
+      assert.ok(missing.includes('builder'));
+      assert.ok(missing.includes('reviewer'));
+    }
+  } finally {
+    restore();
+  }
+});

--- a/src/lib/dispatch/roster-gate.ts
+++ b/src/lib/dispatch/roster-gate.ts
@@ -1,0 +1,252 @@
+/**
+ * Pre-dispatch workspace-roster gate.
+ *
+ * Refuses to dispatch a task whose downstream stages need roles the
+ * workspace can't currently fill. Converts the recurring "mid-flight stall
+ * because no reviewer existed" failure into a one-time, operator-actionable
+ * error at dispatch time.
+ *
+ * See specs/review-stage-robustness-spec.md (Slice 0).
+ *
+ * Activated by env var `MC_ROSTER_GATE=1` (default off for one cycle so
+ * operators can backfill before flipping default-on).
+ */
+import { queryOne, queryAll, run } from '@/lib/db';
+import { logTaskActivity } from '@/lib/activity-log';
+import { sendMail } from '@/lib/mailbox';
+import { getPmAgent } from '@/lib/agents/pm-resolver';
+import type { Task, WorkflowStage } from '@/lib/types';
+
+/** Roles the gate can require. Mirrors resolveBriefingRole's known set. */
+export type RosterRole =
+  | 'builder'
+  | 'tester'
+  | 'reviewer'
+  | 'researcher'
+  | 'writer'
+  | 'learner'
+  | 'coordinator'
+  | 'pm';
+
+const KNOWN_ROLES: ReadonlySet<RosterRole> = new Set([
+  'builder', 'tester', 'reviewer', 'researcher', 'writer', 'learner', 'coordinator', 'pm',
+]);
+
+export function isRosterGateEnabled(): boolean {
+  return process.env.MC_ROSTER_GATE === '1';
+}
+
+/**
+ * Compute the set of roles a task is expected to need across its full
+ * lifecycle. Conservative on purpose: false-positive failures at dispatch
+ * ("you're missing X") are operator-actionable, whereas false negatives
+ * recreate the original stall pattern.
+ */
+export function requiredRolesForTask(taskId: string): Set<RosterRole> {
+  const task = queryOne<Task & { workflow_template_id: string | null }>(
+    `SELECT id, status, convoy_id, workflow_template_id, is_subtask
+     FROM tasks WHERE id = ?`,
+    [taskId],
+  );
+  if (!task) return new Set();
+
+  // Convoy subtask: trust the suggested_role, plus reviewer for the review
+  // stage. Convoy parents that are themselves convoy_active union across
+  // their children below.
+  if (task.convoy_id) {
+    const subtask = queryOne<{ suggested_role: string | null }>(
+      `SELECT suggested_role FROM convoy_subtasks WHERE task_id = ?`,
+      [taskId],
+    );
+    const roles = new Set<RosterRole>();
+    if (subtask?.suggested_role && KNOWN_ROLES.has(subtask.suggested_role as RosterRole)) {
+      roles.add(subtask.suggested_role as RosterRole);
+    } else {
+      roles.add('builder');
+    }
+    roles.add('reviewer');
+    return roles;
+  }
+
+  // Convoy parent (status convoy_active): union across children.
+  if (task.status === 'convoy_active') {
+    const children = queryAll<{ suggested_role: string | null }>(
+      `SELECT suggested_role FROM convoy_subtasks
+       WHERE convoy_id = (SELECT convoy_id FROM convoy_subtasks WHERE task_id = ? LIMIT 1)`,
+      [taskId],
+    );
+    const roles = new Set<RosterRole>();
+    for (const c of children) {
+      if (c.suggested_role && KNOWN_ROLES.has(c.suggested_role as RosterRole)) {
+        roles.add(c.suggested_role as RosterRole);
+      } else {
+        roles.add('builder');
+      }
+    }
+    roles.add('reviewer');
+    return roles;
+  }
+
+  // Workflow-template task: union across stage roles. Default reviewer added
+  // if any stage's status is 'review' (template format may omit explicit role).
+  if (task.workflow_template_id) {
+    const tpl = queryOne<{ stages: string }>(
+      'SELECT stages FROM workflow_templates WHERE id = ?',
+      [task.workflow_template_id],
+    );
+    if (tpl?.stages) {
+      try {
+        const stages = JSON.parse(tpl.stages) as WorkflowStage[];
+        const roles = new Set<RosterRole>();
+        let hasReviewStage = false;
+        for (const stage of stages) {
+          if (stage.role && KNOWN_ROLES.has(stage.role as RosterRole)) {
+            roles.add(stage.role as RosterRole);
+          }
+          if (stage.status === 'review' || stage.status === 'verification') hasReviewStage = true;
+        }
+        if (hasReviewStage) roles.add('reviewer');
+        if (roles.size === 0) {
+          // Empty / malformed template — fall through to default ladder.
+          return new Set<RosterRole>(['builder', 'reviewer']);
+        }
+        return roles;
+      } catch {
+        // Fall through to default.
+      }
+    }
+  }
+
+  // Plain task default: builder works it, reviewer evaluates it.
+  return new Set<RosterRole>(['builder', 'reviewer']);
+}
+
+export interface RosterValidationFail {
+  ok: false;
+  missing: RosterRole[];
+  availableByRole: Record<string, number>;
+}
+export type RosterValidationResult = { ok: true } | RosterValidationFail;
+
+/**
+ * Check whether the workspace has at least one available agent for each
+ * required role. "Available" = not offline, not disabled (`is_active != 0`).
+ * Role match: prefer the agent's `role` column; fall back to gateway-id
+ * derivation for legacy rows where role is unset.
+ */
+export function validateWorkspaceRoster(
+  workspaceId: string,
+  requiredRoles: Iterable<RosterRole>,
+): RosterValidationResult {
+  const required = Array.from(new Set(requiredRoles));
+  if (required.length === 0) return { ok: true };
+
+  const agents = queryAll<{ role: string | null; gateway_agent_id: string | null }>(
+    `SELECT role, gateway_agent_id FROM agents
+     WHERE COALESCE(workspace_id, 'default') = ?
+       AND COALESCE(is_active, 1) = 1
+       AND status != 'offline'`,
+    [workspaceId],
+  );
+
+  const availableByRole: Record<string, number> = {};
+  for (const a of agents) {
+    const resolved = resolveAgentRole(a.role, a.gateway_agent_id);
+    if (resolved) availableByRole[resolved] = (availableByRole[resolved] ?? 0) + 1;
+  }
+
+  const missing = required.filter(r => (availableByRole[r] ?? 0) === 0);
+  if (missing.length === 0) return { ok: true };
+  return { ok: false, missing, availableByRole };
+}
+
+function resolveAgentRole(role: string | null, gatewayId: string | null): RosterRole | null {
+  if (role && KNOWN_ROLES.has(role as RosterRole)) return role as RosterRole;
+  if (!gatewayId) return null;
+  const baseId = gatewayId.replace(/^mc-/, '').replace(/-dev$/, '');
+  if (baseId === 'project-manager') return 'pm';
+  if (KNOWN_ROLES.has(baseId as RosterRole)) return baseId as RosterRole;
+  return null;
+}
+
+export interface RosterGateOk { ok: true }
+export interface RosterGateBlocked {
+  ok: false;
+  code: 'roster_incomplete';
+  missing: RosterRole[];
+  availableByRole: Record<string, number>;
+  message: string;
+}
+export type RosterGateResult = RosterGateOk | RosterGateBlocked;
+
+/**
+ * Top-level entry. Computes required roles, validates against the
+ * workspace, and on failure flips the task to `needs_user_input`, logs an
+ * activity, and writes a mailbox row to the workspace operator/PM.
+ *
+ * Returns { ok: true } when the gate is disabled (`MC_ROSTER_GATE != 1`)
+ * so callers can call unconditionally.
+ */
+export async function enforceRosterGate(taskId: string): Promise<RosterGateResult> {
+  if (!isRosterGateEnabled()) return { ok: true };
+
+  const task = queryOne<{ workspace_id: string | null; status: string }>(
+    'SELECT workspace_id, status FROM tasks WHERE id = ?',
+    [taskId],
+  );
+  if (!task) return { ok: true };
+
+  const workspaceId = task.workspace_id ?? 'default';
+  const required = requiredRolesForTask(taskId);
+  const result = validateWorkspaceRoster(workspaceId, required);
+  if (result.ok) return { ok: true };
+
+  const missing = result.missing;
+  const message = `Cannot dispatch — workspace "${workspaceId}" is missing role(s): ${missing.join(', ')}. Onboard or enable an agent for each missing role and retry dispatch.`;
+  const now = new Date().toISOString();
+
+  // Flip status to needs_user_input with a structured reason.
+  run(
+    `UPDATE tasks
+     SET status = 'needs_user_input',
+         status_reason = ?,
+         updated_at = ?
+     WHERE id = ?`,
+    [`roster_incomplete: ${missing.join(',')}`, now, taskId],
+  );
+
+  logTaskActivity({
+    taskId,
+    type: 'roster_incomplete',
+    message,
+    metadata: { missing, available_by_role: result.availableByRole, workspace_id: workspaceId },
+  });
+
+  // Mailbox-ping the workspace PM (operator surrogate). Best-effort: if
+  // the workspace has no PM resolvable, log and continue — the
+  // status_reason + activity are still actionable in the UI.
+  const pm = getPmAgent(workspaceId);
+  if (pm) {
+    try {
+      await sendMail({
+        taskId,
+        fromAgentId: pm.id,
+        toAgentId: pm.id,
+        subject: `Roster incomplete: missing ${missing.join(', ')}`,
+        body: message,
+      });
+    } catch (err) {
+      console.warn(`[RosterGate] mailbox send failed for task=${taskId}:`, err);
+    }
+  } else {
+    console.warn(`[RosterGate] no PM/operator resolvable for workspace=${workspaceId}; skipping mailbox ping`);
+  }
+
+  return {
+    ok: false,
+    code: 'roster_incomplete',
+    missing,
+    availableByRole: result.availableByRole,
+    message,
+  };
+}

--- a/src/lib/services/services.test.ts
+++ b/src/lib/services/services.test.ts
@@ -266,6 +266,133 @@ test('transitionTaskStatus returns not_found for missing task', () => {
   if (!result.ok) assert.equal(result.code, 'not_found');
 });
 
+// ─── transitionTaskStatus: review-stage gates (Slice 1 of review-robust) ───
+
+function setEnv(key: string, value: string | undefined): () => void {
+  const prior = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  return () => {
+    if (prior === undefined) delete process.env[key];
+    else process.env[key] = prior;
+  };
+}
+
+function seedDeliverable(taskId: string): void {
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, role, created_at)
+     VALUES (?, ?, 'file', 'x', 'output', datetime('now'))`,
+    [crypto.randomUUID(), taskId],
+  );
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (?, ?, 'completed', 'done', datetime('now'))`,
+    [crypto.randomUUID(), taskId],
+  );
+}
+
+test('transitionTaskStatus → review: reviewer_required when no reviewer agent exists (strict mode)', () => {
+  const restore = setEnv('MC_REVIEW_STRICT_GATING', '1');
+  try {
+    const builder = seedAgent({ role: 'builder' });
+    const task = seedTask({ assigned: builder, status: 'in_progress' });
+    seedDeliverable(task);
+    const result = transitionTaskStatus({
+      taskId: task,
+      actingAgentId: builder,
+      newStatus: 'review',
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.code, 'reviewer_required');
+  } finally { restore(); }
+});
+
+test('transitionTaskStatus → review: auto-picks reviewer agent + writes task_roles row (strict mode)', () => {
+  const restore = setEnv('MC_REVIEW_STRICT_GATING', '1');
+  try {
+    const builder = seedAgent({ role: 'builder' });
+    seedAgent({ role: 'reviewer' });
+    const task = seedTask({ assigned: builder, status: 'in_progress' });
+    seedDeliverable(task);
+    const result = transitionTaskStatus({
+      taskId: task,
+      actingAgentId: builder,
+      newStatus: 'review',
+    });
+    assert.equal(result.ok, true);
+    const { queryOne: qOne } = require('@/lib/db') as typeof import('@/lib/db');
+    const reviewerRow = qOne<{ agent_id: string }>(
+      `SELECT agent_id FROM task_roles WHERE task_id = ? AND role = 'reviewer'`,
+      [task],
+    );
+    assert.ok(reviewerRow);
+    assert.notEqual(reviewerRow!.agent_id, builder);
+  } finally { restore(); }
+});
+
+test('transitionTaskStatus → review: self_review_blocked when only reviewer is the completer (strict mode)', () => {
+  const restore = setEnv('MC_REVIEW_STRICT_GATING', '1');
+  try {
+    // Builder agent IS itself flagged as reviewer; no other agent available.
+    const solo = seedAgent({ role: 'reviewer' });
+    const task = seedTask({ assigned: solo, status: 'in_progress' });
+    // Pre-seed an explicit reviewer row pointing at the same agent — this is
+    // how the self-review case manifests when an explicit assignment exists.
+    run(
+      `INSERT INTO task_roles (id, task_id, role, agent_id, created_at)
+       VALUES (?, ?, 'reviewer', ?, datetime('now'))`,
+      [crypto.randomUUID(), task, solo],
+    );
+    seedDeliverable(task);
+    const result = transitionTaskStatus({
+      taskId: task,
+      actingAgentId: solo,
+      newStatus: 'review',
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.code, 'self_review_blocked');
+  } finally { restore(); }
+});
+
+test('transitionTaskStatus → review: respects pre-assigned reviewer (strict mode)', () => {
+  const restore = setEnv('MC_REVIEW_STRICT_GATING', '1');
+  try {
+    const builder = seedAgent({ role: 'builder' });
+    const reviewer = seedAgent({ role: 'reviewer' });
+    const task = seedTask({ assigned: builder, status: 'in_progress' });
+    run(
+      `INSERT INTO task_roles (id, task_id, role, agent_id, created_at)
+       VALUES (?, ?, 'reviewer', ?, datetime('now'))`,
+      [crypto.randomUUID(), task, reviewer],
+    );
+    seedDeliverable(task);
+    const result = transitionTaskStatus({
+      taskId: task,
+      actingAgentId: builder,
+      newStatus: 'review',
+    });
+    assert.equal(result.ok, true);
+  } finally { restore(); }
+});
+
+test('transitionTaskStatus → review: skipped when MC_REVIEW_STRICT_GATING != "1" (back-compat)', () => {
+  const restore = setEnv('MC_REVIEW_STRICT_GATING', undefined);
+  try {
+    const solo = seedAgent({ role: 'builder' });
+    const task = seedTask({ assigned: solo, status: 'in_progress' });
+    seedDeliverable(task);
+    // No reviewer in workspace, builder is completer — strict mode would
+    // reject. With flag off, the legacy behavior (just evidence gate)
+    // applies and the transition succeeds.
+    const result = transitionTaskStatus({
+      taskId: task,
+      actingAgentId: solo,
+      newStatus: 'review',
+    });
+    assert.equal(result.ok, true);
+  } finally { restore(); }
+});
+
 // ─── agent-mailbox ──────────────────────────────────────────────────
 
 test('sendAgentMail throws AuthzError on cross-task mail', async () => {

--- a/src/lib/services/task-status.ts
+++ b/src/lib/services/task-status.ts
@@ -32,9 +32,15 @@ import {
   whyCannotBeDone,
   isTerminalStatus,
   auditBoardOverride,
+  pickReviewerForTask,
 } from '@/lib/task-governance';
 import { assertAgentCanActOnTask } from '@/lib/authz/agent-task';
 import type { Task, TaskStatus } from '@/lib/types';
+
+/** Slice 1 strict gating is opt-in for one cycle while operators backfill. */
+function isStrictReviewGatingEnabled(): boolean {
+  return process.env.MC_REVIEW_STRICT_GATING === '1';
+}
 
 export interface TransitionTaskStatusInput {
   taskId: string;
@@ -62,7 +68,9 @@ export type TransitionTaskStatusResult =
         | 'terminal_blocked'
         | 'evidence_gate'
         | 'status_reason_required'
-        | 'cannot_mark_done';
+        | 'cannot_mark_done'
+        | 'self_review_blocked'
+        | 'reviewer_required';
       error: string;
       missingDeliverableIds?: string[];
     };
@@ -110,6 +118,64 @@ export function transitionTaskStatus(
       code: 'terminal_blocked',
       error: `Cannot transition cancelled task to ${newStatus}. Create a new task or use board_override.`,
     };
+  }
+
+  // Review-stage gates (Slice 1 of review-stage-robustness).
+  // Run before the evidence gate so the rejection reason is unambiguous.
+  // Strict mode is opt-in via MC_REVIEW_STRICT_GATING=1 to allow a backfill
+  // cycle for in-flight workspaces without reviewer agents.
+  if (
+    newStatus === 'review' &&
+    !boardOverride &&
+    isStrictReviewGatingEnabled()
+  ) {
+    const workspaceId = (existing.workspace_id ?? 'default') as string;
+    const completerId = actingAgentId ?? existing.assigned_agent_id ?? null;
+
+    // Self-review interlock. Reviewer must differ from the agent who did
+    // the work. Prefer an explicit task_roles reviewer row when present;
+    // otherwise auto-pick now and persist the row.
+    const explicitReviewer = queryOne<{ agent_id: string }>(
+      `SELECT agent_id FROM task_roles WHERE task_id = ? AND role = 'reviewer' LIMIT 1`,
+      [taskId],
+    );
+    let reviewerAgentId: string | null = explicitReviewer?.agent_id ?? null;
+
+    if (!reviewerAgentId) {
+      const picked = pickReviewerForTask({
+        taskId,
+        workspaceId,
+        excludeAgentId: completerId,
+      });
+      reviewerAgentId = picked?.id ?? null;
+    }
+
+    if (!reviewerAgentId) {
+      return {
+        ok: false,
+        code: 'reviewer_required',
+        error:
+          'Cannot enter review: no reviewer agent available in this workspace. Onboard or enable a reviewer-role agent (or use board_override).',
+      };
+    }
+
+    if (completerId && reviewerAgentId === completerId) {
+      return {
+        ok: false,
+        code: 'self_review_blocked',
+        error:
+          'Cannot enter review: the agent who did the work cannot also be the reviewer. Onboard or enable a separate reviewer agent.',
+      };
+    }
+
+    // Idempotent reviewer assignment: only insert if no row exists.
+    if (!explicitReviewer) {
+      run(
+        `INSERT OR IGNORE INTO task_roles (id, task_id, role, agent_id, created_at)
+         VALUES (lower(hex(randomblob(16))), ?, 'reviewer', ?, datetime('now'))`,
+        [taskId, reviewerAgentId],
+      );
+    }
   }
 
   // Evidence gate for forward moves into quality stages.

--- a/src/lib/task-governance.test.ts
+++ b/src/lib/task-governance.test.ts
@@ -7,6 +7,7 @@ import {
   whyCannotBeDone,
   ensureFixerExists,
   getFailureCountInStage,
+  checkStageEvidence,
 } from './task-governance';
 
 function seedTask(id: string, workspace = 'default') {
@@ -149,6 +150,119 @@ test('ensureFixerExists creates fixer when missing', () => {
   const stored = queryOne<{ id: string; role: string }>('SELECT id, role FROM agents WHERE id = ?', [fixer.id]);
   assert.ok(stored);
   assert.equal(stored?.role, 'fixer');
+});
+
+// ─── Slice 2 of review-stage-robustness: convoy-subtask evidence gate ────
+
+function seedConvoyForSubtask(): { convoyId: string; parentTaskId: string } {
+  const parentTaskId = crypto.randomUUID();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, created_at, updated_at)
+     VALUES (?, 'parent', 'convoy_active', 'normal', 'default', 'default', datetime('now'), datetime('now'))`,
+    [parentTaskId],
+  );
+  const convoyId = crypto.randomUUID();
+  run(
+    `INSERT INTO convoys (id, parent_task_id, name, status, created_at, updated_at)
+     VALUES (?, ?, 'c', 'active', datetime('now'), datetime('now'))`,
+    [convoyId, parentTaskId],
+  );
+  return { convoyId, parentTaskId };
+}
+
+function seedSubtaskInConvoy(convoyId: string, requiredGates: string[] | null): string {
+  const taskId = crypto.randomUUID();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, convoy_id, is_subtask, created_at, updated_at)
+     VALUES (?, 'sub', 'in_progress', 'normal', 'default', 'default', ?, 1, datetime('now'), datetime('now'))`,
+    [taskId, convoyId],
+  );
+  // Output deliverable + completion activity to satisfy the legacy bar in
+  // case the new code path falls through.
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, role, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'file', 'x', 'output', datetime('now'))`,
+    [taskId],
+  );
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'completed', 'done', datetime('now'))`,
+    [taskId],
+  );
+  run(
+    `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, suggested_role, slice, required_evidence_gates, created_at)
+     VALUES (?, ?, ?, 0, 'builder', 'test', ?, datetime('now'))`,
+    [crypto.randomUUID(), convoyId, taskId, requiredGates ? JSON.stringify(requiredGates) : null],
+  );
+  return taskId;
+}
+
+test('checkStageEvidence: subtask with required test_full gate rejects review without evidence', () => {
+  const { convoyId } = seedConvoyForSubtask();
+  const taskId = seedSubtaskInConvoy(convoyId, ['test_full']);
+  const result = checkStageEvidence(taskId, 'review');
+  assert.equal(result.ok, false);
+  assert.match(result.reason ?? '', /test_full required to enter review/);
+});
+
+test('checkStageEvidence: subtask with passing test_full evidence enters review', () => {
+  const { convoyId } = seedConvoyForSubtask();
+  const taskId = seedSubtaskInConvoy(convoyId, ['test_full']);
+  run(
+    `INSERT INTO task_evidence (id, task_id, gate, command, exit_code, passed, stdout_hash, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'test_full', 'yarn test', 0, 1, 'abc', datetime('now'))`,
+    [taskId],
+  );
+  const result = checkStageEvidence(taskId, 'review');
+  assert.equal(result.ok, true);
+});
+
+test('checkStageEvidence: subtask with failing test_full evidence rejects review', () => {
+  const { convoyId } = seedConvoyForSubtask();
+  const taskId = seedSubtaskInConvoy(convoyId, ['test_full']);
+  run(
+    `INSERT INTO task_evidence (id, task_id, gate, command, exit_code, passed, stdout_hash, reject_reason, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'test_full', 'yarn test', 1, 0, 'abc', '3 tests failed', datetime('now'))`,
+    [taskId],
+  );
+  const result = checkStageEvidence(taskId, 'review');
+  assert.equal(result.ok, false);
+  assert.match(result.reason ?? '', /did not pass/);
+});
+
+test('checkStageEvidence: legacy subtask (NULL required_evidence_gates) keeps bypass', () => {
+  const { convoyId } = seedConvoyForSubtask();
+  const taskId = seedSubtaskInConvoy(convoyId, null);
+  // No evidence row but legacy bypass should let it through.
+  const result = checkStageEvidence(taskId, 'review');
+  assert.equal(result.ok, true);
+});
+
+test('checkStageEvidence: subtask with malformed required_evidence_gates falls back to bypass', () => {
+  const { convoyId } = seedConvoyForSubtask();
+  const taskId = crypto.randomUUID();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, convoy_id, is_subtask, created_at, updated_at)
+     VALUES (?, 'sub', 'in_progress', 'normal', 'default', 'default', ?, 1, datetime('now'), datetime('now'))`,
+    [taskId, convoyId],
+  );
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, role, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'file', 'x', 'output', datetime('now'))`,
+    [taskId],
+  );
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'completed', 'done', datetime('now'))`,
+    [taskId],
+  );
+  run(
+    `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, suggested_role, slice, required_evidence_gates, created_at)
+     VALUES (?, ?, ?, 0, 'builder', 'test', 'not-json', datetime('now'))`,
+    [crypto.randomUUID(), convoyId, taskId],
+  );
+  const result = checkStageEvidence(taskId, 'review');
+  assert.equal(result.ok, true);
 });
 
 test('failure counter reads status_changed failure events', () => {

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -109,8 +109,44 @@ export function checkStageEvidence(
 
   // Convoy subtasks don't each carry the parent's spec — they carry their
   // own descriptions. Reconciliation happens at the parent level when the
-  // convoy transitions. So for subtasks we fall back to the baseline bar.
-  if (task?.convoy_id) {
+  // convoy transitions. So for subtasks we skip *spec reconciliation* but
+  // still enforce per-subtask evidence gates from
+  // convoy_subtasks.required_evidence_gates (Slice 2 of
+  // review-stage-robustness). Legacy subtasks with NULL keep the prior
+  // bypass — only the strict-mode gate above (when any task_evidence row
+  // exists) and the baseline deliverable+activity check fire for them.
+  if (task?.convoy_id && newStatus) {
+    const subtask = queryOne<{ required_evidence_gates: string | null }>(
+      `SELECT required_evidence_gates FROM convoy_subtasks WHERE task_id = ?`,
+      [taskId],
+    );
+    if (subtask?.required_evidence_gates) {
+      try {
+        const required = JSON.parse(subtask.required_evidence_gates) as EvidenceGate[];
+        // Only enforce on transitions into the review stage (testing/done
+        // gates are workflow-engine concerns and remain stage-keyed).
+        if (newStatus === 'review' && Array.isArray(required) && required.length > 0) {
+          for (const gate of required) {
+            const latest = getLatestEvidence(taskId, gate);
+            if (!latest) {
+              return {
+                ok: false,
+                reason: `Evidence gate: ${gate} required to enter review (subtask). Submit raw command output via submit_evidence.`,
+              };
+            }
+            if (latest.passed !== 1) {
+              return {
+                ok: false,
+                reason: `Evidence gate: latest ${gate} run did not pass${latest.reject_reason ? ` (${latest.reject_reason})` : ''}. Re-run and resubmit.`,
+              };
+            }
+          }
+          return { ok: true };
+        }
+      } catch {
+        // Malformed JSON: fall through to legacy bypass.
+      }
+    }
     return { ok: true };
   }
 

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -172,6 +172,58 @@ export function getFailureCountInStage(taskId: string, stage: string): number {
   return Number(row?.count || 0);
 }
 
+/**
+ * Pick a reviewer for a task entering the review stage. Mirrors
+ * `ensureFixerExists` selection but never auto-creates: reviewers must
+ * be onboarded explicitly. Excludes the agent who did the work
+ * (self-review interlock — Slice 1 of review-stage-robustness).
+ *
+ * Selection order:
+ *  1. agents with role='reviewer' in the task's workspace, online + active
+ *  2. agents with gateway_agent_id like 'mc-reviewer*' as a fallback for
+ *     workspaces where role isn't set on the catalog row
+ *
+ * Returns null when no eligible reviewer exists. The caller decides
+ * whether to reject the transition or fall back to operator escalation.
+ */
+export function pickReviewerForTask(input: {
+  taskId: string;
+  workspaceId: string;
+  excludeAgentId?: string | null;
+}): { id: string; name: string } | null {
+  const { workspaceId, excludeAgentId } = input;
+  const exclude = excludeAgentId ?? '';
+
+  const byRole = queryOne<{ id: string; name: string }>(
+    `SELECT id, name FROM agents
+     WHERE COALESCE(workspace_id, 'default') = ?
+       AND status != 'offline'
+       AND COALESCE(is_active, 1) = 1
+       AND id != ?
+       AND role = 'reviewer'
+     ORDER BY
+       (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL) DESC,
+       updated_at DESC
+     LIMIT 1`,
+    [workspaceId, exclude],
+  );
+  if (byRole) return byRole;
+
+  // Fallback: gateway-id-derivation for legacy rows without role column set.
+  const byGateway = queryOne<{ id: string; name: string }>(
+    `SELECT id, name FROM agents
+     WHERE COALESCE(workspace_id, 'default') = ?
+       AND status != 'offline'
+       AND COALESCE(is_active, 1) = 1
+       AND id != ?
+       AND (gateway_agent_id LIKE 'mc-reviewer%')
+     ORDER BY updated_at DESC
+     LIMIT 1`,
+    [workspaceId, exclude],
+  );
+  return byGateway ?? null;
+}
+
 export function ensureFixerExists(workspaceId: string): { id: string; name: string; created: boolean } {
   const existing = queryOne<{ id: string; name: string }>(
     `SELECT id, name FROM agents WHERE workspace_id = ? AND role IN ('fixer','senior') AND status != 'offline' ORDER BY role = 'fixer' DESC, updated_at DESC LIMIT 1`,


### PR DESCRIPTION
Stacked on [#320](https://github.com/smb209/mission-control/pull/320) (Slice 1).

Closes FM4 from the [feature spec](../blob/feat/review-robust-2-subtask-evidence/specs/review-stage-robustness-spec.md): convoy subtasks were exempt from the strict-mode evidence gate via a too-broad early-return in `checkStageEvidence`.

## Summary

- **Migration 091** — additive `convoy_subtasks.required_evidence_gates TEXT` (JSON array). Nullable, no backfill needed.
- `spawnDelegationSubtask` now writes `['test_full']` by default for every new spawn.
- `checkStageEvidence` reads the column on `→ review` transitions for convoy subtasks: enforces the listed gates instead of fully bypassing.
- Legacy subtasks (NULL column) keep the prior bypass — guarantees no in-flight breakage.
- Malformed JSON falls back to the bypass too (defensive).

## Changes

| File | Purpose |
|---|---|
| `src/lib/db/migrations.ts` | Migration 091 |
| `src/lib/convoy.ts` | Default required gates on spawn |
| `src/lib/task-governance.ts` | Replace blanket bypass with per-subtask gate enforcement |
| `src/lib/task-governance.test.ts` | 5 new tests |

## Test plan

- [x] `yarn test src/lib/task-governance.test.ts` — 12/12 pass.
- [x] Stack-tip targeted suite (governance + services + roster-gate) — 62/62 pass.
- [x] `tsc --noEmit` — clean.
- [x] Migration applies cleanly on fresh test DB (`yarn test:setup`).
- [ ] Real-agent validation scenario RR-S4 — exercised in stack-tip validation run.

## Notes

- Spec reconciliation (`spec_deliverable_id` checks) still skipped for subtasks — they don't carry the parent's planning_spec. Only the evidence gate now fires.
- Pre-existing failure (`schedule-runner.test.ts`) carries over from prior slices.