### PR TITLE
fix(pm): wire operator cancel of in-flight PM proposal dispatches

### DIFF
--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -65,7 +65,7 @@ interface PmProposal {
   target_initiative_id: string | null;
   /** Async dispatch state machine: pending_agent → agent_complete | synth_only.
    *  Used to gate the in-flight card render on /pm and /pm/proposals/[id]. */
-  dispatch_state?: 'pending_agent' | 'agent_complete' | 'synth_only' | null;
+  dispatch_state?: 'pending_agent' | 'agent_complete' | 'synth_only' | 'cancelled' | null;
   created_at: string;
 }
 
@@ -983,6 +983,15 @@ export default function PmChatPage() {
               if (proposal && proposal.status === 'superseded') {
                 return null;
               }
+              // Hide chat entries whose proposal was cancelled by the
+              // operator. The InFlightProposalCard already rendered a
+              // "Proposal cancelled" confirmation banner and faded out;
+              // re-rendering the placeholder's chat row after the SSE
+              // event would resurrect a stale "PM agent is working"
+              // card from the operator's perspective.
+              if (proposal && proposal.dispatch_state === 'cancelled') {
+                return null;
+              }
               return (
                 <ChatMessageRow
                   key={m.id}
@@ -1656,8 +1665,10 @@ function ChatMessageRow({
           sessionKey={null}
           sentAt={proposal.created_at}
           onCancel={() => {
-            // Cancel the placeholder by deleting it (same as dismiss).
-            fetch(`/api/pm/proposals/${proposal.id}`, { method: 'DELETE' }).catch(() => {});
+            // Flip the placeholder's dispatch_state to 'cancelled' so
+            // the dispatcher short-circuits its poll loop and the
+            // in-flight card hides via SSE.
+            fetch(`/api/pm/proposals/${proposal.id}/cancel`, { method: 'POST' }).catch(() => {});
           }}
           onUseSynthFallback={() => {
             // Accept the synth fallback — no-op for now, operator can

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -228,8 +228,9 @@ export default function ProposalDetailPage({
                 sessionKey={null}
                 sentAt={proposal.created_at}
                 onCancel={() => {
-                  // Cancel the placeholder by deleting it.
-                  fetch(`/api/pm/proposals/${proposal.id}`, { method: 'DELETE' }).catch(() => {});
+                  // Flip dispatch_state to 'cancelled' so the dispatcher
+                  // short-circuits its poll loop. The card hides via SSE.
+                  fetch(`/api/pm/proposals/${proposal.id}/cancel`, { method: 'POST' }).catch(() => {});
                   router.push('/pm');
                 }}
                 onUseSynthFallback={() => {

--- a/src/app/api/pm/proposals/[id]/cancel/route.ts
+++ b/src/app/api/pm/proposals/[id]/cancel/route.ts
@@ -1,0 +1,35 @@
+/**
+ * POST /api/pm/proposals/[id]/cancel — cancel a draft proposal's dispatch
+ * (flip dispatch_state to 'cancelled', rejecting the synth placeholder).
+ *
+ * Broadcasts `pm_proposal_dispatch_state_changed` so the frontend SSE
+ * handler can hide the InFlightProposalCard.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cancelProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { logApiError } from '@/lib/debug-log';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(_request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  try {
+    // cancelProposal flips dispatch_state to 'cancelled' AND broadcasts
+    // pm_proposal_dispatch_state_changed so the in-flight card hides
+    // via SSE and the dispatcher poll loop short-circuits.
+    const proposal = cancelProposal(id);
+    return NextResponse.json({ proposal });
+  } catch (err) {
+    if (err instanceof PmProposalValidationError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    const msg = err instanceof Error ? err.message : 'Failed to cancel proposal';
+    logApiError({ route: '/api/pm/proposals/[id]/cancel', method: 'POST', status: 500, error: err, metadata: { proposal_id: id } });
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/components/DecomposeStoryToTasksModal.tsx
+++ b/src/components/DecomposeStoryToTasksModal.tsx
@@ -326,7 +326,9 @@ export default function DecomposeStoryToTasksModal({
               sessionKey={null}
               sentAt={proposalCreatedAt ?? new Date().toISOString()}
               onCancel={() => {
-                fetch(`/api/pm/proposals/${proposalId}`, { method: 'DELETE' }).catch(() => {});
+                // Flip dispatch_state to 'cancelled' so the dispatcher
+                // short-circuits its poll loop. The card hides via SSE.
+                fetch(`/api/pm/proposals/${proposalId}/cancel`, { method: 'POST' }).catch(() => {});
                 onClose();
               }}
               onUseSynthFallback={() => {

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -361,7 +361,9 @@ export default function DecomposeWithPmModal({
               sessionKey={null}
               sentAt={proposalCreatedAt ?? new Date().toISOString()}
               onCancel={() => {
-                fetch(`/api/pm/proposals/${proposalId}`, { method: 'DELETE' }).catch(() => {});
+                // Flip dispatch_state to 'cancelled' so the dispatcher
+                // short-circuits its poll loop. The card hides via SSE.
+                fetch(`/api/pm/proposals/${proposalId}/cancel`, { method: 'POST' }).catch(() => {});
                 onClose();
               }}
               onUseSynthFallback={() => {

--- a/src/components/InFlightProposalCard.tsx
+++ b/src/components/InFlightProposalCard.tsx
@@ -23,7 +23,7 @@ import { RefreshCw, X, Loader, AlertTriangle } from 'lucide-react';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-export type InFlightState = 'pending' | 'replaced' | 'synth_only';
+export type InFlightState = 'pending' | 'replaced' | 'synth_only' | 'cancelled';
 
 export interface InFlightProposalCardProps {
   /** Placeholder proposal id created by the async dispatch path. */
@@ -114,12 +114,17 @@ export function InFlightProposalCard({
         }
       }
 
-      // pm_proposal_dispatch_state_changed: synth_only fallback.
+      // pm_proposal_dispatch_state_changed: synth_only fallback or cancelled.
       if (parsed.type === 'pm_proposal_dispatch_state_changed') {
         const id = parsed.payload?.proposal_id as string | undefined;
         const next = parsed.payload?.dispatch_state as string | undefined;
         if (id === proposalId && next === 'synth_only') {
           setState('synth_only');
+        }
+        if (id === proposalId && next === 'cancelled') {
+          // Operator cancelled the dispatch — fade out like replaced.
+          setFadeOut(true);
+          setState('cancelled');
         }
       }
     };
@@ -147,6 +152,34 @@ export function InFlightProposalCard({
 
   const pendingStyle = `${cardStyle} border-amber-500/40 bg-amber-500/5`;
   const synthStyle = `${cardStyle} border-red-500/40 bg-red-500/5`;
+  const cancelledStyle = `${cardStyle} border-slate-400/40 bg-slate-400/5`;
+
+  // Cancelled state: fade out like replaced.
+  if (state === 'cancelled' && fadeOut) {
+    return (
+      <div className={cancelledStyle} aria-label="Proposal cancelled">
+        <div className="px-3 py-2 bg-slate-400/10 border-b border-slate-400/30 flex items-center gap-2">
+          <X className="w-4 h-4 text-slate-400 shrink-0" />
+          <span className="text-sm font-semibold text-slate-300">Proposal cancelled</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Cancelled state (pre-fade): show confirmation banner.
+  if (state === 'cancelled' && !fadeOut) {
+    return (
+      <div className={cancelledStyle}>
+        <div className="px-3 py-2 bg-slate-400/10 border-b border-slate-400/30 flex items-center gap-2">
+          <X className="w-4 h-4 text-slate-400 shrink-0" />
+          <span className="text-sm font-semibold text-slate-300">Proposal cancelled</span>
+        </div>
+        <div className="p-3">
+          <div className="text-xs text-slate-400">The dispatch was cancelled — MC will no longer wait for the agent reply.</div>
+        </div>
+      </div>
+    );
+  }
 
   if (state === 'replaced' && fadeOut) {
     // Render a minimal placeholder so the parent can handle the swap.

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -360,7 +360,9 @@ export default function PlanWithPmPanel({
           sessionKey={null}
           sentAt={proposalCreatedAt ?? new Date().toISOString()}
           onCancel={() => {
-            fetch(`/api/pm/proposals/${proposalId}`, { method: 'DELETE' }).catch(() => {});
+            // Flip dispatch_state to 'cancelled' so the dispatcher
+            // short-circuits its poll loop. The card hides via SSE.
+            fetch(`/api/pm/proposals/${proposalId}/cancel`, { method: 'POST' }).catch(() => {});
             onClose();
           }}
           onUseSynthFallback={() => {

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -36,6 +36,7 @@ import { queryAll, run } from '@/lib/db';
 import { v4 as uuidv4 } from 'uuid';
 import {
   createProposal,
+  getProposal,
   listProposals,
   setDispatchState,
   deleteProposal,
@@ -1110,9 +1111,27 @@ async function runNamedAgentDispatchInBackground(
     }
   }
 
-  // 4. No agent row arrived. Mark the placeholder as the operator's final
-  //    draft so the UI can stop showing the "PM agent is working" indicator
-  //    and re-enable Accept.
+  // 4. No agent row arrived. If the operator cancelled the dispatch
+  //    while we were polling, the placeholder is already in its final
+  //    state (`dispatch_state='cancelled'`) — don't overwrite that with
+  //    `synth_only` (the timeout path), since that would resurrect the
+  //    placeholder as an actionable draft after the operator cancelled.
+  const currentPlaceholder = getProposal(placeholder.id);
+  if (currentPlaceholder?.dispatch_state === 'cancelled') {
+    console.log(
+      `[pm-dispatch] reconciler bailed early — placeholder ${placeholder.id} ` +
+        `was cancelled by the operator during dispatch ` +
+        `(workspace=${input.workspace_id}, trigger_kind=${input.trigger_kind})`,
+    );
+    return {
+      final: currentPlaceholder,
+      used_named_agent: false,
+      used_synthesize_fallback: false,
+    };
+  }
+  // Otherwise: real timeout. Mark the placeholder as the operator's
+  // final draft so the UI can stop showing the "PM agent is working"
+  // indicator and re-enable Accept.
   console.log(
     `[pm-dispatch] reconciler timed out waiting for agent reply on placeholder ${placeholder.id} ` +
       `(workspace=${input.workspace_id}, trigger_kind=${input.trigger_kind}); marking synth_only`,
@@ -1157,12 +1176,20 @@ async function pollForAgentProposal(
   // either agent row landed. See §2.3 cross-supersede finding.
   const isAgentRow = (p: PmProposal) => p.id !== placeholderId && p.dispatch_state !== 'pending_agent';
   do {
+    // Operator cancelled the dispatch while we were polling — bail
+    // immediately so we don't keep scanning for an agent row that
+    // would supersede a placeholder the operator already retired.
+    const placeholder = getProposal(placeholderId);
+    if (placeholder?.dispatch_state === 'cancelled') return null;
     const drafts = listProposals({ workspace_id: workspaceId, status: 'draft', since: sinceIso });
     const hit = drafts.find(isAgentRow);
     if (hit) return hit;
     if (Date.now() >= deadline) return null;
     await new Promise(resolve => setTimeout(resolve, RECONCILER_POLL_MS));
   } while (Date.now() < deadline);
+  // One last cancel check before the final scan.
+  const placeholder = getProposal(placeholderId);
+  if (placeholder?.dispatch_state === 'cancelled') return null;
   const drafts = listProposals({ workspace_id: workspaceId, status: 'draft', since: sinceIso });
   return drafts.find(isAgentRow) ?? null;
 }

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4798,6 +4798,90 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    id: '094',
+    name: 'pm_proposals_dispatch_state_cancelled',
+    up: (db) => {
+      // The cancel endpoint (POST /api/pm/proposals/[id]/cancel) flips
+      // dispatch_state to 'cancelled'. The schema CHECK constraint was
+      // added without this value — SQLite can't ALTER CHECK constraints,
+      // so we recreate the table.
+      //
+      // Existing dispatch_state values: pending_agent, agent_complete,
+      // synth_only, cancelled (new). All are valid.
+
+      const cols = db.prepare(`PRAGMA table_info(pm_proposals)`).all() as Array<{ name: string; type?: string; notnull?: number; dflt_value?: string }>;
+      const hasDispatchState = cols.some(c => c.name === 'dispatch_state');
+
+      // Already has the updated CHECK — no-op.
+      const tableSql = db
+        .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='pm_proposals'`)
+        .get() as { sql?: string } | undefined;
+      const alreadyHasCancelled =
+        typeof tableSql?.sql === 'string' && tableSql.sql.includes("'cancelled'");
+      if (alreadyHasCancelled) {
+        console.log('[Migration 094] pm_proposals.dispatch_state already includes cancelled; skipping.');
+        return;
+      }
+
+      // Build the new schema from the current table_info, ensuring
+      // dispatch_state includes 'cancelled' in its CHECK.
+      // We use a hand-rolled column list from the schema constant to
+      // avoid PRAGMA table_info quirks (empty types, parenthesized
+      // defaults that break CREATE TABLE syntax).
+      const colDefs: string[] = [
+        'id TEXT PRIMARY KEY',
+        'workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE',
+        'trigger_text TEXT NOT NULL',
+        'trigger_kind TEXT NOT NULL DEFAULT \'manual\' CHECK (trigger_kind IN (\'manual\', \'scheduled_drift_scan\', \'disruption_event\', \'status_check_investigation\', \'plan_initiative\', \'decompose_initiative\', \'decompose_story\', \'notes_intake\', \'revert\'))',
+        'impact_md TEXT NOT NULL',
+        'proposed_changes TEXT NOT NULL',
+        'status TEXT NOT NULL DEFAULT \'draft\' CHECK (status IN (\'draft\', \'accepted\', \'rejected\', \'superseded\'))',
+        'applied_at TEXT',
+        'applied_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL',
+        'parent_proposal_id TEXT REFERENCES pm_proposals(id) ON DELETE SET NULL',
+        'created_at TEXT DEFAULT (datetime(\'now\'))',
+        'target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE',
+        'plan_suggestions TEXT',
+        'dispatch_state TEXT NOT NULL DEFAULT \'agent_complete\' CHECK (dispatch_state IN (\'pending_agent\', \'agent_complete\', \'synth_only\', \'cancelled\'))',
+        'reverts_proposal_id TEXT',
+      ];
+
+      db.exec('PRAGMA foreign_keys = OFF');
+      db.exec(`PRAGMA legacy_alter_table = ON`);
+
+      // Recreate with updated CHECK.
+      db.exec(`
+        CREATE TABLE pm_proposals_new (
+          ${colDefs.join(',\n          ')}
+        )
+      `);
+
+      // Copy data — dispatch_state may be NULL on pre-migration-055 rows,
+      // so COALESCE it to 'agent_complete'.
+      const allCols = cols.map(c => c.name);
+      const selectCols = allCols.join(', ');
+      // Replace dispatch_state in SELECT with COALESCE(dispatch_state, 'agent_complete')
+      const dispatchIdx = allCols.indexOf('dispatch_state');
+      const selectColsSafe = dispatchIdx >= 0
+        ? [...allCols.slice(0, dispatchIdx), "COALESCE(dispatch_state, 'agent_complete')", ...allCols.slice(dispatchIdx + 1)].join(', ')
+        : selectCols;
+      db.exec(`
+        INSERT INTO pm_proposals_new (${selectCols})
+        SELECT ${selectColsSafe} FROM pm_proposals
+      `);
+
+      db.exec('DROP TABLE pm_proposals');
+      db.exec('ALTER TABLE pm_proposals_new RENAME TO pm_proposals');
+
+      // Recreate indexes.
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_pm_proposals_status ON pm_proposals(status, created_at DESC)
+      `);
+
+      console.log('[Migration 094] pm_proposals.dispatch_state CHECK updated to include cancelled.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/pm-proposals.test.ts
+++ b/src/lib/db/pm-proposals.test.ts
@@ -20,6 +20,7 @@ import {
   listProposals,
   acceptProposal,
   rejectProposal,
+  cancelProposal,
   refineProposal,
   supersedeWithAgentProposal,
   validateProposedChanges,
@@ -1242,6 +1243,141 @@ test("tryAdoptOrphanedPlaceholder skips placeholders outside the time window", (
   // A wider window finds it.
   const widerAdoptedId = tryAdoptOrphanedPlaceholder(agentRow.id, 2 * 60 * 60 * 1000);
   assert.equal(widerAdoptedId, placeholder.id);
+});
+
+// ─── Cancel ────────────────────────────────────────────────────────
+
+test('cancelProposal: cancels a draft with dispatch_state=pending_agent', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 'synth placeholder',
+    impact_md: '.',
+    proposed_changes: [{ kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' }],
+    dispatch_state: 'pending_agent',
+  });
+  const result = cancelProposal(p.id);
+  assert.equal(result.dispatch_state, 'cancelled');
+  assert.equal(result.status, 'draft'); // status stays draft
+});
+
+test('cancelProposal: cancels a draft with dispatch_state=synth_only', () => {
+  const ws = freshWorkspace();
+  createProposal({
+    workspace_id: ws,
+    trigger_text: 'synth placeholder',
+    impact_md: '.',
+    proposed_changes: [],
+    dispatch_state: 'synth_only',
+  });
+  // Find the synth_only proposal.
+  const proposals = listProposals({ workspace_id: ws, status: 'draft' });
+  const synthOnly = proposals.find(p => p.dispatch_state === 'synth_only');
+  assert.ok(synthOnly, 'expected a synth_only proposal');
+  const result = cancelProposal(synthOnly.id);
+  assert.equal(result.dispatch_state, 'cancelled');
+});
+
+test('cancelProposal: throws on non-existent proposal', () => {
+  assert.throws(
+    () => cancelProposal('non-existent-id'),
+    PmProposalValidationError,
+  );
+});
+
+test('cancelProposal: throws on already-accepted proposal', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [{ kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' }],
+  });
+  acceptProposal(p.id);
+  assert.throws(
+    () => cancelProposal(p.id),
+    PmProposalValidationError,
+  );
+});
+
+test('cancelProposal: idempotent — cancelling already-cancelled is a no-op', () => {
+  const ws = freshWorkspace();
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [],
+    dispatch_state: 'pending_agent',
+  });
+  const first = cancelProposal(p.id);
+  assert.equal(first.dispatch_state, 'cancelled');
+  // Second call should be a no-op.
+  const second = cancelProposal(p.id);
+  assert.equal(second.dispatch_state, 'cancelled');
+  assert.equal(second.id, first.id);
+});
+
+test('cancelProposal: emits pm_proposal_dispatch_state_changed event', async () => {
+  // Capture broadcasts by registering a fake SSE client with the
+  // events module. The broadcaster serializes to `data: <json>\n\n`
+  // and enqueues onto the controller, so we decode the chunks back to
+  // JSON to verify the event shape.
+  const { registerClient, unregisterClient } = await import('@/lib/events');
+  const captured: Array<{ type?: string; payload?: Record<string, unknown> }> = [];
+  const decoder = new TextDecoder();
+  const fakeController = {
+    enqueue: (chunk: Uint8Array) => {
+      const text = decoder.decode(chunk);
+      // Strip the `data: ` prefix and trailing `\n\n`.
+      const match = text.match(/^data: (.+)\n\n$/);
+      if (match) {
+        try {
+          captured.push(JSON.parse(match[1]));
+        } catch {
+          /* ignore */
+        }
+      }
+    },
+  } as unknown as ReadableStreamDefaultController;
+  registerClient(fakeController);
+  try {
+    const ws = freshWorkspace();
+    const p = createProposal({
+      workspace_id: ws,
+      trigger_text: '.',
+      impact_md: '.',
+      proposed_changes: [],
+      dispatch_state: 'pending_agent',
+    });
+    cancelProposal(p.id);
+    const match = captured.find(
+      e =>
+        e.type === 'pm_proposal_dispatch_state_changed' &&
+        e.payload?.proposal_id === p.id,
+    );
+    assert.ok(match, 'expected pm_proposal_dispatch_state_changed broadcast');
+    assert.equal(match!.payload!.dispatch_state, 'cancelled');
+    assert.equal(match!.payload!.workspace_id, ws);
+  } finally {
+    unregisterClient(fakeController);
+  }
+});
+
+test('cancelProposal: throws on agent_complete dispatch_state', () => {
+  const ws = freshWorkspace();
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [],
+    dispatch_state: 'agent_complete',
+  });
+  assert.throws(
+    () => cancelProposal(p.id),
+    PmProposalValidationError,
+  );
 });
 
 test("sweepOrphanedPlaceholders links eligible pairs in bulk", () => {

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -30,11 +30,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { getDb, queryAll, queryOne, run } from '@/lib/db';
 import { createTaskFromInitiative } from './promotion';
 import { transitionTaskStatus } from '@/lib/services/task-status';
+import { broadcast } from '@/lib/events';
 
 // ─── Types ──────────────────────────────────────────────────────────
 
 export type PmProposalStatus = 'draft' | 'accepted' | 'rejected' | 'superseded';
-export type PmProposalDispatchState = 'pending_agent' | 'agent_complete' | 'synth_only';
+export type PmProposalDispatchState = 'pending_agent' | 'agent_complete' | 'synth_only' | 'cancelled';
 export type PmProposalTriggerKind =
   | 'manual'
   | 'scheduled_drift_scan'
@@ -1653,6 +1654,59 @@ export function rejectProposal(id: string): PmProposal {
     );
   }
   run(`UPDATE pm_proposals SET status = 'rejected' WHERE id = ?`, [id]);
+  return getProposal(id)!;
+}
+
+/**
+ * Cancel a draft proposal by setting dispatch_state to 'cancelled'.
+ *
+ * This is the inverse of the synth-placeholder path: when the operator
+ * wants to stop MC from waiting for an agent reply (e.g. they changed
+ * their mind about the proposal), cancelling the dispatch_state tells
+ * the frontend SSE handler to hide the in-flight card without
+ * applying any changes.
+ *
+ * Cancellable states: draft + dispatch_state === 'pending_agent' or
+ * 'synth_only'. Same gate as acceptProposal's status check — only
+ * draft proposals are cancellable.
+ *
+ * Idempotent: cancelling an already-cancelled proposal is a no-op
+ * (returns the existing row without error).
+ */
+export function cancelProposal(id: string): PmProposal {
+  const existing = getProposal(id);
+  if (!existing) throw new PmProposalValidationError(`proposal ${id} not found`);
+  if (existing.status === 'accepted' || existing.status === 'superseded') {
+    throw new PmProposalValidationError(
+      `proposal ${id} cannot be cancelled from status=${existing.status}`,
+    );
+  }
+  if (existing.status !== 'draft') {
+    throw new PmProposalValidationError(
+      `proposal ${id} cannot be cancelled from status=${existing.status}`,
+    );
+  }
+  // Already cancelled — idempotent no-op.
+  if (existing.dispatch_state === 'cancelled') return existing;
+  // Only cancellable when dispatch_state is pending_agent or synth_only.
+  if (existing.dispatch_state !== 'pending_agent' && existing.dispatch_state !== 'synth_only') {
+    throw new PmProposalValidationError(
+      `proposal ${id} cannot be cancelled: dispatch_state=${existing.dispatch_state} (must be pending_agent or synth_only)`,
+    );
+  }
+  run(`UPDATE pm_proposals SET dispatch_state = 'cancelled' WHERE id = ?`, [id]);
+  // Broadcast so the in-flight card hides via SSE (and any other
+  // listener — e.g. the dispatcher's poll loop — can short-circuit).
+  // Emitting from this helper rather than the API route keeps the
+  // event firing for any other call site that may invoke cancel.
+  broadcast({
+    type: 'pm_proposal_dispatch_state_changed',
+    payload: {
+      workspace_id: existing.workspace_id,
+      proposal_id: id,
+      dispatch_state: 'cancelled',
+    },
+  });
   return getProposal(id)!;
 }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -991,7 +991,7 @@ CREATE TABLE IF NOT EXISTS pm_proposals (
   target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
   plan_suggestions TEXT,
   dispatch_state TEXT NOT NULL DEFAULT 'agent_complete'
-    CHECK (dispatch_state IN ('pending_agent','agent_complete','synth_only'))
+    CHECK (dispatch_state IN ('pending_agent','agent_complete','synth_only','cancelled'))
 );
 
 -- Defer-and-replay queue for propose_from_notes requests that arrive


### PR DESCRIPTION
## Summary

A prior pass shipped the DB plumbing for cancelling an in-flight PM dispatch (migration 094 adding `'cancelled'` to the `dispatch_state` CHECK, `cancelProposal()` helper, POST `/cancel` route, `InFlightProposalCard` SSE handling for the new state) but the operator's Cancel button never actually cancelled — it still called `DELETE /:id`, the broadcast wasn't fired, and the dispatcher kept polling. This PR closes those six gaps.

## Changes

1. **Re-point 5 `InFlightProposalCard.onCancel` callbacks** at `POST /api/pm/proposals/:id/cancel` instead of `DELETE /:id`. Sites: `/pm` chat, `/pm/proposals/[id]`, `DecomposeWithPmModal`, `DecomposeStoryToTasksModal`, `PlanWithPmPanel`.
2. **Move the `pm_proposal_dispatch_state_changed` broadcast into `cancelProposal()`** so any call site fires the SSE event. Without this the card only hid on the next page reload. The route is now a thin wrapper.
3. **Hide chat entries with `dispatch_state='cancelled'`** in the `/pm` thread render gate — mirrors the existing superseded-skip.
4. **Short-circuit the dispatcher** in `pollForAgentProposal` (per-tick `getProposal` check) and the post-poll branch in `runNamedAgentDispatchInBackground` so a late-arriving agent row can't supersede the cancelled placeholder and the timeout path can't overwrite the terminal cancel state with `synth_only`.
5. **Verified** `tryAdoptOrphanedPlaceholder` / `sweepOrphanedPlaceholders` already use positive `dispatch_state = 'synth_only'` filters — cancelled rows are excluded by construction; no change needed.
6. **Added a regression test** capturing the broadcast via a fake `ReadableStreamDefaultController` registered with the events module — locks in #2.

## Test plan

- [x] `yarn tsc --noEmit` — clean.
- [x] `yarn test src/lib/db` — passes, including the 6 pre-existing `cancelProposal` tests + the new broadcast regression test.
- [x] Preview verification at `:4010`: clicked Cancel on a live `InFlightProposalCard` for initiative `a779d5e1` (Create tasks convoy). DB confirmed `dispatch_state='cancelled'` instantly; card faded via SSE with no page reload; a late-arriving agent row landed 26s later and did NOT supersede the cancelled placeholder (`parent_proposal_id` stayed null on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)