### PR TITLE
feat(pm): chat context strip, self-healing supersede, proposal management UX

### DIFF
--- a/docs/proposals/pm-chat-context-strip.md
+++ b/docs/proposals/pm-chat-context-strip.md
@@ -1,0 +1,146 @@
+---
+status: aspirational
+built: false
+last-verified: 2026-05-11
+audience: ai-subagents-primary, operator-secondary
+related-specs:
+  - docs/reference/pm-chat-prompt.md — the prompt contract; renders alongside the rows this spec describes
+code-anchors:
+  - src/app/(app)/pm/page.tsx
+  - src/components/pm/triggerBadge.ts
+  - src/lib/agents/pm-dispatch.ts
+  - src/app/api/pm/proposals/route.ts
+  - src/app/api/pm/plan-initiative/route.ts
+  - src/app/api/pm/decompose-initiative/route.ts
+  - src/app/api/pm/decompose-story/route.ts
+  - src/app/api/pm/proposals/[id]/accept/route.ts
+  - src/app/api/pm/proposals/[id]/refine/route.ts
+  - src/lib/agents/pm-standup.ts
+  - src/lib/mcp/groups/core.ts
+  - src/lib/mcp/groups/pm.ts
+---
+
+# PM chat context strip + bi-directional links
+
+> **Status: aspirational.** Spec for the next change. Not yet implemented.
+
+## Problem
+
+When `/pm` renders a chat post triggered by an audit, the operator sees a wall of prose ("Please review the following audit note from initiative …") with no immediate signal of:
+
+1. **What kind of action this is.** Trigger-kind badges (`notes-intake`, `plan`, `decompose`, etc.) already exist in [src/components/pm/triggerBadge.ts](src/components/pm/triggerBadge.ts) but render only inside the embedded proposal card — not on the chat row itself. Trigger messages without an embedded proposal (user-side ask-PM posts, mid-flight status posts, accept-result echoes) have no badge at all.
+2. **What initiative / note / audit run this is about.** The proposal carries `target_initiative_id`, `parent_proposal_id`, and a `trigger_text` that embeds note ids — none surfaced as clickable affordances on the chat row.
+3. **How to navigate back to the source.** [agent_notes.pm_proposal_ids](src/lib/db/agent-notes.ts) already records which proposals each note triggered, but neither direction is exposed in the UI.
+
+Today's `agent_chat_messages.metadata` JSON only carries `{ proposal_id }`, and the render in [src/app/(app)/pm/page.tsx](src/app/(app)/pm/page.tsx) parses no further than that.
+
+## Scope
+
+This spec covers **#1 (context strip on each chat row)** and **#2 (bi-directional cross-links to initiatives and notes)** from the design discussion. Threading (#3) and the side-drawer (#4) are explicitly out of scope; they're additive on top of this and gated on observed need.
+
+## Proposal
+
+### A. Widen the chat-message metadata convention
+
+`agent_chat_messages.metadata` is already a free-form JSON column — no schema migration needed. The convention becomes:
+
+```ts
+interface PmChatMetadata {
+  proposal_id?: string;             // pre-existing
+  trigger_kind?: PmProposalTriggerKind;
+  target_initiative_id?: string | null;
+  source_note_ids?: string[];       // audit notes that produced this message
+  audit_run_group_id?: string | null;  // populated when triggered by an audit run
+  parent_proposal_id?: string | null;
+  origin?:
+    | 'pm_dispatch'                 // agent-driven via dispatchPm/dispatchPmSynthesized
+    | 'ask_pm_from_notes'           // operator handed PM a note set
+    | 'standup'                     // recurring standup post
+    | 'accept_result'               // post-acceptance summary
+    | 'system';                     // internal status (e.g. dispatch errors)
+}
+```
+
+Every `postPmChatMessage` call site already has these values in scope. Threading them through is mechanical.
+
+### B. Call-site updates
+
+Extend the [`PostPmChatMessage`](src/lib/agents/pm-dispatch.ts) interface to accept the additional fields and write them into `metadata`. Each call site below gets the relevant fields populated:
+
+| File | Origin | Fields added |
+|---|---|---|
+| [src/lib/agents/pm-dispatch.ts](src/lib/agents/pm-dispatch.ts) (×6) | `pm_dispatch` | trigger_kind, target_initiative_id, parent_proposal_id |
+| [src/lib/mcp/groups/pm.ts](src/lib/mcp/groups/pm.ts) (×1, the retroactive re-echo) | `pm_dispatch` | trigger_kind, target_initiative_id |
+| [src/lib/mcp/groups/core.ts](src/lib/mcp/groups/core.ts) (×1, ask-pm-from-notes) | `ask_pm_from_notes` | trigger_kind=`notes_intake`, target_initiative_id, source_note_ids, audit_run_group_id |
+| [src/app/api/pm/plan-initiative/route.ts](src/app/api/pm/plan-initiative/route.ts) (×2) | `pm_dispatch` | trigger_kind=`plan_initiative`, target_initiative_id |
+| [src/app/api/pm/decompose-initiative/route.ts](src/app/api/pm/decompose-initiative/route.ts) (×2) | `pm_dispatch` | trigger_kind=`decompose_initiative`, target_initiative_id |
+| [src/app/api/pm/decompose-story/route.ts](src/app/api/pm/decompose-story/route.ts) (×2) | `pm_dispatch` | trigger_kind=`decompose_story`, target_initiative_id |
+| [src/app/api/pm/proposals/[id]/accept/route.ts](src/app/api/pm/proposals/[id]/accept/route.ts) (×2) | `accept_result` | trigger_kind, target_initiative_id, parent_proposal_id |
+| [src/app/api/pm/proposals/[id]/refine/route.ts](src/app/api/pm/proposals/[id]/refine/route.ts) | `pm_dispatch` | trigger_kind, target_initiative_id, parent_proposal_id |
+| [src/lib/agents/pm-standup.ts](src/lib/agents/pm-standup.ts) | `standup` | trigger_kind |
+
+For audit-triggered notes_intake messages, `source_note_ids` comes from the `note_ids` body of the `/api/initiatives/[id]/ask-pm-from-notes` POST, and `audit_run_group_id` is looked up by joining `agent_notes` (each note carries `run_group_id`).
+
+### C. Render: per-row context strip in `/pm`
+
+Above each chat message in [src/app/(app)/pm/page.tsx](src/app/(app)/pm/page.tsx), render a one-line strip with:
+
+```
+[badge: notes-intake]  Initiative: Scrub stale localhost:4000…  ·  Note 1c368e63  ·  Audit run 7d4f…  ·  View proposal →
+```
+
+Components:
+
+- **Trigger badge** — reuse `triggerBadgeFor(metadata.trigger_kind)`. Appears on both `user` and `assistant` rows of an audit-triggered exchange so the operator can scan trigger kind without reading the body.
+- **Initiative chip** — clickable, navigates to `/initiatives/<id>`. Title resolved from a small in-page cache keyed by id (already fetched by the page for proposal cards).
+- **Note chips** — one per `source_note_ids` entry, label is the note id's 8-char prefix, hover shows the note kind + importance, click opens the initiative page anchored to that note.
+- **Audit run chip** — appears when `audit_run_group_id` is set, click navigates to a TODO `?run_group=<id>` filter on the relevant page (no-op for v1 if the filter doesn't exist yet — the chip still renders informationally).
+- **"View proposal →"** — present when `metadata.proposal_id` is set; navigates to `/pm/proposals/<id>` (replaces today's implicit linking via the embedded proposal card).
+- **"Refined from →"** — present when `parent_proposal_id` is set; chip navigates to the parent proposal page.
+
+Chips are small, muted (border + low-alpha bg), and wrap on narrow viewports.
+
+### D. Graceful fallback for old rows
+
+Existing rows have `metadata = {"proposal_id": "..."}` only. The renderer derives the missing fields on read by reading the linked proposal (already fetched by `/pm`). When no `proposal_id` is present and metadata is empty (oldest rows), the row renders without the strip — never worse than today.
+
+No backfill migration. The fallback is sufficient; backfill adds risk for marginal benefit since `/pm` already fetches the proposal list.
+
+### E. Bi-directional: initiative-page "Recent PM activity" rail
+
+On the initiative detail page, add a "Recent PM activity" section below the existing Activity rail. Query: the last N chat messages whose `metadata.target_initiative_id = <this id>` OR whose `metadata.source_note_ids` contains a note id belonging to this initiative.
+
+Each row renders a compact preview (truncated `content`, trigger badge, timestamp) and clicks through to `/pm?focus=<message_id>` — the chat surface scrolls the targeted message into view and pulses a highlight.
+
+`/pm` honors `?focus=<id>` with `scrollIntoView({ block: 'center' })` + a 2s ring animation. No new state needed beyond a `useEffect` on mount.
+
+New endpoint: `GET /api/initiatives/[id]/pm-chat?limit=10`. Returns the matching rows with their already-enriched metadata.
+
+## Out of scope
+
+- **#3 Conversation threading.** Group same-`audit_run_group_id` rows into a collapsible thread card. Defer; not justified until audit-day volume warrants.
+- **#4 Context drawer.** A side panel that opens from any chat row with full note bodies / audit verdict markdown / prior proposals on this initiative. Defer; the strip + cross-links cover the common ask.
+- **Backfill of historical rows.** The graceful-fallback path is sufficient.
+
+## Test plan
+
+DB layer:
+- `postPmChatMessage` writes the widened metadata shape; round-trip parse.
+- `GET /api/initiatives/[id]/pm-chat` returns chats whose metadata targets that initiative AND chats whose `source_note_ids` points to a note belonging to that initiative.
+
+UI:
+- Chat row renders the trigger badge for every supported `trigger_kind`.
+- Initiative chip click navigates to `/initiatives/<id>`.
+- Note chip click navigates to the initiative anchored to that note id.
+- "View proposal →" navigates to `/pm/proposals/<id>` for any row with a `proposal_id`.
+- A row with empty metadata (legacy) renders without the strip and without error.
+- `/pm?focus=<message_id>` scrolls and highlights the targeted row.
+
+Verification: preview smoke against the dev DB, which already has audit-triggered notes_intake exchanges (e.g. `c12ab760` ↔ `e0e46c09` from the orphan-adopt verification) — the strip should render an initiative chip + note chip + audit-run chip on the trigger row.
+
+## Migration order
+
+1. Land the widened metadata convention + call-site updates + chat-row strip + graceful fallback. Single PR, behind no flag — the convention is additive.
+2. Land the initiative-page "Recent PM activity" rail + `?focus=` deep link. Second PR.
+
+PR 1 is the foundation; PR 2 closes the bi-directional loop. Threading and the drawer remain proposals.

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -13,7 +13,7 @@
 
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import Link from 'next/link';
-import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox, Sunrise, Pin, ArrowDown, MessageSquarePlus, Trash2, RotateCcw, Info, Sparkles } from 'lucide-react';
+import { Send, AlertTriangle, Check, X, RefreshCw, Loader, Inbox, Sunrise, Pin, ArrowDown, MessageSquarePlus, Trash2, RotateCcw, Info, Sparkles, FileText, StickyNote, ArrowRight, GitBranch, ScanSearch, Maximize2 } from 'lucide-react';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import {
   parseSuggestionsFromImpactMd,
@@ -61,6 +61,7 @@ interface PmProposal {
   status: 'draft' | 'accepted' | 'rejected' | 'superseded';
   applied_at: string | null;
   parent_proposal_id: string | null;
+  target_initiative_id: string | null;
   created_at: string;
 }
 
@@ -103,6 +104,15 @@ export default function PmChatPage() {
   // One-slot pending-delete confirmation. Routes through ConfirmDialog
   // per project convention (no native window.confirm).
   const [pendingDeleteProposal, setPendingDeleteProposal] = useState<PmProposal | null>(null);
+  // Bulk-delete modal: when non-null, render the per-status checklist.
+  // `counts` is the per-status row count for the current workspace,
+  // fetched on open. `selected` is the operator's checkbox selection.
+  const [bulkDelete, setBulkDelete] = useState<{
+    counts: Record<'draft' | 'accepted' | 'rejected' | 'superseded', number>;
+    selected: Set<'draft' | 'rejected' | 'superseded'>;
+    busy: boolean;
+    error: string | null;
+  } | null>(null);
   const [deletingProposalId, setDeletingProposalId] = useState<string | null>(null);
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
@@ -145,12 +155,21 @@ export default function PmChatPage() {
   // no effects ever firing. Reading post-mount avoids the prerender path
   // entirely. See PR #271 for the repro.
   const [focusProposalId, setFocusProposalId] = useState<string | null>(null);
+  // PR pm-chat-context-strip: parallel `?focus=<message_id>` deep link.
+  // Used by the initiative-page "Recent PM activity" rail to jump to a
+  // specific chat row (not all rows have a proposal anchor). Same
+  // post-mount read pattern as `?proposal=` for the same Suspense
+  // reasons.
+  const [focusMessageId, setFocusMessageId] = useState<string | null>(null);
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const params = new URLSearchParams(window.location.search);
     setFocusProposalId(params.get('proposal'));
+    setFocusMessageId(params.get('focus'));
   }, []);
   const [highlightedProposalId, setHighlightedProposalId] = useState<string | null>(null);
+  const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
+  const messageRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
 
   // Load workspace list once. The global switcher in the left nav owns the
   // selected id; we only fetch the list here so the legacy fallback path
@@ -600,6 +619,67 @@ export default function PmChatPage() {
     }
   };
 
+  const openBulkDelete = useCallback(async () => {
+    if (!workspaceId) return;
+    // Open immediately with zero-counts placeholder so the modal isn't
+    // gated on the network round-trip; replace with real counts when
+    // the fetch returns. Pre-select "rejected" + "superseded" — those
+    // are the noise statuses an operator usually wants to sweep, and
+    // it matches the common "delete all rejected" ask.
+    setBulkDelete({
+      counts: { draft: 0, accepted: 0, rejected: 0, superseded: 0 },
+      selected: new Set(['rejected', 'superseded']),
+      busy: false,
+      error: null,
+    });
+    try {
+      const res = await fetch(
+        `/api/pm/proposals/counts?workspace_id=${encodeURIComponent(workspaceId)}`,
+      );
+      if (!res.ok) throw new Error(`counts ${res.status}`);
+      const counts = (await res.json()) as Record<
+        'draft' | 'accepted' | 'rejected' | 'superseded',
+        number
+      >;
+      setBulkDelete(prev => (prev ? { ...prev, counts } : prev));
+    } catch (err) {
+      setBulkDelete(prev =>
+        prev ? { ...prev, error: (err as Error).message } : prev,
+      );
+    }
+  }, [workspaceId]);
+
+  const performBulkDelete = useCallback(async () => {
+    if (!workspaceId || !bulkDelete) return;
+    if (bulkDelete.selected.size === 0) return;
+    if (bulkDelete.busy) return;
+    setBulkDelete(prev => (prev ? { ...prev, busy: true, error: null } : prev));
+    try {
+      const res = await fetch('/api/pm/proposals/bulk-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          workspace_id: workspaceId,
+          statuses: Array.from(bulkDelete.selected),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Bulk delete failed (${res.status})`);
+      }
+      const data = (await res.json()) as { deleted_count: number; deleted_ids: string[] };
+      // Optimistic prune; loadRecent will also catch up.
+      const gone = new Set(data.deleted_ids);
+      setRecentProposals(prev => prev.filter(p => !gone.has(p.id)));
+      setBulkDelete(null);
+      await loadRecent();
+    } catch (err) {
+      setBulkDelete(prev =>
+        prev ? { ...prev, busy: false, error: (err as Error).message } : prev,
+      );
+    }
+  }, [workspaceId, bulkDelete, loadRecent]);
+
   const performDelete = useCallback(async (proposalId: string) => {
     setDeletingProposalId(proposalId);
     try {
@@ -694,6 +774,21 @@ export default function PmChatPage() {
       return () => clearTimeout(timer);
     }
   }, [focusProposalId, proposals]);
+
+  // Same pattern for ?focus=<message_id>: scroll the chat row into view
+  // and pulse the highlight. Waits on `messages` so the row exists in
+  // the DOM by the time we try to grab its ref.
+  useEffect(() => {
+    if (!focusMessageId) return;
+    if (!messages.find(m => m.id === focusMessageId)) return;
+    const el = messageRefs.current.get(focusMessageId);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      setHighlightedMessageId(focusMessageId);
+      const timer = setTimeout(() => setHighlightedMessageId(null), 4000);
+      return () => clearTimeout(timer);
+    }
+  }, [focusMessageId, messages]);
 
   const proposalCount = useMemo(() => {
     const draft = recentProposals.filter(p => p.status === 'draft').length;
@@ -891,6 +986,8 @@ export default function PmChatPage() {
                   onRefineTextChange={setRefineText}
                   setCardRef={(id, el) => cardRefs.current.set(id, el)}
                   highlighted={proposal ? highlightedProposalId === proposal.id : false}
+                  setMessageRef={(id, el) => messageRefs.current.set(id, el)}
+                  messageHighlighted={highlightedMessageId === m.id}
                   resolveInitiativeTitle={resolveInitiativeTitle}
                 />
               );
@@ -1043,14 +1140,26 @@ export default function PmChatPage() {
         <aside className="w-80 border-l border-mc-border overflow-y-auto shrink-0 hidden lg:block">
           <div className="px-4 py-3 border-b border-mc-border flex items-center justify-between">
             <h2 className="text-sm font-semibold">Recent proposals</h2>
-            <button
-              type="button"
-              onClick={loadRecent}
-              className="text-xs text-mc-text-secondary hover:text-mc-text"
-              title="Refresh"
-            >
-              <RefreshCw className="w-3.5 h-3.5" />
-            </button>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={openBulkDelete}
+                disabled={!workspaceId}
+                className="text-xs text-mc-text-secondary hover:text-red-300 disabled:opacity-40 p-1"
+                title="Delete proposals by status…"
+                aria-label="Bulk delete proposals"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={loadRecent}
+                className="text-xs text-mc-text-secondary hover:text-mc-text p-1"
+                title="Refresh"
+              >
+                <RefreshCw className="w-3.5 h-3.5" />
+              </button>
+            </div>
           </div>
           <ul className="divide-y divide-mc-border">
             {recentProposals.length === 0 && (
@@ -1138,16 +1247,260 @@ export default function PmChatPage() {
         }}
       />
 
+      <ConfirmDialog
+        open={bulkDelete !== null}
+        title="Delete proposals by status"
+        body={
+          bulkDelete ? (
+            <div className="space-y-3 text-sm">
+              <p className="text-mc-text-secondary">
+                Pick which statuses to remove from this workspace. Accepted proposals can&apos;t be bulk-deleted — their diffs already mutated initiatives/tasks.
+              </p>
+              <div className="space-y-1.5">
+                {(['draft', 'rejected', 'superseded'] as const).map(status => {
+                  const count = bulkDelete.counts[status];
+                  const checked = bulkDelete.selected.has(status);
+                  return (
+                    <label
+                      key={status}
+                      className={`flex items-center gap-2 px-2 py-1.5 rounded-sm border cursor-pointer ${
+                        checked
+                          ? 'border-red-500/40 bg-red-500/5'
+                          : 'border-mc-border hover:border-mc-border/80'
+                      } ${count === 0 ? 'opacity-60' : ''}`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={bulkDelete.busy}
+                        onChange={() => {
+                          setBulkDelete(prev => {
+                            if (!prev) return prev;
+                            const next = new Set(prev.selected);
+                            if (next.has(status)) next.delete(status);
+                            else next.add(status);
+                            return { ...prev, selected: next };
+                          });
+                        }}
+                      />
+                      <span className={`px-1.5 py-0.5 text-[10px] rounded-sm font-mono ${STATUS_BADGE[status]}`}>
+                        {status}
+                      </span>
+                      <span className="text-mc-text-secondary">
+                        {count} proposal{count === 1 ? '' : 's'}
+                      </span>
+                    </label>
+                  );
+                })}
+                <div className="flex items-center gap-2 px-2 py-1.5 rounded-sm border border-mc-border opacity-50 cursor-not-allowed">
+                  <input type="checkbox" disabled checked={false} />
+                  <span className={`px-1.5 py-0.5 text-[10px] rounded-sm font-mono ${STATUS_BADGE['accepted']}`}>
+                    accepted
+                  </span>
+                  <span className="text-mc-text-secondary">
+                    {bulkDelete.counts.accepted} proposal{bulkDelete.counts.accepted === 1 ? '' : 's'} · can&apos;t bulk-delete
+                  </span>
+                </div>
+              </div>
+              {bulkDelete.error && (
+                <p className="text-xs text-red-300">{bulkDelete.error}</p>
+              )}
+            </div>
+          ) : null
+        }
+        confirmLabel={
+          bulkDelete && bulkDelete.selected.size > 0
+            ? `Delete ${Array.from(bulkDelete.selected).reduce(
+                (n, s) => n + bulkDelete.counts[s],
+                0,
+              )}`
+            : 'Delete'
+        }
+        destructive
+        onCancel={() => setBulkDelete(null)}
+        onConfirm={performBulkDelete}
+      />
+
     </div>
   );
 }
 
-function parseProposalId(m: AgentChatMessage): string | null {
+interface PmChatMetadata {
+  proposal_id?: string;
+  trigger_kind?: string;
+  target_initiative_id?: string | null;
+  source_note_ids?: string[];
+  audit_run_group_id?: string | null;
+  parent_proposal_id?: string | null;
+  origin?: string;
+}
+
+function parseChatMetadata(m: AgentChatMessage): PmChatMetadata | null {
   if (!m.metadata) return null;
   try {
-    const parsed = JSON.parse(m.metadata) as { proposal_id?: string };
-    return parsed.proposal_id ?? null;
-  } catch { return null; }
+    return JSON.parse(m.metadata) as PmChatMetadata;
+  } catch {
+    return null;
+  }
+}
+
+function parseProposalId(m: AgentChatMessage): string | null {
+  return parseChatMetadata(m)?.proposal_id ?? null;
+}
+
+/**
+ * Merge fields available on the linked proposal back into the chat
+ * metadata so old rows (which only carry `{ proposal_id }`) still get
+ * the trigger badge / initiative chip / parent-of-refine chip. The
+ * metadata value takes precedence — the proposal is a fallback only.
+ */
+function enrichChatMetadata(
+  meta: PmChatMetadata | null,
+  proposal: PmProposal | undefined,
+): PmChatMetadata | null {
+  if (!meta && !proposal) return null;
+  const out: PmChatMetadata = { ...(meta ?? {}) };
+  if (proposal) {
+    if (!out.proposal_id) out.proposal_id = proposal.id;
+    if (!out.trigger_kind) out.trigger_kind = proposal.trigger_kind;
+    if (out.target_initiative_id == null && proposal.target_initiative_id) {
+      out.target_initiative_id = proposal.target_initiative_id;
+    }
+    if (out.parent_proposal_id == null && proposal.parent_proposal_id) {
+      out.parent_proposal_id = proposal.parent_proposal_id;
+    }
+  }
+  return out;
+}
+
+/**
+ * One-line context strip rendered above each chat row. Shows trigger
+ * badge, initiative chip, source-note chips, audit-run chip, parent-of-
+ * refine chip, and a "View proposal →" link when applicable.
+ *
+ * Reads from `enrichChatMetadata(...)` so old rows that only have
+ * `{ proposal_id }` still get badges via fallback from the linked
+ * proposal. Renders nothing when the row has no meaningful provenance
+ * (very oldest rows + system messages with no metadata).
+ *
+ * Spec: docs/proposals/pm-chat-context-strip.md.
+ */
+function ChatContextStrip({
+  meta,
+  resolveInitiativeTitle,
+}: {
+  meta: PmChatMetadata | null;
+  resolveInitiativeTitle?: (id: string | null | undefined) => string | undefined;
+}) {
+  if (!meta) return null;
+
+  const chips: React.ReactNode[] = [];
+
+  if (meta.trigger_kind) {
+    const tb = triggerBadgeFor(meta.trigger_kind);
+    chips.push(
+      <span
+        key="trigger"
+        className={`px-1.5 py-0.5 text-[10px] rounded-sm border uppercase tracking-wide ${tb.cls}`}
+        title={`trigger_kind: ${meta.trigger_kind}`}
+      >
+        {tb.label}
+      </span>,
+    );
+  }
+
+  if (meta.target_initiative_id) {
+    const title = resolveInitiativeTitle?.(meta.target_initiative_id);
+    const label = title ?? `Initiative ${meta.target_initiative_id.slice(0, 8)}`;
+    chips.push(
+      <Link
+        key="initiative"
+        href={`/initiatives/${meta.target_initiative_id}`}
+        className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded-sm border border-mc-border bg-mc-surface/40 text-mc-text-secondary hover:text-mc-text hover:border-mc-accent/50 transition-colors"
+        title={`Initiative ${meta.target_initiative_id}`}
+      >
+        <FileText className="w-3 h-3" />
+        <span className="max-w-[16rem] truncate">{label}</span>
+      </Link>,
+    );
+  }
+
+  if (meta.source_note_ids && meta.source_note_ids.length > 0) {
+    for (const noteId of meta.source_note_ids.slice(0, 4)) {
+      chips.push(
+        <Link
+          key={`note-${noteId}`}
+          href={
+            meta.target_initiative_id
+              ? `/initiatives/${meta.target_initiative_id}#note-${noteId}`
+              : `#note-${noteId}`
+          }
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded-sm border border-yellow-500/30 bg-yellow-500/5 text-yellow-200/80 hover:text-yellow-100 transition-colors"
+          title={`Audit note ${noteId}`}
+        >
+          <StickyNote className="w-3 h-3" />
+          {noteId.slice(0, 8)}
+        </Link>,
+      );
+    }
+    if (meta.source_note_ids.length > 4) {
+      chips.push(
+        <span
+          key="note-overflow"
+          className="px-1.5 py-0.5 text-[10px] text-mc-text-secondary"
+        >
+          +{meta.source_note_ids.length - 4} more
+        </span>,
+      );
+    }
+  }
+
+  if (meta.audit_run_group_id) {
+    chips.push(
+      <span
+        key="audit"
+        className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded-sm border border-violet-500/30 bg-violet-500/5 text-violet-200/80"
+        title={`Audit run ${meta.audit_run_group_id}`}
+      >
+        <ScanSearch className="w-3 h-3" />
+        audit {meta.audit_run_group_id.slice(0, 8)}
+      </span>,
+    );
+  }
+
+  if (meta.parent_proposal_id) {
+    chips.push(
+      <Link
+        key="parent"
+        href={`/pm/proposals/${meta.parent_proposal_id}`}
+        className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded-sm border border-mc-border bg-mc-surface/40 text-mc-text-secondary hover:text-mc-text hover:border-mc-accent/50 transition-colors"
+        title="Refined from prior proposal"
+      >
+        <GitBranch className="w-3 h-3" />
+        refined from
+      </Link>,
+    );
+  }
+
+  if (meta.proposal_id) {
+    chips.push(
+      <Link
+        key="proposal"
+        href={`/pm/proposals/${meta.proposal_id}`}
+        className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded-sm border border-mc-border bg-mc-surface/40 text-mc-text-secondary hover:text-mc-text hover:border-mc-accent/50 transition-colors"
+      >
+        view proposal
+        <ArrowRight className="w-3 h-3" />
+      </Link>,
+    );
+  }
+
+  if (chips.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 mb-1 text-mc-text-secondary">
+      {chips}
+    </div>
+  );
 }
 
 interface ChatMessageRowProps {
@@ -1175,6 +1528,12 @@ interface ChatMessageRowProps {
   setCardRef?: (id: string, el: HTMLDivElement | null) => void;
   /** Phase 6: visual highlight after a deep-link scroll. */
   highlighted?: boolean;
+  /** PR pm-chat-context-strip: register the row wrapper so
+   *  ?focus=<message_id> deep links can scroll to a specific message
+   *  (covers rows that have no proposal anchor). */
+  setMessageRef?: (id: string, el: HTMLDivElement | null) => void;
+  /** Transient ring on the row wrapper after a ?focus=<id> scroll. */
+  messageHighlighted?: boolean;
   /** Resolver for diff renderer — id → initiative title. Falls through
    *  to short-hash when undefined. */
   resolveInitiativeTitle?: (id: string | null | undefined) => string | undefined;
@@ -1194,9 +1553,18 @@ function ChatMessageRow({
   onRefineTextChange,
   setCardRef,
   highlighted,
+  setMessageRef,
+  messageHighlighted,
   resolveInitiativeTitle,
 }: ChatMessageRowProps) {
   const isUser = message.role === 'user';
+  // Enriched chat-provenance for the context strip. Pulls from
+  // message.metadata first, falls back to the linked proposal for
+  // legacy rows that only stored `{ proposal_id }`.
+  const stripMeta = useMemo(
+    () => enrichChatMetadata(parseChatMetadata(message), proposal),
+    [message.metadata, proposal?.id],
+  );
 
   // Per-diff selection state. Initialized to "all selected" (the
   // legacy behavior) and reset whenever the proposal id changes —
@@ -1227,7 +1595,15 @@ function ChatMessageRow({
   // Bare chat bubble for messages that aren't proposal cards.
   if (!proposal) {
     return (
-      <div className={isUser ? 'ml-12' : 'mr-12'}>
+      <div
+        ref={(el) => setMessageRef?.(message.id, el)}
+        className={`${isUser ? 'ml-12' : 'mr-12'} ${
+          messageHighlighted
+            ? 'rounded-md ring-2 ring-mc-accent shadow-lg shadow-mc-accent/20 transition-shadow'
+            : ''
+        }`}
+      >
+        <ChatContextStrip meta={stripMeta} resolveInitiativeTitle={resolveInitiativeTitle} />
         <div className={`border rounded-md px-3 py-2 ${
           isUser
             ? 'bg-blue-500/10 border-blue-500/20'
@@ -1245,7 +1621,15 @@ function ChatMessageRow({
   // Proposal card
   const trigger = triggerBadgeFor(proposal.trigger_kind);
   return (
-    <div className="mr-12">
+    <div
+      ref={(el) => setMessageRef?.(message.id, el)}
+      className={`mr-12 ${
+        messageHighlighted
+          ? 'rounded-md ring-2 ring-mc-accent shadow-lg shadow-mc-accent/20 transition-shadow'
+          : ''
+      }`}
+    >
+      <ChatContextStrip meta={stripMeta} resolveInitiativeTitle={resolveInitiativeTitle} />
       <div
         ref={(el) => setCardRef?.(proposal.id, el)}
         className={`border border-amber-500/40 bg-amber-500/5 rounded-md overflow-hidden transition-shadow ${
@@ -1253,10 +1637,17 @@ function ChatMessageRow({
         }`}
       >
         <div className="px-3 py-2 bg-amber-500/10 border-b border-amber-500/30 flex items-center gap-2">
-          <AlertTriangle className="w-4 h-4 text-amber-300" />
-          <span className="text-sm font-semibold text-amber-200">
-            Proposal — {proposal.proposed_changes.length} change{proposal.proposed_changes.length === 1 ? '' : 's'}
-          </span>
+          <Link
+            href={`/pm/proposals/${proposal.id}`}
+            className="group flex items-center gap-2 text-amber-200 hover:text-amber-100"
+            title="Open full proposal detail"
+          >
+            <AlertTriangle className="w-4 h-4 text-amber-300" />
+            <span className="text-sm font-semibold group-hover:underline underline-offset-2">
+              Proposal — {proposal.proposed_changes.length} change{proposal.proposed_changes.length === 1 ? '' : 's'}
+            </span>
+            <Maximize2 className="w-3 h-3 opacity-0 group-hover:opacity-70 transition-opacity" />
+          </Link>
           <span
             className={`px-1.5 py-0.5 text-[10px] rounded-sm border uppercase tracking-wide ${trigger.cls}`}
             title={`trigger_kind: ${proposal.trigger_kind}`}
@@ -1488,11 +1879,18 @@ function PinnedStandupCard({
       }`}
     >
       <div className="px-3 py-2 flex items-center gap-2 border-b border-violet-500/30">
-        <Pin className="w-4 h-4 text-violet-300" />
-        <span className="text-sm font-semibold text-violet-200">
-          Latest standup — {proposal.proposed_changes.length} change
-          {proposal.proposed_changes.length === 1 ? '' : 's'}
-        </span>
+        <Link
+          href={`/pm/proposals/${proposal.id}`}
+          className="group flex items-center gap-2 text-violet-200 hover:text-violet-100"
+          title="Open full proposal detail"
+        >
+          <Pin className="w-4 h-4 text-violet-300" />
+          <span className="text-sm font-semibold group-hover:underline underline-offset-2">
+            Latest standup — {proposal.proposed_changes.length} change
+            {proposal.proposed_changes.length === 1 ? '' : 's'}
+          </span>
+          <Maximize2 className="w-3 h-3 opacity-0 group-hover:opacity-70 transition-opacity" />
+        </Link>
         <span
           className="px-1.5 py-0.5 text-[10px] rounded-sm border bg-violet-500/15 text-violet-300 border-violet-500/30 uppercase tracking-wide"
           title="trigger_kind: scheduled_drift_scan"

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, use } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, Check, X, RefreshCw, AlertTriangle } from 'lucide-react';
+import { ArrowLeft, Check, X, RefreshCw, AlertTriangle, Trash2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -12,6 +12,7 @@ import {
 } from '@/lib/pm/planSuggestionsSidecar';
 import { ProposalDiffsList, type PmDiff } from '@/components/pm/ProposalDiffsList';
 import { triggerBadgeFor } from '@/components/pm/triggerBadge';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 
 interface PmProposal {
   id: string;
@@ -48,11 +49,12 @@ export default function ProposalDetailPage({
   const [proposal, setProposal] = useState<PmProposal | null>(null);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
-  const [acting, setActing] = useState<'accept' | 'reject' | null>(null);
+  const [acting, setActing] = useState<'accept' | 'reject' | 'delete' | null>(null);
   const [refining, setRefining] = useState(false);
   const [refineText, setRefineText] = useState('');
   const [refineErr, setRefineErr] = useState<string | null>(null);
   const [showRefineInput, setShowRefineInput] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState(false);
   // initiative-id → title resolver. Loaded after the proposal lands so
   // we know which workspace to query. Falls back to short-hash UUIDs
   // when missing.
@@ -123,6 +125,27 @@ export default function ProposalDetailPage({
       setErr(e instanceof Error ? e.message : 'Reject failed');
     } finally {
       setActing(null);
+    }
+  };
+
+  const performDelete = async () => {
+    if (!proposal) return;
+    setActing('delete');
+    try {
+      const res = await fetch(`/api/pm/proposals/${proposal.id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error || 'Delete failed');
+      }
+      // The detail page anchors at the proposal id — once it's gone
+      // there's nothing to render. Send the operator back to /pm so
+      // they can pick up the chat thread from there.
+      router.push('/pm');
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Delete failed');
+    } finally {
+      setActing(null);
+      setPendingDelete(false);
     }
   };
 
@@ -249,14 +272,13 @@ export default function ProposalDetailPage({
                 />
               )}
 
-              {/* Actions */}
-              {proposal.status !== 'accepted' && (
-                // Refine is allowed on draft, superseded, and rejected —
-                // the DB only blocks accepted (refineProposal in
-                // pm-proposals.ts). Accept/Reject still gated to draft
-                // below since those mutate state that's already moved on.
-                <div className="px-4 py-3 bg-amber-500/5 flex flex-wrap items-center gap-2">
-                  {showRefineInput ? (
+              {/* Actions. Refine is allowed on draft, superseded, and
+                  rejected — the DB only blocks accepted (refineProposal
+                  in pm-proposals.ts). Accept/Reject gated to draft.
+                  Delete is allowed on every status (matches the /pm
+                  recents-list trash affordance). */}
+              <div className="px-4 py-3 bg-amber-500/5 flex flex-wrap items-center gap-2">
+                {proposal.status !== 'accepted' && showRefineInput ? (
                     <>
                       <input
                         type="text"
@@ -292,13 +314,15 @@ export default function ProposalDetailPage({
                     </>
                   ) : (
                     <>
-                      <button
-                        type="button"
-                        onClick={() => setShowRefineInput(true)}
-                        className="text-xs px-2 py-1 border border-mc-border rounded-sm hover:bg-mc-bg/50 flex items-center gap-1"
-                      >
-                        <RefreshCw className="w-3 h-3" /> Refine
-                      </button>
+                      {proposal.status !== 'accepted' && (
+                        <button
+                          type="button"
+                          onClick={() => setShowRefineInput(true)}
+                          className="text-xs px-2 py-1 border border-mc-border rounded-sm hover:bg-mc-bg/50 flex items-center gap-1"
+                        >
+                          <RefreshCw className="w-3 h-3" /> Refine
+                        </button>
+                      )}
                       {proposal.status === 'draft' && (
                         <>
                           <button
@@ -319,10 +343,18 @@ export default function ProposalDetailPage({
                           </button>
                         </>
                       )}
+                      <button
+                        type="button"
+                        onClick={() => setPendingDelete(true)}
+                        disabled={acting !== null}
+                        className="ml-auto text-xs px-2 py-1 border border-red-500/30 text-red-300/90 rounded-sm hover:bg-red-500/10 hover:text-red-200 flex items-center gap-1 disabled:opacity-50"
+                        title="Permanently remove this proposal"
+                      >
+                        <Trash2 className="w-3 h-3" /> {acting === 'delete' ? 'Deleting…' : 'Delete'}
+                      </button>
                     </>
                   )}
-                </div>
-              )}
+              </div>
             </div>
 
             {/* Metadata */}
@@ -349,6 +381,32 @@ export default function ProposalDetailPage({
                 </div>
               )}
             </div>
+
+            <ConfirmDialog
+              open={pendingDelete}
+              title="Delete proposal?"
+              body={
+                <div className="space-y-2 text-sm">
+                  <p>
+                    This permanently removes the proposal from the recents list
+                    and the database. The action can&apos;t be undone.
+                  </p>
+                  <div className="text-xs text-mc-text-secondary border border-mc-border rounded-sm p-2 bg-mc-bg-secondary/30">
+                    <div className="font-mono mb-1">
+                      {proposal.status} · {proposal.proposed_changes.length}{' '}
+                      change{proposal.proposed_changes.length === 1 ? '' : 's'}
+                    </div>
+                    <div className="line-clamp-3 break-words">
+                      {proposal.trigger_text}
+                    </div>
+                  </div>
+                </div>
+              }
+              confirmLabel="Delete"
+              destructive
+              onCancel={() => setPendingDelete(false)}
+              onConfirm={performDelete}
+            />
           </>
         )}
       </div>

--- a/src/app/api/initiatives/[id]/ask-pm-from-notes/route.test.ts
+++ b/src/app/api/initiatives/[id]/ask-pm-from-notes/route.test.ts
@@ -112,3 +112,41 @@ test('POST: invalid JSON body → 400', async () => {
   const res = await POST(req, ctx);
   assert.equal(res.status, 400);
 });
+
+test('POST: happy path threads note + audit-run provenance into chat metadata', async () => {
+  const { ensurePmAgent } = await import('@/lib/bootstrap-agents');
+  const { queryAll } = await import('@/lib/db');
+  const ws = freshWorkspace();
+  const init = freshInitiative(ws);
+  ensurePmAgent(ws);
+  const note = makeNote(ws, init);
+
+  const { req, ctx } = postReq(init, { note_ids: [note.id] });
+  const res = await POST(req, ctx);
+  assert.equal(res.status, 200, `expected 200, got ${res.status}`);
+
+  const pm = (await import('@/lib/db')).queryOne<{ id: string }>(
+    `SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm'`,
+    [ws],
+  );
+  assert.ok(pm);
+  const rows = queryAll<{ role: string; metadata: string | null }>(
+    `SELECT role, metadata FROM agent_chat_messages WHERE agent_id = ? ORDER BY created_at`,
+    [pm!.id],
+  );
+  assert.ok(rows.length >= 1);
+  const userRow = rows.find(r => r.role === 'user');
+  assert.ok(userRow?.metadata, 'expected user row to carry widened metadata');
+  const meta = JSON.parse(userRow!.metadata!) as {
+    trigger_kind?: string;
+    target_initiative_id?: string | null;
+    source_note_ids?: string[];
+    audit_run_group_id?: string | null;
+    origin?: string;
+  };
+  assert.equal(meta.trigger_kind, 'notes_intake');
+  assert.equal(meta.target_initiative_id, init);
+  assert.deepEqual(meta.source_note_ids, [note.id]);
+  assert.equal(meta.audit_run_group_id, note.run_group_id);
+  assert.equal(meta.origin, 'ask_pm_from_notes');
+});

--- a/src/app/api/initiatives/[id]/ask-pm-from-notes/route.ts
+++ b/src/app/api/initiatives/[id]/ask-pm-from-notes/route.ts
@@ -117,6 +117,12 @@ export async function POST(
 
   const triggerText = formatNoteAsTrigger(notes, initiative.title);
 
+  // Most/all notes from one operator click share the same run_group_id
+  // because they came from the same audit run. Pick the first one and
+  // pass it as the audit-run chip; the renderer treats it as a single
+  // anchor (cross-run mixes are rare and harmless).
+  const auditRunGroupId = notes.find(n => n.run_group_id)?.run_group_id ?? null;
+
   try {
     const result = dispatchPm({
       workspace_id: initiative.workspace_id,
@@ -124,6 +130,12 @@ export async function POST(
       trigger_kind: 'notes_intake',
       // Same as the MCP path — regex on freeform is worse than nothing.
       allowFallback: false,
+      chat_context: {
+        target_initiative_id: id,
+        source_note_ids: notes.map(n => n.id),
+        audit_run_group_id: auditRunGroupId,
+        origin: 'ask_pm_from_notes',
+      },
     });
 
     // Mark notes consumed so the UI can fade the "Ask PM" button on

--- a/src/app/api/initiatives/[id]/pm-chat/route.test.ts
+++ b/src/app/api/initiatives/[id]/pm-chat/route.test.ts
@@ -1,0 +1,207 @@
+/**
+ * GET /api/initiatives/:id/pm-chat — direct + note-bridged anchor cases.
+ * See docs/proposals/pm-chat-context-strip.md §"Test plan".
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+import { run, queryOne } from '@/lib/db';
+import { createNote } from '@/lib/db/agent-notes';
+import { ensurePmAgent } from '@/lib/bootstrap-agents';
+import { postPmChatMessage } from '@/lib/agents/pm-dispatch';
+
+function freshWorkspace(): string {
+  const id = `ws-pmchat-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function freshInitiative(workspaceId: string): string {
+  const id = `init-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO initiatives (id, workspace_id, title, status, kind, created_at, updated_at)
+     VALUES (?, ?, ?, 'planned', 'epic', datetime('now'), datetime('now'))`,
+    [id, workspaceId, `seed ${id}`],
+  );
+  return id;
+}
+
+function call(initId: string, query?: Record<string, string>) {
+  const qs = new URLSearchParams(query ?? {});
+  const url = new URL(
+    `http://localhost/api/initiatives/${initId}/pm-chat${qs.toString() ? '?' + qs : ''}`,
+  );
+  return GET(
+    new NextRequest(url, { method: 'GET' }),
+    { params: Promise.resolve({ id: initId }) },
+  );
+}
+
+test('GET: missing initiative → 404', async () => {
+  const res = await call('does-not-exist');
+  assert.equal(res.status, 404);
+});
+
+test('GET: direct target_initiative_id anchor matches', async () => {
+  const ws = freshWorkspace();
+  const init = freshInitiative(ws);
+  ensurePmAgent(ws);
+
+  postPmChatMessage({
+    workspace_id: ws,
+    content: 'a direct anchor',
+    role: 'assistant',
+    context: {
+      trigger_kind: 'plan_initiative',
+      target_initiative_id: init,
+      origin: 'pm_dispatch',
+    },
+  });
+
+  const res = await call(init);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { messages: Array<{ content: string }> };
+  assert.equal(body.messages.length, 1);
+  assert.equal(body.messages[0].content, 'a direct anchor');
+});
+
+test('GET: note-bridged anchor matches via source_note_ids', async () => {
+  const ws = freshWorkspace();
+  const init = freshInitiative(ws);
+  ensurePmAgent(ws);
+  const note = createNote({
+    workspace_id: ws,
+    agent_id: null,
+    initiative_id: init,
+    scope_key: `scope-${uuidv4()}`,
+    role: 'researcher',
+    run_group_id: `rg-${uuidv4()}`,
+    kind: 'observation',
+    body: 'audit observation',
+  });
+
+  postPmChatMessage({
+    workspace_id: ws,
+    content: 'note-bridged',
+    role: 'user',
+    context: {
+      trigger_kind: 'notes_intake',
+      source_note_ids: [note.id],
+      // Deliberately omit target_initiative_id — the bridge should
+      // still link through the note's initiative.
+      origin: 'ask_pm_from_notes',
+    },
+  });
+
+  const res = await call(init);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { messages: Array<{ content: string }> };
+  assert.equal(body.messages.length, 1);
+  assert.equal(body.messages[0].content, 'note-bridged');
+});
+
+test('GET: only PM-agent rows are returned, not worker rows with same metadata', async () => {
+  const ws = freshWorkspace();
+  const init = freshInitiative(ws);
+  ensurePmAgent(ws);
+  // Seed a worker agent and insert a chat row directly with the same
+  // metadata. The endpoint should ignore it — the rail only cares
+  // about the workspace's PM conversation.
+  const workerId = `worker-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, created_at, updated_at)
+     VALUES (?, 'WorkerA', 'worker', ?, 1, datetime('now'), datetime('now'))`,
+    [workerId, ws],
+  );
+  run(
+    `INSERT INTO agent_chat_messages (id, agent_id, role, content, status, metadata)
+     VALUES (?, ?, 'assistant', 'worker chatter', 'delivered', ?)`,
+    [
+      uuidv4(),
+      workerId,
+      JSON.stringify({ target_initiative_id: init, trigger_kind: 'manual' }),
+    ],
+  );
+  // And a real PM-agent row.
+  postPmChatMessage({
+    workspace_id: ws,
+    content: 'pm row',
+    role: 'assistant',
+    context: { target_initiative_id: init, origin: 'pm_dispatch', trigger_kind: 'manual' },
+  });
+
+  const res = await call(init);
+  const body = (await res.json()) as { messages: Array<{ content: string }> };
+  assert.equal(body.messages.length, 1);
+  assert.equal(body.messages[0].content, 'pm row');
+});
+
+test('GET: limit clamps result count and orders newest-first', async () => {
+  const ws = freshWorkspace();
+  const init = freshInitiative(ws);
+  ensurePmAgent(ws);
+
+  for (let i = 0; i < 5; i++) {
+    postPmChatMessage({
+      workspace_id: ws,
+      content: `row ${i}`,
+      role: 'assistant',
+      context: { target_initiative_id: init, origin: 'pm_dispatch', trigger_kind: 'manual' },
+    });
+    // Bump created_at so ordering is deterministic.
+    run(
+      `UPDATE agent_chat_messages SET created_at = datetime('now', '+' || ? || ' seconds')
+        WHERE content = ? AND agent_id IN (SELECT id FROM agents WHERE workspace_id = ? AND role = 'pm')`,
+      [i, `row ${i}`, ws],
+    );
+  }
+
+  const res = await call(init, { limit: '3' });
+  const body = (await res.json()) as { messages: Array<{ content: string }> };
+  assert.equal(body.messages.length, 3);
+  assert.equal(body.messages[0].content, 'row 4'); // newest first
+  assert.equal(body.messages[2].content, 'row 2');
+});
+
+test('GET: ignores agent_chat_messages on initiatives in other workspaces', async () => {
+  const wsA = freshWorkspace();
+  const wsB = freshWorkspace();
+  const initB = freshInitiative(wsB);
+  ensurePmAgent(wsA);
+  ensurePmAgent(wsB);
+
+  // Workspace A's PM posts a row anchored to wsB's initiative id —
+  // this is a malformed input shape (target_initiative_id from another
+  // workspace) and the endpoint should drop it on the workspace gate.
+  postPmChatMessage({
+    workspace_id: wsA,
+    content: 'cross-workspace anchor',
+    role: 'assistant',
+    context: { target_initiative_id: initB, origin: 'pm_dispatch', trigger_kind: 'manual' },
+  });
+
+  const res = await call(initB);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { messages: Array<{ content: string }> };
+  // initB belongs to wsB; query joins agents on wsB's PM. wsA row excluded.
+  assert.equal(body.messages.length, 0);
+  // Sanity: wsA can see its own row when asked about an initiative in wsA.
+  const initA = freshInitiative(wsA);
+  // Re-post with the correct anchor for the sanity check.
+  postPmChatMessage({
+    workspace_id: wsA,
+    content: 'within-workspace anchor',
+    role: 'assistant',
+    context: { target_initiative_id: initA, origin: 'pm_dispatch', trigger_kind: 'manual' },
+  });
+  const resA = await call(initA);
+  const bodyA = (await resA.json()) as { messages: Array<{ content: string }> };
+  assert.equal(bodyA.messages.length, 1);
+  assert.ok(queryOne(`SELECT 1 FROM agents WHERE workspace_id = ?`, [wsA]));
+});

--- a/src/app/api/initiatives/[id]/pm-chat/route.ts
+++ b/src/app/api/initiatives/[id]/pm-chat/route.ts
@@ -1,0 +1,116 @@
+/**
+ * GET /api/initiatives/:id/pm-chat
+ *
+ * Returns the most recent PM-chat messages whose provenance points at
+ * this initiative — either via `metadata.target_initiative_id` directly
+ * or via `metadata.source_note_ids` containing a note that belongs to
+ * the initiative (the audit/notes-intake path).
+ *
+ * Drives the "Recent PM activity" rail on the initiative detail page.
+ * See docs/proposals/pm-chat-context-strip.md.
+ *
+ * Query:
+ *   limit?: 1..50 (default 10)
+ *
+ * Response:
+ *   { messages: Array<{
+ *       id, role, content, created_at, metadata,
+ *       // Convenience-derived for the rail UI:
+ *       trigger_kind?, proposal_id?, source_note_ids?, audit_run_group_id?
+ *     }> }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getInitiative } from '@/lib/db/initiatives';
+import { queryAll } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+const Query = z.object({
+  limit: z
+    .preprocess(
+      v => (typeof v === 'string' ? parseInt(v, 10) : v),
+      z.number().int().min(1).max(50),
+    )
+    .optional()
+    .default(10),
+});
+
+interface ChatRow {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  created_at: string;
+  metadata: string | null;
+}
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  const init = getInitiative(id);
+  if (!init) {
+    return NextResponse.json({ error: 'initiative not found' }, { status: 404 });
+  }
+
+  const parsed = Query.safeParse(Object.fromEntries(request.nextUrl.searchParams));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid query', issues: parsed.error.format() },
+      { status: 400 },
+    );
+  }
+  const limit = parsed.data.limit;
+
+  // The PM agent is per-workspace (is_pm=1). Scope the chat query to it
+  // so we don't accidentally pick up rows from a worker agent that
+  // happens to share a metadata convention.
+  const rows = queryAll<ChatRow>(
+    `SELECT m.id, m.role, m.content, m.created_at, m.metadata
+       FROM agent_chat_messages m
+       JOIN agents a ON a.id = m.agent_id
+      WHERE a.workspace_id = ?
+        AND a.role = 'pm'
+        AND m.metadata IS NOT NULL
+        AND (
+          -- Direct anchor: metadata.target_initiative_id == this id.
+          json_extract(m.metadata, '$.target_initiative_id') = ?
+          -- OR a source note that belongs to this initiative.
+          OR EXISTS (
+            SELECT 1 FROM json_each(json_extract(m.metadata, '$.source_note_ids'))
+             WHERE json_each.value IN (
+               SELECT id FROM agent_notes WHERE initiative_id = ?
+             )
+          )
+        )
+      ORDER BY m.created_at DESC
+      LIMIT ?`,
+    [init.workspace_id, id, id, limit],
+  );
+
+  const messages = rows.map(r => {
+    let meta: Record<string, unknown> = {};
+    if (r.metadata) {
+      try {
+        meta = JSON.parse(r.metadata);
+      } catch {
+        // leave empty
+      }
+    }
+    return {
+      id: r.id,
+      role: r.role,
+      content: r.content,
+      created_at: r.created_at,
+      metadata: meta,
+      trigger_kind: meta.trigger_kind as string | undefined,
+      proposal_id: meta.proposal_id as string | undefined,
+      source_note_ids: meta.source_note_ids as string[] | undefined,
+      audit_run_group_id: meta.audit_run_group_id as string | undefined,
+    };
+  });
+
+  return NextResponse.json({ messages });
+}

--- a/src/app/api/pm/decompose-initiative/route.ts
+++ b/src/app/api/pm/decompose-initiative/route.ts
@@ -110,6 +110,10 @@ export async function POST(request: NextRequest) {
       // cold sessions.
       timeoutMs: 120_000,
       synth: { impact_md: synth.impact_md, changes: synth.changes },
+      chat_context: {
+        target_initiative_id: parent.id,
+        origin: 'pm_dispatch',
+      },
       agent_prompt:
         `Decompose initiative ${parent.id} ("${parent.title}", kind=${parent.kind}) ` +
         `into 3-7 child initiatives.` +
@@ -125,8 +129,8 @@ export async function POST(request: NextRequest) {
         `Call \`propose_changes\` (trigger_kind='decompose_initiative') with one ` +
         `\`create_child_initiative\` diff per child. Pre-wire each child to depend on the ` +
         `prior sibling using placeholder ids \`$0\`, \`$1\`, etc. See your SOUL.md. ` +
-        `Output discipline: tool call FIRST, then a single-line \`Proposal {id}.\` reply — ` +
-        `no freeform summary (the operator UI discards it).`,
+        `Output discipline: tool call FIRST, then a short confirmation sentence — ` +
+        `do NOT echo the id or use \`{...}\` placeholder syntax (the operator UI discards freeform replies).`,
     });
     const proposal = dispatch.proposal;
 
@@ -134,16 +138,23 @@ export async function POST(request: NextRequest) {
     // analysis isn't overwritten by synth's. On synth fallback the two
     // are identical (proposal was created from synth.impact_md).
     try {
+      const ctx = {
+        trigger_kind: 'decompose_initiative' as const,
+        target_initiative_id: parent.id,
+        origin: 'pm_dispatch' as const,
+      };
       postPmChatMessage({
         workspace_id: parent.workspace_id,
         role: 'user',
         content: `Split: "${parent.title}"` + (parsed.data.hint ? ` (hint: ${parsed.data.hint})` : ''),
+        context: ctx,
       });
       postPmChatMessage({
         workspace_id: parent.workspace_id,
         role: 'assistant',
         content: proposal.impact_md,
         proposal_id: proposal.id,
+        context: ctx,
       });
     } catch (err) {
       console.warn('[pm-decompose] chat insert failed:', (err as Error).message);

--- a/src/app/api/pm/decompose-story/route.ts
+++ b/src/app/api/pm/decompose-story/route.ts
@@ -109,6 +109,10 @@ export async function POST(request: NextRequest) {
       target_initiative_id: parent.id,
       timeoutMs: 120_000,
       synth: { impact_md: synth.impact_md, changes: synth.changes },
+      chat_context: {
+        target_initiative_id: parent.id,
+        origin: 'pm_dispatch',
+      },
       agent_prompt:
         `Decompose story ${parent.id} ("${parent.title}") into a small set of ` +
         `draft TASKS (not initiatives) that an implementer can pick up directly.` +
@@ -121,24 +125,31 @@ export async function POST(request: NextRequest) {
         `Call \`propose_changes\` with trigger_kind='decompose_story' and one ` +
         `\`create_task_under_initiative\` diff per task, all targeting initiative_id='${parent.id}'. ` +
         `Each task should be focused enough to land in a single PR. ` +
-        `Output discipline: tool call FIRST, then a single-line \`Proposal {id}.\` reply — ` +
-        `no freeform summary (the operator UI discards it).`,
+        `Output discipline: tool call FIRST, then a short confirmation sentence — ` +
+        `do NOT echo the id or use \`{...}\` placeholder syntax (the operator UI discards freeform replies).`,
     });
     const proposal = dispatch.proposal;
 
     try {
+      const ctx = {
+        trigger_kind: 'decompose_story' as const,
+        target_initiative_id: parent.id,
+        origin: 'pm_dispatch' as const,
+      };
       postPmChatMessage({
         workspace_id: parent.workspace_id,
         role: 'user',
         content:
           `Create tasks: "${parent.title}"` +
           (parsed.data.hint ? ` (hint: ${parsed.data.hint})` : ''),
+        context: ctx,
       });
       postPmChatMessage({
         workspace_id: parent.workspace_id,
         role: 'assistant',
         content: proposal.impact_md,
         proposal_id: proposal.id,
+        context: ctx,
       });
     } catch (err) {
       console.warn('[pm-decompose-story] chat insert failed:', (err as Error).message);

--- a/src/app/api/pm/plan-initiative/route.ts
+++ b/src/app/api/pm/plan-initiative/route.ts
@@ -147,6 +147,10 @@ export async function POST(request: NextRequest) {
       // round trips at ~70s in the wild.
       timeoutMs: 120_000,
       synth: { impact_md: synth.impact_md, changes: synth.changes, plan_suggestions: synth.suggestions as unknown as Record<string, unknown> },
+      chat_context: {
+        target_initiative_id: parsed.data.target_initiative_id ?? null,
+        origin: 'pm_dispatch',
+      },
       agent_prompt:
         `Plan an initiative draft titled "${parsed.data.draft.title}". ` +
         `Operator-provided draft: ${JSON.stringify(parsed.data.draft)}. ` +
@@ -161,8 +165,8 @@ export async function POST(request: NextRequest) {
         `Call \`propose_changes\` (trigger_kind='plan_initiative') with proposed_changes=[] and ` +
         `pass the structured plan_suggestions parameter directly (do NOT embed JSON in impact_md). ` +
         `See your SOUL.md for the plan_suggestions shape. ` +
-        `Output discipline: tool call FIRST, then a single-line \`Proposal {id}.\` reply — ` +
-        `no freeform summary (the operator UI discards it).`,
+        `Output discipline: tool call FIRST, then a short confirmation sentence — ` +
+        `do NOT echo the id or use \`{...}\` placeholder syntax (the operator UI discards freeform replies).`,
     });
     const proposal = dispatch.proposal;
     // Note: the synth placeholder created by `dispatchPmSynthesized` already
@@ -179,16 +183,23 @@ export async function POST(request: NextRequest) {
     // Posting `synth.impact_md` directly (the old behaviour) discarded
     // the named agent's reasoning whenever the gateway path was used.
     try {
+      const ctx = {
+        trigger_kind: 'plan_initiative' as const,
+        target_initiative_id: parsed.data.target_initiative_id ?? null,
+        origin: 'pm_dispatch' as const,
+      };
       postPmChatMessage({
         workspace_id: parsed.data.workspace_id,
         role: 'user',
         content: `Enrich: "${parsed.data.draft.title}"`,
+        context: ctx,
       });
       postPmChatMessage({
         workspace_id: parsed.data.workspace_id,
         role: 'assistant',
         content: proposal.impact_md,
         proposal_id: proposal.id,
+        context: ctx,
       });
     } catch (err) {
       console.warn('[pm-plan] chat insert failed:', (err as Error).message);

--- a/src/app/api/pm/proposals/[id]/accept/route.ts
+++ b/src/app/api/pm/proposals/[id]/accept/route.ts
@@ -18,7 +18,11 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { acceptProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
+import {
+  acceptProposal,
+  PmProposalValidationError,
+  type PmProposalTriggerKind,
+} from '@/lib/db/pm-proposals';
 import { postPmChatMessage } from '@/lib/agents/pm-dispatch';
 import { queryOne } from '@/lib/db';
 import {
@@ -65,12 +69,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const proposal = queryOne<{
       id: string;
       workspace_id: string;
-      trigger_kind: string;
+      trigger_kind: PmProposalTriggerKind;
       impact_md: string;
       status: string;
       plan_suggestions: string | null;
+      parent_proposal_id: string | null;
     }>(
-      'SELECT id, workspace_id, trigger_kind, impact_md, status, plan_suggestions FROM pm_proposals WHERE id = ?',
+      'SELECT id, workspace_id, trigger_kind, impact_md, status, plan_suggestions, parent_proposal_id FROM pm_proposals WHERE id = ?',
       [id],
     );
     if (!proposal) {
@@ -131,6 +136,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           workspace_id: proposal.workspace_id,
           role: 'assistant',
           content: text,
+          proposal_id: proposal.id,
+          context: {
+            trigger_kind: proposal.trigger_kind,
+            target_initiative_id: targetInitiativeId,
+            parent_proposal_id: proposal.parent_proposal_id ?? null,
+            origin: 'accept_result',
+          },
         });
       } catch (err) {
         console.warn('[pm-accept] chat insert failed:', (err as Error).message);
@@ -176,6 +188,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
             workspace_id: w.workspace_id,
             role: 'assistant',
             content: text,
+            proposal_id: proposal.id,
+            context: {
+              trigger_kind: proposal.trigger_kind,
+              target_initiative_id: proposal.target_initiative_id ?? null,
+              parent_proposal_id: proposal.parent_proposal_id ?? null,
+              origin: 'accept_result',
+            },
           });
         }
       } catch (err) {

--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -128,6 +128,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         // same large-prompt cold-session profile.
         timeoutMs: 120_000,
         synth: { impact_md: synth.impact_md, changes: synth.changes },
+        chat_context: {
+          target_initiative_id: parent.target_initiative_id ?? null,
+          origin: 'pm_dispatch',
+        },
         agent_prompt:
           `Refine the plan for initiative titled "${draftTitle}". ` +
           `Original draft: ${JSON.stringify(draft)}. ` +
@@ -136,8 +140,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           `Call \`propose_changes\` (trigger_kind='plan_initiative') with proposed_changes=[] and ` +
           `pass the structured plan_suggestions parameter directly (do NOT embed JSON in impact_md). ` +
           `See your SOUL.md for the plan_suggestions shape. ` +
-          `Output discipline: tool call FIRST, then a single-line \`Proposal {id}.\` reply — ` +
-          `no freeform summary (the operator UI discards it).`,
+          `Output discipline: tool call FIRST, then a short confirmation sentence — ` +
+          `do NOT echo the id or use \`{...}\` placeholder syntax (the operator UI discards freeform replies).`,
       });
       // Refine has a pre-allocated child row to copy content onto, so we
       // wait for the full dispatch lifecycle (Tier 2 reconciliation
@@ -236,6 +240,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         target_initiative_id: story.id,
         timeoutMs: 120_000,
         synth: { impact_md: synth.impact_md, changes: synth.changes },
+        chat_context: {
+          target_initiative_id: story.id,
+          origin: 'pm_dispatch',
+        },
         agent_prompt:
           `Refine the task decomposition for story ${story.id} ("${story.title}").\n\n` +
           `Operator refinement request: "${parsed.data.additional_constraint}"\n\n` +
@@ -250,8 +258,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           `Call \`propose_changes\` with trigger_kind='decompose_story' and one ` +
           `\`create_task_under_initiative\` diff per task, all targeting ` +
           `initiative_id='${story.id}'. Output discipline: tool call FIRST, then ` +
-          `a single-line \`Proposal {id}.\` reply — no freeform summary (the ` +
-          `operator UI discards it).`,
+          `a short confirmation sentence — do NOT echo the id or use \`{...}\` ` +
+          `placeholder syntax (the operator UI discards freeform replies).`,
       });
       const settled = await dispatch.completion;
       newImpactMd = settled.final.impact_md;

--- a/src/app/api/pm/proposals/bulk-delete/route.ts
+++ b/src/app/api/pm/proposals/bulk-delete/route.ts
@@ -1,0 +1,76 @@
+/**
+ * POST /api/pm/proposals/bulk-delete
+ *
+ * Hard-deletes every pm_proposals row in `workspace_id` whose status
+ * is in `statuses`. Accepted proposals are silently filtered out — the
+ * single-row DELETE endpoint refuses them for the same reason
+ * (acceptance has already mutated other tables, and history rows
+ * reference their ids). Mirrors that contract for the bulk path.
+ *
+ * Body: { workspace_id: string, statuses: ('draft'|'rejected'|'superseded'|'accepted')[] }
+ * Response: { deleted_count, deleted_ids }
+ *
+ * Broadcasts one `pm_proposal_deleted` SSE per row so any other
+ * connected /pm client refreshes its recents list.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  bulkDeleteProposalsByStatus,
+  type PmProposalStatus,
+} from '@/lib/db/pm-proposals';
+import { broadcast } from '@/lib/events';
+
+export const dynamic = 'force-dynamic';
+
+const STATUS_VALUES = ['draft', 'accepted', 'rejected', 'superseded'] as const;
+
+const Body = z.object({
+  workspace_id: z.string().min(1),
+  statuses: z.array(z.enum(STATUS_VALUES)).min(1),
+});
+
+export async function POST(request: NextRequest) {
+  let body: z.infer<typeof Body>;
+  try {
+    const raw = await request.json();
+    const parsed = Body.safeParse(raw);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'invalid body', issues: parsed.error.format() },
+        { status: 400 },
+      );
+    }
+    body = parsed.data;
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  let deletedIds: string[];
+  try {
+    deletedIds = bulkDeleteProposalsByStatus(
+      body.workspace_id,
+      body.statuses as PmProposalStatus[],
+    );
+  } catch (err) {
+    console.error('[proposals/bulk-delete] failed:', err);
+    return NextResponse.json({ error: 'bulk delete failed' }, { status: 500 });
+  }
+
+  for (const id of deletedIds) {
+    try {
+      broadcast({
+        type: 'pm_proposal_deleted',
+        payload: { proposal_id: id, workspace_id: body.workspace_id },
+      });
+    } catch {
+      // Broadcast best-effort — don't fail the response.
+    }
+  }
+
+  return NextResponse.json({
+    deleted_count: deletedIds.length,
+    deleted_ids: deletedIds,
+  });
+}

--- a/src/app/api/pm/proposals/counts/route.ts
+++ b/src/app/api/pm/proposals/counts/route.ts
@@ -1,0 +1,28 @@
+/**
+ * GET /api/pm/proposals/counts?workspace_id=…
+ *
+ * Returns per-status counts for the workspace's pm_proposals. Drives
+ * the /pm sidebar's "Delete proposals…" modal so the operator sees how
+ * many rows each status-checkbox would remove.
+ *
+ * Response: { draft, accepted, rejected, superseded }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { countProposalsByStatus } from '@/lib/db/pm-proposals';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const workspaceId = request.nextUrl.searchParams.get('workspace_id');
+  if (!workspaceId) {
+    return NextResponse.json({ error: 'workspace_id required' }, { status: 400 });
+  }
+  try {
+    const counts = countProposalsByStatus(workspaceId);
+    return NextResponse.json(counts);
+  } catch (err) {
+    console.error('[proposals/counts] failed:', err);
+    return NextResponse.json({ error: 'count failed' }, { status: 500 });
+  }
+}

--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -33,6 +33,7 @@ import {
   Activity,
   MoreHorizontal,
   List,
+  MessageSquare,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -43,6 +44,7 @@ import { InvestigatePicker, type InvestigateOption } from '@/components/inline/I
 import InvestigateModal from '@/components/InvestigateModal';
 import { NotesRail } from '@/components/notes/NotesRail';
 import { InitiativeRunsStrip } from '@/components/initiative/InitiativeRunsStrip';
+import { RecentPmActivity } from '@/components/initiative/RecentPmActivity';
 import { AuditProposalsSection } from '@/components/audit-proposals/AuditProposalsSection';
 import { useAgentNotes } from '@/hooks/useAgentNotes';
 import { countPriorAudits } from '@/components/inline/investigate-helpers';
@@ -1113,6 +1115,19 @@ or "carve out the onboarding flow as its own story first"`}
           />
         </Section>
 
+        {/* Recent PM activity — reverse-direction link from the /pm
+            chat context strip. Shows the last N PM-chat messages whose
+            provenance points at this initiative; click-through jumps
+            to /pm?focus=<id>. See
+            docs/proposals/pm-chat-context-strip.md. */}
+        <Section
+          id="pm-activity"
+          title="Recent PM activity"
+          icon={<MessageSquare className="w-4 h-4" />}
+        >
+          <RecentPmActivity initiativeId={initiative.id} />
+        </Section>
+
         {/* Notes — agent-generated observations for this initiative.
             Surface for the Investigate flow's take_note output. Filters
             to scoped notes only (no child-task rollup) since the audit
@@ -1292,6 +1307,7 @@ or "carve out the onboarding flow as its own story first"`}
             { id: 'tasks', label: 'Tasks', visible: true },
             { id: 'dependencies', label: 'Dependencies', visible: true },
             { id: 'activity', label: 'Activity', visible: true },
+            { id: 'pm-activity', label: 'Recent PM activity', visible: true },
             { id: 'notes', label: 'Notes', visible: true },
             { id: 'parent-history', label: 'Parent-change history', visible: true },
           ].filter(s => s.visible)}

--- a/src/components/initiative/RecentPmActivity.tsx
+++ b/src/components/initiative/RecentPmActivity.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+/**
+ * Per-initiative "Recent PM activity" rail.
+ *
+ * Pulls /api/initiatives/<id>/pm-chat — the last N PM-chat messages whose
+ * provenance points at this initiative (either directly via
+ * `target_initiative_id` or via a `source_note_ids` entry that belongs
+ * to the initiative). Click-through jumps back into /pm with
+ * `?focus=<message_id>` so the chat scrolls + highlights the row.
+ *
+ * Closes the "what did the PM do about this initiative?" gap, the
+ * reverse direction of the chat context strip that links forward to
+ * the initiative.
+ *
+ * See docs/proposals/pm-chat-context-strip.md.
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { MessageSquare, FileText, StickyNote, ScanSearch } from 'lucide-react';
+import { triggerBadgeFor } from '@/components/pm/triggerBadge';
+
+interface PmChatRailMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  created_at: string;
+  trigger_kind?: string;
+  proposal_id?: string;
+  source_note_ids?: string[];
+  audit_run_group_id?: string;
+}
+
+const REFRESH_MS = 5_000;
+const PREVIEW_CHARS = 180;
+
+function formatTimestamp(iso: string): string {
+  // Match the activity rail's terse format: "MM-DD HH:mm".
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function truncate(s: string, n: number): string {
+  const oneLine = s.replace(/\s+/g, ' ').trim();
+  return oneLine.length > n ? oneLine.slice(0, n - 1) + '…' : oneLine;
+}
+
+export function RecentPmActivity({
+  initiativeId,
+  limit = 10,
+}: {
+  initiativeId: string;
+  limit?: number;
+}) {
+  const [messages, setMessages] = useState<PmChatRailMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const r = await fetch(
+        `/api/initiatives/${encodeURIComponent(initiativeId)}/pm-chat?limit=${limit}`,
+      );
+      if (!r.ok) {
+        throw new Error(`HTTP ${r.status}`);
+      }
+      const data = (await r.json()) as { messages: PmChatRailMessage[] };
+      setMessages(data.messages ?? []);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'load failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [initiativeId, limit]);
+
+  useEffect(() => {
+    refresh();
+    const t = window.setInterval(refresh, REFRESH_MS);
+    return () => window.clearInterval(t);
+  }, [refresh]);
+
+  if (loading && messages.length === 0) {
+    return (
+      <p className="text-xs text-mc-text-secondary">Loading PM activity…</p>
+    );
+  }
+  if (error) {
+    return (
+      <p className="text-xs text-red-300">
+        Could not load PM activity: {error}
+      </p>
+    );
+  }
+  if (messages.length === 0) {
+    return (
+      <p className="text-sm text-mc-text-secondary">
+        No PM chat activity for this initiative yet.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-2">
+      {messages.map(m => {
+        const tb = m.trigger_kind ? triggerBadgeFor(m.trigger_kind) : null;
+        return (
+          <li
+            key={m.id}
+            className="border border-mc-border rounded-md bg-mc-surface/40 p-2 text-sm"
+          >
+            <div className="flex flex-wrap items-center gap-1.5 mb-1 text-xs text-mc-text-secondary">
+              <MessageSquare className="w-3 h-3" />
+              <span className="font-medium text-mc-text">
+                {m.role === 'user' ? 'You' : 'PM'}
+              </span>
+              <span>·</span>
+              <span title={m.created_at}>{formatTimestamp(m.created_at)}</span>
+              {tb && (
+                <span
+                  className={`px-1.5 py-0.5 text-[10px] rounded-sm border uppercase tracking-wide ${tb.cls}`}
+                  title={`trigger_kind: ${m.trigger_kind}`}
+                >
+                  {tb.label}
+                </span>
+              )}
+              {m.source_note_ids && m.source_note_ids.length > 0 && (
+                <span
+                  className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded-sm border border-yellow-500/30 bg-yellow-500/5 text-yellow-200/80"
+                  title={`Source notes: ${m.source_note_ids.join(', ')}`}
+                >
+                  <StickyNote className="w-3 h-3" />
+                  {m.source_note_ids.length === 1
+                    ? `note ${m.source_note_ids[0].slice(0, 8)}`
+                    : `${m.source_note_ids.length} notes`}
+                </span>
+              )}
+              {m.audit_run_group_id && (
+                <span
+                  className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded-sm border border-violet-500/30 bg-violet-500/5 text-violet-200/80"
+                  title={`Audit run ${m.audit_run_group_id}`}
+                >
+                  <ScanSearch className="w-3 h-3" />
+                  audit {m.audit_run_group_id.slice(0, 8)}
+                </span>
+              )}
+            </div>
+            <div className="text-mc-text-secondary leading-snug">
+              {truncate(m.content, PREVIEW_CHARS)}
+            </div>
+            <div className="mt-1.5 flex flex-wrap items-center gap-3 text-[11px]">
+              <Link
+                href={`/pm?focus=${encodeURIComponent(m.id)}`}
+                className="text-mc-accent hover:underline"
+              >
+                Open in PM chat →
+              </Link>
+              {m.proposal_id && (
+                <Link
+                  href={`/pm/proposals/${m.proposal_id}`}
+                  className="inline-flex items-center gap-1 text-mc-text-secondary hover:text-mc-text"
+                >
+                  <FileText className="w-3 h-3" />
+                  view proposal
+                </Link>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -19,6 +19,23 @@ export async function register() {
     throw err;
   }
 
+  // Heal any pm_proposals orphans left over from a prior process that
+  // crashed mid-dispatch or where the agent's `propose_changes` landed
+  // after the reconciler had already given up. Idempotent — safe to
+  // run every boot. See pm-proposals.ts `sweepOrphanedPlaceholders`.
+  try {
+    const { sweepOrphanedPlaceholders } = await import('@/lib/db/pm-proposals');
+    const linked = sweepOrphanedPlaceholders();
+    if (linked > 0) {
+      console.log(`[Instrumentation] adopted ${linked} orphaned PM placeholder(s) at boot`);
+    }
+  } catch (err) {
+    console.warn(
+      '[Instrumentation] PM orphan sweep failed (non-fatal):',
+      (err as Error).message,
+    );
+  }
+
   // Register the pm_pending_notes drain worker. The drain is cheap when
   // the queue is empty and it's the only path that recovers
   // propose_from_notes requests captured while the gateway was offline.

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -74,6 +74,18 @@ export interface DispatchPmInput {
    * Defaults to `true` for back-compat with the disruption path.
    */
   allowFallback?: boolean;
+  /**
+   * Optional provenance threaded into every chat post the dispatcher
+   * makes for this run (user trigger, agent reply, synth-only echo,
+   * supersede echo). Lets the /pm renderer show a context strip with
+   * initiative/note/audit-run chips. The dispatcher additionally fills
+   * `trigger_kind`, `target_initiative_id`, `parent_proposal_id` from
+   * its own input — callers only need to pass fields the dispatcher
+   * doesn't already know (`source_note_ids`, `audit_run_group_id`,
+   * `target_initiative_id` when not inferrable, `origin`).
+   * See docs/proposals/pm-chat-context-strip.md.
+   */
+  chat_context?: Omit<PmChatMetadata, 'proposal_id' | 'trigger_kind' | 'parent_proposal_id'>;
 }
 
 export interface DispatchPmResult {
@@ -109,7 +121,7 @@ export class PmDispatchGatewayUnavailableError extends Error {
  * Default time we wait for the named PM agent to respond (i.e. land a
  * row via `propose_changes`) before falling back to the synth path.
  */
-const NAMED_AGENT_TIMEOUT_MS = 60_000;
+const NAMED_AGENT_TIMEOUT_MS = 120_000;
 
 /**
  * In-memory registry of active PM dispatches keyed by workspace_id.
@@ -216,6 +228,10 @@ export function dispatchPm(input: DispatchPmInput): DispatchPmResult {
     );
   }
 
+  // Build the chat-provenance object once and reuse it across every
+  // post the dispatcher makes for this run. See `buildChatContext`.
+  const baseChatContext = buildChatContext(input);
+
   // Echo the operator's trigger as a user message so the /pm chat
   // reflects the conversation faithfully.
   try {
@@ -223,6 +239,7 @@ export function dispatchPm(input: DispatchPmInput): DispatchPmResult {
       workspace_id: input.workspace_id,
       content: input.trigger_text,
       role: 'user',
+      context: baseChatContext,
     });
   } catch (err) {
     console.warn('[pm-dispatch] user chat insert failed:', (err as Error).message);
@@ -242,6 +259,15 @@ export function dispatchPm(input: DispatchPmInput): DispatchPmResult {
     parent_proposal_id: input.parent_proposal_id ?? null,
     dispatch_state: gatewayUp ? 'pending_agent' : 'synth_only',
   });
+  // Backfill target_initiative_id from the resolved placeholder so
+  // every chat row from this run carries the chip even when the caller
+  // didn't pass one explicitly (createProposal infers it from the
+  // diff). Caller-supplied value still wins.
+  if (!baseChatContext.target_initiative_id && placeholder.target_initiative_id) {
+    baseChatContext.target_initiative_id = placeholder.target_initiative_id;
+  }
+  // After this point the dispatcher's gateway-up path returns; the
+  // background runners reconstruct `baseChatContext` via buildChatContext.
   // Echo the synth proposal into chat ONLY when we know the agent
   // can't respond (gateway down). When the gateway is up the synth
   // is a placeholder — posting it as chat now produced a misleading
@@ -256,6 +282,7 @@ export function dispatchPm(input: DispatchPmInput): DispatchPmResult {
         content: synth.impact_md,
         proposal_id: placeholder.id,
         role: 'assistant',
+        context: baseChatContext,
       });
     } catch (err) {
       console.warn('[pm-dispatch] chat insert failed:', (err as Error).message);
@@ -315,6 +342,12 @@ async function runDisruptionDispatchInBackground(
   // the `trigger_body` parameter.
   const correlationId = uuidv4();
   const sinceIso = new Date().toISOString();
+  // Per-run chat-provenance for every chat post the dispatcher makes
+  // on the agent's behalf (agent re-echo, mode-B reply, synth-only
+  // fallback). Mirrors what `dispatchPm` already attached to the
+  // user-trigger row so the /pm context strip is consistent across
+  // the whole exchange.
+  const baseChatContext = buildChatContext(params.input, placeholder);
   // notes_intake still ships the precomputed summary inline because that
   // path is a one-shot bulk-process flow, not interactive chat — context
   // cost matters less and the caller benefits from having every initiative
@@ -332,7 +365,7 @@ async function runDisruptionDispatchInBackground(
       ? buildNotesIntakeMessage({ correlationId, notes: input.trigger_text, summary: buildSnapshotSummary(snapshot) })
       : `**PM dispatch (correlation_id: ${correlationId})**\n\n` +
         `Operator input:\n> ${input.trigger_text}\n\n` +
-        `Pick Mode A (\`propose_changes\` + \`Proposal {id}.\` reply) for roadmap mutations, or Mode B (concise plain-text reply, no \`propose_changes\`) for everything else. Empty reply = bug. ` +
+        `Pick Mode A (call \`propose_changes\`, then a short confirmation sentence — no id echo, no \`{...}\` placeholders) for roadmap mutations, or Mode B (concise plain-text reply, no \`propose_changes\`) for everything else. Empty reply = bug. ` +
         `When you need a tool, **issue the tool call** — don't print the tool's name as prose.`;
   const sessionSuffix = input.trigger_kind === 'notes_intake' ? `notes-${correlationId}` : 'dispatch-main';
 
@@ -497,12 +530,15 @@ async function runDisruptionDispatchInBackground(
     );
   }
 
-  // Gate the reconciler tail on whether the agent actually attempted
-  // propose_changes during the dispatch. If it didn't (Mode B
-  // conversational reply), there's no pm_proposals row to wait for —
-  // skip the wait entirely so MC's chat surfaces the reply at the
-  // same wall-clock moment openclaw's webui shows it.
-  const tailMs = result?.sent && proposeChangesAttempted ? RECONCILER_TAIL_MS : 0;
+  // Always run the tail window when send succeeded. The previous
+  // `proposeChangesAttempted` gate raced with the primary timeout:
+  // under heavy ML-server load the agent's `propose_changes` event can
+  // arrive AFTER the primary timeout fires, leaving the flag false at
+  // this check and orphaning the agent row (placeholder stuck in
+  // synth_only, no supersede broadcast). Mirrors the synthesized path
+  // (line ~965). Polling cost during a true Mode B reply is cheap —
+  // 2s-interval SELECTs that return zero rows.
+  const tailMs = result?.sent ? RECONCILER_TAIL_MS : 0;
   const found = await pollForAgentProposal(input.workspace_id, sinceIso, placeholder.id, tailMs);
 
   if (found) {
@@ -524,6 +560,11 @@ async function runDisruptionDispatchInBackground(
           content: found.impact_md,
           proposal_id: found.id,
           role: 'assistant',
+          context: {
+            ...baseChatContext,
+            target_initiative_id:
+              found.target_initiative_id ?? baseChatContext.target_initiative_id ?? null,
+          },
         });
       } catch (err) {
         console.warn('[pm-dispatch] agent chat re-echo failed:', (err as Error).message);
@@ -572,6 +613,7 @@ async function runDisruptionDispatchInBackground(
           workspace_id: input.workspace_id,
           content: replyTextEarly,
           role: 'assistant',
+          context: baseChatContext,
         });
       } catch (err) {
         console.warn('[pm-dispatch] mode-b chat insert failed:', (err as Error).message);
@@ -606,6 +648,7 @@ async function runDisruptionDispatchInBackground(
         workspace_id: input.workspace_id,
         content: replyText,
         role: 'assistant',
+        context: baseChatContext,
       });
     } catch (err) {
       console.warn('[pm-dispatch] synth-only chat insert failed:', (err as Error).message);
@@ -617,6 +660,7 @@ async function runDisruptionDispatchInBackground(
         content: placeholder.impact_md,
         proposal_id: placeholder.id,
         role: 'assistant',
+        context: baseChatContext,
       });
     } catch (err) {
       console.warn('[pm-dispatch] synth-only chat insert failed:', (err as Error).message);
@@ -830,6 +874,12 @@ export interface DispatchSynthesizedInput {
    * to `namedAgentTimeoutMs()`.
    */
   timeoutMs?: number;
+  /**
+   * Chat-provenance threaded into every chat post the dispatcher makes
+   * for this run. Same contract as `DispatchPmInput.chat_context`. See
+   * docs/proposals/pm-chat-context-strip.md.
+   */
+  chat_context?: Omit<PmChatMetadata, 'proposal_id' | 'trigger_kind' | 'parent_proposal_id'>;
 }
 
 export interface DispatchSynthesizedResult {
@@ -992,6 +1042,14 @@ async function runNamedAgentDispatchInBackground(
           content: found.impact_md,
           proposal_id: found.id,
           role: 'assistant',
+          context: {
+            ...(input.chat_context ?? {}),
+            trigger_kind: input.trigger_kind,
+            parent_proposal_id: input.parent_proposal_id ?? null,
+            target_initiative_id:
+              found.target_initiative_id ?? input.target_initiative_id ?? null,
+            origin: input.chat_context?.origin ?? 'pm_dispatch',
+          },
         });
       } catch (err) {
         console.warn('[pm-dispatch] agent chat re-echo failed:', (err as Error).message);
@@ -1374,11 +1432,65 @@ export function synthesizeImpactAnalysis(
 
 // ─── PM chat helper ─────────────────────────────────────────────────
 
+/**
+ * Provenance fields written into `agent_chat_messages.metadata` so the
+ * /pm renderer can show a "what is this about" context strip on every
+ * row (trigger-kind badge, initiative chip, note chips, audit-run
+ * chip, links to proposal / parent proposal). Pre-existing rows only
+ * carry `{ proposal_id }`; the renderer derives the rest from the
+ * linked proposal as a graceful fallback. See
+ * `docs/proposals/pm-chat-context-strip.md`.
+ */
+export interface PmChatMetadata {
+  proposal_id?: string;
+  trigger_kind?: PmProposalTriggerKind;
+  target_initiative_id?: string | null;
+  source_note_ids?: string[];
+  audit_run_group_id?: string | null;
+  parent_proposal_id?: string | null;
+  origin?:
+    | 'pm_dispatch'
+    | 'ask_pm_from_notes'
+    | 'standup'
+    | 'accept_result'
+    | 'system';
+}
+
+/**
+ * Build the per-run chat-provenance object from a `DispatchPmInput`,
+ * merging caller-supplied `chat_context` with fields the dispatcher
+ * derives from its own input. Used by both the foreground `dispatchPm`
+ * entry point and the background runners so every chat row from a
+ * single dispatch carries identical metadata.
+ */
+export function buildChatContext(
+  input: DispatchPmInput,
+  placeholder?: { target_initiative_id?: string | null },
+): Omit<PmChatMetadata, 'proposal_id'> {
+  const ctx: Omit<PmChatMetadata, 'proposal_id'> = {
+    ...(input.chat_context ?? {}),
+    trigger_kind: input.trigger_kind ?? 'manual',
+    parent_proposal_id: input.parent_proposal_id ?? null,
+    origin: input.chat_context?.origin ?? 'pm_dispatch',
+  };
+  if (!ctx.target_initiative_id && placeholder?.target_initiative_id) {
+    ctx.target_initiative_id = placeholder.target_initiative_id;
+  }
+  return ctx;
+}
+
 interface PostPmChatMessage {
   workspace_id: string;
   content: string;
   role: 'user' | 'assistant';
   proposal_id?: string;
+  /**
+   * Optional structured provenance. Merged with `proposal_id` (if set)
+   * into the row's `metadata` JSON. Pass everything you have at the
+   * call site — the renderer falls back gracefully when fields are
+   * missing.
+   */
+  context?: Omit<PmChatMetadata, 'proposal_id'>;
 }
 
 /**
@@ -1393,9 +1505,14 @@ export function postPmChatMessage(input: PostPmChatMessage): void {
       `No PM agent for workspace ${input.workspace_id} — migration 045 should have seeded one`,
     );
   }
-  const metadata = input.proposal_id
-    ? JSON.stringify({ proposal_id: input.proposal_id })
-    : null;
+  const meta: PmChatMetadata = { ...(input.context ?? {}) };
+  if (input.proposal_id) meta.proposal_id = input.proposal_id;
+  // Drop empty arrays / null-only fields so the JSON stays compact.
+  if (meta.source_note_ids && meta.source_note_ids.length === 0) {
+    delete meta.source_note_ids;
+  }
+  const metadata =
+    Object.keys(meta).length > 0 ? JSON.stringify(meta) : null;
   run(
     `INSERT INTO agent_chat_messages (id, agent_id, role, content, status, metadata)
      VALUES (?, ?, ?, ?, 'delivered', ?)`,

--- a/src/lib/agents/pm-prompts/notes-intake.ts
+++ b/src/lib/agents/pm-prompts/notes-intake.ts
@@ -45,6 +45,6 @@ export function buildNotesIntakeMessage(input: BuildNotesIntakeMessageInput): st
     '- If the notes contain nothing actionable for the roadmap, return an empty `changes` array and explain in `impact_md`.',
     '- Never fabricate agent ids, dates, or initiative titles.',
     '',
-    'Output discipline: call `propose_changes` FIRST. After the tool returns, your reply MUST be a single line: `Proposal {id}.` — no freeform summary. The operator UI renders only `impact_md` + structured fields; anything you say in chat after the tool call is discarded.',
+    'Output discipline: you MUST invoke the `propose_changes` MCP tool. Do not skip the tool call and reply only in chat — the operator UI renders only the structured proposal, so a chat-only reply is invisible and the run is discarded. After the tool call returns successfully, reply with a single short sentence confirming you proposed changes (e.g. "Proposed changes." or "Done — proposal submitted."). Do not echo ids or use `{...}` / `{{...}}` placeholders; the operator already has the id from the tool result.',
   ].join('\n');
 }

--- a/src/lib/agents/pm-soul.md
+++ b/src/lib/agents/pm-soul.md
@@ -75,17 +75,13 @@ after the tool call.** The operator never sees your conversational reply
 Anything you write in the chat after the tool call is wasted tokens and
 latency.
 
-After the tool returns, your reply MUST be a single line of the form:
+After the tool returns successfully, reply with a single short
+confirmation sentence such as `Proposed changes.` or `Done — proposal
+submitted.` Do not echo the proposal id, and do not use `{...}` or
+`{{...}}` placeholder syntax — those are template artefacts, not literal
+output. The operator already has the id from the tool result.
 
-```
-Proposal {proposal_id}.
-```
-
-Examples:
-- `Proposal 8b2f3c10-…`
-- `Proposal 4e9d-… (refined).`
-
-That's it. Put all the substance into `impact_md` and (for plan_initiative)
+Put all the substance into `impact_md` and (for plan_initiative)
 `plan_suggestions`. The `impact_md` is what shows up in the operator's
 chat card; the freeform reply is discarded.
 

--- a/src/lib/agents/pm-standup.ts
+++ b/src/lib/agents/pm-standup.ts
@@ -176,6 +176,11 @@ export function generateStandup(input: GenerateStandupInput): GenerateStandupRes
       content: impactMd,
       proposal_id: proposal.id,
       role: 'assistant',
+      context: {
+        trigger_kind: 'scheduled_drift_scan',
+        target_initiative_id: proposal.target_initiative_id ?? null,
+        origin: 'standup',
+      },
     });
   } catch (err) {
     console.warn('[pm-standup] chat insert failed:', (err as Error).message);

--- a/src/lib/agents/pm.test.ts
+++ b/src/lib/agents/pm.test.ts
@@ -254,8 +254,22 @@ test('dispatchPm: persists a draft proposal AND posts to PM chat with metadata',
   const assistant = messages.find(m => m.role === 'assistant');
   assert.ok(assistant);
   assert.ok(assistant!.metadata);
-  const meta = JSON.parse(assistant!.metadata!) as { proposal_id?: string };
+  const meta = JSON.parse(assistant!.metadata!) as {
+    proposal_id?: string;
+    trigger_kind?: string;
+    origin?: string;
+  };
   assert.equal(meta.proposal_id, result.proposal.id);
+  // PR pm-chat-context-strip: the dispatcher always writes the
+  // widened metadata shape so /pm can render the context strip.
+  assert.equal(meta.trigger_kind, 'manual');
+  assert.equal(meta.origin, 'pm_dispatch');
+  // The user trigger row carries the same provenance.
+  const userRow = messages.find(m => m.role === 'user');
+  assert.ok(userRow?.metadata);
+  const userMeta = JSON.parse(userRow!.metadata!) as { trigger_kind?: string; origin?: string };
+  assert.equal(userMeta.trigger_kind, 'manual');
+  assert.equal(userMeta.origin, 'pm_dispatch');
 
   // Generated availability is for Sarah specifically.
   const avail = result.proposal.proposed_changes.find(c => c.kind === 'add_availability');

--- a/src/lib/db/pm-proposals.test.ts
+++ b/src/lib/db/pm-proposals.test.ts
@@ -23,6 +23,8 @@ import {
   refineProposal,
   validateProposedChanges,
   PmProposalValidationError,
+  tryAdoptOrphanedPlaceholder,
+  sweepOrphanedPlaceholders,
   type PmDiff,
 } from './pm-proposals';
 import { createInitiative, addInitiativeDependency } from './initiatives';
@@ -1106,4 +1108,118 @@ test('set_task_status: forward proposal still rejects status != cancelled', () =
       }),
     PmProposalValidationError,
   );
+});
+
+// ─── Orphan-placeholder retroactive adoption ───────────────────────
+
+function seedSynthPlaceholder(ws: string, triggerKind: string = "notes_intake") {
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: "operator notes about scrubbing localhost:4000",
+    trigger_kind: triggerKind as Parameters<typeof createProposal>[0]["trigger_kind"],
+    impact_md: "### No structured changes inferred yet",
+    proposed_changes: [],
+    dispatch_state: "synth_only",
+  });
+  return p;
+}
+
+function seedAgentRow(ws: string, triggerKind: string = "notes_intake") {
+  const init = createInitiative({ workspace_id: ws, kind: "story", title: "X" });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: "agent freeform trigger",
+    trigger_kind: triggerKind as Parameters<typeof createProposal>[0]["trigger_kind"],
+    impact_md: "### Real agent analysis",
+    proposed_changes: [
+      { kind: "set_initiative_status", initiative_id: init.id, status: "blocked" },
+    ],
+    // createProposal default is agent_complete — matches MCP propose_changes path
+  });
+  return p;
+}
+
+test("tryAdoptOrphanedPlaceholder links matching orphan", () => {
+  const ws = freshWorkspace();
+  const placeholder = seedSynthPlaceholder(ws);
+  const agentRow = seedAgentRow(ws);
+
+  const adoptedId = tryAdoptOrphanedPlaceholder(agentRow.id);
+  assert.equal(adoptedId, placeholder.id);
+
+  const refreshedPlaceholder = getProposal(placeholder.id);
+  const refreshedAgent = getProposal(agentRow.id);
+  assert.equal(refreshedPlaceholder?.status, "superseded");
+  assert.equal(refreshedAgent?.parent_proposal_id, placeholder.id);
+  assert.equal(refreshedAgent?.dispatch_state, "agent_complete");
+});
+
+test("tryAdoptOrphanedPlaceholder ignores other workspaces", () => {
+  const wsA = freshWorkspace();
+  const wsB = freshWorkspace();
+  seedSynthPlaceholder(wsA); // orphan in workspace A
+  const agentRow = seedAgentRow(wsB); // agent row in workspace B
+  const adoptedId = tryAdoptOrphanedPlaceholder(agentRow.id);
+  assert.equal(adoptedId, null);
+});
+
+test("tryAdoptOrphanedPlaceholder ignores mismatched trigger_kind", () => {
+  const ws = freshWorkspace();
+  seedSynthPlaceholder(ws, "notes_intake");
+  const agentRow = seedAgentRow(ws, "disruption_event");
+  const adoptedId = tryAdoptOrphanedPlaceholder(agentRow.id);
+  assert.equal(adoptedId, null);
+});
+
+test("tryAdoptOrphanedPlaceholder is a no-op when placeholder is already linked", () => {
+  const ws = freshWorkspace();
+  const placeholder = seedSynthPlaceholder(ws);
+  // Pre-link via direct UPDATE to simulate the in-flight reconciler having won.
+  run(
+    `UPDATE pm_proposals SET status = ? WHERE id = ?`,
+    ["superseded", placeholder.id],
+  );
+  const agentRow = seedAgentRow(ws);
+  const adoptedId = tryAdoptOrphanedPlaceholder(agentRow.id);
+  assert.equal(adoptedId, null);
+  const refreshedAgent = getProposal(agentRow.id);
+  assert.equal(refreshedAgent?.parent_proposal_id, null);
+});
+
+test("tryAdoptOrphanedPlaceholder skips placeholders outside the time window", () => {
+  const ws = freshWorkspace();
+  const placeholder = seedSynthPlaceholder(ws);
+  // Backdate the placeholder by 1 hour.
+  run(
+    `UPDATE pm_proposals SET created_at = ? WHERE id = ?`,
+    [new Date(Date.now() - 60 * 60 * 1000).toISOString(), placeholder.id],
+  );
+  const agentRow = seedAgentRow(ws);
+  // Default window is 10 minutes.
+  const adoptedId = tryAdoptOrphanedPlaceholder(agentRow.id);
+  assert.equal(adoptedId, null);
+  // A wider window finds it.
+  const widerAdoptedId = tryAdoptOrphanedPlaceholder(agentRow.id, 2 * 60 * 60 * 1000);
+  assert.equal(widerAdoptedId, placeholder.id);
+});
+
+test("sweepOrphanedPlaceholders links eligible pairs in bulk", () => {
+  const wsA = freshWorkspace();
+  const wsB = freshWorkspace();
+  const phA = seedSynthPlaceholder(wsA);
+  const phB = seedSynthPlaceholder(wsB);
+  const agentA = seedAgentRow(wsA);
+  const agentB = seedAgentRow(wsB);
+  // wsC has only a placeholder, no agent row — should remain orphaned.
+  const wsC = freshWorkspace();
+  const phC = seedSynthPlaceholder(wsC);
+
+  const linked = sweepOrphanedPlaceholders();
+  assert.ok(linked >= 2, `expected ≥2 links, got ${linked}`);
+
+  assert.equal(getProposal(phA.id)?.status, "superseded");
+  assert.equal(getProposal(phB.id)?.status, "superseded");
+  assert.equal(getProposal(phC.id)?.status, "draft");
+  assert.equal(getProposal(agentA.id)?.parent_proposal_id, phA.id);
+  assert.equal(getProposal(agentB.id)?.parent_proposal_id, phB.id);
 });

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -768,6 +768,64 @@ export function deleteProposal(id: string): void {
 }
 
 /**
+ * Per-status counts for a workspace's pm_proposals. Drives the
+ * "Delete all rejected/draft/superseded" panel modal — operator sees
+ * how many rows each checkbox would remove before confirming.
+ */
+export type PmProposalStatusCounts = Record<PmProposalStatus, number>;
+
+export function countProposalsByStatus(workspaceId: string): PmProposalStatusCounts {
+  const rows = queryAll<{ status: PmProposalStatus; n: number }>(
+    `SELECT status, COUNT(*) AS n
+       FROM pm_proposals
+      WHERE workspace_id = ?
+      GROUP BY status`,
+    [workspaceId],
+  );
+  const out: PmProposalStatusCounts = {
+    draft: 0,
+    accepted: 0,
+    rejected: 0,
+    superseded: 0,
+  };
+  for (const r of rows) {
+    if (r.status in out) out[r.status] = r.n;
+  }
+  return out;
+}
+
+/**
+ * Bulk hard-delete every proposal in `workspaceId` whose status is in
+ * `statuses`. Refuses to touch `accepted` rows for the same reason as
+ * the single-row DELETE endpoint (their diffs already mutated other
+ * tables, and history rows reference their ids). Returns the ids that
+ * were actually deleted so the caller can broadcast individual SSE
+ * events.
+ */
+export function bulkDeleteProposalsByStatus(
+  workspaceId: string,
+  statuses: PmProposalStatus[],
+): string[] {
+  const safe = statuses.filter(s => s !== 'accepted');
+  if (safe.length === 0) return [];
+  const placeholders = safe.map(() => '?').join(',');
+  const rows = queryAll<{ id: string }>(
+    `SELECT id FROM pm_proposals
+      WHERE workspace_id = ?
+        AND status IN (${placeholders})`,
+    [workspaceId, ...safe],
+  );
+  if (rows.length === 0) return [];
+  run(
+    `DELETE FROM pm_proposals
+      WHERE workspace_id = ?
+        AND status IN (${placeholders})`,
+    [workspaceId, ...safe],
+  );
+  return rows.map(r => r.id);
+}
+
+/**
  * Mark a row as superseded by another. Used when the agent's `propose_changes`
  * lands after a synth placeholder was already persisted: the synth row is
  * superseded, and the agent's row inherits the synth row's
@@ -808,6 +866,174 @@ export function supersedeWithAgentProposal(
     vals.push(agentRowId);
     run(`UPDATE pm_proposals SET ${sets.join(', ')} WHERE id = ?`, vals);
   })();
+}
+
+/**
+ * Retroactively link a freshly-created agent proposal to any orphaned
+ * synth placeholder from the same dispatch.
+ *
+ * Why: pm-dispatch fires a synth placeholder, dispatches the named PM
+ * agent, and waits with a primary timeout + tail-window reconciler for
+ * the agent's `propose_changes` row to land — at which point
+ * `supersedeWithAgentProposal` links them and broadcasts
+ * `pm_proposal_replaced`. Under heavy ML-server load the agent's tool
+ * call can land AFTER both windows elapse, leaving the placeholder
+ * stuck in `synth_only` and the agent row floating without a
+ * `parent_proposal_id`. The UI never swaps the card and the operator
+ * sees an empty "0 changes" placeholder.
+ *
+ * This function is the self-healing fallback: when the MCP
+ * `propose_changes` handler finishes inserting the agent row, it calls
+ * us, we look for a matching orphan placeholder within a recent
+ * window, and we adopt it atomically. The in-flight reconciler is a
+ * fast path; this is the correctness fallback.
+ *
+ * Returns the placeholder id that was adopted (so the caller can
+ * broadcast `pm_proposal_replaced`), or null when no match was found
+ * or another writer beat us to the supersede.
+ *
+ * Match key:
+ *   - same workspace_id
+ *   - same trigger_kind
+ *   - placeholder status='draft', dispatch_state='synth_only',
+ *     parent_proposal_id IS NULL (i.e. genuinely orphaned)
+ *   - placeholder.created_at within `windowMs` of the agent row
+ *   - excludes self
+ *
+ * The pm-dispatch registry only allows one in-flight dispatch per
+ * workspace, so the most-recent matching orphan is unambiguously the
+ * one this agent row belongs to.
+ */
+export function tryAdoptOrphanedPlaceholder(
+  agentProposalId: string,
+  windowMs: number = 10 * 60 * 1000,
+): string | null {
+  const agentRow = queryOne<{
+    workspace_id: string;
+    trigger_kind: PmProposalTriggerKind;
+    created_at: string;
+  }>(
+    `SELECT workspace_id, trigger_kind, created_at FROM pm_proposals WHERE id = ?`,
+    [agentProposalId],
+  );
+  if (!agentRow) return null;
+
+  const earliestMs = new Date(agentRow.created_at).getTime() - windowMs;
+  const earliestIso = new Date(earliestMs).toISOString();
+
+  const candidate = queryOne<{ id: string; trigger_text: string | null; target_initiative_id: string | null }>(
+    `SELECT id, trigger_text, target_initiative_id FROM pm_proposals
+      WHERE workspace_id = ?
+        AND trigger_kind = ?
+        AND status = 'draft'
+        AND dispatch_state = 'synth_only'
+        AND parent_proposal_id IS NULL
+        AND id != ?
+        AND created_at >= ?
+        AND created_at <= ?
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [
+      agentRow.workspace_id,
+      agentRow.trigger_kind,
+      agentProposalId,
+      earliestIso,
+      agentRow.created_at,
+    ],
+  );
+  if (!candidate) return null;
+
+  const db = getDb();
+  let adopted = false;
+  db.transaction(() => {
+    // Atomic claim: only mark superseded if the placeholder is still
+    // an orphan. If a concurrent reconciler already linked it, the
+    // UPDATE matches zero rows and we bail without touching the agent
+    // row.
+    const stmt = db.prepare(
+      `UPDATE pm_proposals
+          SET status = 'superseded'
+        WHERE id = ?
+          AND status = 'draft'
+          AND dispatch_state = 'synth_only'
+          AND parent_proposal_id IS NULL`,
+    );
+    const info = stmt.run(candidate.id);
+    if (info.changes !== 1) return;
+
+    const sets: string[] = ['parent_proposal_id = ?', 'dispatch_state = ?'];
+    const vals: unknown[] = [candidate.id, 'agent_complete'];
+    if (candidate.target_initiative_id) {
+      sets.push('target_initiative_id = ?');
+      vals.push(candidate.target_initiative_id);
+    }
+    if (candidate.trigger_text) {
+      sets.push('trigger_text = ?');
+      vals.push(candidate.trigger_text);
+    }
+    vals.push(agentProposalId);
+    run(`UPDATE pm_proposals SET ${sets.join(', ')} WHERE id = ?`, vals);
+    adopted = true;
+  })();
+
+  return adopted ? candidate.id : null;
+}
+
+/**
+ * Boot-time sweep: find orphaned synth placeholders that have a
+ * matching agent-authored row already in the DB, and link them via
+ * `tryAdoptOrphanedPlaceholder`. Idempotent.
+ *
+ * Used by the Next.js instrumentation hook to heal orphans left by a
+ * prior process that crashed mid-dispatch or where the agent's tool
+ * call landed after the reconciler had already given up. Returns the
+ * number of placeholders successfully adopted.
+ *
+ * The reverse-lookup (agent row → orphan placeholder) is what
+ * `tryAdoptOrphanedPlaceholder` already implements, so the sweep
+ * iterates candidate agent rows and delegates.
+ */
+export function sweepOrphanedPlaceholders(): number {
+  // Bound the lookback so a long-running DB with thousands of rows
+  // doesn't scan everything. 24h covers any realistic gap between
+  // dispatch and boot (the orphan window inside
+  // tryAdoptOrphanedPlaceholder is 10m by default, but a placeholder
+  // that's been orphaned for hours is still a candidate as long as
+  // its agent row was created shortly after).
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const candidates = queryAll<{ id: string }>(
+    `SELECT a.id
+       FROM pm_proposals a
+       JOIN pm_proposals p
+         ON p.workspace_id = a.workspace_id
+        AND p.trigger_kind = a.trigger_kind
+        AND p.status = 'draft'
+        AND p.dispatch_state = 'synth_only'
+        AND p.parent_proposal_id IS NULL
+        AND p.id != a.id
+        AND p.created_at <= a.created_at
+      WHERE a.dispatch_state = 'agent_complete'
+        AND a.parent_proposal_id IS NULL
+        AND a.created_at >= ?
+      GROUP BY a.id`,
+    [cutoff],
+  );
+
+  let linked = 0;
+  for (const { id } of candidates) {
+    try {
+      // Use a wider window for the sweep than the live path — agent
+      // and placeholder may be hours apart in a long-orphan scenario.
+      const adopted = tryAdoptOrphanedPlaceholder(id, 24 * 60 * 60 * 1000);
+      if (adopted) linked += 1;
+    } catch (err) {
+      console.warn(
+        `[sweepOrphanedPlaceholders] adopt failed for agent row ${id}:`,
+        (err as Error).message,
+      );
+    }
+  }
+  return linked;
 }
 
 export function getProposal(id: string): PmProposal | undefined {

--- a/src/lib/mcp/groups/core.ts
+++ b/src/lib/mcp/groups/core.ts
@@ -555,6 +555,12 @@ export function registerCoreTools(server: McpServer): void {
               role: 'assistant',
               content:
                 `**🚩 ${note.kind} (from ${note.role})**\n\n${note.body}${filesLine}`,
+              context: {
+                target_initiative_id: note.initiative_id ?? null,
+                source_note_ids: [note.id],
+                audit_run_group_id: note.run_group_id ?? null,
+                origin: 'system',
+              },
             });
           } catch (chatErr) {
             console.warn(

--- a/src/lib/mcp/groups/pm.ts
+++ b/src/lib/mcp/groups/pm.ts
@@ -15,11 +15,17 @@ import { previewDerivation } from '@/lib/roadmap/apply-derivation';
 import {
   createProposal,
   refineProposal as refineProposalDb,
+  tryAdoptOrphanedPlaceholder,
   type PmDiff,
 } from '@/lib/db/pm-proposals';
-import { dispatchPm, PmDispatchGatewayUnavailableError } from '@/lib/agents/pm-dispatch';
+import {
+  dispatchPm,
+  PmDispatchGatewayUnavailableError,
+  postPmChatMessage,
+} from '@/lib/agents/pm-dispatch';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { enqueuePendingNote } from '@/lib/db/pm-pending-notes';
+import { broadcast } from '@/lib/events';
 
 import {
   agentIdArg,
@@ -170,7 +176,7 @@ export function registerPmTools(server: McpServer): void {
       annotations: { destructiveHint: false, openWorldHint: false },
     },
     async (args) => safeWrap(() => {
-      return createProposal({
+      const created = createProposal({
         workspace_id: args.workspace_id,
         trigger_text: args.trigger_text,
         trigger_kind: args.trigger_kind,
@@ -179,6 +185,63 @@ export function registerPmTools(server: McpServer): void {
         plan_suggestions: args.plan_suggestions ?? null,
         parent_proposal_id: args.parent_proposal_id ?? null,
       });
+
+      // Retroactive supersede: if a synth placeholder is still
+      // orphaned (in-flight reconciler timed out before the agent's
+      // tool call arrived — happens under heavy ML-server load), adopt
+      // it now. The agent caller didn't pass parent_proposal_id, so
+      // only run this when the row is unlinked.
+      if (!created.parent_proposal_id) {
+        try {
+          const adoptedPlaceholderId = tryAdoptOrphanedPlaceholder(created.id);
+          if (adoptedPlaceholderId) {
+            // Re-echo the agent's (richer) impact_md into chat anchored
+            // to the new agent-row id. Mirrors the in-flight reconciler
+            // path in pm-dispatch.ts.
+            try {
+              postPmChatMessage({
+                workspace_id: created.workspace_id,
+                content: created.impact_md,
+                proposal_id: created.id,
+                role: 'assistant',
+                context: {
+                  trigger_kind: created.trigger_kind,
+                  target_initiative_id: created.target_initiative_id ?? null,
+                  parent_proposal_id: adoptedPlaceholderId,
+                  origin: 'pm_dispatch',
+                },
+              });
+            } catch (err) {
+              console.warn(
+                '[propose_changes] retroactive chat re-echo failed:',
+                (err as Error).message,
+              );
+            }
+            broadcast({
+              type: 'pm_proposal_replaced',
+              payload: {
+                workspace_id: created.workspace_id,
+                old_id: adoptedPlaceholderId,
+                new_id: created.id,
+                target_initiative_id: created.target_initiative_id ?? null,
+                trigger_kind: created.trigger_kind,
+              },
+            });
+            console.log(
+              `[propose_changes] retroactively adopted orphan placeholder ${adoptedPlaceholderId} ` +
+                `← agent row ${created.id} (workspace=${created.workspace_id}, ` +
+                `trigger_kind=${created.trigger_kind})`,
+            );
+          }
+        } catch (err) {
+          console.warn(
+            '[propose_changes] orphan-adopt failed (non-fatal):',
+            (err as Error).message,
+          );
+        }
+      }
+
+      return created;
     }),
   );
 


### PR DESCRIPTION
## Summary

Three interlocking threads of PM-surface work, all anchored on widening the chat metadata.

1. **Correctness — self-healing supersede.** Orphaned synth placeholders (the `Proposal {id}.` prompt-template trap + the reconciler's tail-window race under heavy ML-server load) now get adopted retroactively.
2. **Feature — PM chat context strip + bi-directional initiative links.** Per [docs/proposals/pm-chat-context-strip.md](docs/proposals/pm-chat-context-strip.md).
3. **UX — proposal management.** Delete from detail page, clickable card header, bulk-delete by status from the sidebar.

## Changes

**Correctness (PM proposal supersede self-heal):**
- Strip the `Proposal {id}.` Mustache-style placeholder from every prompt site — the model was echoing it literally instead of calling `propose_changes`. Affected: `pm-soul.md`, `pm-prompts/notes-intake.ts`, `pm-dispatch.ts`, and the 4 route handlers.
- `NAMED_AGENT_TIMEOUT_MS` 60s → 120s and drop the `proposeChangesAttempted` half of the tail-window gate (`pm-dispatch.ts:505`). The flag-and-timeout race was orphaning agent rows under load.
- New `tryAdoptOrphanedPlaceholder` + `sweepOrphanedPlaceholders` in `pm-proposals.ts`. MCP `propose_changes` calls the adopter post-insert and broadcasts `pm_proposal_replaced`; `instrumentation.ts` runs the sweep at boot to heal orphans left by prior crashes.

**Context strip + cross-links:**
- Widen `agent_chat_messages.metadata` shape (`trigger_kind`, `target_initiative_id`, `source_note_ids`, `audit_run_group_id`, `parent_proposal_id`, `origin`). New `buildChatContext` helper + threaded through every `postPmChatMessage` call site.
- `ChatContextStrip` component in `/pm` renders trigger badge + initiative chip + note chips + audit-run chip + refined-from + view-proposal. `enrichChatMetadata` falls back to the linked proposal so legacy rows still get badges.
- New `GET /api/initiatives/:id/pm-chat` (workspace-gated; matches direct `target_initiative_id` or notes anchored to the initiative).
- New `RecentPmActivity` rail in `InitiativeDetailView` (+ TOC entry). Click-through navigates to `/pm?focus=<message_id>` which scrolls + pulses a highlight ring.

**Proposal management UX:**
- Delete button on `/pm/proposals/[id]` (any non-accepted status) with the same `ConfirmDialog` pattern as the inline trash; navigates to `/pm` after delete.
- Inline proposal-card header on `/pm` becomes a Link to the detail page (`Maximize2` hover icon). Same treatment on the pinned standup card.
- Bulk-delete: trash button in the Recent-proposals header opens a per-status checkbox modal backed by `countProposalsByStatus` + `bulkDeleteProposalsByStatus` and `POST /api/pm/proposals/bulk-delete`. Accepted shown disabled; rejected + superseded pre-selected.

## Test plan

- [x] `yarn tsc --noEmit` clean.
- [x] `yarn docs:check` clean (frontmatter on new spec validates).
- [x] `yarn test` — 1021/1022 green. The 1 fail (`schedule-runner: produces a brief and advances run_count`) is a pre-existing flake on `main`, confirmed via `git stash` baseline.
- [x] New test coverage:
  - 5 orphan-adopt cases in `pm-proposals.test.ts`
  - 1 metadata-shape assertion extended in `pm.test.ts`
  - 1 happy-path provenance test in `ask-pm-from-notes/route.test.ts`
  - 6 endpoint cases in `pm-chat/route.test.ts` (direct anchor, note-bridged anchor, worker-agent exclusion, cross-workspace isolation, limit clamping, 404)
- [x] Preview-verify on dev (`:4010`):
  - Fresh `ask-pm-from-notes` dispatch under load: agent emitted `propose_changes` cleanly; placeholder was superseded via the retroactive adopter (not the in-flight reconciler) and `view proposal` chip rendered on the chat row.
  - Sweep-on-boot adopted the existing orphan pair in the dev DB (`c12ab760` ↔ `e0e46c09`).
  - Context strip renders all 6 chips on a notes-intake row (DOM eval confirmed positions + labels).
  - Initiative-page "Recent PM activity" rail shows 2 rows for the localhost-4000 initiative; `?focus=` deep link applies the ring.
  - Delete button visible + enabled on the rejected `c0f9c8ec…` detail page; ConfirmDialog opens.
  - Bulk-delete modal renders all 4 statuses with counts (draft 31 / accepted 5 / rejected 5 / superseded 6); confirm label updates to "Delete N"; cancel dismisses cleanly.

## Follow-ups (out of scope, flagged separately)

- `yarn test` may be silently skipping ~15 `[id]/route.test.ts` files under the current `find … -print0 | xargs … tsx --test` glob — spawned task created.
- `docs/reference/pm-chat-prompt.md` still describes the removed `Proposal {id}.` format; sync needed.
- Threading (#3) and side-drawer (#4) from the spec are deferred until volume warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)