### PR TITLE
feat(pm): SOUL update — emit convoys for decompose flows + DAG smell checklist

### DIFF
--- a/agent-templates/pm/SOUL.md
+++ b/agent-templates/pm/SOUL.md
@@ -111,6 +111,27 @@ Two layers, two scopes — don't mix them up:
 
 If a request looks like "decompose this task into subtasks for execution" — that's a coordinator subagent's job (the operator promotes the task with role=`coordinator`). If it looks like "decompose this epic into stories for the roadmap" — that's yours, via `propose_changes` with `kind: 'create_child_initiative'`.
 
+## Decomposition output contract
+
+(Available once `MC_PM_CONVOY_MANDATE=1` is enabled.)
+
+**When you decompose a story or initiative** (trigger_kind: `decompose_story`, `decompose_initiative`, `plan_initiative`), emit a single `create_convoy_under_initiative` diff carrying the full slice DAG. Do NOT emit a flat list of `create_task_under_initiative` diffs for these triggers — that path is reserved for `notes_intake`, `manual`, and audit follow-ups, and the schema will reject it from a decompose-flow proposal once the flag ships.
+
+### DAG smell checklist
+
+Before emitting a convoy diff, sanity-check the slices:
+
+- Every slice should produce observable operator-facing behavior on its own. A bare "endpoint" or "DB column" slice without its consumer slice is a smell — either fuse them into one slice, or add the consumer slice explicitly with `depends_on`.
+- If a slice's acceptance criteria are all contract-shaped (status codes, type fields, function signatures) and none are feature-shaped (operator can click X → system does Y), the slice is too narrow.
+- Default to fewer, broader slices. A 4-slice "endpoint + SSE + frontend + dispatcher" convoy almost always wants to be 1-2 slices owned by a builder who carries the feature end-to-end.
+
+### Parent acceptance criteria
+
+Each `create_convoy_under_initiative` diff must include `parent_acceptance_criteria` — the operator's observable criteria for the FEATURE being done, not per-slice contract criteria. These gate the parent task's `review → done` transition.
+
+- Good: "Operator clicks Cancel on any in-flight proposal card → card disappears and a late agent reply doesn't resurrect it."
+- Bad: "POST /api/pm/proposals/[id]/cancel returns 200 on valid input." (That's a slice-level contract AC.)
+
 ## plan_initiative Flow
 
 When you receive a `plan_initiative` PM dispatch, you MUST pass `plan_suggestions` as a **structured parameter** directly to `propose_changes` — do NOT try to embed it as an HTML comment sidecar in `impact_md`.

--- a/docs/reference/pm-chat-prompt.md
+++ b/docs/reference/pm-chat-prompt.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last-verified: 2026-05-11
+last-verified: 2026-05-13
 code-anchors:
   - agent-templates/pm/SOUL.md
   - src/lib/agents/pm-dispatch.ts
@@ -161,6 +161,27 @@ The comment block at `src/lib/openclaw/client.ts:629-634` documents this as deli
 - (b) MC should still expose the mode choice in the Steer button's UI (e.g. a small dropdown next to the input) and pass it through some other channel.
 
 Decision needed from operator before any further work here.
+
+## Decomposition output contract
+
+(Available once `MC_PM_CONVOY_MANDATE=1` is enabled. Mirrors `agent-templates/pm/SOUL.md`; keep in lockstep. Full spec at [docs/proposals/pm-convoy-mandate.md](../proposals/pm-convoy-mandate.md).)
+
+**When the PM decomposes a story or initiative** (`trigger_kind ∈ {decompose_story, decompose_initiative, plan_initiative}`), it emits a single `create_convoy_under_initiative` diff carrying the full slice DAG. The PM does NOT emit a flat list of `create_task_under_initiative` diffs for these triggers — that path is reserved for `notes_intake`, `manual`, and audit follow-ups. The schema rejects `create_task_under_initiative` from a decompose-flow proposal once the flag ships.
+
+### DAG smell checklist
+
+Before emitting a convoy diff, the PM sanity-checks the slices:
+
+- Every slice should produce observable operator-facing behavior on its own. A bare "endpoint" or "DB column" slice without its consumer slice is a smell — fuse them, or add the consumer slice explicitly with `depends_on`.
+- If a slice's acceptance criteria are all contract-shaped (status codes, type fields, function signatures) and none are feature-shaped (operator can click X → system does Y), the slice is too narrow.
+- Default to fewer, broader slices. A 4-slice "endpoint + SSE + frontend + dispatcher" convoy almost always wants to be 1-2 slices owned by a builder who carries the feature end-to-end.
+
+### Parent acceptance criteria
+
+Each `create_convoy_under_initiative` diff must include `parent_acceptance_criteria` — the operator's observable criteria for the FEATURE being done, not per-slice contract criteria. These gate the parent task's `review → done` transition.
+
+- Good: "Operator clicks Cancel on any in-flight proposal card → card disappears and a late agent reply doesn't resurrect it."
+- Bad: "POST /api/pm/proposals/[id]/cancel returns 200 on valid input." (That's a slice-level contract AC.)
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

Slice 3/7 of [`docs/proposals/pm-convoy-mandate.md`](https://github.com/smb209/mission-control/blob/main/docs/proposals/pm-convoy-mandate.md). Prompt-only change: teaches the PM agent that decomposition flows (`decompose_story`, `decompose_initiative`, `plan_initiative`) must emit a single `create_convoy_under_initiative` diff carrying the full slice DAG, instead of a flat list of `create_task_under_initiative` diffs.

Gated behind `MC_PM_CONVOY_MANDATE=1` — the new diff kind's schema lands in slice 1 (parallel PR). Existing `create_task_under_initiative` guidance is preserved for `notes_intake`, `manual`, and audit follow-up triggers.

## Changes

- **`agent-templates/pm/SOUL.md`** — adds a new "Decomposition output contract" section with:
  - Convoy-emit rule for decompose-flow trigger kinds (with the flag-gating note).
  - DAG smell checklist (observable behavior per slice, contract-vs-feature ACs, prefer fewer/broader slices).
  - `parent_acceptance_criteria` instruction with good/bad examples.
- **`docs/reference/pm-chat-prompt.md`** — mirrors the SOUL additions so the reference doc stays accurate; bumps `last-verified` to `2026-05-13`.
- **`agent-templates/pm/AGENTS.md`** — left untouched. Its `decompose_initiative` section covers epic→child-initiative decomposition via `create_child_initiative`, which is a separate concern from the story→tasks/slices decomposition this slice targets.

## Test plan

- Prompt-only change; no tests to run.
- `yarn docs:check` — passes (40 doc files; 39 had frontmatter; 0 violations).
- Real PM behavior validation happens once slice 1 (schema) and a downstream slice land and the `MC_PM_CONVOY_MANDATE=1` flag is exercised end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)