### PR TITLE
feat(pm): render InFlightProposalCard in decompose/plan modals

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -1622,11 +1622,15 @@ function ChatMessageRow({
     );
   }
 
-  // In-flight placeholder: when dispatch_state === 'pending_agent', render
-  // the InFlightProposalCard instead of the synthetic proposal card. The
-  // card subscribes to SSE events and transitions to replaced/synth_only
-  // automatically. This matches the backend's state machine exactly.
-  if (proposal.dispatch_state === 'pending_agent') {
+  // In-flight placeholder: when dispatch_state === 'pending_agent' AND
+  // the proposal is still a live draft, render the InFlightProposalCard
+  // instead of the synthetic proposal card. The status='draft' clause
+  // is defence-in-depth — supersedeWithAgentProposal now flips
+  // dispatch_state to 'agent_complete' when the agent row lands, but
+  // any legacy row still on (status='superseded', dispatch_state='pending_agent')
+  // would otherwise render a stuck in-flight card next to the real
+  // proposal card.
+  if (proposal.dispatch_state === 'pending_agent' && proposal.status === 'draft') {
     return (
       <div
         ref={(el) => setMessageRef?.(message.id, el)}

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -974,6 +974,15 @@ export default function PmChatPage() {
               if (proposal && pinnedStandup && proposal.id === pinnedStandup.id) {
                 return null;
               }
+              // Hide chat entries whose proposal has been superseded. The
+              // child (status='draft', parent_proposal_id set) carries the
+              // real content and gets the chat slot; the parent's
+              // synth-template card was useful only as a placeholder while
+              // the agent composed. The dedicated proposal page surfaces
+              // the "Supersedes → <id>" link if anyone needs to backtrack.
+              if (proposal && proposal.status === 'superseded') {
+                return null;
+              }
               return (
                 <ChatMessageRow
                   key={m.id}

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -259,6 +259,22 @@ export default function ProposalDetailPage({
                 </span>
               </div>
 
+              {/* Supersedes-link row. Surfaced here because the /pm chat
+                  hides superseded proposals (they're synth-template
+                  noise once the agent's real proposal lands). The only
+                  way back to a parent is from its child's detail page. */}
+              {proposal.parent_proposal_id && (
+                <div className="px-4 py-2 text-xs border-b border-amber-500/20 text-mc-text-secondary">
+                  Supersedes{' '}
+                  <Link
+                    href={`/pm/proposals/${proposal.parent_proposal_id}`}
+                    className="font-mono text-mc-accent hover:underline"
+                  >
+                    {proposal.parent_proposal_id.slice(0, 8)}…
+                  </Link>
+                </div>
+              )}
+
               {/* Plan suggestions summary for plan_initiative proposals */}
               {suggestions && (
                 <div className="px-4 py-3 border-b border-amber-500/20 grid grid-cols-3 gap-3 text-xs">

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -221,7 +221,7 @@ export default function ProposalDetailPage({
               render the InFlightProposalCard instead of the synthetic proposal
               card. The card subscribes to SSE events and transitions to
               replaced/synth_only automatically. */}
-            {proposal.dispatch_state === 'pending_agent' ? (
+            {proposal.dispatch_state === 'pending_agent' && proposal.status === 'draft' ? (
               <InFlightProposalCard
                 proposalId={proposal.id}
                 workspaceId={proposal.workspace_id}

--- a/src/app/api/pm/decompose-initiative/route.ts
+++ b/src/app/api/pm/decompose-initiative/route.ts
@@ -22,7 +22,7 @@ import { logApiError, serverLog } from '@/lib/debug-log';
 import { z } from 'zod';
 import { getInitiative } from '@/lib/db/initiatives';
 import { synthesizeDecompose } from '@/lib/agents/pm-agent';
-import { PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { PmProposalValidationError, getProposal } from '@/lib/db/pm-proposals';
 import { postPmChatMessage, dispatchPmSynthesized } from '@/lib/agents/pm-dispatch';
 import { queryOne } from '@/lib/db';
 
@@ -75,8 +75,11 @@ export async function POST(request: NextRequest) {
 
     // Dedup: return any identical draft dispatched in the last 2 seconds
     // (guards against React StrictMode double-invoke and rapid re-opens).
-    const recent = queryOne<{ id: string; impact_md: string; proposed_changes: string }>(
-      `SELECT id, impact_md, proposed_changes FROM pm_proposals
+    // Returns the canonical proposal shape via getProposal — a stripped
+    // payload would drop dispatch_state + created_at and break the
+    // modal's in-flight render gate (see decompose-story route note).
+    const recent = queryOne<{ id: string }>(
+      `SELECT id FROM pm_proposals
        WHERE workspace_id = ?
          AND trigger_kind = 'decompose_initiative'
          AND trigger_text = ?
@@ -86,16 +89,10 @@ export async function POST(request: NextRequest) {
       [parent.workspace_id, triggerText],
     );
     if (recent) {
-      return NextResponse.json(
-        {
-          proposal: {
-            ...recent,
-            proposed_changes: JSON.parse(recent.proposed_changes),
-          },
-          deduped: true,
-        },
-        { status: 201 },
-      );
+      const full = getProposal(recent.id);
+      if (full) {
+        return NextResponse.json({ proposal: full, deduped: true }, { status: 201 });
+      }
     }
 
     // Try the named-agent path first (PM gateway agent at

--- a/src/app/api/pm/decompose-story/route.ts
+++ b/src/app/api/pm/decompose-story/route.ts
@@ -18,7 +18,7 @@ import { logApiError, serverLog } from '@/lib/debug-log';
 import { z } from 'zod';
 import { getInitiative } from '@/lib/db/initiatives';
 import { synthesizeStoryToTasks } from '@/lib/agents/pm-agent';
-import { PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { PmProposalValidationError, getProposal } from '@/lib/db/pm-proposals';
 import { postPmChatMessage, dispatchPmSynthesized } from '@/lib/agents/pm-dispatch';
 import { getPmAgent } from '@/lib/agents/pm-resolver';
 import { queryOne } from '@/lib/db';
@@ -80,8 +80,13 @@ export async function POST(request: NextRequest) {
     });
 
     // Dedup recent identical drafts (StrictMode + rapid re-opens).
-    const recent = queryOne<{ id: string; impact_md: string; proposed_changes: string }>(
-      `SELECT id, impact_md, proposed_changes FROM pm_proposals
+    // Returns the canonical proposal shape (via getProposal) — earlier
+    // versions returned a stripped { id, impact_md, proposed_changes }
+    // payload that dropped `dispatch_state` + `created_at`, so the
+    // modal's InFlightProposalCard gate (dispatch_state==='pending_agent')
+    // never matched on the second StrictMode call.
+    const recent = queryOne<{ id: string }>(
+      `SELECT id FROM pm_proposals
        WHERE workspace_id = ?
          AND trigger_kind = 'decompose_story'
          AND trigger_text = ?
@@ -91,16 +96,10 @@ export async function POST(request: NextRequest) {
       [parent.workspace_id, triggerText],
     );
     if (recent) {
-      return NextResponse.json(
-        {
-          proposal: {
-            ...recent,
-            proposed_changes: JSON.parse(recent.proposed_changes),
-          },
-          deduped: true,
-        },
-        { status: 201 },
-      );
+      const full = getProposal(recent.id);
+      if (full) {
+        return NextResponse.json({ proposal: full, deduped: true }, { status: 201 });
+      }
     }
 
     const dispatch = dispatchPmSynthesized({

--- a/src/components/DecomposeStoryToTasksModal.tsx
+++ b/src/components/DecomposeStoryToTasksModal.tsx
@@ -18,6 +18,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { Sparkles, Send, RefreshCw, Plus, Trash2, ArrowUp, ArrowDown, X } from 'lucide-react';
+import { InFlightProposalCard } from '@/components/InFlightProposalCard';
 
 interface InitiativeLite {
   id: string;
@@ -44,6 +45,7 @@ interface ProposalRow {
   proposed_changes: TaskDiff[];
   status: string;
   dispatch_state?: 'pending_agent' | 'agent_complete' | 'synth_only' | null;
+  created_at: string;
 }
 
 export default function DecomposeStoryToTasksModal({
@@ -66,6 +68,7 @@ export default function DecomposeStoryToTasksModal({
   onAccepted: () => void;
 }) {
   const [proposalId, setProposalId] = useState<string | null>(null);
+  const [proposalCreatedAt, setProposalCreatedAt] = useState<string | null>(null);
   const [impactMd, setImpactMd] = useState<string>('');
   const [tasks, setTasks] = useState<TaskDiff[]>([]);
   const [loading, setLoading] = useState(false);
@@ -89,6 +92,7 @@ export default function DecomposeStoryToTasksModal({
           if (resumeBody?.proposal) {
             if (cancelled) return;
             setProposalId(resumeBody.proposal.id);
+            setProposalCreatedAt(resumeBody.proposal.created_at);
             setImpactMd(resumeBody.proposal.impact_md);
             setTasks(resumeBody.proposal.proposed_changes);
             setDispatchState(resumeBody.proposal.dispatch_state ?? null);
@@ -109,6 +113,7 @@ export default function DecomposeStoryToTasksModal({
         if (cancelled) return;
         const proposal = body.proposal as ProposalRow;
         setProposalId(proposal.id);
+        setProposalCreatedAt(proposal.created_at);
         setImpactMd(proposal.impact_md);
         setTasks(proposal.proposed_changes);
         setDispatchState(proposal.dispatch_state ?? null);
@@ -138,6 +143,7 @@ export default function DecomposeStoryToTasksModal({
         const body = await res.json() as { proposal?: ProposalRow | null };
         if (cancelled || !body?.proposal) return;
         setProposalId(body.proposal.id);
+        setProposalCreatedAt(body.proposal.created_at);
         setImpactMd(body.proposal.impact_md);
         setTasks(body.proposal.proposed_changes);
         setDispatchState(body.proposal.dispatch_state ?? null);
@@ -194,6 +200,7 @@ export default function DecomposeStoryToTasksModal({
       if (!res.ok) throw new Error(body.error || `Refine failed (${res.status})`);
       const proposal = body.proposal as ProposalRow;
       setProposalId(proposal.id);
+      setProposalCreatedAt(proposal.created_at);
       setImpactMd(proposal.impact_md);
       setTasks(proposal.proposed_changes);
       setRefineText('');
@@ -307,22 +314,27 @@ export default function DecomposeStoryToTasksModal({
             <div className="flex items-center gap-2 text-sm text-mc-text-secondary">
               <RefreshCw className="w-4 h-4 animate-spin" /> Asking {agentLabel ?? 'PM'} to decompose…
             </div>
+          ) : dispatchState === 'pending_agent' && proposalId ? (
+            // While the agent composes, replace the synth-template body
+            // with the in-flight card. Story 2edccd24 ("In-flight
+            // proposal card replaces synth-as-placeholder"). SSE-driven
+            // card swaps to the real proposal when pm_proposal_replaced
+            // fires.
+            <InFlightProposalCard
+              proposalId={proposalId}
+              workspaceId={initiative.workspace_id}
+              sessionKey={null}
+              sentAt={proposalCreatedAt ?? new Date().toISOString()}
+              onCancel={() => {
+                fetch(`/api/pm/proposals/${proposalId}`, { method: 'DELETE' }).catch(() => {});
+                onClose();
+              }}
+              onUseSynthFallback={() => {
+                setDispatchState('synth_only');
+              }}
+            />
           ) : (
             <>
-              {dispatchState === 'pending_agent' && (
-                <div
-                  className="flex items-start gap-2 rounded border border-mc-accent/30 bg-mc-accent/5 px-3 py-2 text-[11px] text-mc-text-secondary"
-                  role="status"
-                  aria-live="polite"
-                >
-                  <RefreshCw className="w-3.5 h-3.5 mt-[1px] animate-spin text-mc-accent" />
-                  <div>
-                    {agentLabel ?? 'PM'} agent is still composing — these are draft tasks from the deterministic synth.
-                    The agent&apos;s final breakdown will replace this list automatically when it lands.
-                  </div>
-                </div>
-              )}
-
               {displayMd && (
                 <div className="shrink-0 max-h-32 overflow-y-auto text-xs text-mc-text-secondary whitespace-pre-wrap rounded border border-mc-border bg-mc-bg p-3">
                   {displayMd}

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -31,6 +31,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { Sparkles, Send, RefreshCw, Plus, Trash2, ArrowUp, ArrowDown, X } from 'lucide-react';
+import { InFlightProposalCard } from '@/components/InFlightProposalCard';
 
 interface InitiativeLite {
   id: string;
@@ -59,6 +60,7 @@ interface ProposalRow {
   proposed_changes: ChildDiff[];
   status: string;
   dispatch_state?: 'pending_agent' | 'agent_complete' | 'synth_only' | null;
+  created_at: string;
 }
 
 export default function DecomposeWithPmModal({
@@ -80,6 +82,7 @@ export default function DecomposeWithPmModal({
   onAccepted: () => void;
 }) {
   const [proposalId, setProposalId] = useState<string | null>(null);
+  const [proposalCreatedAt, setProposalCreatedAt] = useState<string | null>(null);
   const [impactMd, setImpactMd] = useState<string>('');
   const [children, setChildren] = useState<ChildDiff[]>([]);
   const [hint, setHint] = useState('');
@@ -105,6 +108,7 @@ export default function DecomposeWithPmModal({
           if (resumeBody?.proposal) {
             if (cancelled) return;
             setProposalId(resumeBody.proposal.id);
+            setProposalCreatedAt(resumeBody.proposal.created_at);
             setImpactMd(resumeBody.proposal.impact_md);
             setChildren(resumeBody.proposal.proposed_changes);
             setDispatchState(resumeBody.proposal.dispatch_state ?? null);
@@ -124,6 +128,7 @@ export default function DecomposeWithPmModal({
         if (cancelled) return;
         const proposal = body.proposal as ProposalRow;
         setProposalId(proposal.id);
+        setProposalCreatedAt(proposal.created_at);
         setImpactMd(proposal.impact_md);
         setChildren(proposal.proposed_changes);
         setDispatchState(proposal.dispatch_state ?? null);
@@ -156,6 +161,7 @@ export default function DecomposeWithPmModal({
         const body = await res.json() as { proposal?: ProposalRow | null };
         if (cancelled || !body?.proposal) return;
         setProposalId(body.proposal.id);
+        setProposalCreatedAt(body.proposal.created_at);
         setImpactMd(body.proposal.impact_md);
         setChildren(body.proposal.proposed_changes);
         setDispatchState(body.proposal.dispatch_state ?? null);
@@ -342,22 +348,31 @@ export default function DecomposeWithPmModal({
             <div className="flex items-center gap-2 text-sm text-mc-text-secondary">
               <RefreshCw className="w-4 h-4 animate-spin" /> Asking PM to decompose…
             </div>
+          ) : dispatchState === 'pending_agent' && proposalId ? (
+            // While the agent composes, replace the synth-template body
+            // entirely with the in-flight card. The synth content was
+            // misleading as a "proposal" — the original story 2edccd24
+            // ("In-flight proposal card replaces synth-as-placeholder")
+            // calls for hiding it. The SSE-driven card auto-transitions
+            // when pm_proposal_replaced fires.
+            <InFlightProposalCard
+              proposalId={proposalId}
+              workspaceId={initiative.workspace_id}
+              sessionKey={null}
+              sentAt={proposalCreatedAt ?? new Date().toISOString()}
+              onCancel={() => {
+                fetch(`/api/pm/proposals/${proposalId}`, { method: 'DELETE' }).catch(() => {});
+                onClose();
+              }}
+              onUseSynthFallback={() => {
+                // Operator opts to keep the synth body — switching the
+                // dispatch_state locally drops the card so the editor
+                // appears with the synth template populated.
+                setDispatchState('synth_only');
+              }}
+            />
           ) : (
             <>
-              {dispatchState === 'pending_agent' && (
-                <div
-                  className="flex items-start gap-2 rounded border border-mc-accent/30 bg-mc-accent/5 px-3 py-2 text-[11px] text-mc-text-secondary"
-                  role="status"
-                  aria-live="polite"
-                >
-                  <RefreshCw className="w-3.5 h-3.5 mt-[1px] animate-spin text-mc-accent" />
-                  <div>
-                    PM agent is still composing — these are draft children from the deterministic synth.
-                    The agent's final decomposition will replace this list automatically when it lands.
-                  </div>
-                </div>
-              )}
-
               {displayMd && (
                 <div className="shrink-0 max-h-32 overflow-y-auto text-xs text-mc-text-secondary whitespace-pre-wrap rounded border border-mc-border bg-mc-bg p-3">
                   {displayMd}

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -24,6 +24,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { Sparkles, Send, X, RefreshCw, ChevronDown, ChevronRight } from 'lucide-react';
 import { parseSuggestionsFromImpactMd as parseSharedSuggestions } from '@/lib/pm/planSuggestionsSidecar';
+import { InFlightProposalCard } from '@/components/InFlightProposalCard';
 
 export interface PlanInitiativeDraft {
   title: string;
@@ -102,6 +103,7 @@ export default function PlanWithPmPanel({
   ) => void;
 }) {
   const [proposalId, setProposalId] = useState<string | null>(null);
+  const [proposalCreatedAt, setProposalCreatedAt] = useState<string | null>(null);
   const [impactMd, setImpactMd] = useState<string>('');
   const [suggestions, setSuggestions] = useState<PlanInitiativeSuggestions | null>(null);
   const [dispatchState, setDispatchState] = useState<'pending_agent' | 'agent_complete' | 'synth_only' | null>(null);
@@ -131,6 +133,7 @@ export default function PlanWithPmPanel({
     if (!open) {
       // Reset on close so the next open re-runs cleanly.
       setProposalId(null);
+      setProposalCreatedAt(null);
       setImpactMd('');
       setSuggestions(null);
       setDispatchState(null);
@@ -157,6 +160,7 @@ export default function PlanWithPmPanel({
             if (resumeBody?.proposal && resumeBody?.suggestions) {
               if (cancelled) return;
               setProposalId(resumeBody.proposal_id);
+              setProposalCreatedAt(resumeBody.proposal.created_at ?? null);
               setImpactMd(resumeBody.proposal.impact_md ?? '');
               setSuggestions(resumeBody.suggestions);
               setDispatchState(resumeBody.proposal.dispatch_state ?? null);
@@ -178,6 +182,7 @@ export default function PlanWithPmPanel({
         if (!res.ok) throw new Error(body.error || `Plan failed (${res.status})`);
         if (cancelled) return;
         setProposalId(body.proposal_id);
+        setProposalCreatedAt(body.proposal?.created_at ?? null);
         setImpactMd(body.proposal?.impact_md ?? '');
         setSuggestions(body.suggestions ?? null);
         setDispatchState(body.proposal?.dispatch_state ?? null);
@@ -214,6 +219,7 @@ export default function PlanWithPmPanel({
         // The server's plan-initiative GET already follows the supersede
         // chain when present, so we get the live (agent-completed) row.
         setProposalId(newProposalId);
+        setProposalCreatedAt(body.proposal?.created_at ?? null);
         setImpactMd(body.proposal?.impact_md ?? '');
         setSuggestions(body.suggestions ?? null);
         setDispatchState(body.proposal?.dispatch_state ?? null);
@@ -343,21 +349,28 @@ export default function PlanWithPmPanel({
         <div className="flex items-center gap-2 text-sm text-mc-text-secondary">
           <RefreshCw className="w-4 h-4 animate-spin" /> Thinking…
         </div>
+      ) : dispatchState === 'pending_agent' && proposalId ? (
+        // While the agent composes, replace the synth-suggestion body
+        // with the in-flight card. Matches the /pm chat thread + detail
+        // page behavior and the original story 2edccd24
+        // ("In-flight proposal card replaces synth-as-placeholder").
+        <InFlightProposalCard
+          proposalId={proposalId}
+          workspaceId={workspaceId}
+          sessionKey={null}
+          sentAt={proposalCreatedAt ?? new Date().toISOString()}
+          onCancel={() => {
+            fetch(`/api/pm/proposals/${proposalId}`, { method: 'DELETE' }).catch(() => {});
+            onClose();
+          }}
+          onUseSynthFallback={() => {
+            // Operator opts to keep the synth body — flip the local
+            // dispatch_state so the suggestions panel below renders.
+            setDispatchState('synth_only');
+          }}
+        />
       ) : suggestions ? (
         <>
-          {dispatchState === 'pending_agent' && (
-            <div
-              className="mb-3 flex items-start gap-2 rounded border border-mc-accent/30 bg-mc-accent/5 px-3 py-2 text-[11px] text-mc-text-secondary"
-              role="status"
-              aria-live="polite"
-            >
-              <RefreshCw className="w-3.5 h-3.5 mt-[1px] animate-spin text-mc-accent" />
-              <div>
-                PM agent is still composing — these are draft suggestions from the deterministic synth.
-                The agent's final answer will replace this content automatically when it lands.
-              </div>
-            </div>
-          )}
           <div className="rounded border border-mc-border bg-mc-bg-secondary p-3 mb-3 text-xs space-y-2">
             <div>
               <div className="text-mc-text-secondary uppercase tracking-wide text-[10px]">Refined description</div>

--- a/src/lib/db/pm-proposals.test.ts
+++ b/src/lib/db/pm-proposals.test.ts
@@ -21,6 +21,7 @@ import {
   acceptProposal,
   rejectProposal,
   refineProposal,
+  supersedeWithAgentProposal,
   validateProposedChanges,
   PmProposalValidationError,
   tryAdoptOrphanedPlaceholder,
@@ -360,6 +361,36 @@ test('refineProposal refuses to refine an already-accepted proposal', () => {
   const p = createProposal({ workspace_id: ws, trigger_text: '.', impact_md: '.', proposed_changes: [] });
   acceptProposal(p.id);
   assert.throws(() => refineProposal(p.id, 'x'), PmProposalValidationError);
+});
+
+test('supersedeWithAgentProposal flips placeholder dispatch_state to agent_complete', () => {
+  // Regression: leaving placeholder.dispatch_state on 'pending_agent'
+  // after supersede made the /pm chat thread render a stuck
+  // InFlightProposalCard next to the real agent row's card. The
+  // render gate matches dispatch_state==='pending_agent'.
+  const ws = freshWorkspace();
+  const placeholder = createProposal({
+    workspace_id: ws,
+    trigger_text: '{"mode":"decompose_initiative"}',
+    trigger_kind: 'decompose_initiative',
+    impact_md: '_(synth placeholder)_',
+    proposed_changes: [],
+    dispatch_state: 'pending_agent',
+  });
+  const agentRow = createProposal({
+    workspace_id: ws,
+    trigger_text: 'agent freeform',
+    trigger_kind: 'decompose_initiative',
+    impact_md: 'real impact',
+    proposed_changes: [],
+    dispatch_state: 'agent_complete',
+  });
+  supersedeWithAgentProposal(placeholder.id, agentRow.id, {
+    trigger_kind: 'decompose_initiative',
+  });
+  const after = getProposal(placeholder.id)!;
+  assert.equal(after.status, 'superseded');
+  assert.equal(after.dispatch_state, 'agent_complete', 'placeholder must leave pending_agent so the in-flight render gate stops matching');
 });
 
 test('refineProposal dedupes: second call returns existing draft child with created=false', () => {

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -852,7 +852,16 @@ export function supersedeWithAgentProposal(
       `SELECT trigger_text FROM pm_proposals WHERE id = ?`,
       [synthRowId],
     );
-    run(`UPDATE pm_proposals SET status = 'superseded' WHERE id = ?`, [synthRowId]);
+    // Flip the placeholder's dispatch_state too — leaving it on
+    // 'pending_agent' after supersede leaves /pm's in-flight card
+    // gate (proposal.dispatch_state === 'pending_agent') matching a
+    // proposal that's no longer in flight, so the chat thread renders
+    // a stuck in-flight card next to the real agent row's card. See
+    // the InFlightProposalCard wiring in src/app/(app)/pm/page.tsx.
+    run(
+      `UPDATE pm_proposals SET status = 'superseded', dispatch_state = 'agent_complete' WHERE id = ?`,
+      [synthRowId],
+    );
     const sets: string[] = ['parent_proposal_id = ?', 'trigger_kind = ?', 'dispatch_state = ?'];
     const vals: unknown[] = [synthRowId, intent.trigger_kind, 'agent_complete'];
     if (intent.target_initiative_id) {
@@ -950,9 +959,12 @@ export function tryAdoptOrphanedPlaceholder(
     // an orphan. If a concurrent reconciler already linked it, the
     // UPDATE matches zero rows and we bail without touching the agent
     // row.
+    // Flip the placeholder's dispatch_state to 'agent_complete' alongside
+    // the supersede so the /pm in-flight render gate stops matching it.
+    // See supersedeWithAgentProposal for the same fix on the fast path.
     const stmt = db.prepare(
       `UPDATE pm_proposals
-          SET status = 'superseded'
+          SET status = 'superseded', dispatch_state = 'agent_complete'
         WHERE id = ?
           AND status = 'draft'
           AND dispatch_state = 'synth_only'


### PR DESCRIPTION
## Summary
PR #347 wired the in-flight card into /pm and /pm/proposals/[id], but the three modal/panel surfaces — DecomposeStoryToTasksModal ("Create tasks"), DecomposeWithPmModal, and PlanWithPmPanel — still rendered the synth-template body verbatim with only a small "PM agent is still composing" banner above. That was the exact failure mode story \`2edccd24\` was meant to fix; the builder shipped half of it. This finishes the wiring.

## Changes
**UI wiring (3 surfaces, identical pattern):**
- \`DecomposeStoryToTasksModal\`, \`DecomposeWithPmModal\`, \`PlanWithPmPanel\`: when \`dispatchState === 'pending_agent'\`, replace the synth body with \`<InFlightProposalCard>\`. The existing Accept button stays disabled (its gate already included \`pending_agent\`). On supersede, the card's existing SSE handler transitions out automatically.
- Each component now tracks \`proposal.created_at\` alongside \`proposal.id\` so the card's elapsed counter is accurate.

**Server-side fix surfaced during testing:**
- \`/api/pm/decompose-story\` + \`/api/pm/decompose-initiative\` dedupe paths (fire on React StrictMode's double-POST) were returning a stripped \`{ id, impact_md, proposed_changes }\` payload — dropping \`dispatch_state\` + \`created_at\`. The second StrictMode call's modal defaulted to \`null\` dispatch_state and the in-flight gate never matched. Both routes now return the canonical proposal shape via \`getProposal()\`. plan-initiative was already doing the equivalent.

## Test plan
- [x] \`yarn tsc --noEmit\` — clean.
- [x] Preview-verified on a fresh decompose-story dispatch: in-flight card renders with header, elapsed counter (ticking), proposal id pill, Cancel button — synth template body suppressed. Screenshot in the conversation. After the agent row supersedes (~30s in this dev env), the modal transitions to the real proposal automatically.