### PR TITLE
fix(research): dispatch brief on suggestion accept + Live status column

### DIFF
--- a/src/app/(app)/jobs/page.tsx
+++ b/src/app/(app)/jobs/page.tsx
@@ -307,6 +307,7 @@ export default function JobsPage() {
             <thead className="text-[11px] uppercase tracking-wider text-mc-text-secondary">
               <tr className="text-left">
                 <Th>Kind</Th>
+                <Th>Status</Th>
                 <Th>Label</Th>
                 <Th>Agent</Th>
                 <Th>Scope</Th>
@@ -333,6 +334,11 @@ export default function JobsPage() {
                     className={`border-t border-mc-border cursor-pointer hover:bg-mc-bg-tertiary/50 ${amber ? 'bg-amber-500/10' : ''}`}
                   >
                     <Td><KindBadge kind={row.kind} /></Td>
+                    <Td>
+                      <span className={`px-1.5 py-0.5 rounded text-[11px] ${statusChipClass(row.status)}`}>
+                        {row.status}
+                      </span>
+                    </Td>
                     <Td className="text-mc-text">
                       {depth > 0 ? (
                         <span className="text-mc-text-secondary mr-2 font-mono">└─</span>

--- a/src/app/api/research/suggestions/[id]/route.ts
+++ b/src/app/api/research/suggestions/[id]/route.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/db/research-suggestions';
 import { createTopic } from '@/lib/db/topics';
 import { createBriefWithRun } from '@/lib/db/briefs';
+import { runBrief } from '@/lib/research/run-brief';
 import { logApiError } from '@/lib/debug-log';
 
 export const dynamic = 'force-dynamic';
@@ -95,6 +96,13 @@ export async function POST(
         requested_by: `suggestion:${suggestion.id}`,
       });
       const updated = markAccepted(id, created.brief.id);
+      // Fire-and-forget dispatch so the brief actually progresses
+      // instead of stranding in `queued` forever. runBrief returns as
+      // soon as the orchestrator promise is scheduled; the brief runs
+      // in the background and emits SSE for the UI.
+      runBrief(created.brief.id).catch(err => {
+        console.error(`[suggestions/accept] runBrief failed for brief ${created.brief.id}:`, err);
+      });
       return NextResponse.json(
         { suggestion: updated, created: { kind: 'brief', brief: created.brief, agent_run: created.agent_run } },
         { status: 201 },


### PR DESCRIPTION
## Summary
- Accepted research-brief suggestions now dispatch immediately instead of stranding in `queued` forever
- Live jobs table gains a Status column so queued-but-never-dispatched rows are visually distinct from actively running ones

## Changes
- `src/app/api/research/suggestions/[id]/route.ts` — after `createBriefWithRun + markAccepted`, fire-and-forget `runBrief(created.brief.id)` so the orchestrator picks the brief up. The 2026-05-09→2026-05-13 user-visible bug: a brief from an accepted suggestion sat queued for 30+ minutes with no LLM activity until manually kicked.
- `src/app/(app)/jobs/page.tsx` — add a Status column to the Live table using the existing `statusChipClass` palette (amber `queued`, cyan `running`). The Live API already includes `status IN ('queued','running')` so a stranded queued run was indistinguishable from an in-flight one.

## Test plan
- [x] Manually kick the stranded brief via `/api/briefs/{id}/run` (sanity)
- [x] Preview-verify the Live table renders the Status chip with `running` (cyan) — chip matches Recent table styling
- [x] No console errors on `/jobs`
- [ ] Accept a new brief suggestion end-to-end via UI; confirm it transitions queued → running without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)