### PR TITLE
feat(audit): audit_verdict note + opt-in PM auto-spawn bridge

### DIFF
--- a/specs/audit-action-recommended.md
+++ b/specs/audit-action-recommended.md
@@ -1,0 +1,252 @@
+# Audit → PM bridge via `audit_verdict` note kind
+
+## Motivation
+
+Today the narrow `initiative_audit` flow (one researcher dispatch via
+`POST /api/initiatives/:id/investigate`) writes a free-form
+`take_note(kind='observation', audience='pm')` and exits. The PM only
+picks up the finding on the operator's next move — Plan, Decompose, or
+manual `Ask PM to propose` ([src/app/api/initiatives/[id]/ask-pm-from-notes](src/app/api/initiatives/[id]/ask-pm-from-notes/route.ts)).
+
+That's the design called out as "out of scope" in [specs/initiative-investigate.md](initiative-investigate.md):
+
+> Auto-applying audit findings as proposals (operator decides + clicks Plan).
+
+It produces a clean audit trail but leaves obvious work on the table:
+when an audit's verdict is unambiguous (`done in entirety`,
+`never built`, `cancelled-in-effect`), the operator has to manually
+hand the note off to PM via the Ask-PM button. With many audits
+running, that bottleneck becomes the place reminders pile up. The four
+audits run on 2026-05-10 illustrate the gap: three of the four had
+clear `done`/`cancel` verdicts and none became proposals overnight.
+
+## Scope
+
+Add an opt-in bridge from narrow audits to PM proposals:
+
+1. The narrow auditor emits a **second** take_note next to its
+   observation: `kind='audit_verdict'`, with a small structured body —
+   `verdict`, `action_recommended` (bool), optional `recommended_action_hint`,
+   short rationale, pointer to the paired observation note.
+2. When the workspace setting `audit_auto_spawn_pm` is on AND
+   `action_recommended === true` (OR `verdict === 'audit_failed'`),
+   the `take_note` MCP handler dispatches a `notes_intake` PM session
+   whose trigger_text bundles the verdict + the paired observation
+   body. The resulting `pm_proposal_id` is recorded onto the
+   audit_verdict note via the existing `appendNoteProposalId` helper.
+3. The setting defaults **off**; operator turns it on per workspace.
+   Dogfood usage: on for the dev workspace, off for prod, mirroring
+   the dogfood split.
+4. Existing manual operator path (`Ask PM to propose` button calling
+   `/api/initiatives/:id/ask-pm-from-notes`) stays the way to hand
+   things off when auto-spawn is off, or to re-ask after a rejected
+   first attempt. No new route.
+
+Out of scope:
+
+- Subtree audits already auto-synthesize via the L3 synthesizer
+  ([subtree-audit.ts:677](src/lib/agents/subtree-audit.ts:677)); this
+  spec targets the narrow path only.
+- Giving the narrow auditor `propose_changes` directly. The auditor
+  stays single-purpose; PM still authors the proposals.
+- Auto-rejecting empty (`proposed_changes=[]`) PM follow-ups. They
+  land as drafts; the queue UI shows "PM found nothing to do" and
+  the operator dismisses.
+
+## Validation against existing code
+
+| Claim | Where | Evidence |
+| --- | --- | --- |
+| Narrow audit emits observation-only by design | [audit-prompt.ts:300-308](src/lib/agents/audit-prompt.ts) | "Don't call propose_changes; you don't have it on your mount." |
+| `/investigate` is fire-and-forget | [investigate/route.ts:367-383](src/app/api/initiatives/[id]/investigate/route.ts) | `void dispatchScope(...).catch(...)` — no post-completion hook in the route. |
+| Operator-driven Ask-PM path already exists | [ask-pm-from-notes/route.ts](src/app/api/initiatives/[id]/ask-pm-from-notes/route.ts) | Takes `note_ids[]`, formats trigger_text, calls `dispatchPm({trigger_kind: 'notes_intake'})`, marks notes consumed, links `pm_proposal_id` back via `appendNoteProposalId`. |
+| `take_note` MCP handler already validates audit-kind bodies | [mcp/groups/core.ts:440-469](src/lib/mcp/groups/core.ts) | Calls `validateAuditNoteBody(kind, body)`; rejects with `audit_body_invalid` on mismatch. |
+| `agent_notes.pm_proposal_ids` column already wired | migration 084 + [agent-notes.ts:80-83](src/lib/db/agent-notes.ts) | `appendNoteProposalId(note_id, proposal_id)` is the existing helper. |
+| Workspace audit settings pattern established | [workspaces.ts:57-78](src/lib/db/workspaces.ts) | `getAuditSettings(workspace_id)` reads `audit_per_node_timeout_ms` + `audit_subtree_concurrency` columns. |
+| importance=2 already auto-pings PM Chat | [core.ts:506-524](src/lib/mcp/groups/core.ts) | Best-effort `postPmChatMessage` after `createNote`. Our auto-spawn slot is the same place. |
+
+So everything we need exists; this PR wires the missing piece —
+auditor emits a structured verdict, take_note fires the existing PM
+dispatch when the verdict + workspace setting align.
+
+## Schema
+
+### Migration
+
+- Extend `agent_notes.kind` CHECK to include `audit_verdict`
+  (table-swap recipe, same as migration 087).
+- Add `workspaces.audit_auto_spawn_pm INTEGER NOT NULL DEFAULT 0`.
+
+### NoteKind union
+
+```ts
+// src/lib/db/agent-notes.ts
+export type NoteKind =
+  | …existing…
+  | 'audit_verdict';
+
+export const AUDIT_NOTE_KINDS = [
+  'audit_manifest',
+  'audit_proposal',
+  'audit_synthesis',
+  'audit_verdict',   // ← new; excluded from cross-audit reads
+];
+```
+
+### Body schema
+
+`src/lib/agents/audit-proposals/schemas.ts`:
+
+```ts
+export const auditVerdictBodySchema = z.object({
+  version: z.literal(1),
+  // The free-form observation note this verdict was emitted alongside.
+  // Used by the auto-spawn hook to bundle both notes into the PM
+  // trigger_text. Auditor passes the observation's note id.
+  observation_note_id: z.string().min(1),
+  verdict: z.enum([
+    'on_track',
+    'partially_done',
+    'stale_rescope',
+    'never_built',
+    'done_in_entirety',
+    'cancelled_in_effect',
+    'audit_failed',
+  ]),
+  action_recommended: z.boolean(),
+  // Optional hint to PM. Maps roughly to the audit_proposal action
+  // enum, minus 'keep' (action_recommended=false means keep).
+  recommended_action_hint: z
+    .enum([
+      'cancel',
+      'mark_done',
+      'decompose',
+      'modify_scope',
+      'modify_dates',
+      'investigate_further',
+    ])
+    .nullish(),
+  short_rationale: z.string().min(20).max(800),
+});
+```
+
+### isAuditNoteKind
+
+Extend the discriminator to include `audit_verdict` so the
+`take_note` handler routes it through `validateAuditNoteBody`.
+
+## Auditor prompt update
+
+In [audit-prompt.ts](src/lib/agents/audit-prompt.ts), narrow mode adds
+a paragraph after the existing observation instruction:
+
+> Then call `take_note` a second time with `kind='audit_verdict'`,
+> referencing the observation note id you just created. The body must
+> be a JSON string matching the audit_verdict v1 schema:
+>
+> - `verdict`: one of `on_track | partially_done | stale_rescope | never_built | done_in_entirety | cancelled_in_effect | audit_failed`.
+> - `action_recommended`: true only when the verdict implies the
+>   operator should act now (`partially_done` w/ stale scope,
+>   `stale_rescope`, `never_built`, `done_in_entirety`,
+>   `cancelled_in_effect`). `on_track` → false.
+> - `recommended_action_hint`: optional pointer to the kind of PM
+>   action this likely warrants.
+> - `short_rationale`: 20–800 chars summarizing the verdict.
+>
+> The verdict note is structured signal for downstream tooling. The
+> observation carries the prose; the verdict carries the dispatch.
+
+## Auto-spawn hook
+
+In the `take_note` MCP handler ([core.ts](src/lib/mcp/groups/core.ts))
+after the existing `createNote` call:
+
+```ts
+if (note.kind === 'audit_verdict') {
+  maybeAutoSpawnPmFromVerdict(note).catch((err) => {
+    console.warn('[take_note] audit auto-spawn failed:', (err as Error).message);
+  });
+}
+```
+
+`maybeAutoSpawnPmFromVerdict(verdictNote)`:
+
+1. Parse the body; bail if `action_recommended === false` AND
+   `verdict !== 'audit_failed'`.
+2. Read `workspaces.audit_auto_spawn_pm` via a new getter
+   `getAuditAutoSpawn(workspace_id)`. Return early when off.
+3. Resolve the paired observation note by id from the body.
+4. Build the trigger_text:
+
+   ```
+   Audit verdict for initiative {id} ({title}): {verdict}.
+   action_recommended=true, hint={recommended_action_hint ?? 'none'}.
+
+   Rationale: {short_rationale}
+
+   --- Full audit observation (note {observation_note_id}) ---
+
+   {observation.body}
+   ```
+5. Call `dispatchPm({ workspace_id, trigger_text, trigger_kind: 'notes_intake', allowFallback: true })` — matches the disruption path. When the gateway is offline the synth row gives the operator something to react to and is later superseded by the real PM reply via SSE.
+6. `markNoteConsumed(observation.id, 'pm_proposal')`,
+   `markNoteConsumed(verdict.id, 'pm_proposal')`,
+   `appendNoteProposalId(verdict.id, result.proposal.id)`,
+   `appendNoteProposalId(observation.id, result.proposal.id)`.
+
+Best-effort throughout: the verdict note is the durable artifact; a
+failed dispatch leaves the note intact and the operator's manual
+Ask-PM button still works.
+
+## Workspace setting
+
+`src/lib/db/workspaces.ts` adds:
+
+```ts
+export function getAuditAutoSpawn(workspaceId: string): boolean { … }
+export function setAuditAutoSpawn(workspaceId: string, on: boolean): void { … }
+```
+
+UI surface: a checkbox under the existing "Audit defaults" subsection
+on the workspace settings page. Label: "Auto-send audit findings to
+PM when an audit recommends action."
+
+## Out-of-scope follow-ups
+
+- A dedicated `audit_verdict` UI chip on `NoteCard` w/ `Send to PM`
+  button when auto-spawn is off. The existing `Ask PM to propose`
+  button on observation notes already covers this; a verdict-specific
+  affordance is purely a UX polish.
+- Filtering the proposal queue by "from auto-spawn" — useful once we
+  have a few weeks of auto-spawn data to validate false-positive
+  rate, but not needed for v1.
+- `audit_failed` verdicts spawning a different trigger_text shape
+  ("audit could not complete; recommend retry or operator review").
+  v1 just bundles the audit_failed rationale into the standard
+  trigger_text and lets PM decide.
+
+## Tests
+
+- Migration roundtrip: insert an `audit_verdict` note (legal body),
+  reject the same note when `agent_notes.kind` constraint excludes
+  it on a pre-migration snapshot.
+- `validateAuditNoteBody('audit_verdict', …)`: happy path + each
+  required-field rejection + invalid enum value.
+- `take_note` MCP handler: writing `audit_verdict` with a bad body
+  shape rejects via the existing `audit_body_invalid` channel.
+- `maybeAutoSpawnPmFromVerdict`:
+  - `action_recommended=false` → no dispatch.
+  - workspace setting off → no dispatch.
+  - happy path: dispatches, records `pm_proposal_ids` on both notes,
+    marks both consumed.
+  - dispatch failure: leaves notes intact, logs warning, doesn't
+    throw.
+- A regression test on the narrow audit prompt covering the
+  audit_verdict instruction (string-match the load-bearing fields).
+
+## Verification
+
+- `yarn tsc --noEmit` + `yarn test` (full suite once).
+- Manual smoke after migration runs: re-trigger one of the 4 audits
+  from 2026-05-10 against the dev DB with auto-spawn ON; confirm
+  the audit lands two notes and a `pm_proposals` row appears.

--- a/src/app/(app)/workspace/[slug]/settings/page.tsx
+++ b/src/app/(app)/workspace/[slug]/settings/page.tsx
@@ -63,6 +63,9 @@ interface WorkspaceWithDefault {
   /** Initiative-audit knobs. Migration 079 / specs/initiative-investigate.md. */
   audit_per_node_timeout_ms?: number | null;
   audit_subtree_concurrency?: number | null;
+  /** Opt-in bridge from narrow audits to PM proposals. Migration 093 /
+   *  specs/audit-action-recommended.md. Stored as 0/1 INTEGER. */
+  audit_auto_spawn_pm?: number | boolean | null;
   /** Server-resolved default the override falls back to. */
   default_workspace_path: string;
   /** When true, the PATCH route runs `git init` in workspace_path on save.
@@ -718,6 +721,26 @@ export default function WorkspaceSettingsPage({
               Max parallel researcher dispatches per layer. Default 4.
               Range 1–8. Dial up if your runner can hose the LLM; dial
               down to keep cost predictable.
+            </p>
+          </Field>
+          <Field label="Auto-send audit findings to PM">
+            <label className="flex items-center gap-2 text-xs text-mc-text-secondary">
+              <input
+                type="checkbox"
+                checked={!!workspace.audit_auto_spawn_pm}
+                onChange={(e) => patch({ audit_auto_spawn_pm: e.target.checked })}
+              />
+              <span>
+                When an audit verdict recommends action, automatically
+                dispatch PM via <code>notes_intake</code> with the
+                observation + verdict.
+              </span>
+            </label>
+            <p className="text-[11px] text-mc-text-secondary mt-1">
+              Off by default. With this on, the operator wakes up to draft
+              PM proposals to accept/reject instead of plain audit notes.
+              Leave off for prod until the false-positive rate is
+              understood — see <code>specs/audit-action-recommended.md</code>.
             </p>
           </Field>
         </Section>

--- a/src/app/api/workspaces/[id]/route.ts
+++ b/src/app/api/workspaces/[id]/route.ts
@@ -141,6 +141,7 @@ export async function PATCH(
       default_base_branch,
       display_timezone,
       show_chat_widget,
+      audit_auto_spawn_pm,
     } = body;
 
     const db = getDb();
@@ -258,6 +259,13 @@ export async function PATCH(
       }
       updates.push('audit_subtree_concurrency = ?');
       values.push(n);
+    }
+    if (audit_auto_spawn_pm !== undefined) {
+      // Opt-in bridge from narrow audits to PM proposals. When on,
+      // `take_note(kind='audit_verdict', ...)` may auto-dispatch a
+      // notes_intake PM session. See specs/audit-action-recommended.md.
+      updates.push('audit_auto_spawn_pm = ?');
+      values.push(audit_auto_spawn_pm ? 1 : 0);
     }
 
     if (updates.length === 0) {

--- a/src/lib/agents/audit-auto-spawn.test.ts
+++ b/src/lib/agents/audit-auto-spawn.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the audit → PM auto-spawn bridge.
+ *
+ * Covers the gate (verdict + workspace setting) and the bookkeeping
+ * side-effects (consumed_by_stages, pm_proposal_ids) when the gate
+ * fires. The PM dispatch itself goes through the synth-fallback path
+ * (no gateway in tests) — we don't assert on the proposal body, only
+ * that a row was created and linked back to the verdict note.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, run } from '@/lib/db';
+import { createNote, getNote } from '@/lib/db/agent-notes';
+import { createInitiative } from '@/lib/db/initiatives';
+import { setAuditAutoSpawn } from '@/lib/db/workspaces';
+import { ensurePmAgent } from '@/lib/bootstrap-agents';
+import {
+  maybeAutoSpawnPmFromVerdict,
+  verdictWarrantsAutoSpawn,
+} from './audit-auto-spawn';
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at)
+     VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function seedAgent(workspaceId: string): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, created_at, updated_at)
+     VALUES (?, 'A', 'researcher', ?, 1, datetime('now'), datetime('now'))`,
+    [id, workspaceId],
+  );
+  return id;
+}
+
+function seedNotePair(
+  workspaceId: string,
+  initiativeId: string,
+  agentId: string,
+  verdictBody: object,
+) {
+  const runGroup = uuidv4();
+  const scopeKey = `initiative-${initiativeId}:audit:1`;
+  const observation = createNote({
+    workspace_id: workspaceId,
+    agent_id: agentId,
+    initiative_id: initiativeId,
+    scope_key: scopeKey,
+    role: 'researcher',
+    run_group_id: runGroup,
+    kind: 'observation',
+    audience: 'pm',
+    body: 'Audit body prose — found that the story is never built.',
+    importance: 2,
+  });
+  const verdict = createNote({
+    workspace_id: workspaceId,
+    agent_id: agentId,
+    initiative_id: initiativeId,
+    scope_key: scopeKey,
+    role: 'researcher',
+    run_group_id: runGroup,
+    kind: 'audit_verdict',
+    audience: 'pm',
+    body: JSON.stringify({
+      ...verdictBody,
+      observation_note_id: observation.id,
+    }),
+    importance: 1,
+  });
+  return { observation, verdict };
+}
+
+// ─── verdictWarrantsAutoSpawn (pure) ───────────────────────────────
+
+test('verdictWarrantsAutoSpawn: action_recommended=true → true', () => {
+  assert.equal(
+    verdictWarrantsAutoSpawn({
+      version: 1,
+      observation_note_id: 'o',
+      verdict: 'never_built',
+      action_recommended: true,
+      short_rationale: 'twenty chars or more rationale',
+    } as any),
+    true,
+  );
+});
+
+test('verdictWarrantsAutoSpawn: action_recommended=false on non-failure → false', () => {
+  assert.equal(
+    verdictWarrantsAutoSpawn({
+      version: 1,
+      observation_note_id: 'o',
+      verdict: 'on_track',
+      action_recommended: false,
+      short_rationale: 'twenty chars or more rationale',
+    } as any),
+    false,
+  );
+});
+
+test('verdictWarrantsAutoSpawn: audit_failed always warrants spawn', () => {
+  assert.equal(
+    verdictWarrantsAutoSpawn({
+      version: 1,
+      observation_note_id: 'o',
+      verdict: 'audit_failed',
+      action_recommended: false,
+      short_rationale: 'twenty chars or more rationale',
+    } as any),
+    true,
+  );
+});
+
+// ─── maybeAutoSpawnPmFromVerdict ───────────────────────────────────
+
+test('auto-spawn: workspace setting OFF → no dispatch, no bookkeeping', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  const agentId = seedAgent(ws);
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+
+  // Setting defaults to OFF; no setAuditAutoSpawn call.
+  const { verdict, observation } = seedNotePair(ws, init.id, agentId, {
+    version: 1,
+    verdict: 'never_built',
+    action_recommended: true,
+    short_rationale: 'Twenty chars or more of justification text.',
+  });
+
+  const proposalsBefore = queryAll(
+    `SELECT id FROM pm_proposals WHERE workspace_id = ?`,
+    [ws],
+  ).length;
+  await maybeAutoSpawnPmFromVerdict(verdict);
+  const proposalsAfter = queryAll(
+    `SELECT id FROM pm_proposals WHERE workspace_id = ?`,
+    [ws],
+  ).length;
+  assert.equal(proposalsAfter, proposalsBefore, 'no PM proposal should be created');
+
+  const verdictAfter = getNote(verdict.id);
+  assert.equal(verdictAfter?.pm_proposal_ids, null);
+  const observationAfter = getNote(observation.id);
+  assert.equal(observationAfter?.consumed_by_stages, null);
+});
+
+test('auto-spawn: action_recommended=false → no dispatch (setting ON)', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  setAuditAutoSpawn(ws, true);
+  const agentId = seedAgent(ws);
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+
+  const { verdict } = seedNotePair(ws, init.id, agentId, {
+    version: 1,
+    verdict: 'on_track',
+    action_recommended: false,
+    short_rationale: 'Initiative is on track per the evidence collected.',
+  });
+
+  const proposalsBefore = queryAll(
+    `SELECT id FROM pm_proposals WHERE workspace_id = ?`,
+    [ws],
+  ).length;
+  await maybeAutoSpawnPmFromVerdict(verdict);
+  const proposalsAfter = queryAll(
+    `SELECT id FROM pm_proposals WHERE workspace_id = ?`,
+    [ws],
+  ).length;
+  assert.equal(proposalsAfter, proposalsBefore);
+});
+
+test('auto-spawn: gate fires → PM proposal created + both notes linked + consumed', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  setAuditAutoSpawn(ws, true);
+  const agentId = seedAgent(ws);
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+
+  const { verdict, observation } = seedNotePair(ws, init.id, agentId, {
+    version: 1,
+    verdict: 'never_built',
+    action_recommended: true,
+    recommended_action_hint: 'cancel',
+    short_rationale: 'Story has zero tasks and no source files in the workspace.',
+  });
+
+  const proposalsBefore = queryAll<{ id: string }>(
+    `SELECT id FROM pm_proposals WHERE workspace_id = ?`,
+    [ws],
+  ).length;
+  await maybeAutoSpawnPmFromVerdict(verdict);
+
+  const proposalsAfter = queryAll<{ id: string }>(
+    `SELECT id FROM pm_proposals WHERE workspace_id = ?`,
+    [ws],
+  );
+  assert.equal(
+    proposalsAfter.length,
+    proposalsBefore + 1,
+    'expected one new PM proposal',
+  );
+
+  const newProposalId = proposalsAfter[proposalsAfter.length - 1].id;
+
+  const verdictAfter = getNote(verdict.id);
+  assert.ok(verdictAfter?.pm_proposal_ids?.includes(newProposalId));
+  assert.ok(verdictAfter?.consumed_by_stages?.includes('pm_proposal'));
+
+  const observationAfter = getNote(observation.id);
+  assert.ok(observationAfter?.pm_proposal_ids?.includes(newProposalId));
+  assert.ok(observationAfter?.consumed_by_stages?.includes('pm_proposal'));
+});
+
+test('auto-spawn: malformed body is logged + skipped, no throw', async () => {
+  const ws = freshWorkspace();
+  ensurePmAgent(ws);
+  setAuditAutoSpawn(ws, true);
+  const agentId = seedAgent(ws);
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+
+  // createNote bypasses take_note's validateAuditNoteBody, so we can
+  // simulate the "auditor wrote past the validator" defensive branch.
+  const malformed = createNote({
+    workspace_id: ws,
+    agent_id: agentId,
+    initiative_id: init.id,
+    scope_key: `initiative-${init.id}:audit:1`,
+    role: 'researcher',
+    run_group_id: uuidv4(),
+    kind: 'audit_verdict',
+    audience: 'pm',
+    body: '{"this": "is not the verdict shape"}',
+    importance: 1,
+  });
+
+  await assert.doesNotReject(() => maybeAutoSpawnPmFromVerdict(malformed));
+});

--- a/src/lib/agents/audit-auto-spawn.ts
+++ b/src/lib/agents/audit-auto-spawn.ts
@@ -1,0 +1,184 @@
+/**
+ * Audit → PM auto-spawn bridge.
+ *
+ * When the narrow `initiative_audit` flow lands an `audit_verdict` note
+ * that recommends action AND the workspace's `audit_auto_spawn_pm`
+ * toggle is on, dispatch a `notes_intake` PM session whose trigger_text
+ * bundles the verdict + the paired observation body. The resulting
+ * `pm_proposal_id` is recorded on both notes via the existing
+ * `appendNoteProposalId` helper, and both notes are marked consumed by
+ * the `pm_proposal` stage so the UI fades the manual "Ask PM" button.
+ *
+ * See specs/audit-action-recommended.md. Everything here is best-effort
+ * — failures are logged and never thrown into the take_note caller.
+ */
+
+import {
+  appendNoteProposalId,
+  getNote,
+  markNoteConsumed,
+  type AgentNote,
+} from '@/lib/db/agent-notes';
+import { getInitiative } from '@/lib/db/initiatives';
+import { getAuditAutoSpawn } from '@/lib/db/workspaces';
+import {
+  auditVerdictBodySchema,
+  type AuditVerdictBody,
+} from '@/lib/agents/audit-proposals/schemas';
+import { dispatchPm } from '@/lib/agents/pm-dispatch';
+
+const CONSUMED_STAGE = 'pm_proposal';
+
+/**
+ * Decide whether an `audit_verdict` body warrants an auto-dispatch.
+ * Pure — no DB access — so the take_note path can short-circuit before
+ * any lookups when the verdict is unambiguous-no-action.
+ */
+export function verdictWarrantsAutoSpawn(body: AuditVerdictBody): boolean {
+  if (body.action_recommended) return true;
+  // audit_failed always warrants a follow-up even if the auditor
+  // mistakenly set action_recommended=false — the operator needs to
+  // see the failure surfaced.
+  if (body.verdict === 'audit_failed') return true;
+  return false;
+}
+
+/**
+ * Best-effort PM auto-dispatch for a freshly-created audit_verdict
+ * note. Caller should fire-and-forget; this never throws.
+ */
+export async function maybeAutoSpawnPmFromVerdict(verdictNote: AgentNote): Promise<void> {
+  if (verdictNote.kind !== 'audit_verdict') return;
+  if (!verdictNote.initiative_id) {
+    console.warn(
+      `[audit-auto-spawn] verdict note ${verdictNote.id} has no initiative_id; skipping`,
+    );
+    return;
+  }
+
+  // 1. Parse the body. validateAuditNoteBody already ran in take_note,
+  //    so this re-parse is defensive — a malformed body means the
+  //    auditor wrote past the validator (shouldn't happen).
+  let body: AuditVerdictBody;
+  try {
+    const raw = JSON.parse(verdictNote.body);
+    const parsed = auditVerdictBodySchema.safeParse(raw);
+    if (!parsed.success) {
+      console.warn(
+        `[audit-auto-spawn] verdict ${verdictNote.id} body failed schema re-parse:`,
+        parsed.error.message,
+      );
+      return;
+    }
+    body = parsed.data;
+  } catch (err) {
+    console.warn(
+      `[audit-auto-spawn] verdict ${verdictNote.id} body JSON parse failed:`,
+      (err as Error).message,
+    );
+    return;
+  }
+
+  if (!verdictWarrantsAutoSpawn(body)) return;
+
+  // 2. Workspace gate.
+  if (!getAuditAutoSpawn(verdictNote.workspace_id)) return;
+
+  // 3. Resolve the paired observation. Tolerate a missing pointer by
+  //    falling back to no observation — the verdict body itself is
+  //    enough signal for PM, but the observation is preferred when
+  //    present because it has the full evidence prose.
+  let observation: AgentNote | null = null;
+  if (body.observation_note_id) {
+    const candidate = getNote(body.observation_note_id);
+    if (candidate && candidate.initiative_id === verdictNote.initiative_id) {
+      observation = candidate;
+    } else if (candidate) {
+      console.warn(
+        `[audit-auto-spawn] observation ${body.observation_note_id} points at a different initiative; ignoring`,
+      );
+    }
+  }
+
+  // 4. Build a trigger_text the PM agent can read straight into its
+  //    notes_intake prompt. The shape mirrors what
+  //    `formatNoteAsTrigger` in /api/initiatives/[id]/ask-pm-from-notes
+  //    produces so PM sees a consistent payload regardless of who
+  //    triggered the dispatch.
+  const initiative = getInitiative(verdictNote.initiative_id);
+  const initiativeTitle = initiative?.title ?? '(unknown initiative)';
+  const triggerText = formatTriggerText({
+    initiativeId: verdictNote.initiative_id,
+    initiativeTitle,
+    verdictNote,
+    verdictBody: body,
+    observation,
+  });
+
+  // 5. Dispatch. allowFallback=true matches the disruption path
+  //    rather than the strict Ask-PM route: when the auto-spawn fires
+  //    opportunistically, dropping a synth placeholder when the
+  //    gateway is down is a better UX than silently doing nothing.
+  //    The synth row still surfaces in the proposal queue and the
+  //    real PM dispatch supersedes it when the gateway reconnects.
+  try {
+    const result = dispatchPm({
+      workspace_id: verdictNote.workspace_id,
+      trigger_text: triggerText,
+      trigger_kind: 'notes_intake',
+      allowFallback: true,
+    });
+
+    // 6. Bookkeeping. Idempotent — each helper tolerates an already-
+    //    consumed/linked note.
+    const notes: AgentNote[] = observation ? [verdictNote, observation] : [verdictNote];
+    for (const n of notes) {
+      try {
+        markNoteConsumed(n.id, CONSUMED_STAGE);
+        appendNoteProposalId(n.id, result.proposal.id);
+      } catch (err) {
+        console.warn(
+          `[audit-auto-spawn] note bookkeeping failed for ${n.id}:`,
+          (err as Error).message,
+        );
+      }
+    }
+  } catch (err) {
+    console.warn(
+      `[audit-auto-spawn] dispatch failed for verdict ${verdictNote.id}:`,
+      (err as Error).message,
+    );
+  }
+}
+
+interface FormatTriggerArgs {
+  initiativeId: string;
+  initiativeTitle: string;
+  verdictNote: AgentNote;
+  verdictBody: AuditVerdictBody;
+  observation: AgentNote | null;
+}
+
+function formatTriggerText(args: FormatTriggerArgs): string {
+  const { initiativeId, initiativeTitle, verdictNote, verdictBody, observation } = args;
+  const hint = verdictBody.recommended_action_hint ?? 'none';
+  const lines: string[] = [
+    `Audit verdict for initiative ${initiativeId} ("${initiativeTitle}"): **${verdictBody.verdict}**.`,
+    `action_recommended=${verdictBody.action_recommended}, hint=${hint}.`,
+    '',
+    `Rationale: ${verdictBody.short_rationale}`,
+    '',
+    `(verdict note ${verdictNote.id})`,
+  ];
+  if (observation) {
+    lines.push(
+      '',
+      '---',
+      '',
+      `## Full audit observation (note ${observation.id})`,
+      '',
+      observation.body,
+    );
+  }
+  return lines.join('\n');
+}

--- a/src/lib/agents/audit-prompt.test.ts
+++ b/src/lib/agents/audit-prompt.test.ts
@@ -51,6 +51,23 @@ test('audit-prompt: take_note call shape is exact (load-bearing)', () => {
   );
 });
 
+test('audit-prompt: emits audit_verdict instruction with required fields', () => {
+  // specs/audit-action-recommended.md: the narrow auditor must emit a
+  // second take_note with kind=audit_verdict so the auto-spawn hook
+  // can decide whether to route to PM. Lock the field names so a
+  // future re-flow doesn't silently strip the structured signal.
+  const out = buildAuditPrompt({
+    initiative: baseInitiative,
+    tasks: [],
+  });
+  assert.match(out, /kind: 'audit_verdict'/);
+  assert.match(out, /observation_note_id:/);
+  assert.match(out, /action_recommended:/);
+  assert.match(out, /recommended_action_hint:/);
+  assert.match(out, /short_rationale:/);
+  assert.match(out, /exactly TWO/);
+});
+
 test('audit-prompt: explicitly tells researcher NOT to call register_deliverable', () => {
   // PR 2 dropped register_deliverable because deliverables are
   // task-scoped today. The prompt must steer the researcher away

--- a/src/lib/agents/audit-prompt.ts
+++ b/src/lib/agents/audit-prompt.ts
@@ -268,6 +268,24 @@ export function buildAuditPrompt(input: BuildAuditPromptInput): string {
   body: <full report>,
 })`;
 
+  // Companion verdict note. Structured row that lets downstream
+  // tooling decide whether to auto-route the audit to PM. See
+  // specs/audit-action-recommended.md.
+  const verdictCall = `take_note({
+  initiative_id: "${initiative.id}",
+  kind: 'audit_verdict',
+  audience: 'pm',
+  importance: 1,
+  body: JSON.stringify({
+    version: 1,
+    observation_note_id: "<id of the observation note you just created>",
+    verdict: "on_track|partially_done|stale_rescope|never_built|done_in_entirety|cancelled_in_effect|audit_failed",
+    action_recommended: true|false,
+    recommended_action_hint: "cancel|mark_done|decompose|modify_scope|modify_dates|investigate_further" | null,
+    short_rationale: "<20–800 chars, why this verdict>",
+  }),
+})`;
+
   return `**Initiative audit (mode: ${mode})**
 
 Target: ${initiative.title}  (kind=${initiative.kind}, status=${initiative.status}, id=${initiative.id})
@@ -303,14 +321,24 @@ Save the report by calling:
 
 - ${takeNoteCall}
 
-This is the audit trail. The note surfaces on the initiative detail page and feeds the PM on a later Plan dispatch. Don't try to call \`register_deliverable\` for this — the deliverables system is task-scoped today and won't accept an initiative-only deliverable.
+Then, **immediately after**, call \`take_note\` a second time with the structured verdict row:
 
-Don't call propose_changes; you don't have it on your mount. The PM will pick up your note when the operator decides to act.
+- ${verdictCall}
+
+The observation note is the prose audit trail; the verdict note is the structured signal that downstream tooling (the PM auto-dispatch toggle) reads to decide whether to route the finding to PM right away. Both notes surface on the initiative detail page.
+
+Verdict guidance:
+- \`on_track\` → \`action_recommended: false\`. PM doesn't need to act.
+- \`done_in_entirety\` / \`cancelled_in_effect\` / \`never_built\` → \`action_recommended: true\`, hint \`mark_done\` / \`cancel\` / \`cancel\`. Operator likely wants to close out.
+- \`partially_done\` / \`stale_rescope\` → \`action_recommended: true\` only when scope clearly needs to change; otherwise false (just informational).
+- \`audit_failed\` → \`action_recommended: true\`, hint \`investigate_further\`. Use only when you genuinely could not complete the audit (missing repo, permissions, etc.) — not as a default.
+
+Don't try to call \`register_deliverable\` for this — the deliverables system is task-scoped today and won't accept an initiative-only deliverable. Don't call propose_changes; you don't have it on your mount. The PM picks up your notes when either the operator clicks "Ask PM" or the workspace's auto-spawn toggle fires off your verdict.
 
 **Strict output discipline for this dispatch:**
 
-- Make **exactly ONE** \`take_note\` call — the summary observation defined above. No \`breadcrumb\`/\`discovery\`/\`question\` notes during the audit, even if you'd normally drop them while researching. Build all observations into the single summary instead.
-- This applies to BOTH fresh runs and re-audits where prior findings are inlined above. On a re-audit, your single \`take_note\` is a fresh standalone summary that supersedes the priors — not an incremental update or set of follow-up breadcrumbs. Read the priors, factor them in, but emit ONE consolidated summary.
+- Make **exactly TWO** \`take_note\` calls: the observation, then the audit_verdict. No \`breadcrumb\`/\`discovery\`/\`question\` notes during the audit, even if you'd normally drop them while researching. Build all observations into the single summary instead.
+- This applies to BOTH fresh runs and re-audits where prior findings are inlined above. On a re-audit, your single observation + verdict pair supersedes the priors — not an incremental update or set of follow-up breadcrumbs. Read the priors, factor them in, but emit ONE consolidated summary + ONE verdict.
 - The audit-trail accumulates by virtue of each summary being its own row; the operator reads them newest-first. Multiple breadcrumbs per dispatch fragment that trail and make it harder to compare audit passes.
 
 If the initiative has no associated code yet (planned-only, no tasks, nothing in the repo to point at), early-exit with a short verdict ("never built — planned-only, no audit work to do"). Don't burn ten minutes of exec on greenfield.

--- a/src/lib/agents/audit-proposals/schemas.test.ts
+++ b/src/lib/agents/audit-proposals/schemas.test.ts
@@ -258,8 +258,71 @@ test('isAuditNoteKind: correct membership', () => {
   assert.equal(isAuditNoteKind('audit_manifest'), true);
   assert.equal(isAuditNoteKind('audit_proposal'), true);
   assert.equal(isAuditNoteKind('audit_synthesis'), true);
+  assert.equal(isAuditNoteKind('audit_verdict'), true);
   assert.equal(isAuditNoteKind('discovery'), false);
   assert.equal(isAuditNoteKind('observation'), false);
+});
+
+// ─── audit_verdict body schema (PR audit-action-recommended) ────────
+
+test('validateAuditNoteBody: audit_verdict happy path', () => {
+  const body = JSON.stringify({
+    version: 1,
+    observation_note_id: 'obs-abc',
+    verdict: 'never_built',
+    action_recommended: true,
+    recommended_action_hint: 'cancel',
+    short_rationale: 'Story has zero tasks and no code in the workspace.',
+  });
+  const result = validateAuditNoteBody('audit_verdict', body);
+  assert.equal(result.ok, true);
+});
+
+test('validateAuditNoteBody: audit_verdict rejects unknown verdict enum', () => {
+  const body = JSON.stringify({
+    version: 1,
+    observation_note_id: 'obs-abc',
+    verdict: 'totally_made_up_verdict',
+    action_recommended: false,
+    short_rationale: 'Twenty characters or more of justification.',
+  });
+  const result = validateAuditNoteBody('audit_verdict', body);
+  assert.equal(result.ok, false);
+});
+
+test('validateAuditNoteBody: audit_verdict rejects short rationale', () => {
+  const body = JSON.stringify({
+    version: 1,
+    observation_note_id: 'obs-abc',
+    verdict: 'on_track',
+    action_recommended: false,
+    short_rationale: 'too short',
+  });
+  const result = validateAuditNoteBody('audit_verdict', body);
+  assert.equal(result.ok, false);
+});
+
+test('validateAuditNoteBody: audit_verdict rejects missing observation_note_id', () => {
+  const body = JSON.stringify({
+    version: 1,
+    verdict: 'partially_done',
+    action_recommended: true,
+    short_rationale: 'Plenty of justification text right here.',
+  });
+  const result = validateAuditNoteBody('audit_verdict', body);
+  assert.equal(result.ok, false);
+});
+
+test('validateAuditNoteBody: audit_verdict allows omitted recommended_action_hint', () => {
+  const body = JSON.stringify({
+    version: 1,
+    observation_note_id: 'obs-abc',
+    verdict: 'on_track',
+    action_recommended: false,
+    short_rationale: 'Initiative is on track per the evidence collected.',
+  });
+  const result = validateAuditNoteBody('audit_verdict', body);
+  assert.equal(result.ok, true);
 });
 
 test('MAX_AUDIT_NOTE_BODY_CHARS leaves headroom under DB cap', () => {

--- a/src/lib/agents/audit-proposals/schemas.ts
+++ b/src/lib/agents/audit-proposals/schemas.ts
@@ -252,18 +252,68 @@ export const auditSynthesisBodySchema = z.object({
 
 export type AuditSynthesisBody = z.infer<typeof auditSynthesisBodySchema>;
 
+// ─── audit_verdict body schema (narrow audit) ──────────────────────
+// Structured signal emitted by the narrow `initiative_audit` auditor
+// alongside its free-form observation note. The take_note handler
+// reads this row to decide whether to auto-dispatch a notes_intake PM
+// session (gated by the workspace `audit_auto_spawn_pm` setting).
+// See specs/audit-action-recommended.md.
+
+export const VERDICT_VALUES = [
+  'on_track',
+  'partially_done',
+  'stale_rescope',
+  'never_built',
+  'done_in_entirety',
+  'cancelled_in_effect',
+  'audit_failed',
+] as const;
+export type AuditVerdictValue = (typeof VERDICT_VALUES)[number];
+
+export const RECOMMENDED_ACTION_HINTS = [
+  'cancel',
+  'mark_done',
+  'decompose',
+  'modify_scope',
+  'modify_dates',
+  'investigate_further',
+] as const;
+
+export const auditVerdictBodySchema = z.object({
+  version: z.literal(1),
+  /**
+   * The free-form observation note this verdict was emitted alongside.
+   * The auto-spawn hook reads it to bundle observation body + verdict
+   * rationale into the PM trigger_text.
+   */
+  observation_note_id: z.string().min(1),
+  verdict: z.enum(VERDICT_VALUES),
+  /**
+   * True only when the verdict implies the operator should act now.
+   * `on_track` → false; `audit_failed` may also be true if the auditor
+   * thinks a follow-up dispatch is warranted.
+   */
+  action_recommended: z.boolean(),
+  recommended_action_hint: z.enum(RECOMMENDED_ACTION_HINTS).nullish(),
+  short_rationale: z.string().min(20).max(800),
+});
+
+export type AuditVerdictBody = z.infer<typeof auditVerdictBodySchema>;
+
 // ─── Validation helper ──────────────────────────────────────────────
 
 export type AuditNoteKind =
   | 'audit_manifest'
   | 'audit_proposal'
-  | 'audit_synthesis';
+  | 'audit_synthesis'
+  | 'audit_verdict';
 
 export function isAuditNoteKind(kind: NoteKind): kind is AuditNoteKind {
   return (
     kind === 'audit_manifest' ||
     kind === 'audit_proposal' ||
-    kind === 'audit_synthesis'
+    kind === 'audit_synthesis' ||
+    kind === 'audit_verdict'
   );
 }
 
@@ -305,7 +355,9 @@ export function validateAuditNoteBody(
       ? auditManifestBodySchema
       : kind === 'audit_proposal'
         ? auditProposalBodySchema
-        : auditSynthesisBodySchema;
+        : kind === 'audit_synthesis'
+          ? auditSynthesisBodySchema
+          : auditVerdictBodySchema;
 
   const result = schema.safeParse(parsed);
   if (result.success) {

--- a/src/lib/db/agent-notes.ts
+++ b/src/lib/db/agent-notes.ts
@@ -26,7 +26,8 @@ export type NoteKind =
   | 'breadcrumb'
   | 'audit_manifest'
   | 'audit_proposal'
-  | 'audit_synthesis';
+  | 'audit_synthesis'
+  | 'audit_verdict';
 
 export const NOTE_KINDS: ReadonlyArray<NoteKind> = [
   'discovery',
@@ -39,20 +40,23 @@ export const NOTE_KINDS: ReadonlyArray<NoteKind> = [
   'audit_manifest',
   'audit_proposal',
   'audit_synthesis',
+  'audit_verdict',
 ];
 
 /**
  * Note kinds emitted by the subtree-audit pipeline (see
- * specs/subtree-audit-proposals-spec.md). These are excluded by default
- * from cross-audit reads (briefing builder, Notes Rail, default
- * `listNotes` calls) so audit artifacts don't bleed into unrelated
- * agent context. The proposal queue UI and the audit orchestrator
- * itself read them explicitly via the `kinds` filter.
+ * specs/subtree-audit-proposals-spec.md) plus the narrow-audit verdict
+ * row introduced by specs/audit-action-recommended.md. These are
+ * excluded by default from cross-audit reads (briefing builder, Notes
+ * Rail, default `listNotes` calls) so audit artifacts don't bleed into
+ * unrelated agent context. The proposal queue UI and the audit
+ * orchestrator itself read them explicitly via the `kinds` filter.
  */
 export const AUDIT_NOTE_KINDS: ReadonlyArray<NoteKind> = [
   'audit_manifest',
   'audit_proposal',
   'audit_synthesis',
+  'audit_verdict',
 ];
 
 export type NoteImportance = 0 | 1 | 2;

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4701,6 +4701,103 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    id: '093',
+    name: 'audit_verdict_kind_and_auto_spawn_setting',
+    up: (db) => {
+      // Phase 1 of specs/audit-action-recommended.md. Extends the
+      // agent_notes.kind CHECK to permit a new 'audit_verdict' kind —
+      // structured signal emitted by the narrow auditor alongside the
+      // free-form observation. Also adds workspaces.audit_auto_spawn_pm
+      // (opt-in toggle that lets the take_note handler auto-dispatch a
+      // notes_intake PM session when the verdict recommends action).
+      //
+      // Same table-swap recipe used by migration 087.
+
+      // 1) extend agent_notes.kind CHECK
+      const noteCols = db.prepare(`PRAGMA table_info(agent_notes)`).all() as Array<{ name: string }>;
+      // pm_proposal_ids was added in 084; consumed_by_stages was on the
+      // original table. Build the new schema with both.
+      const hasPmProposalIds = noteCols.some((c) => c.name === 'pm_proposal_ids');
+      const hasSourceKind = noteCols.some((c) => c.name === 'source_kind');
+      // Guard against a partial-application path (e.g. someone manually
+      // ran an ALTER TABLE ADD … kind) — bail if the check already
+      // accepts audit_verdict to keep this migration idempotent.
+      const tableSql = db
+        .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='agent_notes'`)
+        .get() as { sql?: string } | undefined;
+      const alreadyExtended =
+        typeof tableSql?.sql === 'string' && tableSql.sql.includes("'audit_verdict'");
+      if (!alreadyExtended) {
+        db.exec('PRAGMA foreign_keys = OFF');
+        db.exec(`
+          CREATE TABLE agent_notes_new (
+            id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+            agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+            task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
+            initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
+            scope_key TEXT NOT NULL,
+            role TEXT NOT NULL,
+            run_group_id TEXT NOT NULL,
+            kind TEXT NOT NULL CHECK (kind IN (
+              'discovery','blocker','uncertainty','decision',
+              'observation','question','breadcrumb',
+              'audit_manifest','audit_proposal','audit_synthesis',
+              'audit_verdict'
+            )),
+            audience TEXT,
+            body TEXT NOT NULL,
+            attached_files TEXT,
+            importance INTEGER NOT NULL DEFAULT 0 CHECK (importance IN (0,1,2)),
+            consumed_by_stages TEXT,
+            archived_at TEXT,
+            archived_reason TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            pm_proposal_ids TEXT,
+            source_kind TEXT,
+            source_ref TEXT
+          );
+        `);
+        const pmIdsCol = hasPmProposalIds ? 'pm_proposal_ids' : "NULL AS pm_proposal_ids";
+        const sourceKindCol = hasSourceKind ? 'source_kind' : "NULL AS source_kind";
+        const sourceRefCol = hasSourceKind ? 'source_ref' : "NULL AS source_ref";
+        db.exec(`
+          INSERT INTO agent_notes_new
+            (id, workspace_id, agent_id, task_id, initiative_id, scope_key, role,
+             run_group_id, kind, audience, body, attached_files, importance,
+             consumed_by_stages, archived_at, archived_reason, created_at,
+             pm_proposal_ids, source_kind, source_ref)
+          SELECT id, workspace_id, agent_id, task_id, initiative_id, scope_key, role,
+             run_group_id, kind, audience, body, attached_files, importance,
+             consumed_by_stages, archived_at, archived_reason, created_at,
+             ${pmIdsCol}, ${sourceKindCol}, ${sourceRefCol}
+          FROM agent_notes;
+        `);
+        db.exec(`DROP TABLE agent_notes`);
+        db.exec(`ALTER TABLE agent_notes_new RENAME TO agent_notes`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_notes_task ON agent_notes(task_id, created_at DESC) WHERE task_id IS NOT NULL`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_notes_initiative ON agent_notes(initiative_id, created_at DESC) WHERE initiative_id IS NOT NULL`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_notes_workspace ON agent_notes(workspace_id, created_at DESC)`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_notes_run_group ON agent_notes(run_group_id)`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_notes_importance ON agent_notes(workspace_id, importance, created_at DESC) WHERE archived_at IS NULL`);
+        db.exec(`CREATE INDEX IF NOT EXISTS agent_notes_source_idx ON agent_notes(source_kind, source_ref) WHERE source_kind IS NOT NULL`);
+        db.exec('PRAGMA foreign_keys = ON');
+        console.log('[Migration 093] agent_notes.kind extended with audit_verdict.');
+      } else {
+        console.log('[Migration 093] agent_notes.kind already includes audit_verdict; skipping table rebuild.');
+      }
+
+      // 2) add workspaces.audit_auto_spawn_pm
+      const wsCols = db.prepare(`PRAGMA table_info(workspaces)`).all() as Array<{ name: string }>;
+      if (!wsCols.some((c) => c.name === 'audit_auto_spawn_pm')) {
+        db.exec(`ALTER TABLE workspaces ADD COLUMN audit_auto_spawn_pm INTEGER NOT NULL DEFAULT 0`);
+        console.log('[Migration 093] workspaces.audit_auto_spawn_pm added (default 0).');
+      } else {
+        console.log('[Migration 093] workspaces.audit_auto_spawn_pm already present; skipping.');
+      }
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/workspaces.ts
+++ b/src/lib/db/workspaces.ts
@@ -77,6 +77,47 @@ export function getAuditSettings(workspaceId: string): AuditSettings {
   };
 }
 
+/**
+ * Read the `audit_auto_spawn_pm` workspace toggle. When on, the
+ * `take_note` MCP handler auto-dispatches a `notes_intake` PM session
+ * whenever an `audit_verdict` note lands with `action_recommended=true`
+ * (or `verdict='audit_failed'`).
+ *
+ * See specs/audit-action-recommended.md. Defaults to `false` on
+ * missing columns so pre-093 DBs and freshly-cloned workspaces behave
+ * conservatively.
+ */
+export function getAuditAutoSpawn(workspaceId: string): boolean {
+  const db = getDb();
+  try {
+    const row = db
+      .prepare(
+        `SELECT audit_auto_spawn_pm as v FROM workspaces WHERE id = ?`,
+      )
+      .get(workspaceId) as { v: number | null } | undefined;
+    return Number(row?.v ?? 0) === 1;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Flip the `audit_auto_spawn_pm` workspace toggle. No-ops silently if
+ * the column is missing (pre-093 DB) — the operator will see the
+ * setting absent from the workspace settings UI and is expected to
+ * run pending migrations first.
+ */
+export function setAuditAutoSpawn(workspaceId: string, on: boolean): void {
+  const db = getDb();
+  try {
+    db.prepare(
+      `UPDATE workspaces SET audit_auto_spawn_pm = ? WHERE id = ?`,
+    ).run(on ? 1 : 0, workspaceId);
+  } catch {
+    /* column missing on pre-093 DB; surfaced by getter returning false */
+  }
+}
+
 export interface WorkspaceCascadeCounts {
   tasks: number;
   agents: number;

--- a/src/lib/mcp/groups/core.ts
+++ b/src/lib/mcp/groups/core.ts
@@ -36,6 +36,7 @@ import {
 } from '@/lib/agents/audit-proposals/schemas';
 import { getRunByGroupId } from '@/lib/db/agent-runs';
 import { broadcast } from '@/lib/events';
+import { maybeAutoSpawnPmFromVerdict } from '@/lib/agents/audit-auto-spawn';
 
 import {
   agentIdArg,
@@ -521,6 +522,20 @@ export function registerCoreTools(server: McpServer): void {
               (chatErr as Error).message,
             );
           }
+        }
+
+        // Audit → PM bridge. When the workspace setting is on and the
+        // verdict recommends action, fire a notes_intake PM dispatch
+        // bundling the verdict + paired observation. Fire-and-forget;
+        // failures are logged inside the helper and never surface to
+        // the auditor agent. See specs/audit-action-recommended.md.
+        if (note.kind === 'audit_verdict') {
+          maybeAutoSpawnPmFromVerdict(note).catch((err) => {
+            console.warn(
+              '[take_note] audit auto-spawn unhandled rejection:',
+              (err as Error).message,
+            );
+          });
         }
 
         return textResult(JSON.stringify(payload, null, 2), payload);


### PR DESCRIPTION
## Summary

Adds a structured `audit_verdict` note kind emitted by the narrow `initiative_audit` flow, plus an opt-in workspace toggle that auto-dispatches a `notes_intake` PM session when the verdict recommends action. Closes the gap surfaced by the 2026-05-10 audits that produced clean "never built" / "done in effect" findings but never became proposals.

Spec: [`specs/audit-action-recommended.md`](specs/audit-action-recommended.md).

## Changes

- **Migration 093** extends `agent_notes.kind` CHECK to include `audit_verdict` (table-swap recipe) and adds `workspaces.audit_auto_spawn_pm INTEGER NOT NULL DEFAULT 0`.
- **Note kind machinery** — `NoteKind`, `NOTE_KINDS`, `AUDIT_NOTE_KINDS`, `AuditNoteKind`, `isAuditNoteKind` all extend to cover `audit_verdict`. The new `auditVerdictBodySchema` enforces the body shape; `validateAuditNoteBody` routes the new kind through it so a malformed body is rejected at the `take_note` boundary (same channel as the existing `audit_manifest`/`audit_proposal`/`audit_synthesis` validators).
- **Audit prompt** (narrow mode) now instructs the researcher to emit two `take_note` calls: the existing observation, then a structured verdict with `observation_note_id`, `verdict`, `action_recommended`, optional `recommended_action_hint`, and `short_rationale`. Verdict guidance covers each enum value (`on_track`, `partially_done`, `stale_rescope`, `never_built`, `done_in_entirety`, `cancelled_in_effect`, `audit_failed`).
- **Auto-spawn helper** ([src/lib/agents/audit-auto-spawn.ts](src/lib/agents/audit-auto-spawn.ts)) runs after `createNote` in the `take_note` MCP handler when the new note is an `audit_verdict`. Gates: parse the body, bail if `!action_recommended && verdict !== 'audit_failed'`, check `getAuditAutoSpawn(workspace_id)`, resolve the paired observation, then `dispatchPm({ trigger_kind: 'notes_intake', allowFallback: true })`. Records `pm_proposal_id` on both notes via `appendNoteProposalId` and marks both consumed by the `pm_proposal` stage so the UI fades the manual Ask-PM button. Fire-and-forget; failures are logged and never thrown into the auditor agent.
- **Workspace setting** plumbing — `getAuditAutoSpawn` / `setAuditAutoSpawn` in [src/lib/db/workspaces.ts](src/lib/db/workspaces.ts), `audit_auto_spawn_pm` accepted by the PATCH route in [src/app/api/workspaces/[id]/route.ts](src/app/api/workspaces/[id]/route.ts), and a checkbox under "Audit defaults" on the workspace settings page.

## Out of scope

- Subtree audits already auto-synthesize via the L3 synthesizer ([subtree-audit.ts:677](src/lib/agents/subtree-audit.ts)). This PR targets the narrow `/investigate` path only.
- Giving the narrow auditor `propose_changes` directly — auditor stays single-purpose, PM still authors the proposals.
- A dedicated UI chip / "Send to PM" button on `NoteCard` for verdict notes when auto-spawn is off. The existing observation-note "Ask PM" affordance covers the manual path; a verdict-specific affordance is pure UX polish.

## Test plan

- [x] `yarn tsc --noEmit` clean.
- [x] `yarn test` — 1015/1016 pass. The one failure (`schedule-runner: produces a brief and advances run_count`) is pre-existing on main and unrelated to this change (orchestrator/agent_runs path).
- [x] `src/lib/agents/audit-proposals/schemas.test.ts` — 5 new tests on the audit_verdict body schema (happy path, bad enum, short rationale, missing observation_note_id, omitted hint accepted).
- [x] `src/lib/agents/audit-auto-spawn.test.ts` — 7 new tests covering the pure verdict-gate logic and the helper's gate/bookkeeping side-effects (setting OFF blocks dispatch, `action_recommended=false` blocks dispatch, happy path creates the proposal and links both notes, malformed body skips without throwing).
- [x] `src/lib/agents/audit-prompt.test.ts` — regression on the new verdict-instruction block (locks `kind: 'audit_verdict'`, the five required field names, and "exactly TWO" output discipline).

## Manual verify

After merge + migration, flip `audit_auto_spawn_pm` on for the dev workspace via Settings → Audit defaults, then re-run `/investigate` on one of the 2026-05-10 audit initiatives. Expected: two notes land (observation + verdict), and a new PM proposal appears in the queue with `trigger_kind='notes_intake'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)