### PR TITLE
fix(pm): clear placeholder dispatch_state on supersede so in-flight card stops rendering

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -1622,11 +1622,15 @@ function ChatMessageRow({
     );
   }
 
-  // In-flight placeholder: when dispatch_state === 'pending_agent', render
-  // the InFlightProposalCard instead of the synthetic proposal card. The
-  // card subscribes to SSE events and transitions to replaced/synth_only
-  // automatically. This matches the backend's state machine exactly.
-  if (proposal.dispatch_state === 'pending_agent') {
+  // In-flight placeholder: when dispatch_state === 'pending_agent' AND
+  // the proposal is still a live draft, render the InFlightProposalCard
+  // instead of the synthetic proposal card. The status='draft' clause
+  // is defence-in-depth — supersedeWithAgentProposal now flips
+  // dispatch_state to 'agent_complete' when the agent row lands, but
+  // any legacy row still on (status='superseded', dispatch_state='pending_agent')
+  // would otherwise render a stuck in-flight card next to the real
+  // proposal card.
+  if (proposal.dispatch_state === 'pending_agent' && proposal.status === 'draft') {
     return (
       <div
         ref={(el) => setMessageRef?.(message.id, el)}

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -221,7 +221,7 @@ export default function ProposalDetailPage({
               render the InFlightProposalCard instead of the synthetic proposal
               card. The card subscribes to SSE events and transitions to
               replaced/synth_only automatically. */}
-            {proposal.dispatch_state === 'pending_agent' ? (
+            {proposal.dispatch_state === 'pending_agent' && proposal.status === 'draft' ? (
               <InFlightProposalCard
                 proposalId={proposal.id}
                 workspaceId={proposal.workspace_id}

--- a/src/lib/db/pm-proposals.test.ts
+++ b/src/lib/db/pm-proposals.test.ts
@@ -21,6 +21,7 @@ import {
   acceptProposal,
   rejectProposal,
   refineProposal,
+  supersedeWithAgentProposal,
   validateProposedChanges,
   PmProposalValidationError,
   tryAdoptOrphanedPlaceholder,
@@ -360,6 +361,36 @@ test('refineProposal refuses to refine an already-accepted proposal', () => {
   const p = createProposal({ workspace_id: ws, trigger_text: '.', impact_md: '.', proposed_changes: [] });
   acceptProposal(p.id);
   assert.throws(() => refineProposal(p.id, 'x'), PmProposalValidationError);
+});
+
+test('supersedeWithAgentProposal flips placeholder dispatch_state to agent_complete', () => {
+  // Regression: leaving placeholder.dispatch_state on 'pending_agent'
+  // after supersede made the /pm chat thread render a stuck
+  // InFlightProposalCard next to the real agent row's card. The
+  // render gate matches dispatch_state==='pending_agent'.
+  const ws = freshWorkspace();
+  const placeholder = createProposal({
+    workspace_id: ws,
+    trigger_text: '{"mode":"decompose_initiative"}',
+    trigger_kind: 'decompose_initiative',
+    impact_md: '_(synth placeholder)_',
+    proposed_changes: [],
+    dispatch_state: 'pending_agent',
+  });
+  const agentRow = createProposal({
+    workspace_id: ws,
+    trigger_text: 'agent freeform',
+    trigger_kind: 'decompose_initiative',
+    impact_md: 'real impact',
+    proposed_changes: [],
+    dispatch_state: 'agent_complete',
+  });
+  supersedeWithAgentProposal(placeholder.id, agentRow.id, {
+    trigger_kind: 'decompose_initiative',
+  });
+  const after = getProposal(placeholder.id)!;
+  assert.equal(after.status, 'superseded');
+  assert.equal(after.dispatch_state, 'agent_complete', 'placeholder must leave pending_agent so the in-flight render gate stops matching');
 });
 
 test('refineProposal dedupes: second call returns existing draft child with created=false', () => {

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -852,7 +852,16 @@ export function supersedeWithAgentProposal(
       `SELECT trigger_text FROM pm_proposals WHERE id = ?`,
       [synthRowId],
     );
-    run(`UPDATE pm_proposals SET status = 'superseded' WHERE id = ?`, [synthRowId]);
+    // Flip the placeholder's dispatch_state too — leaving it on
+    // 'pending_agent' after supersede leaves /pm's in-flight card
+    // gate (proposal.dispatch_state === 'pending_agent') matching a
+    // proposal that's no longer in flight, so the chat thread renders
+    // a stuck in-flight card next to the real agent row's card. See
+    // the InFlightProposalCard wiring in src/app/(app)/pm/page.tsx.
+    run(
+      `UPDATE pm_proposals SET status = 'superseded', dispatch_state = 'agent_complete' WHERE id = ?`,
+      [synthRowId],
+    );
     const sets: string[] = ['parent_proposal_id = ?', 'trigger_kind = ?', 'dispatch_state = ?'];
     const vals: unknown[] = [synthRowId, intent.trigger_kind, 'agent_complete'];
     if (intent.target_initiative_id) {
@@ -950,9 +959,12 @@ export function tryAdoptOrphanedPlaceholder(
     // an orphan. If a concurrent reconciler already linked it, the
     // UPDATE matches zero rows and we bail without touching the agent
     // row.
+    // Flip the placeholder's dispatch_state to 'agent_complete' alongside
+    // the supersede so the /pm in-flight render gate stops matching it.
+    // See supersedeWithAgentProposal for the same fix on the fast path.
     const stmt = db.prepare(
       `UPDATE pm_proposals
-          SET status = 'superseded'
+          SET status = 'superseded', dispatch_state = 'agent_complete'
         WHERE id = ?
           AND status = 'draft'
           AND dispatch_state = 'synth_only'


### PR DESCRIPTION
## Summary
Operator screenshot today: the "Create tasks with PM" flow produced the real agent proposal card *and* a stuck "PM Agent In Flight" card sitting above it, both rendered for the same exchange. Root cause: when the agent row supersedes the synth placeholder, the placeholder's `status` flips to `superseded` but its `dispatch_state` stays on `pending_agent`. The /pm chat thread's render gate only consults `dispatch_state`, so the placeholder keeps rendering as in-flight forever.

## Changes
- `src/lib/db/pm-proposals.ts`
  - `supersedeWithAgentProposal` (the fast path) now flips the placeholder's `dispatch_state` to `agent_complete` alongside the `status='superseded'` update.
  - `tryAdoptOrphanedPlaceholder` (the retroactive self-heal path) does the same.
- `src/app/(app)/pm/page.tsx` + `src/app/(app)/pm/proposals/[id]/page.tsx`: render gate now requires `dispatch_state === 'pending_agent' && status === 'draft'`. Defence-in-depth so any legacy stuck row stops rendering as in-flight without waiting on a backfill.
- `src/lib/db/pm-proposals.test.ts`: new regression test pinning the placeholder's dispatch_state transition.

## Backfill
Manual on dev DB cleared 2 stuck rows. Prod equivalent:
```sql
UPDATE pm_proposals SET dispatch_state = 'agent_complete'
 WHERE status = 'superseded'
   AND dispatch_state IN ('pending_agent', 'synth_only');
```

## Test plan
- [x] `yarn tsc --noEmit` — clean.
- [x] `yarn test src/lib/db` — passes including new `supersedeWithAgentProposal` placeholder dispatch_state test.
- [x] Preview-verified: after dev-server restart + backfill, /pm shows 0 in-flight cards and the previously-stuck `458639cd…` reference is gone; the real "Proposal — 2 changes" card renders alone. Screenshot in the conversation.

## Known follow-up (not in this PR)
The `DecomposeWithPmModal` and `PlanWithPmPanel` surfaces still render the old synth-as-placeholder pattern (small "PM agent is still composing…" banner + the full synth template) instead of using `InFlightProposalCard` like /pm does. That was the original story's goal (`2edccd24`) and the builder only wired two of four surfaces. Worth a follow-up PR.