### PR TITLE
fix(test): collect bracket-path test files (Next [id] routes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start -p ${PORT:-4010}",
     "lint": "eslint .",
-    "test": "npm run test:setup && find src -name '*.test.ts' -print0 | NODE_ENV=test xargs -0 tsx --test",
+    "test": "npm run test:setup && NODE_ENV=test tsx scripts/run-tests.mjs",
     "test:setup": "mkdir -p .tmp/test-dbs && rm -rf .tmp/test-dbs/* && rm -f .tmp/test-template.db .tmp/test-template.db-shm .tmp/test-template.db-wal .tmp/mission-control-test.db .tmp/mission-control-test.db-shm .tmp/mission-control-test.db-wal && NODE_ENV=test tsx scripts/build-test-template.ts",
     "mcp:smoke": "cd mcp-launcher && npm run smoke",
     "mcp:integration": "tsx scripts/mcp-integration-test.mjs",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Discover and run *.test.ts files via node:test's programmatic run() API.
+// Avoids the CLI's glob interpretation, which silently drops paths with
+// literal `[` / `]` (e.g. Next.js `[id]` route segments).
+
+import { run } from 'node:test';
+import { spec } from 'node:test/reporters';
+import { readdir } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+async function walk(dir, out = []) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+      await walk(p, out);
+    } else if (entry.isFile() && entry.name.endsWith('.test.ts')) {
+      out.push(resolve(p));
+    }
+  }
+  return out;
+}
+
+const roots = process.argv.slice(2);
+const searchRoots = roots.length ? roots : ['src'];
+
+const files = [];
+for (const root of searchRoots) {
+  await walk(root, files);
+}
+
+if (files.length === 0) {
+  console.error('No *.test.ts files found under:', searchRoots.join(', '));
+  process.exit(1);
+}
+
+const stream = run({ files, concurrency: false });
+let failed = false;
+stream.on('test:fail', (event) => {
+  if (event.details?.error && !event.todo && !event.skip) {
+    failed = true;
+  }
+});
+stream.compose(new spec()).pipe(process.stdout);
+stream.once('end', () => {
+  process.exit(failed ? 1 : 0);
+});


### PR DESCRIPTION
## Summary
- `yarn test` was silently skipping ~14 test files with literal `[`/`]` in the path (every Next.js `[id]/route.test.ts`). Root cause: `tsx --test <path>` forwards positional args to `node --test`, which treats them as glob patterns — `[id]` is parsed as an empty char class and matches nothing.
- Replace the `find | xargs tsx --test` pipeline with a small runner that walks `src/` and invokes `node:test`'s programmatic `run({ files })`, which accepts literal paths.

## Changes
- `scripts/run-tests.mjs` — new runner using `node:test` programmatic API + spec reporter.
- `package.json` — `test` script switched from the find/xargs pipeline to `tsx scripts/run-tests.mjs`.

## Test plan
- [x] `yarn test` now executes the previously-dropped bracket-path files. Verified e.g. `src/app/api/initiatives/[id]/ask-pm-from-notes/route.test.ts` — all 6 `POST: …` tests appear in output.
- [x] Total: 1059 pass, 1 pre-existing fail (`schedule-runner: produces a brief and advances run_count`) — unrelated to this change.
- [x] No new bracket-path failures introduced (the collected tests pass).

Reporter note: switching to the `spec` reporter changes output format (`✔ POST: …` instead of TAP's `Subtest: POST`). Functionally equivalent, easier to scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)