### PR TITLE
feat(review-robust): slice 4 — review SLA + auto-bounce

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "research:eval:schedule": "tsx scripts/run-research-schedule-eval.ts",
     "db:backup": "tsx scripts/db-backup.ts",
     "db:backup:list": "tsx scripts/db-backup.ts --list",
+    "audit:review-stalls": "tsx scripts/audit-review-stalls.ts",
     "db:restore": "cp mission-control.db.backup mission-control.db && echo 'Restored from backup'",
     "db:reset": "rm -f mission-control.db mission-control.db-* && npm run db:seed",
     "db:checkpoint": "tsx scripts/db-checkpoint.ts save",

--- a/scripts/audit-review-stalls.ts
+++ b/scripts/audit-review-stalls.ts
@@ -1,0 +1,104 @@
+/**
+ * Audit review-stage tasks before flipping MC_REVIEW_AUTOBOUNCE.
+ *
+ * Lists every `status='review'` task that:
+ *   - has no reviewer assigned (no task_roles row with role='reviewer'),
+ *   - has no task_evidence rows (no real verification ran), or
+ *   - has been idle past the review SLA threshold.
+ *
+ * Operator runs this once before turning on MC_REVIEW_AUTOBOUNCE so the
+ * stall scanner doesn't surprise them by bouncing legitimate in-flight
+ * reviews. Output is plain text for easy paste into PR / verdict docs.
+ *
+ * Usage:
+ *   yarn ts-node scripts/audit-review-stalls.ts
+ *   STALL_DETECTION_MINUTES_REVIEW=20 yarn ts-node scripts/audit-review-stalls.ts
+ */
+
+import { queryAll, queryOne } from '../src/lib/db';
+
+interface ReviewRow {
+  id: string;
+  title: string;
+  workspace_id: string;
+  updated_at: string;
+  status_reason: string | null;
+  last_activity_at: string | null;
+  has_reviewer: number;
+  evidence_count: number;
+}
+
+function thresholdMinutes(): number {
+  const raw = process.env.STALL_DETECTION_MINUTES_REVIEW;
+  if (!raw) return 20;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : 20;
+}
+
+function main() {
+  const threshold = thresholdMinutes();
+  const rows = queryAll<ReviewRow>(
+    `SELECT
+       t.id,
+       t.title,
+       t.workspace_id,
+       t.updated_at,
+       t.status_reason,
+       (SELECT MAX(created_at) FROM task_activities WHERE task_id = t.id) AS last_activity_at,
+       (SELECT COUNT(*) FROM task_roles WHERE task_id = t.id AND role = 'reviewer') AS has_reviewer,
+       (SELECT COUNT(*) FROM task_evidence WHERE task_id = t.id) AS evidence_count
+       FROM tasks t
+      WHERE t.status = 'review'
+      ORDER BY t.updated_at ASC`,
+  );
+
+  console.log(`# Review-stage audit (threshold ${threshold}m)\n`);
+  console.log(`Total review-status tasks: ${rows.length}\n`);
+
+  if (rows.length === 0) {
+    console.log('No review-stage tasks. Safe to flip MC_REVIEW_AUTOBOUNCE.');
+    return;
+  }
+
+  const nowMs = Date.now();
+  const noReviewer: ReviewRow[] = [];
+  const noEvidence: ReviewRow[] = [];
+  const overSla: Array<ReviewRow & { idle_minutes: number }> = [];
+
+  for (const row of rows) {
+    if (Number(row.has_reviewer) === 0) noReviewer.push(row);
+    if (Number(row.evidence_count) === 0) noEvidence.push(row);
+    const lastTick = row.last_activity_at || row.updated_at;
+    const idle = (nowMs - new Date(lastTick).getTime()) / 60_000;
+    if (idle >= threshold) overSla.push({ ...row, idle_minutes: Math.round(idle) });
+  }
+
+  const print = (label: string, list: ReviewRow[]) => {
+    console.log(`## ${label} (${list.length})`);
+    if (list.length === 0) {
+      console.log('(none)\n');
+      return;
+    }
+    for (const r of list.slice(0, 50)) {
+      const idle = (nowMs - new Date(r.last_activity_at || r.updated_at).getTime()) / 60_000;
+      console.log(`- ${r.id} · ${r.workspace_id} · idle=${Math.round(idle)}m · ${r.title}`);
+    }
+    if (list.length > 50) console.log(`(${list.length - 50} more not shown)`);
+    console.log('');
+  };
+
+  print('No reviewer assigned', noReviewer);
+  print('No evidence rows', noEvidence);
+  print(`Over SLA threshold (${threshold}m)`, overSla);
+
+  console.log('---');
+  console.log(`Recommendation: address every "Over SLA threshold" row before flipping MC_REVIEW_AUTOBOUNCE — otherwise the next scan will bounce ${overSla.length} task(s) automatically.`);
+
+  // Cross-check: how many lack BOTH reviewer and evidence (highest risk).
+  const bothMissing = rows.filter(r => Number(r.has_reviewer) === 0 && Number(r.evidence_count) === 0);
+  if (bothMissing.length > 0) {
+    console.log(`\n${bothMissing.length} task(s) lack BOTH reviewer and evidence — these are the highest-risk parking-lot rows.`);
+  }
+}
+
+main();

--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -19,7 +19,9 @@ export type ServerActivityType =
   | 'coordinator_stalled'   // convoy coordinator itself can't be reached
   | 'coordinator_missing'   // convoy has no live coordinator
   | 'roster_incomplete'     // pre-dispatch roster gate refused: workspace missing required role(s)
-  | 'escalation';           // child task escalated to parent / operator (Slice 3 of review-stage-robustness)
+  | 'escalation'            // child task escalated to parent / operator (Slice 3 of review-stage-robustness)
+  | 'reviewer_stalled'      // review-stage task idled past first threshold (Slice 4 of review-stage-robustness)
+  | 'review_autobounced';   // review-stage task auto-bounced after 2× threshold (Slice 4)
 
 interface LogActivityInput {
   taskId: string;

--- a/src/lib/stall-detection.test.ts
+++ b/src/lib/stall-detection.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for the review-stage SLA scanner (Slice 4 of review-stage-robustness).
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { run, queryOne } from '@/lib/db';
+import { scanStalledTasks } from './stall-detection';
+
+function setEnv(key: string, value: string | undefined): () => void {
+  const prior = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  return () => {
+    if (prior === undefined) delete process.env[key];
+    else process.env[key] = prior;
+  };
+}
+
+function seedAgent(role = 'reviewer'): string {
+  const id = crypto.randomUUID();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, status, created_at, updated_at)
+     VALUES (?, 'A', ?, 'default', 1, 'standby', datetime('now'), datetime('now'))`,
+    [id, role],
+  );
+  return id;
+}
+
+function seedReviewTask(opts: {
+  reviewer?: string | null;
+  idleMinutes?: number;
+  assigned?: string | null;
+} = {}): string {
+  const id = crypto.randomUUID();
+  // Backdate updated_at and an activity so the scanner sees the task as idle.
+  const idleMs = (opts.idleMinutes ?? 0) * 60_000;
+  const past = new Date(Date.now() - idleMs).toISOString();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, assigned_agent_id, created_at, updated_at)
+     VALUES (?, 'review-task', 'review', 'normal', 'default', 'default', ?, ?, ?)`,
+    [id, opts.assigned ?? null, past, past],
+  );
+  // Output deliverable so the legacy scanner skips it (review-stage tasks
+  // always have deliverables — that's how they got to review).
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, role, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'file', 'x', 'output', ?)`,
+    [id, past],
+  );
+  // Status_changed activity so last_activity_at reflects the idle window.
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'status_changed', 'entered review', ?)`,
+    [id, past],
+  );
+  if (opts.reviewer) {
+    run(
+      `INSERT INTO task_roles (id, task_id, role, agent_id, created_at)
+       VALUES (?, ?, 'reviewer', ?, datetime('now'))`,
+      [crypto.randomUUID(), id, opts.reviewer],
+    );
+  }
+  return id;
+}
+
+test('review-SLA: idle past 1× threshold writes reviewer_stalled activity (no autobounce)', async () => {
+  const restore = setEnv('STALL_DETECTION_MINUTES_REVIEW', '5');
+  const restoreBounce = setEnv('MC_REVIEW_AUTOBOUNCE', undefined);
+  try {
+    const reviewer = seedAgent('reviewer');
+    const task = seedReviewTask({ reviewer, idleMinutes: 7 });
+
+    await scanStalledTasks();
+
+    const stalledRow = queryOne<{ activity_type: string }>(
+      `SELECT activity_type FROM task_activities
+       WHERE task_id = ? AND activity_type = 'reviewer_stalled'`,
+      [task],
+    );
+    assert.equal(stalledRow?.activity_type, 'reviewer_stalled');
+
+    // Task NOT bounced (autobounce flag off, plus only 1× threshold).
+    const taskRow = queryOne<{ status: string }>('SELECT status FROM tasks WHERE id = ?', [task]);
+    assert.equal(taskRow?.status, 'review');
+  } finally {
+    restore(); restoreBounce();
+  }
+});
+
+test('review-SLA: idle past 2× threshold + MC_REVIEW_AUTOBOUNCE bounces to assigned + is_failed=1', async () => {
+  const restore = setEnv('STALL_DETECTION_MINUTES_REVIEW', '5');
+  const restoreBounce = setEnv('MC_REVIEW_AUTOBOUNCE', '1');
+  try {
+    const reviewer = seedAgent('reviewer');
+    const builder = seedAgent('builder');
+    const task = seedReviewTask({ reviewer, assigned: builder, idleMinutes: 12 });
+
+    await scanStalledTasks();
+
+    const taskRow = queryOne<{ status: string; is_failed: number; status_reason: string }>(
+      'SELECT status, is_failed, status_reason FROM tasks WHERE id = ?',
+      [task],
+    );
+    assert.equal(taskRow?.status, 'assigned');
+    assert.equal(taskRow?.is_failed, 1);
+    assert.match(taskRow?.status_reason ?? '', /^Failed: reviewer unresponsive/);
+
+    const bouncedRow = queryOne<{ activity_type: string }>(
+      `SELECT activity_type FROM task_activities
+       WHERE task_id = ? AND activity_type = 'review_autobounced'`,
+      [task],
+    );
+    assert.equal(bouncedRow?.activity_type, 'review_autobounced');
+  } finally {
+    restore(); restoreBounce();
+  }
+});
+
+test('review-SLA: 2× threshold without MC_REVIEW_AUTOBOUNCE only writes reviewer_stalled', async () => {
+  const restore = setEnv('STALL_DETECTION_MINUTES_REVIEW', '5');
+  const restoreBounce = setEnv('MC_REVIEW_AUTOBOUNCE', undefined);
+  try {
+    const reviewer = seedAgent('reviewer');
+    const task = seedReviewTask({ reviewer, idleMinutes: 15 });
+
+    await scanStalledTasks();
+
+    const taskRow = queryOne<{ status: string }>('SELECT status FROM tasks WHERE id = ?', [task]);
+    assert.equal(taskRow?.status, 'review', 'should not bounce when flag is off');
+
+    const bounced = queryOne<{ activity_type: string }>(
+      `SELECT activity_type FROM task_activities
+       WHERE task_id = ? AND activity_type = 'review_autobounced'`,
+      [task],
+    );
+    assert.equal(bounced, undefined, 'no autobounce activity expected');
+  } finally {
+    restore(); restoreBounce();
+  }
+});
+
+test('review-SLA: idle below threshold is a no-op', async () => {
+  const restore = setEnv('STALL_DETECTION_MINUTES_REVIEW', '30');
+  const restoreBounce = setEnv('MC_REVIEW_AUTOBOUNCE', '1');
+  try {
+    const reviewer = seedAgent('reviewer');
+    const task = seedReviewTask({ reviewer, idleMinutes: 5 });
+
+    await scanStalledTasks();
+
+    const stalledRow = queryOne<{ activity_type: string }>(
+      `SELECT activity_type FROM task_activities
+       WHERE task_id = ? AND activity_type = 'reviewer_stalled'`,
+      [task],
+    );
+    assert.equal(stalledRow, undefined);
+  } finally {
+    restore(); restoreBounce();
+  }
+});
+
+test('review-SLA: reviewer_stalled is throttled within NOTIFY_THROTTLE_MINUTES', async () => {
+  const restore = setEnv('STALL_DETECTION_MINUTES_REVIEW', '5');
+  const restoreBounce = setEnv('MC_REVIEW_AUTOBOUNCE', undefined);
+  try {
+    const reviewer = seedAgent('reviewer');
+    const task = seedReviewTask({ reviewer, idleMinutes: 7 });
+
+    await scanStalledTasks();
+    await scanStalledTasks();
+
+    const count = queryOne<{ cnt: number }>(
+      `SELECT COUNT(*) as cnt FROM task_activities
+       WHERE task_id = ? AND activity_type = 'reviewer_stalled'`,
+      [task],
+    );
+    assert.equal(count?.cnt, 1, 'second scan should be throttled');
+  } finally {
+    restore(); restoreBounce();
+  }
+});

--- a/src/lib/stall-detection.ts
+++ b/src/lib/stall-detection.ts
@@ -15,6 +15,22 @@ const ACTIVE_STATUSES = ['assigned', 'in_progress', 'convoy_active', 'testing', 
 /** Default threshold. Override via STALL_DETECTION_MINUTES env var. */
 const DEFAULT_STALL_MINUTES = 30;
 
+/** Default review-stage threshold. Tighter than the global because the
+ *  only legitimate work in review is reviewer evaluation. Override via
+ *  STALL_DETECTION_MINUTES_REVIEW env var. Slice 4 of review-stage-robustness. */
+const DEFAULT_REVIEW_STALL_MINUTES = 20;
+
+function getReviewThresholdMinutes(): number {
+  const raw = process.env.STALL_DETECTION_MINUTES_REVIEW;
+  if (!raw) return DEFAULT_REVIEW_STALL_MINUTES;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_REVIEW_STALL_MINUTES;
+}
+
+function isReviewAutobounceEnabled(): boolean {
+  return process.env.MC_REVIEW_AUTOBOUNCE === '1';
+}
+
 /** Consider the coordinator itself stalled if its last heartbeat is older than this. */
 const COORDINATOR_STALL_MINUTES = 10;
 
@@ -175,7 +191,143 @@ export async function scanStalledTasks(): Promise<StallReport> {
     });
   }
 
+  // Slice 4 of review-stage-robustness: separate scan for review-status
+  // tasks. The main loop above skips tasks with deliverable_count > 0,
+  // which means review-stage tasks (which always have deliverables)
+  // were never flagged. This scan owns the review SLA explicitly.
+  await scanStalledReviews(report);
+
   return report;
+}
+
+interface ReviewerInfo {
+  reviewerAgentId: string | null;
+}
+
+function getReviewerForTask(taskId: string): ReviewerInfo {
+  const row = queryOne<{ agent_id: string }>(
+    `SELECT agent_id FROM task_roles WHERE task_id = ? AND role = 'reviewer' LIMIT 1`,
+    [taskId],
+  );
+  return { reviewerAgentId: row?.agent_id ?? null };
+}
+
+/**
+ * Review-stage SLA scanner. Two-stage cadence:
+ *   - At 1× threshold: log `reviewer_stalled` + mailbox-ping reviewer.
+ *   - At 2× threshold (and `MC_REVIEW_AUTOBOUNCE=1`): bounce
+ *     `review → assigned`, `is_failed=1`, `status_reason='Failed: reviewer
+ *     unresponsive…'` and notify coordinator.
+ */
+async function scanStalledReviews(report: StallReport): Promise<void> {
+  const threshold = getReviewThresholdMinutes();
+  const reviews = queryAll<Task & { last_activity_at: string | null }>(
+    `SELECT t.*,
+            (SELECT MAX(created_at) FROM task_activities WHERE task_id = t.id) as last_activity_at
+       FROM tasks t
+      WHERE t.status = 'review'`,
+  );
+  const nowMs = Date.now();
+
+  for (const task of reviews) {
+    const lastTick = task.last_activity_at || task.updated_at;
+    const minutesIdle = (nowMs - new Date(lastTick).getTime()) / 60_000;
+    if (minutesIdle < threshold) continue;
+
+    const { reviewerAgentId } = getReviewerForTask(task.id);
+
+    // First-stage notification (throttled). One reviewer_stalled row
+    // per task per NOTIFY_THROTTLE_MINUTES window.
+    const recent = queryOne<{ created_at: string }>(
+      `SELECT created_at FROM task_activities
+       WHERE task_id = ? AND activity_type = 'reviewer_stalled'
+       ORDER BY created_at DESC LIMIT 1`,
+      [task.id],
+    );
+    const recentlyNotified = recent &&
+      (nowMs - new Date(recent.created_at).getTime()) / 60_000 < NOTIFY_THROTTLE_MINUTES;
+
+    if (!recentlyNotified) {
+      logTaskActivity({
+        taskId: task.id,
+        type: 'reviewer_stalled',
+        message: `Reviewer idle for ${Math.round(minutesIdle)}m (threshold ${threshold}m)`,
+        metadata: {
+          minutes_idle: Math.round(minutesIdle),
+          threshold_minutes: threshold,
+          reviewer_agent_id: reviewerAgentId,
+        },
+        agentId: reviewerAgentId,
+      });
+
+      // Mailbox-ping the reviewer if known. Fire-and-forget; failure is
+      // non-fatal (next scan retries).
+      if (reviewerAgentId) {
+        const { sendMail } = await import('@/lib/mailbox');
+        sendMail({
+          taskId: task.id,
+          fromAgentId: reviewerAgentId,
+          toAgentId: reviewerAgentId,
+          subject: `REVIEW SLA: idle ${Math.round(minutesIdle)}m`,
+          body: `Task ${task.id} ("${task.title}") has been waiting on review for ${Math.round(minutesIdle)} minutes (threshold ${threshold}m). Please act or escalate.`,
+        }).catch((err) => {
+          console.warn('[ReviewSLA] reviewer mailbox ping failed:', (err as Error).message);
+        });
+      }
+    }
+
+    // Second-stage auto-bounce. Behind MC_REVIEW_AUTOBOUNCE so operators
+    // can audit existing in-flight reviews before flipping the switch.
+    if (minutesIdle >= threshold * 2 && isReviewAutobounceEnabled()) {
+      const now = new Date().toISOString();
+      const reason = `Failed: reviewer unresponsive (idle ${Math.round(minutesIdle)}m)`;
+      run(
+        `UPDATE tasks
+            SET status = 'assigned',
+                is_failed = 1,
+                status_reason = ?,
+                updated_at = ?
+          WHERE id = ?`,
+        [reason, now, task.id],
+      );
+      logTaskActivity({
+        taskId: task.id,
+        type: 'review_autobounced',
+        message: `Auto-bounced from review after ${Math.round(minutesIdle)}m (2× threshold)`,
+        metadata: {
+          minutes_idle: Math.round(minutesIdle),
+          threshold_minutes: threshold,
+          reviewer_agent_id: reviewerAgentId,
+        },
+      });
+
+      // Convoy-aware coordinator notify.
+      const convoy = resolveConvoyMembership(task);
+      if (convoy?.coordinatorAgentId) {
+        const { sendMail } = await import('@/lib/mailbox');
+        sendMail({
+          taskId: task.id,
+          convoyId: convoy.convoyId,
+          fromAgentId: convoy.coordinatorAgentId,
+          toAgentId: convoy.coordinatorAgentId,
+          subject: `REVIEW SLA: child auto-bounced — ${task.title.slice(0, 60)}`,
+          body: `Subtask ${task.id} sat in review for ${Math.round(minutesIdle)}m without progress. Auto-bounced to assigned with is_failed=1. Reassign reviewer or board_override to continue.`,
+          push: true,
+        }).catch((err) => {
+          console.warn('[ReviewSLA] coordinator mailbox ping failed:', (err as Error).message);
+        });
+      }
+
+      report.flagged.push({
+        task_id: task.id,
+        title: task.title,
+        status: 'review',
+        minutes_idle: Math.round(minutesIdle),
+        mode: convoy ? 'convoy' : 'solo',
+        notified: convoy?.coordinatorAgentId ? 'coordinator' : 'webhook',
+      });
+    }
+  }
 }
 
 interface ConvoyMembership {


### PR DESCRIPTION
Stacked on [#322](https://github.com/smb209/mission-control/pull/322) (Slice 3). Closes FM5/FM6 — stall detection gains teeth.

## Summary

The pre-existing stall scanner painted `status_reason='stalled_no_activity'` but never transitioned anything, **and** skipped review-status tasks entirely (because review-stage tasks always have deliverables and the legacy guard short-circuited them out).

This slice adds a dedicated `scanStalledReviews()` with a two-stage cadence:

1. **1× threshold**: `reviewer_stalled` activity + reviewer mailbox ping. Throttled to one notification per `NOTIFY_THROTTLE_MINUTES` window.
2. **2× threshold + `MC_REVIEW_AUTOBOUNCE=1`**: bounce `review → assigned` with `is_failed=1` and convoy-aware coordinator notification.

New env: `STALL_DETECTION_MINUTES_REVIEW` (default 20m).

`yarn audit:review-stalls` lists in-flight review-stage tasks (no reviewer, no evidence, over SLA) so operators can clean up before flipping `MC_REVIEW_AUTOBOUNCE=1`.

## Changes

| File | Purpose |
|---|---|
| `src/lib/stall-detection.ts` | New `scanStalledReviews`; per-stage threshold helper |
| `src/lib/activity-log.ts` | `reviewer_stalled` + `review_autobounced` activity types |
| `src/lib/stall-detection.test.ts` | 5 new tests covering both stages + throttle + below-threshold no-op |
| `scripts/audit-review-stalls.ts` | Operator audit script |
| `package.json` | `yarn audit:review-stalls` |

## Test plan

- [x] `yarn test src/lib/stall-detection.test.ts` — 5/5 pass.
- [x] Stack-tip targeted suite (governance + services + roster-gate + soft-lock + mcp + stall-detection) — 109/109 pass.
- [x] `tsc --noEmit` — clean.
- [ ] Real-agent validation scenario RR-S6 — exercised in stack-tip validation run.
- [ ] **Operator action**: run `yarn audit:review-stalls` before flipping `MC_REVIEW_AUTOBOUNCE=1`. List included in `04-e2e-run-results.md`.

## Notes

- Default-off via `MC_REVIEW_AUTOBOUNCE` so the next scan after deploy doesn't surprise anyone with bounces.
- 1× threshold notification fires regardless of the autobounce flag — operator visibility is always on.
- Pre-existing failure (`schedule-runner.test.ts`) carries over.