### PR TITLE
feat(convoy): plan_convoy — submit the full DAG in one tool call

### DIFF
--- a/agent-templates/coordinator/SOUL.md
+++ b/agent-templates/coordinator/SOUL.md
@@ -25,11 +25,15 @@ You are a Mission Control **Coordinator** subagent. You're spawned for a single 
 - **ALWAYS** declare every required field on `spawn_subtask` (slice, message, expected_deliverables, acceptance_criteria, expected_duration_minutes). The tool rejects partial calls.
 - **NEVER** chat directly to peer sessions. The convoy IS the channel — your delegations + their state changes are the conversation.
 - **NEVER** `sessions_spawn` (openclaw native). Subagent spawning is reserved for the workspace PM via the META envelope flow; coordinators delegate via `spawn_subtask` (which goes through Mission Control, not openclaw).
-- **PREFER** parallel slices when work is independent — fan-out reduces wall-clock time. When there IS an ordering constraint (e.g. tester / reviewer wait for the builder), you **MUST** pass `depends_on_subtask_ids` on the dependent `spawn_subtask` calls. Mission Control honors that field as a hard gate: dependent subtasks stay queued (no dispatch, no briefing sent) until each dep transitions to `done` via `update_subtask({action: "accept"})`. Prose like "Prerequisites: wait for the builder" in the message body is **not enforced** — the subagent will receive the briefing immediately and start work. Example:
+- **PREFER `plan_convoy` for the initial fan-out.** It takes the full DAG in a single call — slices reference each other by symbolic id via `depends_on`, MC validates topology (no cycles, all peers resolvable) before any briefing fires, and dependent slices stay queued (`inbox`, no chat.send) until their prerequisites are accepted. Use `spawn_subtask` only for single slices or for follow-ups discovered after monitoring. Mission Control honors `depends_on` (in `plan_convoy`) and `depends_on_subtask_ids` (in `spawn_subtask`) as a HARD gate. Prose like "Prerequisites: wait for the builder" inside a `message` field is **not enforced** — the subagent will receive the briefing immediately and start work. Example:
   ```
-  const builder  = spawn_subtask({ role: 'builder',  slice: '...', ... });
-  const tester   = spawn_subtask({ role: 'tester',   slice: '...', ..., depends_on_subtask_ids: [builder.subtask_id] });
-  const reviewer = spawn_subtask({ role: 'reviewer', slice: '...', ..., depends_on_subtask_ids: [builder.subtask_id] });
+  plan_convoy({
+    slices: [
+      { id: 'builder',  role: 'builder',  slice: '...', ... },
+      { id: 'tester',   role: 'tester',   slice: '...', ..., depends_on: ['builder'] },
+      { id: 'reviewer', role: 'reviewer', slice: '...', ..., depends_on: ['builder'] },
+    ],
+  })
   ```
 - **FLAG** scope creep immediately. If the parent task balloons, mail the workspace PM (`send_mail`) — don't quietly add slices.
 

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -701,22 +701,52 @@ If a tool returns \`MCP endpoint is disabled\` (HTTP 503), the operator has the 
 
 If the answer to all three is "no", spawn one builder subtask and accept it when delivered. If any is "yes", spawn the additional slices explicitly — typically a tester or reviewer subtask gated on the builder's deliverable. Skip ceremony when it isn't earned; add gates when the work needs them.
 
-**Per peer, call once:**
+**For a multi-slice fan-out, use \`plan_convoy\` (single tool call, full DAG):**
+\`\`\`
+plan_convoy({
+  agent_id: "${agentId}",
+  task_id: "${taskIdForMcp}",
+  slices: [
+    {
+      id: "builder",
+      role: "builder",
+      slice: "<what builder owns>",
+      message: "<brief>",
+      expected_deliverables: [ { title: "<...>", kind: "file" } ],
+      acceptance_criteria: [ "<...>" ],
+      expected_duration_minutes: 60
+    },
+    {
+      id: "tester",
+      role: "tester",
+      slice: "<what tester owns>",
+      message: "<brief>",
+      expected_deliverables: [ { title: "<...>", kind: "report" } ],
+      acceptance_criteria: [ "<...>" ],
+      expected_duration_minutes: 30,
+      depends_on: [ "builder" ]    // tester briefing held until builder is accepted
+    }
+  ]
+})
+\`\`\`
+
+\`plan_convoy\` validates the DAG (no cycles, all peers resolvable) BEFORE any briefing fires. Dependent slices stay queued (\`inbox\`, no chat.send) until their prerequisites are \`accept\`ed — the system enforces ordering. Prose like "wait for the builder" in a \`message\` field is NOT enforced; only \`depends_on\` is.
+
+**For a single slice OR a follow-up after monitoring, use \`spawn_subtask\`:**
 \`\`\`
 spawn_subtask({
   agent_id: "${agentId}",
   task_id: "${taskIdForMcp}",
-  peer_gateway_id: "<mc-researcher | mc-writer | …>",
+  role: "<builder | tester | reviewer | …>",
   slice: "<one-line summary of what this peer owns>",
   message: "You are the <role> for this task.\\n\\n<context + why this slice exists>",
   expected_deliverables: [ { title: "<name>", kind: "file" | "note" | "report" } ],
   acceptance_criteria: [ "<criterion 1>", "<criterion 2>" ],
   expected_duration_minutes: 30,
-  checkin_interval_minutes: 15
+  checkin_interval_minutes: 15,
+  depends_on_subtask_ids: [ "<prior subtask_id>" ]  // optional; same hard-gate semantics as plan_convoy
 })
 \`\`\`
-
-\`spawn_subtask\` creates a tracked convoy subtask with the SLO you declare, dispatches the peer through the normal pipeline, and returns a \`subtask_id\`. The peer sees your contract inline in its briefing.
 
 **While peers are working, check on them:**
 \`\`\`

--- a/src/lib/mcp/groups/work.ts
+++ b/src/lib/mcp/groups/work.ts
@@ -228,6 +228,83 @@ async function cancelSubtaskImpl(args: { agent_id: string; subtask_id: string; r
   });
 }
 
+// Peer-resolution helper shared by spawn_subtask + plan_convoy. Returns
+// either the resolved agent row + addressing axis, or a structured error
+// describing why it couldn't resolve. Mirrors the inline resolver in the
+// spawn_subtask handler exactly — kept terse because plan_convoy needs
+// to aggregate errors across many slices rather than short-circuit on
+// the first one. (spawn_subtask still uses its own inline copy because
+// its error text is hand-tuned for the single-slice case.)
+type DelegationPeerRow = {
+  id: string;
+  name: string;
+  role: string | null;
+  gateway_agent_id: string | null;
+};
+type ResolvePeerOk = {
+  ok: true;
+  peer: DelegationPeerRow;
+  resolvedVia: 'role' | 'peer_agent_id' | 'peer_gateway_id';
+};
+type ResolvePeerErr = {
+  ok: false;
+  code: string;
+  message: string;
+  addressing: Record<string, string>;
+};
+function resolveDelegationPeer(
+  axes: { role?: string; peer_agent_id?: string; peer_gateway_id?: string },
+  parentWs: string,
+): ResolvePeerOk | ResolvePeerErr {
+  const provided = [axes.role, axes.peer_agent_id, axes.peer_gateway_id]
+    .filter((v): v is string => typeof v === 'string' && v.length > 0);
+  if (provided.length === 0) {
+    return { ok: false, code: 'peer_addressing_missing', message: 'Specify exactly one of role / peer_agent_id / peer_gateway_id.', addressing: {} };
+  }
+  if (provided.length > 1) {
+    return { ok: false, code: 'peer_addressing_conflict', message: 'role / peer_agent_id / peer_gateway_id are mutually exclusive.', addressing: {} };
+  }
+  if (axes.role) {
+    const peer = queryOne<DelegationPeerRow>(
+      `SELECT id, name, role, gateway_agent_id FROM agents
+        WHERE role = ?
+          AND COALESCE(workspace_id, 'default') = ?
+          AND COALESCE(status, 'standby') != 'offline'
+          AND COALESCE(is_active, 1) = 1
+        ORDER BY updated_at DESC LIMIT 1`,
+      [axes.role, parentWs],
+    );
+    if (!peer) {
+      return { ok: false, code: 'peer_not_found', message: `No active agent with role "${axes.role}" in workspace ${parentWs}.`, addressing: { role: axes.role } };
+    }
+    return { ok: true, peer, resolvedVia: 'role' };
+  }
+  if (axes.peer_agent_id) {
+    const peer = queryOne<DelegationPeerRow & { workspace_id: string | null }>(
+      `SELECT id, name, role, gateway_agent_id, workspace_id FROM agents WHERE id = ? LIMIT 1`,
+      [axes.peer_agent_id],
+    );
+    if (!peer) {
+      return { ok: false, code: 'peer_not_found', message: `No agent with id "${axes.peer_agent_id}".`, addressing: { peer_agent_id: axes.peer_agent_id } };
+    }
+    const isOrgRunner = peer.gateway_agent_id === 'mc-runner' || peer.gateway_agent_id === 'mc-runner-dev';
+    const peerWs = peer.workspace_id ?? 'default';
+    if (peerWs !== parentWs && !isOrgRunner) {
+      return { ok: false, code: 'peer_not_in_workspace', message: `Peer "${peer.name}" is in workspace ${peerWs}, not ${parentWs}.`, addressing: { peer_agent_id: axes.peer_agent_id } };
+    }
+    return { ok: true, peer: { id: peer.id, name: peer.name, role: peer.role, gateway_agent_id: peer.gateway_agent_id }, resolvedVia: 'peer_agent_id' };
+  }
+  const gwId = axes.peer_gateway_id as string;
+  const isOrgRunner = gwId === 'mc-runner' || gwId === 'mc-runner-dev';
+  const peer = isOrgRunner
+    ? queryOne<DelegationPeerRow>(`SELECT id, name, role, gateway_agent_id FROM agents WHERE gateway_agent_id = ? LIMIT 1`, [gwId])
+    : queryOne<DelegationPeerRow>(`SELECT id, name, role, gateway_agent_id FROM agents WHERE gateway_agent_id = ? AND COALESCE(workspace_id, 'default') = ? LIMIT 1`, [gwId, parentWs]);
+  if (!peer) {
+    return { ok: false, code: 'peer_not_found', message: `No agent with gateway_agent_id "${gwId}" in workspace ${parentWs}.`, addressing: { peer_gateway_id: gwId } };
+  }
+  return { ok: true, peer, resolvedVia: 'peer_gateway_id' };
+}
+
 export function registerWorkTools(server: McpServer): void {
   // get_task ──────────────────────────────────────────────────────
   server.registerTool(
@@ -1591,6 +1668,236 @@ export function registerWorkTools(server: McpServer): void {
       return textResult(
         `Spawned subtask ${spawn.subtaskId} to ${peerLabel}. Due at ${spawn.dueAt}; check-in cadence ${checkinInterval}m.`,
         payload,
+      );
+    }),
+  );
+
+  // plan_convoy ───────────────────────────────────────────────────
+  // Coordinator-only. Submits the full DAG for a parent task in a
+  // single tool call. Slices reference each other by symbolic `id`
+  // (string the coordinator picks); the tool validates the topology,
+  // resolves every peer up front, then creates convoy_subtasks rows
+  // in topological order with resolved `depends_on_subtask_ids`. Roots
+  // dispatch immediately; dependent slices stay in `inbox` until their
+  // deps complete (the gate landed in PR #344). Use this for the
+  // initial fan-out — use `spawn_subtask` for follow-ups discovered
+  // mid-flight.
+  server.registerTool(
+    'plan_convoy',
+    {
+      title: 'Submit the full convoy DAG in one call (coordinator-only)',
+      description:
+        "Atomic decomposition: declares every slice + its dependencies as one structured plan. Dependent slices stay queued (no briefing sent) until each prerequisite is accepted. Use this instead of issuing N sequential spawn_subtask calls — it forces topology-first thinking and rejects cycles / orphan refs before any briefing fires. spawn_subtask remains for late additions.",
+      inputSchema: {
+        agent_id: agentIdArg.describe('The calling coordinator agent.'),
+        task_id: taskIdArg.describe("The coordinator's parent task id."),
+        slices: z
+          .array(
+            z.object({
+              id: z.string().min(1).max(40).regex(/^[a-zA-Z0-9_-]+$/).describe('Symbolic slice id (e.g. "builder", "test"). Used by depends_on; not stored.'),
+              role: z.string().min(1).optional(),
+              peer_agent_id: z.string().min(1).optional(),
+              peer_gateway_id: z.string().min(1).optional(),
+              slice: z.string().min(10).max(500),
+              message: z.string().min(1).max(10000),
+              expected_deliverables: z
+                .array(z.object({ title: z.string().min(1).max(200), kind: z.enum(['file', 'note', 'report']) }))
+                .min(1),
+              acceptance_criteria: z.array(z.string().min(10).max(500)).min(1),
+              expected_duration_minutes: z.number().int().min(5).max(240),
+              checkin_interval_minutes: z.number().int().min(5).max(60).optional(),
+              depends_on: z.array(z.string().min(1).max(40)).optional().describe('Symbolic ids of other slices in this plan that must complete first.'),
+            }),
+          )
+          .min(1)
+          .max(12)
+          .describe('The full slice list. Max 12 per plan; if you need more, split into multiple plan_convoy calls or use spawn_subtask follow-ups.'),
+      },
+      annotations: { destructiveHint: true, openWorldHint: false },
+    },
+    trace('plan_convoy', async (args) => {
+      const { assertAgentCanActOnTask, AuthzError, setTaskCompletionLock } =
+        await import('@/lib/authz/agent-task');
+      try {
+        assertAgentCanActOnTask(args.agent_id, args.task_id, 'delegate');
+      } catch (err) {
+        if (err instanceof AuthzError && err.code === 'agent_not_coordinator') {
+          setTaskCompletionLock(args.task_id, 'agent_not_coordinator');
+          return {
+            isError: true,
+            content: [{ type: 'text', text: 'You are not the coordinator for this task and cannot delegate. The task is now locked pending escalation: your only valid next call is escalate_to_parent({ task_id, agent_id, reason }).' }],
+            structuredContent: { error: 'agent_not_coordinator', next_action: 'escalate_to_parent' },
+          };
+        }
+        throw err;
+      }
+
+      const parent = queryOne<{ is_subtask: number | null; workspace_id: string | null }>(
+        'SELECT is_subtask, workspace_id FROM tasks WHERE id = ?',
+        [args.task_id],
+      );
+      if (!parent) {
+        return { isError: true, content: [{ type: 'text', text: `Parent task ${args.task_id} not found.` }], structuredContent: { error: 'task_not_found' } };
+      }
+      if (parent.is_subtask === 1) {
+        return { isError: true, content: [{ type: 'text', text: 'Peer sub-delegation is not allowed — your task is itself a subtask.' }], structuredContent: { error: 'peer_sub_delegation_blocked' } };
+      }
+      const parentWs = parent.workspace_id ?? 'default';
+
+      // ── DAG validation ─────────────────────────────────────────
+      const ids = new Set<string>();
+      for (const s of args.slices) {
+        if (ids.has(s.id)) {
+          return { isError: true, content: [{ type: 'text', text: `Duplicate slice id "${s.id}".` }], structuredContent: { error: 'duplicate_slice_id', id: s.id } };
+        }
+        ids.add(s.id);
+      }
+      for (const s of args.slices) {
+        for (const dep of s.depends_on ?? []) {
+          if (!ids.has(dep)) {
+            return { isError: true, content: [{ type: 'text', text: `Slice "${s.id}" depends on unknown id "${dep}".` }], structuredContent: { error: 'unknown_dep', slice_id: s.id, dep } };
+          }
+          if (dep === s.id) {
+            return { isError: true, content: [{ type: 'text', text: `Slice "${s.id}" depends on itself.` }], structuredContent: { error: 'self_dependency', slice_id: s.id } };
+          }
+        }
+      }
+      // Topological sort via Kahn's algorithm. Surfaces cycles before
+      // any row is written.
+      const inDegree = new Map<string, number>();
+      const outEdges = new Map<string, string[]>();
+      for (const s of args.slices) {
+        inDegree.set(s.id, (s.depends_on ?? []).length);
+        for (const dep of s.depends_on ?? []) {
+          const arr = outEdges.get(dep) ?? [];
+          arr.push(s.id);
+          outEdges.set(dep, arr);
+        }
+      }
+      const ready: string[] = [];
+      for (const [id, deg] of inDegree) if (deg === 0) ready.push(id);
+      const topo: string[] = [];
+      while (ready.length > 0) {
+        const id = ready.shift()!;
+        topo.push(id);
+        for (const next of outEdges.get(id) ?? []) {
+          const d = (inDegree.get(next) ?? 0) - 1;
+          inDegree.set(next, d);
+          if (d === 0) ready.push(next);
+        }
+      }
+      if (topo.length !== args.slices.length) {
+        const stuck = args.slices.filter(s => !topo.includes(s.id)).map(s => s.id);
+        return { isError: true, content: [{ type: 'text', text: `Cycle detected: slices ${stuck.join(', ')} form a dependency loop.` }], structuredContent: { error: 'cycle_detected', stuck } };
+      }
+
+      // ── Peer resolution pre-pass (collect ALL errors before writes) ─
+      const resolved = new Map<string, { peer: DelegationPeerRow; resolvedVia: 'role' | 'peer_agent_id' | 'peer_gateway_id' }>();
+      const peerErrors: Array<{ slice_id: string; code: string; message: string }> = [];
+      for (const s of args.slices) {
+        const r = resolveDelegationPeer(
+          { role: s.role, peer_agent_id: s.peer_agent_id, peer_gateway_id: s.peer_gateway_id },
+          parentWs,
+        );
+        if (!r.ok) peerErrors.push({ slice_id: s.id, code: r.code, message: r.message });
+        else resolved.set(s.id, { peer: r.peer, resolvedVia: r.resolvedVia });
+      }
+      if (peerErrors.length > 0) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `Could not resolve ${peerErrors.length} peer(s):\n${peerErrors.map(e => `- ${e.slice_id}: ${e.message}`).join('\n')}` }],
+          structuredContent: { error: 'peer_resolution_failed', failures: peerErrors },
+        };
+      }
+
+      // ── Create rows in topological order so depends_on_subtask_ids
+      //    resolves cleanly per slice.
+      const symbolicToSubtaskId = new Map<string, string>();
+      const symbolicToChildTaskId = new Map<string, string>();
+      const slicesById = new Map(args.slices.map(s => [s.id, s] as const));
+      const created: Array<{
+        symbolic_id: string;
+        subtask_id: string;
+        child_task_id: string;
+        peer: { id: string; name: string; role: string; gateway_agent_id: string | null; addressed_via: string };
+        depends_on_subtask_ids: string[];
+        due_at: string;
+        will_dispatch_immediately: boolean;
+      }> = [];
+
+      let convoyId: string | null = null;
+      for (const symId of topo) {
+        const s = slicesById.get(symId)!;
+        const r = resolved.get(symId)!;
+        const checkin = s.checkin_interval_minutes ?? 15;
+        const depSubtaskIds = (s.depends_on ?? []).map(d => symbolicToSubtaskId.get(d)!).filter(Boolean);
+        const peerRoleForLog = r.peer.role ?? s.role ?? 'builder';
+
+        const spawn = spawnDelegationSubtask({
+          parentTaskId: args.task_id,
+          parentAgentId: args.agent_id,
+          peerAgentId: r.peer.id,
+          peerGatewayId: r.peer.gateway_agent_id ?? '',
+          suggestedRole: peerRoleForLog,
+          slice: s.slice,
+          message: s.message,
+          expectedDeliverables: s.expected_deliverables,
+          acceptanceCriteria: s.acceptance_criteria,
+          expectedDurationMinutes: s.expected_duration_minutes,
+          checkinIntervalMinutes: checkin,
+          dependsOnSubtaskIds: depSubtaskIds.length > 0 ? depSubtaskIds : undefined,
+        });
+        convoyId = spawn.convoyId;
+        symbolicToSubtaskId.set(symId, spawn.subtaskId);
+        symbolicToChildTaskId.set(symId, spawn.childTaskId);
+
+        logActivity({
+          taskId: args.task_id,
+          actingAgentId: args.agent_id,
+          activityType: 'updated',
+          message: `[delegation_spawned] (plan_convoy) peer=${r.peer.name} role=${peerRoleForLog} child_task=${spawn.childTaskId} deps=${depSubtaskIds.length} slice="${s.slice.replace(/"/g, "'")}"`,
+        });
+
+        created.push({
+          symbolic_id: symId,
+          subtask_id: spawn.subtaskId,
+          child_task_id: spawn.childTaskId,
+          peer: {
+            id: r.peer.id,
+            name: r.peer.name,
+            role: peerRoleForLog,
+            gateway_agent_id: r.peer.gateway_agent_id,
+            addressed_via: r.resolvedVia,
+          },
+          depends_on_subtask_ids: depSubtaskIds,
+          due_at: spawn.dueAt,
+          will_dispatch_immediately: depSubtaskIds.length === 0,
+        });
+      }
+
+      // ── Fire root slices via the shared dispatcher. The dep gate
+      //    already keeps everything else in `inbox`; this single call
+      //    picks up just the deps-free roots and respects the
+      //    MAX_PARALLEL_CONVOY_SUBTASKS cap.
+      let dispatchSummary: { dispatched: number; total: number; skipped?: string } | null = null;
+      if (convoyId) {
+        try {
+          const r = await dispatchReadyConvoySubtasks(convoyId);
+          dispatchSummary = { dispatched: r.dispatched, total: r.total, skipped: r.skipped };
+        } catch (err) {
+          console.warn('[plan_convoy] dispatchReadyConvoySubtasks failed:', (err as Error).message);
+        }
+      }
+
+      const rootCount = created.filter(c => c.will_dispatch_immediately).length;
+      const depCount = created.length - rootCount;
+      return textResult(
+        `Convoy planned: ${created.length} slice${created.length === 1 ? '' : 's'} (${rootCount} root${rootCount === 1 ? '' : 's'} dispatching now, ${depCount} queued behind deps).`,
+        {
+          convoy_id: convoyId,
+          slices: created,
+          dispatch_summary: dispatchSummary,
+        },
       );
     }),
   );

--- a/src/lib/mcp/mcp.test.ts
+++ b/src/lib/mcp/mcp.test.ts
@@ -79,6 +79,7 @@ test('tools/list returns the full sc-mission-control tool surface', async () => 
     // Coordinator delegation surface (replaces the old `delegate` tool).
     // See docs/archive/coordinator-delegation-via-convoy-spec.md §3.
     'spawn_subtask',
+    'plan_convoy',
     'list_my_subtasks',
     'update_subtask',
     // Slice 3 of review-stage-robustness: escape hatch when an agent
@@ -124,7 +125,7 @@ test('PM-scoped server (core+read+pm) excludes worker + crud tools', async () =>
   }
   // Worker absent
   for (const t of ['register_deliverable', 'submit_evidence', 'update_task_status', 'fail_task',
-                   'spawn_subtask', 'update_subtask', 'escalate_to_parent',
+                   'spawn_subtask', 'plan_convoy', 'update_subtask', 'escalate_to_parent',
                    'register_subagent_dispatch', 'update_note']) {
     assert.ok(!names.has(t), `pm mount must not expose worker tool ${t}`);
   }
@@ -153,16 +154,17 @@ test('CRUD-scoped server (core+read+crud) excludes worker + pm tools', async () 
     assert.ok(!names.has(t), `crud mount must not expose pm tool ${t}`);
   }
   // Worker absent
-  for (const t of ['register_deliverable', 'spawn_subtask']) {
+  for (const t of ['register_deliverable', 'spawn_subtask', 'plan_convoy']) {
     assert.ok(!names.has(t), `crud mount must not expose worker tool ${t}`);
   }
 });
 
-test('default server (no groups arg) keeps full union of 45 tools', async () => {
+test('default server (no groups arg) keeps full union of 47 tools', async () => {
   const names = await listToolsForGroups(undefined);
-  // 46 tools after Slice 3 of review-stage-robustness adds escalate_to_parent.
-  // (45 after read_brief; 44 after the update_subtask / update_note collapses.)
-  assert.equal(names.size, 46, `expected 46 tools, got ${names.size}: ${[...names].sort().join(', ')}`);
+  // 47 tools after plan_convoy. (46 after escalate_to_parent; 45 after
+  // read_brief; 44 after the update_subtask / update_note collapses.)
+  assert.equal(names.size, 47, `expected 47 tools, got ${names.size}: ${[...names].sort().join(', ')}`);
+  assert.ok(names.has('plan_convoy'), 'plan_convoy should be present');
   assert.ok(names.has('read_brief'), 'read_brief should be present');
   // Make absences explicit so a regression has a clear failure.
   for (const removed of ['accept_subtask', 'reject_subtask', 'cancel_subtask', 'mark_note_consumed', 'archive_note']) {
@@ -846,6 +848,103 @@ test('spawn_subtask: agent_not_coordinator sets soft-lock and returns next_actio
 
   // Sanity: peer agent exists so spawn would otherwise validate.
   void peer;
+});
+
+test('plan_convoy: validates DAG, dispatches roots only, queues dependents', async () => {
+  const { client } = await makePair();
+  const coordinator = seedAgent({ role: 'coordinator' });
+  seedAgent({ role: 'builder' });
+  seedAgent({ role: 'tester' });
+  seedAgent({ role: 'reviewer' });
+  const parent = seedTask({ assigned: coordinator, status: 'in_progress' });
+
+  const res = await client.callTool({
+    name: 'plan_convoy',
+    arguments: {
+      agent_id: coordinator,
+      task_id: parent,
+      slices: [
+        {
+          id: 'builder',
+          role: 'builder',
+          slice: 'Build the thing properly',
+          message: 'You are the builder.',
+          expected_deliverables: [{ title: 'PR', kind: 'file' }],
+          acceptance_criteria: ['PR opened and CI green'],
+          expected_duration_minutes: 60,
+        },
+        {
+          id: 'tester',
+          role: 'tester',
+          slice: 'Verify the thing works in a browser',
+          message: 'You are the tester.',
+          expected_deliverables: [{ title: 'Test report', kind: 'report' }],
+          acceptance_criteria: ['Each acceptance criterion covered'],
+          expected_duration_minutes: 30,
+          depends_on: ['builder'],
+        },
+        {
+          id: 'reviewer',
+          role: 'reviewer',
+          slice: 'Review the thing for code quality',
+          message: 'You are the reviewer.',
+          expected_deliverables: [{ title: 'Review report', kind: 'report' }],
+          acceptance_criteria: ['No critical findings'],
+          expected_duration_minutes: 30,
+          depends_on: ['builder'],
+        },
+      ],
+    },
+  });
+  assert.equal(res.isError, undefined);
+  const payload = parseStructured<{
+    convoy_id: string;
+    slices: Array<{ symbolic_id: string; subtask_id: string; child_task_id: string; depends_on_subtask_ids: string[]; will_dispatch_immediately: boolean }>;
+  }>(res);
+  assert.ok(payload?.convoy_id, 'convoy_id should be returned');
+  assert.equal(payload.slices.length, 3);
+  const builder = payload.slices.find(s => s.symbolic_id === 'builder')!;
+  const tester = payload.slices.find(s => s.symbolic_id === 'tester')!;
+  const reviewer = payload.slices.find(s => s.symbolic_id === 'reviewer')!;
+  assert.equal(builder.depends_on_subtask_ids.length, 0);
+  assert.deepEqual(tester.depends_on_subtask_ids, [builder.subtask_id]);
+  assert.deepEqual(reviewer.depends_on_subtask_ids, [builder.subtask_id]);
+  assert.equal(builder.will_dispatch_immediately, true);
+  assert.equal(tester.will_dispatch_immediately, false);
+  assert.equal(reviewer.will_dispatch_immediately, false);
+
+  // Dependent slices must remain in 'inbox' until their dep is accepted.
+  for (const s of [tester, reviewer]) {
+    const row = queryOne<{ status: string }>('SELECT status FROM tasks WHERE id = ?', [s.child_task_id]);
+    assert.equal(row?.status, 'inbox', `${s.symbolic_id} should be queued in inbox, got ${row?.status}`);
+  }
+});
+
+test('plan_convoy: rejects dependency cycles before any row is written', async () => {
+  const { client } = await makePair();
+  const coordinator = seedAgent({ role: 'coordinator' });
+  seedAgent({ role: 'builder' });
+  seedAgent({ role: 'tester' });
+  const parent = seedTask({ assigned: coordinator, status: 'in_progress' });
+
+  const res = await client.callTool({
+    name: 'plan_convoy',
+    arguments: {
+      agent_id: coordinator,
+      task_id: parent,
+      slices: [
+        { id: 'a', role: 'builder', slice: 'Slice A — builder step', message: '.', expected_deliverables: [{ title: 'x', kind: 'file' }], acceptance_criteria: ['everything works end-to-end'], expected_duration_minutes: 30, depends_on: ['b'] },
+        { id: 'b', role: 'tester',  slice: 'Slice B — tester step', message: '.', expected_deliverables: [{ title: 'x', kind: 'file' }], acceptance_criteria: ['everything works end-to-end'], expected_duration_minutes: 30, depends_on: ['a'] },
+      ],
+    },
+  });
+  assert.equal(res.isError, true);
+  const payload = parseStructured<{ error: string; stuck: string[] }>(res);
+  assert.equal(payload.error, 'cycle_detected');
+  assert.deepEqual(payload.stuck.sort(), ['a', 'b']);
+  // No convoy was created.
+  const convoys = queryOne<{ n: number }>('SELECT COUNT(*) as n FROM convoys WHERE parent_task_id = ?', [parent]);
+  assert.equal(convoys?.n, 0);
 });
 
 test('locked task: register_deliverable rejected with task_locked_pending_escalation', async () => {


### PR DESCRIPTION
## Summary
- New coordinator MCP tool `plan_convoy` that takes the full slice list + symbolic dependencies in a single atomic call. Validates the DAG (duplicate ids, unknown deps, self-deps, cycles) BEFORE any row is written; resolves every peer up front; creates rows in topological order; dispatches roots; leaves dependents in `inbox` for the existing dep-gate release (PR #344) to pick up on accept.
- Builds on #344, which made `depends_on_subtask_ids` a hard dispatch gate. That fix was correct but still relied on the coordinator remembering to pass the field on every individual `spawn_subtask` call — `plan_convoy` makes the topology a first-class input.
- `spawn_subtask` stays for single slices and follow-ups discovered after monitoring.

## Changes
- `src/lib/mcp/groups/work.ts`
  - Shared peer-resolution helper (`resolveDelegationPeer`).
  - New `plan_convoy` tool: schema, DAG validation (Kahn's topological sort), pre-pass peer resolution that aggregates failures, topological-order row creation, post-loop call to `dispatchReadyConvoySubtasks` for roots.
- `src/app/api/tasks/[id]/dispatch/route.ts`: coordinator dispatch briefing recommends `plan_convoy` for the initial fan-out, `spawn_subtask` for follow-ups; explicit example included.
- `agent-templates/coordinator/SOUL.md`: same shift in guidance with a builder→tester/reviewer DAG example.
- `src/lib/mcp/mcp.test.ts`:
  - New test: `plan_convoy` creates a DAG, dispatches only roots, leaves dependents in `inbox`.
  - New test: cycle detection rejects before any row is written.
  - Tool-catalog tests updated: 47 total, present in worker mount, absent from PM / CRUD mounts.

## Test plan
- [x] `yarn tsc --noEmit` — clean.
- [x] `yarn test src/lib/mcp` — passes (47-tool roster, two new behavior tests green, no regressions).
- [ ] Manual UI smoke skipped: pure MCP server-side surface. The next coordinator dispatch will pick the new briefing automatically.

## Out of scope
- Operator-side review of the proposed plan before dispatch (i.e. a `propose_changes`-style review surface for convoys). Worth doing later for high-stakes parents; not in this PR.
- Deduplicating `spawn_subtask`'s inline peer resolution against `resolveDelegationPeer`. Left in place to keep the single-slice error text hand-tuned; can be unified in a follow-up.