### PR TITLE
feat(dispatch): inject story context into task briefings + require self-contained descriptions

### DIFF
--- a/src/app/api/pm/decompose-story/route.ts
+++ b/src/app/api/pm/decompose-story/route.ts
@@ -130,6 +130,10 @@ export async function POST(request: NextRequest) {
         `ride in the same PR by the same role, fuse them. Do not emit ` +
         `"task 2 and 3 can be done together by the same implementer" — that is the ` +
         `decomposer confessing it over-fragmented; collapse them instead. ` +
+        `Each task's \`description\` must stand alone: lead with one sentence ` +
+        `restating the parent purpose, then state the concrete deliverable, then ` +
+        `flag peer-interface boundaries (shared file paths, types, names) so the ` +
+        `implementer composes cleanly with siblings without coordinating mid-flight. ` +
         `See SOUL.md "Decompose a story into tasks" for the full granularity contract. ` +
         `Output discipline: tool call FIRST, then a short confirmation sentence — ` +
         `do NOT echo the id or use \`{...}\` placeholder syntax (the operator UI discards freeform replies).`,

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -29,6 +29,7 @@ import {
   type RoleName,
 } from '@/lib/gates/config';
 import { formatRoleSoulSection } from '@/lib/agents/role-souls';
+import { getInitiative } from '@/lib/db/initiatives';
 import { dispatchScope } from '@/lib/agents/dispatch-scope';
 import { dispatchSubagent } from '@/lib/agents/dispatch-subagent';
 import {
@@ -1002,7 +1003,56 @@ ${criteria.length > 0 ? criteria.map(c => `  - ${c}`).join('\n') : '  - (none de
       console.warn('[Dispatch] workspace context lookup failed:', (err as Error).message);
     }
 
-    const taskMessage = `${workspaceConventionsSection}${priorityEmoji} **${headline}**
+    // Story context — if the task is bound to an initiative (typical
+    // for PM-decomposed tasks), prepend the parent's title/description
+    // and the sibling task titles so the dispatched agent can ground
+    // its work in the wider intent rather than relying on the bare
+    // task row alone. Without this block the coordinator only sees
+    // title + description and has to call MCP lookups (or guess) to
+    // recover why the task exists. Bounded: parent description capped
+    // at 600 chars, sibling list capped at 10 titles.
+    let storyContextSection = '';
+    try {
+      const initiativeId = (task as Task & { initiative_id?: string | null }).initiative_id;
+      if (initiativeId) {
+        const initiative = getInitiative(initiativeId, { includeTasks: true });
+        if (initiative) {
+          const parent = initiative.parent_initiative_id
+            ? getInitiative(initiative.parent_initiative_id)
+            : null;
+          const trimDesc = (s: string | null | undefined, n: number) =>
+            !s ? '' : (s.length > n ? s.slice(0, n).trimEnd() + '…' : s);
+          const siblings = (initiative.tasks ?? [])
+            .filter(t => t.id !== task.id)
+            .slice(0, 10);
+          const lines: string[] = ['## Story context', ''];
+          lines.push(`This task belongs to ${initiative.kind} **"${initiative.title}"** (id: ${initiative.id}).`);
+          if (initiative.description) {
+            lines.push('', `> ${trimDesc(initiative.description, 600).replace(/\n+/g, ' ')}`);
+          }
+          if (parent) {
+            lines.push('', `Part of ${parent.kind} **"${parent.title}"** (id: ${parent.id}).`);
+          }
+          if (siblings.length > 0) {
+            lines.push('', 'Sibling tasks under the same initiative:');
+            for (const s of siblings) {
+              lines.push(`- ${s.title} _(${s.status})_`);
+            }
+            lines.push('');
+            lines.push(
+              'Your scope is *this task only* — do not absorb sibling work. ' +
+              'But align with peers where the interface meets (shared types, ' +
+              'naming, file boundaries) so the pieces compose.',
+            );
+          }
+          storyContextSection = lines.join('\n') + '\n\n---\n\n';
+        }
+      }
+    } catch (err) {
+      console.warn('[Dispatch] story context lookup failed:', (err as Error).message);
+    }
+
+    const taskMessage = `${workspaceConventionsSection}${storyContextSection}${priorityEmoji} **${headline}**
 
 **Title:** ${task.title}
 ${task.description ? `**Description:** ${task.description}\n` : ''}

--- a/src/lib/agents/pm-soul.md
+++ b/src/lib/agents/pm-soul.md
@@ -194,6 +194,24 @@ decomposition problem — don't pre-fragment tasks to accommodate weaker
 implementers. The role agent's own coordinator can chunk in-context at
 dispatch time.
 
+**Each `description` must stand alone.** The operator reads task cards
+out of context, and a dispatched agent may not have automatic story
+context. Every `description` must:
+
+1. Lead with one sentence restating the parent purpose — *why this task
+   exists in the story*. E.g. "Part of replacing the synth placeholder
+   on the in-flight proposal card with a real SSE-driven component."
+2. State the deliverable concretely — what code/artifact lands when
+   this task is done.
+3. Note any meaningful peer-interface boundaries — file paths, shared
+   types, names other sibling tasks depend on — so the implementer
+   composes cleanly with peers without coordinating mid-flight.
+
+Do not write descriptions like "Wire the API hook" — that's a step,
+not a self-contained brief. Write "Wire the SSE subscription hook
+`useInFlightProposalStream` that the InFlightProposalCard (peer task)
+consumes. Replaces the polling hook at `src/hooks/useProposalPolling.ts`."
+
 ## When a tool returns `next_action: escalate_to_parent`
 
 You are the planner, not the doer. If you find yourself assigned to an


### PR DESCRIPTION
## Summary
- Closes the context gap a dispatched coordinator faced: previously it saw only `title`, `description`, and operational dressing — parent initiative, sibling tasks, and story scope were invisible
- Two complementary fixes (operator-facing UI + agent-facing dispatch) so the wider intent survives at every layer

## Changes
- `src/app/api/tasks/[id]/dispatch/route.ts` — when `task.initiative_id` is set, fetch parent initiative + one level up + siblings (cap 10) and prepend a `## Story context` block to the briefing. Bounded (600-char description trim) and failure-soft (try/catch — dispatch still proceeds without the block on lookup error).
- `src/lib/agents/pm-soul.md` — new contract clause: every task `description` must stand alone — one sentence restating parent purpose, then concrete deliverable, then peer-interface boundaries. With a "do not write `Wire the API hook`" anti-example.
- `src/app/api/pm/decompose-story/route.ts` — inline prompt restates the self-contained-description requirement.

## Test plan
- [x] Typecheck clean
- [x] Probe-rendered the new section against the InFlightProposalCard task in dev DB — story title, trimmed parent description, parent epic, sibling titles all render correctly
- [ ] Dispatch a real task end-to-end and observe the briefing carries the block
- [ ] Run a decompose_story on a new candidate and confirm descriptions are self-contained

## Why both layers
- (1) protects already-existing tasks whose descriptions are bare — context arrives at dispatch time
- (2) keeps operator-facing task cards (which don't get the dispatch-time block) readable in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)