### PR TITLE
feat(pm): hide superseded proposals from chat + surface Supersedes link on detail page

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -1622,11 +1622,15 @@ function ChatMessageRow({
     );
   }
 
-  // In-flight placeholder: when dispatch_state === 'pending_agent', render
-  // the InFlightProposalCard instead of the synthetic proposal card. The
-  // card subscribes to SSE events and transitions to replaced/synth_only
-  // automatically. This matches the backend's state machine exactly.
-  if (proposal.dispatch_state === 'pending_agent') {
+  // In-flight placeholder: when dispatch_state === 'pending_agent' AND
+  // the proposal is still a live draft, render the InFlightProposalCard
+  // instead of the synthetic proposal card. The status='draft' clause
+  // is defence-in-depth — supersedeWithAgentProposal now flips
+  // dispatch_state to 'agent_complete' when the agent row lands, but
+  // any legacy row still on (status='superseded', dispatch_state='pending_agent')
+  // would otherwise render a stuck in-flight card next to the real
+  // proposal card.
+  if (proposal.dispatch_state === 'pending_agent' && proposal.status === 'draft') {
     return (
       <div
         ref={(el) => setMessageRef?.(message.id, el)}

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -974,6 +974,15 @@ export default function PmChatPage() {
               if (proposal && pinnedStandup && proposal.id === pinnedStandup.id) {
                 return null;
               }
+              // Hide chat entries whose proposal has been superseded. The
+              // child (status='draft', parent_proposal_id set) carries the
+              // real content and gets the chat slot; the parent's
+              // synth-template card was useful only as a placeholder while
+              // the agent composed. The dedicated proposal page surfaces
+              // the "Supersedes → <id>" link if anyone needs to backtrack.
+              if (proposal && proposal.status === 'superseded') {
+                return null;
+              }
               return (
                 <ChatMessageRow
                   key={m.id}

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -259,6 +259,22 @@ export default function ProposalDetailPage({
                 </span>
               </div>
 
+              {/* Supersedes-link row. Surfaced here because the /pm chat
+                  hides superseded proposals (they're synth-template
+                  noise once the agent's real proposal lands). The only
+                  way back to a parent is from its child's detail page. */}
+              {proposal.parent_proposal_id && (
+                <div className="px-4 py-2 text-xs border-b border-amber-500/20 text-mc-text-secondary">
+                  Supersedes{' '}
+                  <Link
+                    href={`/pm/proposals/${proposal.parent_proposal_id}`}
+                    className="font-mono text-mc-accent hover:underline"
+                  >
+                    {proposal.parent_proposal_id.slice(0, 8)}…
+                  </Link>
+                </div>
+              )}
+
               {/* Plan suggestions summary for plan_initiative proposals */}
               {suggestions && (
                 <div className="px-4 py-3 border-b border-amber-500/20 grid grid-cols-3 gap-3 text-xs">

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -221,7 +221,7 @@ export default function ProposalDetailPage({
               render the InFlightProposalCard instead of the synthetic proposal
               card. The card subscribes to SSE events and transitions to
               replaced/synth_only automatically. */}
-            {proposal.dispatch_state === 'pending_agent' ? (
+            {proposal.dispatch_state === 'pending_agent' && proposal.status === 'draft' ? (
               <InFlightProposalCard
                 proposalId={proposal.id}
                 workspaceId={proposal.workspace_id}

--- a/src/lib/db/pm-proposals.test.ts
+++ b/src/lib/db/pm-proposals.test.ts
@@ -21,6 +21,7 @@ import {
   acceptProposal,
   rejectProposal,
   refineProposal,
+  supersedeWithAgentProposal,
   validateProposedChanges,
   PmProposalValidationError,
   tryAdoptOrphanedPlaceholder,
@@ -360,6 +361,36 @@ test('refineProposal refuses to refine an already-accepted proposal', () => {
   const p = createProposal({ workspace_id: ws, trigger_text: '.', impact_md: '.', proposed_changes: [] });
   acceptProposal(p.id);
   assert.throws(() => refineProposal(p.id, 'x'), PmProposalValidationError);
+});
+
+test('supersedeWithAgentProposal flips placeholder dispatch_state to agent_complete', () => {
+  // Regression: leaving placeholder.dispatch_state on 'pending_agent'
+  // after supersede made the /pm chat thread render a stuck
+  // InFlightProposalCard next to the real agent row's card. The
+  // render gate matches dispatch_state==='pending_agent'.
+  const ws = freshWorkspace();
+  const placeholder = createProposal({
+    workspace_id: ws,
+    trigger_text: '{"mode":"decompose_initiative"}',
+    trigger_kind: 'decompose_initiative',
+    impact_md: '_(synth placeholder)_',
+    proposed_changes: [],
+    dispatch_state: 'pending_agent',
+  });
+  const agentRow = createProposal({
+    workspace_id: ws,
+    trigger_text: 'agent freeform',
+    trigger_kind: 'decompose_initiative',
+    impact_md: 'real impact',
+    proposed_changes: [],
+    dispatch_state: 'agent_complete',
+  });
+  supersedeWithAgentProposal(placeholder.id, agentRow.id, {
+    trigger_kind: 'decompose_initiative',
+  });
+  const after = getProposal(placeholder.id)!;
+  assert.equal(after.status, 'superseded');
+  assert.equal(after.dispatch_state, 'agent_complete', 'placeholder must leave pending_agent so the in-flight render gate stops matching');
 });
 
 test('refineProposal dedupes: second call returns existing draft child with created=false', () => {

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -852,7 +852,16 @@ export function supersedeWithAgentProposal(
       `SELECT trigger_text FROM pm_proposals WHERE id = ?`,
       [synthRowId],
     );
-    run(`UPDATE pm_proposals SET status = 'superseded' WHERE id = ?`, [synthRowId]);
+    // Flip the placeholder's dispatch_state too — leaving it on
+    // 'pending_agent' after supersede leaves /pm's in-flight card
+    // gate (proposal.dispatch_state === 'pending_agent') matching a
+    // proposal that's no longer in flight, so the chat thread renders
+    // a stuck in-flight card next to the real agent row's card. See
+    // the InFlightProposalCard wiring in src/app/(app)/pm/page.tsx.
+    run(
+      `UPDATE pm_proposals SET status = 'superseded', dispatch_state = 'agent_complete' WHERE id = ?`,
+      [synthRowId],
+    );
     const sets: string[] = ['parent_proposal_id = ?', 'trigger_kind = ?', 'dispatch_state = ?'];
     const vals: unknown[] = [synthRowId, intent.trigger_kind, 'agent_complete'];
     if (intent.target_initiative_id) {
@@ -950,9 +959,12 @@ export function tryAdoptOrphanedPlaceholder(
     // an orphan. If a concurrent reconciler already linked it, the
     // UPDATE matches zero rows and we bail without touching the agent
     // row.
+    // Flip the placeholder's dispatch_state to 'agent_complete' alongside
+    // the supersede so the /pm in-flight render gate stops matching it.
+    // See supersedeWithAgentProposal for the same fix on the fast path.
     const stmt = db.prepare(
       `UPDATE pm_proposals
-          SET status = 'superseded'
+          SET status = 'superseded', dispatch_state = 'agent_complete'
         WHERE id = ?
           AND status = 'draft'
           AND dispatch_state = 'synth_only'


### PR DESCRIPTION
## Summary
Synth-template proposals that get superseded by the agent's real proposal are noise in the /pm chat — the active child carries the useful content, the parent is just the placeholder MC wrote while waiting on the agent. Hide them from the chat; surface the relationship via a 'Supersedes &lt;short-id&gt;' link on the active proposal's detail page so the parent is still reachable when needed.

## Changes
- \`src/app/(app)/pm/page.tsx\`: chat-thread render skips messages whose proposal is \`status === 'superseded'\`. Draft / accepted / rejected still render.
- \`src/app/(app)/pm/proposals/[id]/page.tsx\`: when \`proposal.parent_proposal_id\` is set, render a 'Supersedes &lt;parent-id-prefix&gt;…' row in the header linking to the parent.

## Test plan
- [x] \`yarn tsc --noEmit\` — clean.
- [x] Preview-verified: /pm shows only the active draft proposal for the recent decompose exchange (down from one stuck-in-flight + one real card before PR #347, then two cards after #347, now one). Detail page for the child shows 'Supersedes 458639cd…' linking to the parent.