### PR TITLE
fix(convoy): enforce depends_on_subtask_ids as a hard dispatch gate

### DIFF
--- a/agent-templates/coordinator/SOUL.md
+++ b/agent-templates/coordinator/SOUL.md
@@ -25,7 +25,12 @@ You are a Mission Control **Coordinator** subagent. You're spawned for a single 
 - **ALWAYS** declare every required field on `spawn_subtask` (slice, message, expected_deliverables, acceptance_criteria, expected_duration_minutes). The tool rejects partial calls.
 - **NEVER** chat directly to peer sessions. The convoy IS the channel — your delegations + their state changes are the conversation.
 - **NEVER** `sessions_spawn` (openclaw native). Subagent spawning is reserved for the workspace PM via the META envelope flow; coordinators delegate via `spawn_subtask` (which goes through Mission Control, not openclaw).
-- **PREFER** parallel slices when work is independent — fan-out reduces wall-clock time. Use `depends_on_subtask_ids` only when there's a real ordering constraint.
+- **PREFER** parallel slices when work is independent — fan-out reduces wall-clock time. When there IS an ordering constraint (e.g. tester / reviewer wait for the builder), you **MUST** pass `depends_on_subtask_ids` on the dependent `spawn_subtask` calls. Mission Control honors that field as a hard gate: dependent subtasks stay queued (no dispatch, no briefing sent) until each dep transitions to `done` via `update_subtask({action: "accept"})`. Prose like "Prerequisites: wait for the builder" in the message body is **not enforced** — the subagent will receive the briefing immediately and start work. Example:
+  ```
+  const builder  = spawn_subtask({ role: 'builder',  slice: '...', ... });
+  const tester   = spawn_subtask({ role: 'tester',   slice: '...', ..., depends_on_subtask_ids: [builder.subtask_id] });
+  const reviewer = spawn_subtask({ role: 'reviewer', slice: '...', ..., depends_on_subtask_ids: [builder.subtask_id] });
+  ```
 - **FLAG** scope creep immediately. If the parent task balloons, mail the workspace PM (`send_mail`) — don't quietly add slices.
 
 ## Coordination process

--- a/src/components/TeamTab.tsx
+++ b/src/components/TeamTab.tsx
@@ -28,6 +28,7 @@ export function TeamTab({ taskId, workspaceId }: TeamTabProps) {
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [convoyActive, setConvoyActive] = useState(false);
 
   // Load existing roles and workflows
   useEffect(() => {
@@ -57,6 +58,12 @@ export function TeamTab({ taskId, workspaceId }: TeamTabProps) {
         if (taskRes.ok) {
           const task = await taskRes.json();
           setSelectedWorkflow(task.workflow_template_id || '');
+          // A coordinator-spawned convoy puts the PARENT task in
+          // `convoy_active` (the per-child `convoy_id` is set on the
+          // children, not the parent — see convoy.ts:spawnDelegationSubtask).
+          // Either signal qualifies: the parent's status or, for a child
+          // task viewed directly, its own convoy_id membership.
+          setConvoyActive(task.status === 'convoy_active' || !!task.convoy_id);
         }
       } catch (err) {
         console.error('Failed to load team data:', err);
@@ -237,8 +244,28 @@ export function TeamTab({ taskId, workspaceId }: TeamTabProps) {
         </div>
       )}
 
+      {/* Live convoy banner — when a coordinator has spawned subtasks
+          ad-hoc, this tab's template-derived roles are stale advisory
+          info, not the source of truth. Point the operator at the
+          Convoy tab and suppress the missing-roles warning. */}
+      {convoyActive && (
+        <div className="p-3 bg-blue-500/10 border border-blue-500/30 rounded-lg">
+          <div className="flex items-start gap-2">
+            <CheckCircle2 className="w-4 h-4 text-blue-300 mt-0.5 shrink-0" />
+            <div>
+              <p className="text-sm text-blue-200">
+                Live convoy active — see the Convoy tab for the actual delegations and their status.
+              </p>
+              <p className="text-xs text-blue-300/70 mt-1">
+                The stages + role assignments below describe the workflow template, not the running convoy.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Missing Roles Warning */}
-      {missingRoles.length > 0 && (
+      {!convoyActive && missingRoles.length > 0 && (
         <div className="p-3 bg-orange-500/10 border border-orange-500/30 rounded-lg">
           <div className="flex items-start gap-2">
             <AlertCircle className="w-4 h-4 text-orange-300 mt-0.5 shrink-0" />

--- a/src/lib/mcp/groups/work.ts
+++ b/src/lib/mcp/groups/work.ts
@@ -24,7 +24,7 @@ import { sendAgentMail } from '@/lib/services/agent-mailbox';
 import { saveKnowledge, searchKnowledge } from '@/lib/services/knowledge';
 import { getUnreadMail } from '@/lib/mailbox';
 import { getOpenClawClient } from '@/lib/openclaw/client';
-import { spawnDelegationSubtask } from '@/lib/convoy';
+import { spawnDelegationSubtask, dispatchReadyConvoySubtasks } from '@/lib/convoy';
 import { internalDispatch } from '@/lib/internal-dispatch';
 import { upsertSession, type ScopeType } from '@/lib/db/mc-sessions';
 import {
@@ -98,7 +98,17 @@ async function acceptSubtaskImpl(args: { agent_id: string; subtask_id: string })
   const convoyId = queryOne<{ convoy_id: string }>(
     'SELECT convoy_id FROM convoy_subtasks WHERE id = ?', [args.subtask_id],
   )?.convoy_id;
-  if (convoyId) checkConvoyCompletion(convoyId);
+  if (convoyId) {
+    checkConvoyCompletion(convoyId);
+    // Release any siblings whose depends_on now resolves. Subtasks
+    // spawned with unsatisfied deps stay in 'inbox' (see spawn_subtask
+    // dep gate); this is the matching release path. Best-effort — a
+    // dispatch failure surfaces in the convoy view, not as an accept
+    // error, since the accept itself already succeeded.
+    void dispatchReadyConvoySubtasks(convoyId).catch(err => {
+      console.warn('[update_subtask:accept] dispatchReadyConvoySubtasks failed:', (err as Error).message);
+    });
+  }
 
   return textResult(`Accepted subtask ${args.subtask_id}.`, {
     subtask_id: args.subtask_id,
@@ -1481,6 +1491,52 @@ export function registerWorkTools(server: McpServer): void {
         activityType: 'updated',
         message: `[delegation_spawned] peer=${peer.name} role=${peerRoleForLog}${peerGatewayForLog ? ` gateway_id=${peerGatewayForLog}` : ''} addressed_via=${resolvedVia} child_task=${spawn.childTaskId} due_at=${spawn.dueAt} slice="${args.slice.replace(/"/g, "'")}"`,
       });
+
+      // Dep gate: if any depends_on_subtask_ids aren't done yet, leave
+      // the child task in 'inbox' so dispatchReadyConvoySubtasks (called
+      // from acceptSubtaskImpl when a parent dep completes) picks it up
+      // later. Without this gate every spawn_subtask immediately ran
+      // its briefing through the gateway regardless of declared
+      // dependencies — tester/reviewer briefings landed before the
+      // builder branch even existed.
+      const depIds = args.depends_on_subtask_ids ?? [];
+      const unsatisfiedDeps = depIds.length > 0
+        ? queryAll<{ id: string; task_status: string }>(
+            `SELECT cs.id, t.status as task_status
+               FROM convoy_subtasks cs JOIN tasks t ON t.id = cs.task_id
+              WHERE cs.id IN (${depIds.map(() => '?').join(',')})`,
+            depIds,
+          ).filter(r => r.task_status !== 'done').map(r => r.id)
+        : [];
+
+      if (unsatisfiedDeps.length > 0) {
+        logActivity({
+          taskId: args.task_id,
+          actingAgentId: args.agent_id,
+          activityType: 'updated',
+          message: `[delegation_queued] child_task=${spawn.childTaskId} awaiting_deps=${unsatisfiedDeps.join(',')}`,
+        });
+        const payload = {
+          subtask_id: spawn.subtaskId,
+          child_task_id: spawn.childTaskId,
+          convoy_id: spawn.convoyId,
+          peer: {
+            id: peer.id,
+            name: peer.name,
+            role: peerRoleForLog,
+            gateway_agent_id: peer.gateway_agent_id,
+            addressed_via: resolvedVia,
+          },
+          dispatched_at: null,
+          due_at: spawn.dueAt,
+          checkin_interval_minutes: checkinInterval,
+          awaiting_deps: unsatisfiedDeps,
+        };
+        return textResult(
+          `Queued subtask ${spawn.subtaskId} to ${peer.name} (role: ${peerRoleForLog}). Awaiting ${unsatisfiedDeps.length} dependenc${unsatisfiedDeps.length === 1 ? 'y' : 'ies'}; dispatches automatically when each dep is accepted.`,
+          payload,
+        );
+      }
 
       // Move child to 'assigned' before dispatch so the dispatch route
       // sees a valid state. The convoy dispatcher does the same.


### PR DESCRIPTION
## Summary
- A coordinator that called `spawn_subtask` for builder + tester + reviewer (with the tester/reviewer task descriptions saying "wait for the builder") saw all three briefings land at the gateway within ~30s. The descendants started clicking around before the builder branch existed.
- Root cause: `spawn_subtask` recorded `depends_on_subtask_ids` but immediately invoked `internalDispatch` regardless. The dependency check only existed in `getDispatchableSubtasks`, consulted by the convoy auto-dispatcher — not by coordinator delegations.
- This change adds the gate at the spawn path and a matching release at the accept path.

## Changes
- `src/lib/mcp/groups/work.ts`
  - `spawn_subtask`: when any `depends_on_subtask_ids` aren't `done`, leave the child task in `inbox` and skip `internalDispatch`. Return success with `awaiting_deps` populated so the coordinator sees the queued state.
  - `update_subtask` accept handler: after the child transitions to `done`, call `dispatchReadyConvoySubtasks(convoyId)` to release any siblings whose deps are now satisfied.
- `agent-templates/coordinator/SOUL.md`: state that `depends_on_subtask_ids` is the system-enforced gate, with a builder→tester/reviewer example. Prose prerequisites in the message body are NOT enforced.
- `src/components/TeamTab.tsx`: when `task.status === 'convoy_active'` or `task.convoy_id` is set, show a "Live convoy active — see Convoy tab" banner and suppress the misleading "Missing agents for: builder" warning. The template-derived role list is advisory in that state, not a source of truth.

## Test plan
- [x] `yarn tsc --noEmit` — clean.
- [x] `yarn test src/lib/mcp` — passes (no regressions; coordinator/escalate tests green).
- [x] Preview verified: banner renders on the convoy-active parent task's Team tab; "Missing agents" warning suppressed; the template stages remain visible labelled as advisory. Screenshot in the conversation.

## Out of scope
- The gateway-side trigger replay (same `correlation_id` ×3) noted on the parent PM proposal — that's an openclaw issue, not MC.