### PR TITLE
docs(pm): proposal — PM decomposition must emit convoys, not flat task lists

### DIFF
--- a/docs/proposals/pm-convoy-mandate.md
+++ b/docs/proposals/pm-convoy-mandate.md
@@ -1,0 +1,294 @@
+---
+status: aspirational
+last-verified: 2026-05-13
+audience: ai-subagents-primary, operator-secondary
+code-anchors:
+  - src/lib/mcp/shared.ts:285-299
+  - src/lib/db/pm-proposals.ts
+  - src/lib/agents/pm-agent.ts
+  - src/lib/convoy.ts
+  - src/lib/mcp/groups/work.ts:1565-1872
+  - src/lib/services/task-status.ts:78-192
+  - src/app/api/pm/proposals/[id]/accept/route.ts
+  - src/components/DecomposeWithPmModal.tsx
+  - src/components/DecomposeStoryToTasksModal.tsx
+  - src/components/PlanWithPmPanel.tsx
+mcp-tools: [propose_changes, plan_convoy, spawn_subtask]
+db-tables: [pm_proposals, convoys, convoy_subtasks, tasks, initiatives]
+related-specs:
+  - pm-diff-conventions.md — adds the new diff kind to that table
+  - task-delegation-and-convoys.md — shifts decomposition upstream from coordinator
+  - roadmap-and-pm-spec.md — PM's decompose-flow output changes shape
+  - pm-revertable-proposals.md — revert semantics for the new diff kind
+  - review-stage-robustness-spec.md — parent review→done gets the AC gate
+---
+
+# PM convoy mandate — decomposition produces convoys, not flat task lists
+
+## Status
+
+Aspirational. The mandate replaces the current `decompose_story` / `decompose_initiative` / `plan_initiative` output shape (an array of `create_task_under_initiative` diffs) with a `create_convoy_under_initiative` diff carrying a slice DAG. The wholistic fix to two locality bugs we keep re-hitting.
+
+## Problem
+
+Mission Control today has **two decomposition steps**, and only the second one uses convoy machinery:
+
+```
+Story  →  PM emits flat list of create_task_under_initiative diffs  (no inter-task deps)
+       →  Operator accepts → N independent task rows created
+       →  Coordinator dispatched on one of them
+       →  Coordinator emits spawn_subtask / plan_convoy        (gates appear HERE for the first time)
+       →  Convoy slices run with dep + evidence gates
+```
+
+The gates exist (`depends_on_subtask_ids` since PR #344, `required_evidence_gates` per slice, parent auto-promote, `QUALITY_STAGES` evidence check) but they only operate **inside** a convoy. Everything **before** the convoy — i.e. the PM's actual story decomposition — is gate-free. Two failure modes we've audited:
+
+1. **Layer-sliced narrow tasks** (PR #348 audit). The PM decomposed "In-flight proposal card replaces synth-as-placeholder" into 4 tasks, one of which was "Implement cancel endpoint POST /api/pm/proposals/[id]/cancel". The builder shipped exactly that endpoint and stopped. The convoy was locally correct (1 builder slice, 7 acceptance criteria, all green) and globally wrong (no SSE broadcast, no frontend wiring, no dispatcher short-circuit, no orphan-sweep exclusion). Each layer was locally consistent; the system had no notion of feature-level completeness.
+
+2. **No sibling ordering at the PM layer.** [`src/lib/mcp/shared.ts:285-299`](../src/lib/mcp/shared.ts) defines `create_task_under_initiative` without a `depends_on` field. The PM cannot express "task B waits for task A" inside a `propose_changes` call. The only way to get ordered, gated, multi-step work is to skip task creation and dispatch a coordinator who'll emit a convoy. So coordinator decomposition is doing double duty as both delegation and dependency planning, and the PM's plan is impoverished.
+
+The bug class is structural, not a one-off. SOUL-prompt nudges to "be a better decomposer" are bandaids — they patch each instance, the system stays unable to express what the operator needs.
+
+## The mandate
+
+When the PM emits a `propose_changes` call with `trigger_kind ∈ {decompose_story, decompose_initiative, plan_initiative}`, it MUST emit at least one `create_convoy_under_initiative` diff and MUST NOT emit `create_task_under_initiative` diffs. The zod refinement on [`shared.ts`](../src/lib/mcp/shared.ts) enforces this server-side.
+
+Every multi-step work output from PM decomposition is now a DAG with explicit deps, per-slice acceptance criteria, and parent-level acceptance criteria the convoy must satisfy before auto-promoting the parent task to `done`.
+
+### Carve-outs
+
+`create_task_under_initiative` survives, but only from non-decomposition contexts:
+
+| trigger_kind | Allowed diff kinds for task creation |
+|---|---|
+| `decompose_story`, `decompose_initiative`, `plan_initiative` | `create_convoy_under_initiative` only |
+| `notes_intake` | `create_task_under_initiative` (scattered tactical capture across initiatives; not coordinated work) |
+| `manual` | `create_task_under_initiative` (operator-driven; not PM decomposition) |
+| Audit follow-ups, `audit_finding`-triggered proposals | `create_task_under_initiative` (tactical, not strategic) |
+| `create_child_initiative` placeholder pattern | `create_task_under_initiative` still works for stubs against just-proposed child initiatives — those tasks are registered for FUTURE decomposition, not as the decomposition output |
+
+The distinction is already encoded in `trigger_kind` on the proposal row, so the rule is mechanically enforceable.
+
+### Single-slice convoys are allowed and UI-collapsed
+
+A story that genuinely is "one builder owns this end-to-end" decomposes to a 1-slice convoy. Convoy machinery underneath, plain-task surface above. The Task Board renders 1-slice convoys as if they were the parent task; the Convoy tab elides the ceremony. Schema stays uniform; UX stays light.
+
+## Data model
+
+### New diff kind: `create_convoy_under_initiative`
+
+Add to [`src/lib/mcp/shared.ts`](../src/lib/mcp/shared.ts) `DiffSchema` union:
+
+```ts
+z.object({
+  kind: z.literal('create_convoy_under_initiative'),
+  initiative_id: z.string().min(1),
+  // Symbolic-ref placeholders ($0..$N) for create_child_initiative in
+  // the same proposal still resolve here, mirroring the current pattern.
+
+  // Parent-level acceptance criteria the convoy must satisfy before the
+  // parent task can transition from `review` to `done`. These are
+  // operator-facing, feature-level — NOT the per-slice contract criteria.
+  // Example: "Operator clicks Cancel on any InFlightProposalCard surface
+  // → card disappears + late agent reply doesn't resurrect."
+  parent_acceptance_criteria: z.array(z.string().min(10).max(500)).min(1),
+
+  // The DAG. Mirrors plan_convoy's slice schema (same fields the
+  // coordinator-driven path uses today) so a single apply-pass helper
+  // serves both entry points.
+  slices: z.array(z.object({
+    id: z.string().min(1).max(40).regex(/^[a-zA-Z0-9_-]+$/),
+    role: z.string().min(1).optional(),
+    peer_agent_id: z.string().min(1).optional(),
+    peer_gateway_id: z.string().min(1).optional(),
+    slice: z.string().min(10).max(500),
+    message: z.string().min(1).max(10000),
+    expected_deliverables: z.array(z.object({
+      title: z.string().min(1).max(200),
+      kind: z.enum(['file', 'note', 'report']),
+    })).min(1),
+    acceptance_criteria: z.array(z.string().min(10).max(500)).min(1),
+    expected_duration_minutes: z.number().int().min(5).max(240),
+    checkin_interval_minutes: z.number().int().min(5).max(60).optional(),
+    depends_on: z.array(z.string().min(1).max(40)).optional(),
+    // Per-slice evidence gate override; default ['test_full'] for tester
+    // slices, none for others. Inherits today's convoy_subtasks behavior.
+    required_evidence_gates: z.array(z.string()).optional(),
+  })).min(1).max(12),
+}),
+```
+
+DAG validation (Kahn's topological sort, cycle detection, peer resolution) reuses the same code path as `plan_convoy` — see [`src/lib/mcp/groups/work.ts:1565-1872`](../src/lib/mcp/groups/work.ts).
+
+### Schema additions to `pm_proposals` table
+
+None directly — the convoy plan lives in `proposed_changes` JSON. Apply-pass materializes it.
+
+### Schema additions to `convoys` table
+
+```sql
+ALTER TABLE convoys ADD COLUMN acceptance_criteria TEXT;
+-- JSON array of strings. Populated when the convoy is spawned from
+-- a create_convoy_under_initiative diff. NULL for coordinator-spawned
+-- convoys (back-compat).
+```
+
+### Apply pass: zod-validated `acceptProposal`
+
+When a proposal accept walks a `create_convoy_under_initiative` diff:
+
+1. Resolve `initiative_id` (real or placeholder `$N` from a sibling `create_child_initiative` diff in the same proposal).
+2. Find-or-create the parent task for the initiative (mirrors `promote_initiative_to_task` semantics — story-kind initiatives without a task row get one created at this moment).
+3. Validate the DAG (cycles, unknown refs, peer resolution). Identical to `plan_convoy`'s validation.
+4. Create the `convoys` row with `acceptance_criteria` populated from the diff.
+5. Create per-slice `tasks` + `convoy_subtasks` rows in topological order with resolved `depends_on_subtask_ids`. Reuses [`spawnDelegationSubtask`](../src/lib/convoy.ts).
+6. Call `dispatchReadyConvoySubtasks(convoyId)` to fire root slices. Dep gate (PR #344) keeps dependents in `inbox`.
+
+The atomic-fail-on-validation invariant is critical: if any slice's peer resolution fails or any cycle is detected, the entire diff rejects and nothing materializes. Today's behavior (apply N tasks, leave whichever ones validated) is replaced by all-or-nothing.
+
+## Gate at parent `review → done`
+
+The convoy auto-promote ([`checkConvoyCompletion`](../src/lib/convoy.ts) line 230-264) currently flips the parent task to `review` when all subtasks reach `done`. This is the existing rail. The operator-driven `review → done` click becomes the AC gate.
+
+Add a check in [`src/lib/services/task-status.ts`](../src/lib/services/task-status.ts):
+
+```ts
+// In transitionTaskStatus, after the existing QUALITY_STAGES evidence
+// check, before the actual UPDATE:
+if (newStatus === 'done' && !boardOverride) {
+  const convoy = queryOne<{ acceptance_criteria: string | null }>(
+    `SELECT acceptance_criteria FROM convoys WHERE parent_task_id = ? AND status = 'done'`,
+    [taskId],
+  );
+  if (convoy?.acceptance_criteria) {
+    return {
+      ok: false,
+      code: 'parent_ac_check_pending',
+      error: `Parent task has convoy ACs requiring explicit review. Operator must acknowledge each before transitioning to done.`,
+    };
+  }
+}
+```
+
+The frontend transitions become two-step: operator sees parent task in `review`, opens the AC review surface, ticks each criterion (or types why it's not satisfied), then transitions to `done`. The "tick each AC" surface is a small modal — much simpler than the convoy plan approval surface.
+
+`board_override: true` bypasses the AC check (operator escape hatch). Same pattern as evidence gate bypass today.
+
+## UX surface: operator-approves-the-DAG
+
+The current [`DecomposeWithPmModal`](../src/components/DecomposeWithPmModal.tsx) renders a checkbox list of `create_task_under_initiative` diffs. The new shape is a slice DAG. V1 UX:
+
+- Slices rendered in topological order, top-to-bottom.
+- Each slice row shows: role, slice title, expected duration, deliverable count, and a `depends on: X, Y` label.
+- Parent acceptance criteria rendered as a separate section above the slices (the feature-level contract).
+- Accept button labeled "Plan and dispatch convoy (N slices)" — clearer blast radius than the current "Accept all 4 draft tasks."
+- Refine input behaves the same way it does today (revises the proposal; details below).
+
+DAG visualization (arrows, swim lanes) is future polish. Topological list with explicit deps is enough for V1.
+
+### Two-stage commit (optional)
+
+For high-stakes parents the Accept button can split into "Accept plan" (creates convoy in `paused` status, no dispatch) and "Dispatch" (flips to `active`, fires root slices). Reduces blast radius and gives the operator time to review the plan before agents start running. Defer to V2.
+
+## Refine semantics
+
+`POST /api/pm/proposals/[id]/refine` creates a child proposal with revised content. Refining a convoy proposal:
+
+- **Before any slice dispatches** (`status='draft'`, convoy not yet spawned): replace the entire DAG. Easy — the child proposal carries the new plan.
+- **After dispatch starts** (any slice is `assigned`/`in_progress`/`done`): use [`addSubtasks`](../src/lib/convoy.ts) to append new slices to the existing active convoy. The previous DAG isn't replaced; the convoy grows. Symbolic deps in the refined proposal resolve against the existing convoy's subtask ids.
+
+Both paths inherit the dedupe-by-existing-draft-child guard from PR #343.
+
+## PM SOUL changes
+
+`agent-templates/pm/SOUL.md` (or the equivalent prompt loaded by the PM agent):
+
+- Add a "decomposition output contract" section:
+  > **When you decompose a story or initiative**, emit a single `create_convoy_under_initiative` diff carrying the full DAG. Do NOT emit a flat list of `create_task_under_initiative` diffs — that path is reserved for notes-intake and tactical follow-ups, and the schema will reject it from a decompose-flow proposal.
+- Add a "DAG smell checklist" the PM consults before emitting:
+  > Before emitting the convoy diff, check: does every slice have observable operator-facing behavior on its own? A bare "endpoint" or "component" slice without its consumer slice is a smell — fuse them, or add the consumer slice explicitly with a `depends_on`. If a slice's acceptance criteria are all contract-shaped (status codes, type fields, function signatures) and none are feature-shaped (operator can click X, the system does Y), the slice is too narrow.
+- Add a "parent ACs are feature-level" instruction:
+  > Each `create_convoy_under_initiative` diff must include `parent_acceptance_criteria` — these are the operator's observable criteria for the feature being done, not per-slice contract criteria. Example good AC: "Operator clicks Cancel on any in-flight proposal card → card disappears and late agent reply doesn't resurrect." Example bad AC: "Endpoint returns 200 on valid input."
+
+## Coordinator SOUL changes
+
+`agent-templates/coordinator/SOUL.md` becomes narrower:
+
+- Remove the "decompose the parent task" responsibility. Decomposition happens at PM-emit time.
+- Coordinator's job: monitor convoy slices via `list_my_subtasks`, accept delivered slices via `update_subtask({action: 'accept'})`, reject on miss, escalate failures.
+- The `spawn_subtask` and `plan_convoy` tools remain available for follow-up work discovered mid-flight (a builder reports a missing slice; coordinator can append). Not the primary decomposition path.
+
+## Migration plan
+
+Phased. None of these need to land atomically.
+
+### Phase 1 — bandaid (1-2 days)
+
+- SOUL nudges: "no naked-endpoint tasks" for the PM, "broaden if parent's intent is wider than the task description" for the coordinator.
+- Parent-task ACs as advisory metadata on the existing `create_task_under_initiative` apply pass — store on the task row, surface in the UI, no enforcement.
+
+These help today's decompositions without touching the schema. Buy time.
+
+### Phase 2 — structural mandate (~1 week)
+
+- Add `create_convoy_under_initiative` diff kind + zod schema.
+- Add `convoys.acceptance_criteria` column.
+- Apply-pass: route the new diff through `spawnDelegationSubtask` loop.
+- PM SOUL updates to emit the new diff for decompose flows.
+- Schema refinement that REJECTS `create_task_under_initiative` in decompose-flow proposals.
+- DAG approval UX in the three modals/panels.
+- Parent `review → done` AC check.
+
+### Phase 3 — cleanup (~3 days, can lag)
+
+- Task Board renders convoy slices as first-class rows (with parent-task collapse for 1-slice convoys).
+- Coordinator SOUL shrinks to monitor + accept + escalate.
+- Historical `create_task_under_initiative` diffs from decompose-flow proposals stay valid (no data migration needed) — only forward emissions are constrained.
+- Spec edits per the table below.
+
+## Edge cases handled
+
+- **Cross-initiative decomposition.** PM may emit multiple `create_convoy_under_initiative` diffs in one proposal (one per target initiative). Schema rule: each diff targets exactly one initiative. Operator reviews K convoy plans on one Accept.
+- **Story has no parent task yet.** Apply-pass auto-creates the parent task at spawn time (mirrors `promote_initiative_to_task`).
+- **Failed slice → rework.** Existing `update_subtask({action: 'reject'})` flow unchanged.
+- **`create_child_initiative` + tasks under it.** PM can still emit child-initiative + placeholder tasks against it in a notes-intake proposal. The tasks are stubs, not decomposition output. Convoy mandate doesn't apply.
+- **Operator manually creates tasks.** Not a PM emission. Unaffected.
+- **Audit follow-ups.** `audit_finding`-triggered proposals are tactical, not strategic. Mandate doesn't apply.
+- **Workflow templates and convoy interaction.** PR #346 already removed `workflow_template_id` from convoy children. The mandate continues that — parent stories have no workflow template either, only convoy ACs.
+
+## Open questions / things to settle before Phase 2
+
+- Two-stage commit (Accept plan → Dispatch) or single-stage? Single-stage matches today's friction profile; two-stage is safer. Lean: single-stage for V1, add a feature flag for two-stage.
+- DAG editing in the approval modal. V1: read-only display of the PM's proposal; operator can `/refine` to revise. V2: inline slice edit / remove / add.
+- Should `plan_convoy` (the coordinator's MCP tool) survive once the PM is the primary convoy emitter? Yes — coordinators still need it for mid-flight slice appends and for tasks that were created via non-PM paths.
+- Should the AC check use a free-text "why each AC is satisfied" or a checkbox? Free-text is more honest, checkbox is faster. Lean: free-text required for ACs that aren't auto-verifiable; checkbox-only is too easy to bypass.
+
+## Specs that need edits when this ships
+
+| Spec | Edit | Severity |
+|---|---|---|
+| [`docs/reference/pm-diff-conventions.md`](../docs/reference/pm-diff-conventions.md) | Add `create_convoy_under_initiative` row to the diff-kind table; add "decompose-flow-only / non-decompose-flow-only" column or note; document the new shape. | Material |
+| [`docs/reference/task-delegation-and-convoys.md`](../docs/reference/task-delegation-and-convoys.md) | Note that convoys now have two entry points (PM-emit at proposal-accept time AND coordinator `spawn_subtask`/`plan_convoy` for mid-flight); shrink the coordinator's described scope; document `convoys.acceptance_criteria`. | Material |
+| [`docs/reference/roadmap-and-pm-spec.md`](../docs/reference/roadmap-and-pm-spec.md) | Section ~line 499 describes today's flat-list decompose output. Replace with the convoy mandate; describe the parent-task auto-create-on-accept; describe `parent_acceptance_criteria`. | Material |
+| [`docs/reference/pm-revertable-proposals.md`](../docs/reference/pm-revertable-proposals.md) | Define `invertDiff` for `create_convoy_under_initiative`: cancel the convoy + delete unscheduled child tasks; refuse revert if any slice has reached `done`. Material edit to [`src/lib/pm/invertDiff.ts`](../src/lib/pm/invertDiff.ts) needed alongside the spec. | Material |
+| [`docs/reference/review-stage-robustness-spec.md`](../docs/reference/review-stage-robustness-spec.md) | Document the parent `review → done` AC gate; how it composes with evidence gate; how `board_override` bypasses. | Material |
+| `docs/reference/pm-chat-prompt.md` (and any pm SOUL file under `agent-templates/pm/`) | Add the decompose-flow output contract, the DAG smell checklist, and the parent-AC instruction. | Material |
+| [`docs/reference/agent-model-cleanup.md`](../docs/reference/agent-model-cleanup.md) | Coordinator described as decomposer; needs the role-shift (monitor + accept + escalate). | Light |
+| [`docs/reference/audit-pipeline.md`](../docs/reference/audit-pipeline.md) | Add an explicit "audit follow-ups bypass the convoy mandate" note so future readers don't think the mandate applies universally. | Light |
+| [`docs/reference/autonomous-flow-tightening-spec.md`](../docs/reference/autonomous-flow-tightening-spec.md) | Verify nothing in the autonomous flow assumes coordinator-led decomposition. Likely a frontmatter `last-verified` bump after a re-read; no content edit. | Light / re-verify |
+| [`docs/proposals/subagent-orchestration.md`](../docs/proposals/subagent-orchestration.md) | Re-read for overlap. Aspirational doc; might be subsumed by this proposal or might describe an adjacent layer. Decide at Phase 2 ship time. | Re-read |
+
+When this proposal is promoted to `reference/` (Phase 2 ships), file gets renamed `pm-convoy-mandate.md` → stays the same name; `status: aspirational` → `current`; `last-verified` updated.
+
+## Acceptance for "this proposal itself ships"
+
+- [ ] Phase 1 (SOUL nudges + advisory ACs) merged.
+- [ ] Phase 2 schema + apply-pass + UX merged behind a feature flag (`MC_PM_CONVOY_MANDATE=1`).
+- [ ] Schema validator rejects `create_task_under_initiative` in decompose-flow proposals when the flag is on.
+- [ ] AC gate enforces parent `review → done`.
+- [ ] DAG approval UX renders and accepts; refine semantics tested for both pre- and post-dispatch.
+- [ ] One real-world dogfood: the PM uses this flow to decompose a follow-up to this proposal itself.
+- [ ] Spec edits per the table above land in the same PR as Phase 2.
+- [ ] Phase 3 cleanup (Task Board, coordinator SOUL) merged.
+
+Then this file moves to `docs/reference/`.

--- a/src/app/(app)/pm/page.tsx
+++ b/src/app/(app)/pm/page.tsx
@@ -65,7 +65,7 @@ interface PmProposal {
   target_initiative_id: string | null;
   /** Async dispatch state machine: pending_agent → agent_complete | synth_only.
    *  Used to gate the in-flight card render on /pm and /pm/proposals/[id]. */
-  dispatch_state?: 'pending_agent' | 'agent_complete' | 'synth_only' | null;
+  dispatch_state?: 'pending_agent' | 'agent_complete' | 'synth_only' | 'cancelled' | null;
   created_at: string;
 }
 
@@ -983,6 +983,15 @@ export default function PmChatPage() {
               if (proposal && proposal.status === 'superseded') {
                 return null;
               }
+              // Hide chat entries whose proposal was cancelled by the
+              // operator. The InFlightProposalCard already rendered a
+              // "Proposal cancelled" confirmation banner and faded out;
+              // re-rendering the placeholder's chat row after the SSE
+              // event would resurrect a stale "PM agent is working"
+              // card from the operator's perspective.
+              if (proposal && proposal.dispatch_state === 'cancelled') {
+                return null;
+              }
               return (
                 <ChatMessageRow
                   key={m.id}
@@ -1656,8 +1665,10 @@ function ChatMessageRow({
           sessionKey={null}
           sentAt={proposal.created_at}
           onCancel={() => {
-            // Cancel the placeholder by deleting it (same as dismiss).
-            fetch(`/api/pm/proposals/${proposal.id}`, { method: 'DELETE' }).catch(() => {});
+            // Flip the placeholder's dispatch_state to 'cancelled' so
+            // the dispatcher short-circuits its poll loop and the
+            // in-flight card hides via SSE.
+            fetch(`/api/pm/proposals/${proposal.id}/cancel`, { method: 'POST' }).catch(() => {});
           }}
           onUseSynthFallback={() => {
             // Accept the synth fallback — no-op for now, operator can

--- a/src/app/(app)/pm/proposals/[id]/page.tsx
+++ b/src/app/(app)/pm/proposals/[id]/page.tsx
@@ -228,8 +228,9 @@ export default function ProposalDetailPage({
                 sessionKey={null}
                 sentAt={proposal.created_at}
                 onCancel={() => {
-                  // Cancel the placeholder by deleting it.
-                  fetch(`/api/pm/proposals/${proposal.id}`, { method: 'DELETE' }).catch(() => {});
+                  // Flip dispatch_state to 'cancelled' so the dispatcher
+                  // short-circuits its poll loop. The card hides via SSE.
+                  fetch(`/api/pm/proposals/${proposal.id}/cancel`, { method: 'POST' }).catch(() => {});
                   router.push('/pm');
                 }}
                 onUseSynthFallback={() => {

--- a/src/app/api/pm/proposals/[id]/cancel/route.ts
+++ b/src/app/api/pm/proposals/[id]/cancel/route.ts
@@ -1,0 +1,35 @@
+/**
+ * POST /api/pm/proposals/[id]/cancel — cancel a draft proposal's dispatch
+ * (flip dispatch_state to 'cancelled', rejecting the synth placeholder).
+ *
+ * Broadcasts `pm_proposal_dispatch_state_changed` so the frontend SSE
+ * handler can hide the InFlightProposalCard.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cancelProposal, PmProposalValidationError } from '@/lib/db/pm-proposals';
+import { logApiError } from '@/lib/debug-log';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(_request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+  try {
+    // cancelProposal flips dispatch_state to 'cancelled' AND broadcasts
+    // pm_proposal_dispatch_state_changed so the in-flight card hides
+    // via SSE and the dispatcher poll loop short-circuits.
+    const proposal = cancelProposal(id);
+    return NextResponse.json({ proposal });
+  } catch (err) {
+    if (err instanceof PmProposalValidationError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    const msg = err instanceof Error ? err.message : 'Failed to cancel proposal';
+    logApiError({ route: '/api/pm/proposals/[id]/cancel', method: 'POST', status: 500, error: err, metadata: { proposal_id: id } });
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/components/DecomposeStoryToTasksModal.tsx
+++ b/src/components/DecomposeStoryToTasksModal.tsx
@@ -326,7 +326,9 @@ export default function DecomposeStoryToTasksModal({
               sessionKey={null}
               sentAt={proposalCreatedAt ?? new Date().toISOString()}
               onCancel={() => {
-                fetch(`/api/pm/proposals/${proposalId}`, { method: 'DELETE' }).catch(() => {});
+                // Flip dispatch_state to 'cancelled' so the dispatcher
+                // short-circuits its poll loop. The card hides via SSE.
+                fetch(`/api/pm/proposals/${proposalId}/cancel`, { method: 'POST' }).catch(() => {});
                 onClose();
               }}
               onUseSynthFallback={() => {

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -361,7 +361,9 @@ export default function DecomposeWithPmModal({
               sessionKey={null}
               sentAt={proposalCreatedAt ?? new Date().toISOString()}
               onCancel={() => {
-                fetch(`/api/pm/proposals/${proposalId}`, { method: 'DELETE' }).catch(() => {});
+                // Flip dispatch_state to 'cancelled' so the dispatcher
+                // short-circuits its poll loop. The card hides via SSE.
+                fetch(`/api/pm/proposals/${proposalId}/cancel`, { method: 'POST' }).catch(() => {});
                 onClose();
               }}
               onUseSynthFallback={() => {

--- a/src/components/InFlightProposalCard.tsx
+++ b/src/components/InFlightProposalCard.tsx
@@ -23,7 +23,7 @@ import { RefreshCw, X, Loader, AlertTriangle } from 'lucide-react';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-export type InFlightState = 'pending' | 'replaced' | 'synth_only';
+export type InFlightState = 'pending' | 'replaced' | 'synth_only' | 'cancelled';
 
 export interface InFlightProposalCardProps {
   /** Placeholder proposal id created by the async dispatch path. */
@@ -114,12 +114,17 @@ export function InFlightProposalCard({
         }
       }
 
-      // pm_proposal_dispatch_state_changed: synth_only fallback.
+      // pm_proposal_dispatch_state_changed: synth_only fallback or cancelled.
       if (parsed.type === 'pm_proposal_dispatch_state_changed') {
         const id = parsed.payload?.proposal_id as string | undefined;
         const next = parsed.payload?.dispatch_state as string | undefined;
         if (id === proposalId && next === 'synth_only') {
           setState('synth_only');
+        }
+        if (id === proposalId && next === 'cancelled') {
+          // Operator cancelled the dispatch — fade out like replaced.
+          setFadeOut(true);
+          setState('cancelled');
         }
       }
     };
@@ -147,6 +152,34 @@ export function InFlightProposalCard({
 
   const pendingStyle = `${cardStyle} border-amber-500/40 bg-amber-500/5`;
   const synthStyle = `${cardStyle} border-red-500/40 bg-red-500/5`;
+  const cancelledStyle = `${cardStyle} border-slate-400/40 bg-slate-400/5`;
+
+  // Cancelled state: fade out like replaced.
+  if (state === 'cancelled' && fadeOut) {
+    return (
+      <div className={cancelledStyle} aria-label="Proposal cancelled">
+        <div className="px-3 py-2 bg-slate-400/10 border-b border-slate-400/30 flex items-center gap-2">
+          <X className="w-4 h-4 text-slate-400 shrink-0" />
+          <span className="text-sm font-semibold text-slate-300">Proposal cancelled</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Cancelled state (pre-fade): show confirmation banner.
+  if (state === 'cancelled' && !fadeOut) {
+    return (
+      <div className={cancelledStyle}>
+        <div className="px-3 py-2 bg-slate-400/10 border-b border-slate-400/30 flex items-center gap-2">
+          <X className="w-4 h-4 text-slate-400 shrink-0" />
+          <span className="text-sm font-semibold text-slate-300">Proposal cancelled</span>
+        </div>
+        <div className="p-3">
+          <div className="text-xs text-slate-400">The dispatch was cancelled — MC will no longer wait for the agent reply.</div>
+        </div>
+      </div>
+    );
+  }
 
   if (state === 'replaced' && fadeOut) {
     // Render a minimal placeholder so the parent can handle the swap.

--- a/src/components/PlanWithPmPanel.tsx
+++ b/src/components/PlanWithPmPanel.tsx
@@ -360,7 +360,9 @@ export default function PlanWithPmPanel({
           sessionKey={null}
           sentAt={proposalCreatedAt ?? new Date().toISOString()}
           onCancel={() => {
-            fetch(`/api/pm/proposals/${proposalId}`, { method: 'DELETE' }).catch(() => {});
+            // Flip dispatch_state to 'cancelled' so the dispatcher
+            // short-circuits its poll loop. The card hides via SSE.
+            fetch(`/api/pm/proposals/${proposalId}/cancel`, { method: 'POST' }).catch(() => {});
             onClose();
           }}
           onUseSynthFallback={() => {

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -36,6 +36,7 @@ import { queryAll, run } from '@/lib/db';
 import { v4 as uuidv4 } from 'uuid';
 import {
   createProposal,
+  getProposal,
   listProposals,
   setDispatchState,
   deleteProposal,
@@ -1110,9 +1111,27 @@ async function runNamedAgentDispatchInBackground(
     }
   }
 
-  // 4. No agent row arrived. Mark the placeholder as the operator's final
-  //    draft so the UI can stop showing the "PM agent is working" indicator
-  //    and re-enable Accept.
+  // 4. No agent row arrived. If the operator cancelled the dispatch
+  //    while we were polling, the placeholder is already in its final
+  //    state (`dispatch_state='cancelled'`) — don't overwrite that with
+  //    `synth_only` (the timeout path), since that would resurrect the
+  //    placeholder as an actionable draft after the operator cancelled.
+  const currentPlaceholder = getProposal(placeholder.id);
+  if (currentPlaceholder?.dispatch_state === 'cancelled') {
+    console.log(
+      `[pm-dispatch] reconciler bailed early — placeholder ${placeholder.id} ` +
+        `was cancelled by the operator during dispatch ` +
+        `(workspace=${input.workspace_id}, trigger_kind=${input.trigger_kind})`,
+    );
+    return {
+      final: currentPlaceholder,
+      used_named_agent: false,
+      used_synthesize_fallback: false,
+    };
+  }
+  // Otherwise: real timeout. Mark the placeholder as the operator's
+  // final draft so the UI can stop showing the "PM agent is working"
+  // indicator and re-enable Accept.
   console.log(
     `[pm-dispatch] reconciler timed out waiting for agent reply on placeholder ${placeholder.id} ` +
       `(workspace=${input.workspace_id}, trigger_kind=${input.trigger_kind}); marking synth_only`,
@@ -1157,12 +1176,20 @@ async function pollForAgentProposal(
   // either agent row landed. See §2.3 cross-supersede finding.
   const isAgentRow = (p: PmProposal) => p.id !== placeholderId && p.dispatch_state !== 'pending_agent';
   do {
+    // Operator cancelled the dispatch while we were polling — bail
+    // immediately so we don't keep scanning for an agent row that
+    // would supersede a placeholder the operator already retired.
+    const placeholder = getProposal(placeholderId);
+    if (placeholder?.dispatch_state === 'cancelled') return null;
     const drafts = listProposals({ workspace_id: workspaceId, status: 'draft', since: sinceIso });
     const hit = drafts.find(isAgentRow);
     if (hit) return hit;
     if (Date.now() >= deadline) return null;
     await new Promise(resolve => setTimeout(resolve, RECONCILER_POLL_MS));
   } while (Date.now() < deadline);
+  // One last cancel check before the final scan.
+  const placeholder = getProposal(placeholderId);
+  if (placeholder?.dispatch_state === 'cancelled') return null;
   const drafts = listProposals({ workspace_id: workspaceId, status: 'draft', since: sinceIso });
   return drafts.find(isAgentRow) ?? null;
 }

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4798,6 +4798,90 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    id: '094',
+    name: 'pm_proposals_dispatch_state_cancelled',
+    up: (db) => {
+      // The cancel endpoint (POST /api/pm/proposals/[id]/cancel) flips
+      // dispatch_state to 'cancelled'. The schema CHECK constraint was
+      // added without this value — SQLite can't ALTER CHECK constraints,
+      // so we recreate the table.
+      //
+      // Existing dispatch_state values: pending_agent, agent_complete,
+      // synth_only, cancelled (new). All are valid.
+
+      const cols = db.prepare(`PRAGMA table_info(pm_proposals)`).all() as Array<{ name: string; type?: string; notnull?: number; dflt_value?: string }>;
+      const hasDispatchState = cols.some(c => c.name === 'dispatch_state');
+
+      // Already has the updated CHECK — no-op.
+      const tableSql = db
+        .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='pm_proposals'`)
+        .get() as { sql?: string } | undefined;
+      const alreadyHasCancelled =
+        typeof tableSql?.sql === 'string' && tableSql.sql.includes("'cancelled'");
+      if (alreadyHasCancelled) {
+        console.log('[Migration 094] pm_proposals.dispatch_state already includes cancelled; skipping.');
+        return;
+      }
+
+      // Build the new schema from the current table_info, ensuring
+      // dispatch_state includes 'cancelled' in its CHECK.
+      // We use a hand-rolled column list from the schema constant to
+      // avoid PRAGMA table_info quirks (empty types, parenthesized
+      // defaults that break CREATE TABLE syntax).
+      const colDefs: string[] = [
+        'id TEXT PRIMARY KEY',
+        'workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE',
+        'trigger_text TEXT NOT NULL',
+        'trigger_kind TEXT NOT NULL DEFAULT \'manual\' CHECK (trigger_kind IN (\'manual\', \'scheduled_drift_scan\', \'disruption_event\', \'status_check_investigation\', \'plan_initiative\', \'decompose_initiative\', \'decompose_story\', \'notes_intake\', \'revert\'))',
+        'impact_md TEXT NOT NULL',
+        'proposed_changes TEXT NOT NULL',
+        'status TEXT NOT NULL DEFAULT \'draft\' CHECK (status IN (\'draft\', \'accepted\', \'rejected\', \'superseded\'))',
+        'applied_at TEXT',
+        'applied_by_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL',
+        'parent_proposal_id TEXT REFERENCES pm_proposals(id) ON DELETE SET NULL',
+        'created_at TEXT DEFAULT (datetime(\'now\'))',
+        'target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE',
+        'plan_suggestions TEXT',
+        'dispatch_state TEXT NOT NULL DEFAULT \'agent_complete\' CHECK (dispatch_state IN (\'pending_agent\', \'agent_complete\', \'synth_only\', \'cancelled\'))',
+        'reverts_proposal_id TEXT',
+      ];
+
+      db.exec('PRAGMA foreign_keys = OFF');
+      db.exec(`PRAGMA legacy_alter_table = ON`);
+
+      // Recreate with updated CHECK.
+      db.exec(`
+        CREATE TABLE pm_proposals_new (
+          ${colDefs.join(',\n          ')}
+        )
+      `);
+
+      // Copy data — dispatch_state may be NULL on pre-migration-055 rows,
+      // so COALESCE it to 'agent_complete'.
+      const allCols = cols.map(c => c.name);
+      const selectCols = allCols.join(', ');
+      // Replace dispatch_state in SELECT with COALESCE(dispatch_state, 'agent_complete')
+      const dispatchIdx = allCols.indexOf('dispatch_state');
+      const selectColsSafe = dispatchIdx >= 0
+        ? [...allCols.slice(0, dispatchIdx), "COALESCE(dispatch_state, 'agent_complete')", ...allCols.slice(dispatchIdx + 1)].join(', ')
+        : selectCols;
+      db.exec(`
+        INSERT INTO pm_proposals_new (${selectCols})
+        SELECT ${selectColsSafe} FROM pm_proposals
+      `);
+
+      db.exec('DROP TABLE pm_proposals');
+      db.exec('ALTER TABLE pm_proposals_new RENAME TO pm_proposals');
+
+      // Recreate indexes.
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_pm_proposals_status ON pm_proposals(status, created_at DESC)
+      `);
+
+      console.log('[Migration 094] pm_proposals.dispatch_state CHECK updated to include cancelled.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/pm-proposals.test.ts
+++ b/src/lib/db/pm-proposals.test.ts
@@ -20,6 +20,7 @@ import {
   listProposals,
   acceptProposal,
   rejectProposal,
+  cancelProposal,
   refineProposal,
   supersedeWithAgentProposal,
   validateProposedChanges,
@@ -1242,6 +1243,141 @@ test("tryAdoptOrphanedPlaceholder skips placeholders outside the time window", (
   // A wider window finds it.
   const widerAdoptedId = tryAdoptOrphanedPlaceholder(agentRow.id, 2 * 60 * 60 * 1000);
   assert.equal(widerAdoptedId, placeholder.id);
+});
+
+// ─── Cancel ────────────────────────────────────────────────────────
+
+test('cancelProposal: cancels a draft with dispatch_state=pending_agent', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: 'synth placeholder',
+    impact_md: '.',
+    proposed_changes: [{ kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' }],
+    dispatch_state: 'pending_agent',
+  });
+  const result = cancelProposal(p.id);
+  assert.equal(result.dispatch_state, 'cancelled');
+  assert.equal(result.status, 'draft'); // status stays draft
+});
+
+test('cancelProposal: cancels a draft with dispatch_state=synth_only', () => {
+  const ws = freshWorkspace();
+  createProposal({
+    workspace_id: ws,
+    trigger_text: 'synth placeholder',
+    impact_md: '.',
+    proposed_changes: [],
+    dispatch_state: 'synth_only',
+  });
+  // Find the synth_only proposal.
+  const proposals = listProposals({ workspace_id: ws, status: 'draft' });
+  const synthOnly = proposals.find(p => p.dispatch_state === 'synth_only');
+  assert.ok(synthOnly, 'expected a synth_only proposal');
+  const result = cancelProposal(synthOnly.id);
+  assert.equal(result.dispatch_state, 'cancelled');
+});
+
+test('cancelProposal: throws on non-existent proposal', () => {
+  assert.throws(
+    () => cancelProposal('non-existent-id'),
+    PmProposalValidationError,
+  );
+});
+
+test('cancelProposal: throws on already-accepted proposal', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'S' });
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [{ kind: 'set_initiative_status', initiative_id: init.id, status: 'at_risk' }],
+  });
+  acceptProposal(p.id);
+  assert.throws(
+    () => cancelProposal(p.id),
+    PmProposalValidationError,
+  );
+});
+
+test('cancelProposal: idempotent — cancelling already-cancelled is a no-op', () => {
+  const ws = freshWorkspace();
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [],
+    dispatch_state: 'pending_agent',
+  });
+  const first = cancelProposal(p.id);
+  assert.equal(first.dispatch_state, 'cancelled');
+  // Second call should be a no-op.
+  const second = cancelProposal(p.id);
+  assert.equal(second.dispatch_state, 'cancelled');
+  assert.equal(second.id, first.id);
+});
+
+test('cancelProposal: emits pm_proposal_dispatch_state_changed event', async () => {
+  // Capture broadcasts by registering a fake SSE client with the
+  // events module. The broadcaster serializes to `data: <json>\n\n`
+  // and enqueues onto the controller, so we decode the chunks back to
+  // JSON to verify the event shape.
+  const { registerClient, unregisterClient } = await import('@/lib/events');
+  const captured: Array<{ type?: string; payload?: Record<string, unknown> }> = [];
+  const decoder = new TextDecoder();
+  const fakeController = {
+    enqueue: (chunk: Uint8Array) => {
+      const text = decoder.decode(chunk);
+      // Strip the `data: ` prefix and trailing `\n\n`.
+      const match = text.match(/^data: (.+)\n\n$/);
+      if (match) {
+        try {
+          captured.push(JSON.parse(match[1]));
+        } catch {
+          /* ignore */
+        }
+      }
+    },
+  } as unknown as ReadableStreamDefaultController;
+  registerClient(fakeController);
+  try {
+    const ws = freshWorkspace();
+    const p = createProposal({
+      workspace_id: ws,
+      trigger_text: '.',
+      impact_md: '.',
+      proposed_changes: [],
+      dispatch_state: 'pending_agent',
+    });
+    cancelProposal(p.id);
+    const match = captured.find(
+      e =>
+        e.type === 'pm_proposal_dispatch_state_changed' &&
+        e.payload?.proposal_id === p.id,
+    );
+    assert.ok(match, 'expected pm_proposal_dispatch_state_changed broadcast');
+    assert.equal(match!.payload!.dispatch_state, 'cancelled');
+    assert.equal(match!.payload!.workspace_id, ws);
+  } finally {
+    unregisterClient(fakeController);
+  }
+});
+
+test('cancelProposal: throws on agent_complete dispatch_state', () => {
+  const ws = freshWorkspace();
+  const p = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    impact_md: '.',
+    proposed_changes: [],
+    dispatch_state: 'agent_complete',
+  });
+  assert.throws(
+    () => cancelProposal(p.id),
+    PmProposalValidationError,
+  );
 });
 
 test("sweepOrphanedPlaceholders links eligible pairs in bulk", () => {

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -30,11 +30,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { getDb, queryAll, queryOne, run } from '@/lib/db';
 import { createTaskFromInitiative } from './promotion';
 import { transitionTaskStatus } from '@/lib/services/task-status';
+import { broadcast } from '@/lib/events';
 
 // ─── Types ──────────────────────────────────────────────────────────
 
 export type PmProposalStatus = 'draft' | 'accepted' | 'rejected' | 'superseded';
-export type PmProposalDispatchState = 'pending_agent' | 'agent_complete' | 'synth_only';
+export type PmProposalDispatchState = 'pending_agent' | 'agent_complete' | 'synth_only' | 'cancelled';
 export type PmProposalTriggerKind =
   | 'manual'
   | 'scheduled_drift_scan'
@@ -1653,6 +1654,59 @@ export function rejectProposal(id: string): PmProposal {
     );
   }
   run(`UPDATE pm_proposals SET status = 'rejected' WHERE id = ?`, [id]);
+  return getProposal(id)!;
+}
+
+/**
+ * Cancel a draft proposal by setting dispatch_state to 'cancelled'.
+ *
+ * This is the inverse of the synth-placeholder path: when the operator
+ * wants to stop MC from waiting for an agent reply (e.g. they changed
+ * their mind about the proposal), cancelling the dispatch_state tells
+ * the frontend SSE handler to hide the in-flight card without
+ * applying any changes.
+ *
+ * Cancellable states: draft + dispatch_state === 'pending_agent' or
+ * 'synth_only'. Same gate as acceptProposal's status check — only
+ * draft proposals are cancellable.
+ *
+ * Idempotent: cancelling an already-cancelled proposal is a no-op
+ * (returns the existing row without error).
+ */
+export function cancelProposal(id: string): PmProposal {
+  const existing = getProposal(id);
+  if (!existing) throw new PmProposalValidationError(`proposal ${id} not found`);
+  if (existing.status === 'accepted' || existing.status === 'superseded') {
+    throw new PmProposalValidationError(
+      `proposal ${id} cannot be cancelled from status=${existing.status}`,
+    );
+  }
+  if (existing.status !== 'draft') {
+    throw new PmProposalValidationError(
+      `proposal ${id} cannot be cancelled from status=${existing.status}`,
+    );
+  }
+  // Already cancelled — idempotent no-op.
+  if (existing.dispatch_state === 'cancelled') return existing;
+  // Only cancellable when dispatch_state is pending_agent or synth_only.
+  if (existing.dispatch_state !== 'pending_agent' && existing.dispatch_state !== 'synth_only') {
+    throw new PmProposalValidationError(
+      `proposal ${id} cannot be cancelled: dispatch_state=${existing.dispatch_state} (must be pending_agent or synth_only)`,
+    );
+  }
+  run(`UPDATE pm_proposals SET dispatch_state = 'cancelled' WHERE id = ?`, [id]);
+  // Broadcast so the in-flight card hides via SSE (and any other
+  // listener — e.g. the dispatcher's poll loop — can short-circuit).
+  // Emitting from this helper rather than the API route keeps the
+  // event firing for any other call site that may invoke cancel.
+  broadcast({
+    type: 'pm_proposal_dispatch_state_changed',
+    payload: {
+      workspace_id: existing.workspace_id,
+      proposal_id: id,
+      dispatch_state: 'cancelled',
+    },
+  });
   return getProposal(id)!;
 }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -991,7 +991,7 @@ CREATE TABLE IF NOT EXISTS pm_proposals (
   target_initiative_id TEXT REFERENCES initiatives(id) ON DELETE CASCADE,
   plan_suggestions TEXT,
   dispatch_state TEXT NOT NULL DEFAULT 'agent_complete'
-    CHECK (dispatch_state IN ('pending_agent','agent_complete','synth_only'))
+    CHECK (dispatch_state IN ('pending_agent','agent_complete','synth_only','cancelled'))
 );
 
 -- Defer-and-replay queue for propose_from_notes requests that arrive


### PR DESCRIPTION
## Summary
Captures the wholistic fix discussed in conversation today: the PM's decomposition flows (\`decompose_story\` / \`decompose_initiative\` / \`plan_initiative\`) must emit a \`create_convoy_under_initiative\` diff carrying a slice DAG, NOT a flat list of \`create_task_under_initiative\` diffs. The two locality bugs audited yesterday (PR #347 — InFlightProposalCard shipped 2 of 4 surfaces; PR #351 — cancel feature shipped backend without wiring) share a structural cause: convoy machinery (deps, evidence gates, parent auto-promote) only enters the flow at coordinator dispatch time, AFTER the PM has already over-narrowed the slicing.

## Scope of the proposal
- New diff kind \`create_convoy_under_initiative\` with parent ACs + slice DAG.
- One new column \`convoys.acceptance_criteria\`.
- Apply-pass converges PM-emit + coordinator \`plan_convoy\` on \`spawnDelegationSubtask\`.
- Parent \`review → done\` AC gate plugs into existing \`transitionTaskStatus\` rail.
- Phased migration: bandaid (SOUL nudges) → structural (schema + UX) → cleanup (Task Board renders slices, coordinator SOUL shrinks).
- Carve-outs: \`notes_intake\`, audit follow-ups, manual creation keep \`create_task_under_initiative\`.

## Status
\`status: aspirational\`. Lives in \`docs/proposals/\` until Phase 2 ships, then promotes to \`docs/reference/\`. Frontmatter validates (\`yarn docs:check\`: 0 violations).

## Specs that will need edits when this lands
Captured in the proposal itself — \`pm-diff-conventions.md\` and \`task-delegation-and-convoys.md\` are the heaviest; \`roadmap-and-pm-spec.md\`, \`pm-revertable-proposals.md\`, \`review-stage-robustness-spec.md\`, and the PM SOUL files are material; \`agent-model-cleanup.md\` + \`audit-pipeline.md\` + \`autonomous-flow-tightening-spec.md\` are light.

## Test plan
- [x] \`yarn docs:check\` — 0 violations.
- [ ] No implementation in this PR — proposal-only. Phase 2 will dogfood the new flow via the PM decomposing this proposal's follow-ups.