### PR TITLE
fix(pm): tighten decompose_story prompt to discourage over-fragmentation

### DIFF
--- a/src/app/api/pm/decompose-story/route.ts
+++ b/src/app/api/pm/decompose-story/route.ts
@@ -125,7 +125,12 @@ export async function POST(request: NextRequest) {
         `See SOUL.md "Ingest recent audit findings".\n\n` +
         `Call \`propose_changes\` with trigger_kind='decompose_story' and one ` +
         `\`create_task_under_initiative\` diff per task, all targeting initiative_id='${parent.id}'. ` +
-        `Each task should be focused enough to land in a single PR. ` +
+        `Each task = one PR by one role, independently reviewable. ` +
+        `Bias toward FEWER, FATTER tasks — if two candidate tasks would naturally ` +
+        `ride in the same PR by the same role, fuse them. Do not emit ` +
+        `"task 2 and 3 can be done together by the same implementer" — that is the ` +
+        `decomposer confessing it over-fragmented; collapse them instead. ` +
+        `See SOUL.md "Decompose a story into tasks" for the full granularity contract. ` +
         `Output discipline: tool call FIRST, then a short confirmation sentence — ` +
         `do NOT echo the id or use \`{...}\` placeholder syntax (the operator UI discards freeform replies).`,
     });

--- a/src/lib/agents/pm-soul.md
+++ b/src/lib/agents/pm-soul.md
@@ -161,6 +161,39 @@ an array of `create_child_initiative` diffs. On accept the children
 are inserted under the parent in a single transaction with matching
 `initiative_parent_history` rows; sibling deps are resolved post-insert.
 
+### Decompose a story into tasks (`trigger_kind=decompose_story`)
+
+When asked to DECOMPOSE A STORY into tasks, each task must be a unit
+of **independently reviewable work** — one PR by one role, sized so an
+implementer can ship it without needing to coordinate mid-flight with
+another task in the same set. Bias toward **fewer, fatter tasks**, not
+more granular ones.
+
+**Anti-pattern — do NOT split:** if two candidate tasks would naturally
+ride in the same PR by the same role, fuse them into one task. The
+moment you find yourself writing "tasks 2 and 3 can be done together"
+or "task 3 is a small follow-up to task 2 by the same implementer,"
+that is a signal you over-fragmented — collapse them.
+
+**Legitimate reasons to split, even by the same role:**
+
+- The work crosses a real gate the implementer can't cross unsupervised
+  (migration must land + be observed in prod before the dependent column
+  ships; feature flag must deploy off before being flipped on).
+- The work spans roles (builder vs. tester vs. reviewer is enforced by
+  the role field, not by task count — but if the *implementation* and
+  the *verification* are genuinely separate sessions with handoff, two
+  tasks is correct).
+- A single PR would exceed reasonable review size (rare; usually a
+  signal the parent story was scoped too large).
+
+**Model-tier note:** task granularity is the human-review boundary, not
+the executor's context window. A small local implementer that can't
+carry a PR-sized task end-to-end is an assignment problem, not a
+decomposition problem — don't pre-fragment tasks to accommodate weaker
+implementers. The role agent's own coordinator can chunk in-context at
+dispatch time.
+
 ## When a tool returns `next_action: escalate_to_parent`
 
 You are the planner, not the doer. If you find yourself assigned to an


### PR DESCRIPTION
## Summary
- PM decompose_story over-fragments: a recent run produced 5 tasks for a story where the PM itself wrote "tasks 2 and 3 can be done by the same implementer after 1 lands" — a confession that 2 and 3 should have been one task
- Tightens the prompt contract: task = one PR by one role, fuse anything smaller
- No self-critique pass (same-session self-review anchors on the original output); revisit if prompt-only proves insufficient

## Changes
- `src/lib/agents/pm-soul.md` — new "Decompose a story into tasks" section with the explicit anti-pattern, the legitimate reasons to split (real gates, cross-role handoff, oversize PR), and a note that task granularity is the human-review boundary, not the executor's context window
- `src/app/api/pm/decompose-story/route.ts` — replace the weak "focused enough to land in a single PR" hint with the fuse-rule and a pointer to the soul section

## Test plan
- [ ] Decompose a story end-to-end via PM; confirm fewer, fatter tasks
- [ ] Confirm the model no longer emits "task 2 and 3 can be done together" language in impact_md
- [ ] Watch for over-correction (decomposes that should split staying as one) — adjust if the pendulum swung too far

🤖 Generated with [Claude Code](https://claude.com/claude-code)