### PR TITLE
fix(pm): dedupe refine when a draft child already exists

### DIFF
--- a/src/app/api/pm/proposals/[id]/refine/route.ts
+++ b/src/app/api/pm/proposals/[id]/refine/route.ts
@@ -76,7 +76,19 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     //     (parsed out of trigger_text).
     //   - everything else → fall back to dispatchPm (the disruption-
     //     analysis synthesizer).
-    const { child } = refineProposal(id, parsed.data.additional_constraint);
+    const { child, created } = refineProposal(id, parsed.data.additional_constraint);
+
+    // Server-side dedupe: an in-flight refine already created this child
+    // slot. Return it without spinning up a second dispatch — the original
+    // dispatch is still racing to fill it in. Without this guard the route
+    // would have stacked a second 60–180s LLM run on the same parent and
+    // left a `_(refining…)_` orphan when the new dispatch lost the cleanup
+    // race (root cause of the d12533ec + 97f93775 split observed on
+    // proposal 397f8db3 — refine fired twice 14s apart, second slot
+    // never settled).
+    if (!created) {
+      return NextResponse.json({ proposal: child }, { status: 200 });
+    }
 
     let newImpactMd: string;
     let newChanges: unknown[];

--- a/src/lib/db/pm-proposals.test.ts
+++ b/src/lib/db/pm-proposals.test.ts
@@ -362,6 +362,16 @@ test('refineProposal refuses to refine an already-accepted proposal', () => {
   assert.throws(() => refineProposal(p.id, 'x'), PmProposalValidationError);
 });
 
+test('refineProposal dedupes: second call returns existing draft child with created=false', () => {
+  const ws = freshWorkspace();
+  const parent = createProposal({ workspace_id: ws, trigger_text: 'orig', impact_md: '.', proposed_changes: [] });
+  const first = refineProposal(parent.id, 'constraint A');
+  assert.equal(first.created, true);
+  const second = refineProposal(parent.id, 'constraint B');
+  assert.equal(second.created, false);
+  assert.equal(second.child.id, first.child.id);
+});
+
 // ─── Reject + idempotency ──────────────────────────────────────────
 
 test('rejectProposal flips status without applying changes', () => {

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -1648,6 +1648,15 @@ export interface RefineProposalResult {
   parent: PmProposal;
   /** The new (still-empty) draft slot. The dispatch path fills it. */
   child: PmProposal;
+  /**
+   * False when an existing draft child for this parent was returned
+   * instead of creating a new one (server-side dedupe of double-fires —
+   * client-side disable guards aren't sufficient when the route hangs
+   * 60–180s on `await dispatch.completion` and the operator clicks
+   * again). The caller must skip the dispatch step in that case to
+   * avoid layering a second in-flight LLM run on the same slot.
+   */
+  created: boolean;
 }
 
 /**
@@ -1659,6 +1668,11 @@ export interface RefineProposalResult {
  * In v1 the new draft starts with empty impact + empty changes — the
  * caller (`/api/pm/proposals/[id]/refine` route) then triggers the
  * synthesize/LLM path which rewrites both fields.
+ *
+ * Dedupe: if a draft child of `parentId` already exists, return it
+ * (`created: false`). The refine route's `await dispatch.completion`
+ * stalls 60–180s, and a second submit during that window otherwise
+ * creates a second `_(refining…)_` slot that never settles.
  */
 export function refineProposal(
   parentId: string,
@@ -1670,6 +1684,20 @@ export function refineProposal(
     throw new PmProposalValidationError(
       `proposal ${parentId} already accepted; cannot refine`,
     );
+  }
+
+  const existingDraft = queryOne<{ id: string }>(
+    `SELECT id FROM pm_proposals
+       WHERE parent_proposal_id = ? AND status = 'draft'
+       ORDER BY created_at DESC LIMIT 1`,
+    [parentId],
+  );
+  if (existingDraft) {
+    return {
+      parent,
+      child: getProposal(existingDraft.id)!,
+      created: false,
+    };
   }
 
   const childId = uuidv4();
@@ -1700,5 +1728,5 @@ export function refineProposal(
     );
   })();
 
-  return { parent: getProposal(parentId)!, child: getProposal(childId)! };
+  return { parent: getProposal(parentId)!, child: getProposal(childId)!, created: true };
 }


### PR DESCRIPTION
## Summary
- A second POST to `/api/pm/proposals/[id]/refine` while the first is still awaiting `dispatch.completion` (60–180s) was creating a duplicate `_(refining…)_` child that never settled.
- Client-side `if (refining) return` + `disabled={refining}` aren't enough when the route blocks that long.
- `refineProposal` now dedupes server-side: if a draft child of the parent exists, return it with `created: false`. The route early-returns 200 in that case, skipping the second dispatch.

## Changes
- `src/lib/db/pm-proposals.ts`: `refineProposal` returns `{ parent, child, created }`. Adds a transactional check for an existing draft child before INSERT.
- `src/app/api/pm/proposals/[id]/refine/route.ts`: skip the dispatch branch and return the existing child when `created` is false.
- `src/lib/db/pm-proposals.test.ts`: new test pins the dedupe — second call returns the same child id with `created: false`.

## Test plan
- [x] `yarn test src/lib/db` — refineProposal tests pass (supersede, refuse-accepted, dedupe).
- [x] `yarn tsc --noEmit` — clean.
- [ ] Manual UI smoke skipped: the bug is a 60–180s timing race operator-side; unit test pins the dedupe more reliably than UI clicks.

## Context
Observed on proposal `397f8db3-3171-458d-8870-642097fab649`:
- Two children created 14.2s apart (`d12533ec` accepted; `97f93775` stalled `_(refining…)_`).
- Separate issue not addressed here: the agent's chat session received the same `correlation_id` 3× — that's gateway-side replay (MC mints fresh uuids per dispatch and the openclaw client doesn't retry). Tracked separately.