### PR TITLE
feat(pm): add create_convoy_under_initiative diff schema + convoys.acceptance_criteria migration

### DIFF
--- a/src/lib/db/migration-095.test.ts
+++ b/src/lib/db/migration-095.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Migration 095 (`pm_convoy_mandate_convoys_acceptance_criteria`).
+ *
+ * Schema-only check: after the shared test DB applies all migrations on
+ * boot, the `convoys` table must expose an `acceptance_criteria` column.
+ * No reader consumes the column yet — that lands in slice 2 behind
+ * MC_PM_CONVOY_MANDATE. See docs/proposals/pm-convoy-mandate.md.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getDb } from '@/lib/db';
+
+test('migration 095: convoys.acceptance_criteria column exists', () => {
+  const db = getDb();
+  const cols = db.prepare(`PRAGMA table_info(convoys)`).all() as Array<{ name: string; type: string }>;
+  const col = cols.find((c) => c.name === 'acceptance_criteria');
+  assert.ok(col, 'expected convoys.acceptance_criteria column to exist after migrations run');
+  assert.equal(col!.type.toUpperCase(), 'TEXT', 'acceptance_criteria should be TEXT (JSON-encoded string[])');
+});
+
+test('migration 095: acceptance_criteria is nullable (NULL = back-compat coordinator-spawned convoy)', () => {
+  const db = getDb();
+  const cols = db.prepare(`PRAGMA table_info(convoys)`).all() as Array<{ name: string; notnull: number }>;
+  const col = cols.find((c) => c.name === 'acceptance_criteria');
+  assert.ok(col);
+  assert.equal(col!.notnull, 0, 'acceptance_criteria must remain nullable for back-compat');
+});
+
+test('migration 095: re-running ALTER would fail — migration must be idempotent', () => {
+  // Sanity-check our idempotency guard: if we tried to ALTER again, sqlite
+  // would error with "duplicate column name". The migration's PRAGMA check
+  // skips that path; here we simulate the second-run case directly.
+  const db = getDb();
+  const cols = db.prepare(`PRAGMA table_info(convoys)`).all() as Array<{ name: string }>;
+  const hasCol = cols.some((c) => c.name === 'acceptance_criteria');
+  assert.equal(hasCol, true);
+  if (hasCol) {
+    assert.throws(
+      () => db.exec(`ALTER TABLE convoys ADD COLUMN acceptance_criteria TEXT`),
+      /duplicate column name/i,
+      'second ALTER should fail; migration 095 guards against this with PRAGMA check',
+    );
+  }
+});

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4882,6 +4882,30 @@ const migrations: Migration[] = [
       console.log('[Migration 094] pm_proposals.dispatch_state CHECK updated to include cancelled.');
     },
   },
+  {
+    id: '095',
+    name: 'pm_convoy_mandate_convoys_acceptance_criteria',
+    up: (db) => {
+      // PM convoy mandate (slice 1/7): adds convoys.acceptance_criteria
+      // as a nullable JSON-encoded string[] column.
+      //
+      // NULL  = coordinator-spawned convoy (back-compat).
+      // Set   = PM-emitted convoy via create_convoy_under_initiative;
+      //         feature-level parent ACs that gate parent review → done.
+      //
+      // No reader consumes this yet — that lands in slice 2 behind
+      // MC_PM_CONVOY_MANDATE. See docs/proposals/pm-convoy-mandate.md.
+      //
+      // Idempotent — re-runs against partially-applied DBs must skip cleanly.
+      const cols = db.prepare(`PRAGMA table_info(convoys)`).all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'acceptance_criteria')) {
+        db.exec(`ALTER TABLE convoys ADD COLUMN acceptance_criteria TEXT`);
+        console.log('[Migration 095] convoys.acceptance_criteria added.');
+      } else {
+        console.log('[Migration 095] convoys.acceptance_criteria already present; skipping.');
+      }
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/mcp/diff-schema.test.ts
+++ b/src/lib/mcp/diff-schema.test.ts
@@ -58,3 +58,79 @@ test('DiffSchema: set_initiative_status REJECTS unknown status', () => {
   });
   assert.equal(result.success, false);
 });
+
+// -----------------------------------------------------------------------------
+// PM convoy mandate (slice 1/7): create_convoy_under_initiative shape checks.
+// Schema-only. DAG cycle / unknown-ref validation lives at apply time and is
+// out of scope here. See docs/proposals/pm-convoy-mandate.md.
+// -----------------------------------------------------------------------------
+
+function makeSlice(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'slice_a',
+    slice: 'Build the cancel endpoint and wire it through',
+    message: 'Implement and ship the cancel endpoint per the AC list.',
+    expected_deliverables: [{ title: 'cancel route handler', kind: 'file' }],
+    acceptance_criteria: ['Endpoint returns 200 on a valid cancel request.'],
+    expected_duration_minutes: 60,
+    ...overrides,
+  };
+}
+
+function makeConvoyDiff(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    kind: 'create_convoy_under_initiative',
+    initiative_id: 'init-1',
+    parent_acceptance_criteria: [
+      'Operator clicks Cancel on any in-flight proposal card and the card disappears.',
+    ],
+    slices: [makeSlice()],
+    ...overrides,
+  };
+}
+
+test('DiffSchema: create_convoy_under_initiative accepts minimal valid diff', () => {
+  const result = DiffSchema.safeParse(makeConvoyDiff());
+  assert.equal(result.success, true, result.success ? '' : JSON.stringify(result.error.issues));
+});
+
+test('DiffSchema: create_convoy_under_initiative accepts multi-slice with depends_on cross-refs', () => {
+  const result = DiffSchema.safeParse(
+    makeConvoyDiff({
+      slices: [
+        makeSlice({ id: 'slice_a' }),
+        makeSlice({ id: 'slice_b', depends_on: ['slice_a'] }),
+        makeSlice({ id: 'slice_c', depends_on: ['slice_a', 'slice_b'] }),
+      ],
+    }),
+  );
+  assert.equal(result.success, true, result.success ? '' : JSON.stringify(result.error.issues));
+});
+
+test('DiffSchema: create_convoy_under_initiative REJECTS empty slices array', () => {
+  const result = DiffSchema.safeParse(makeConvoyDiff({ slices: [] }));
+  assert.equal(result.success, false, 'empty slices array must be rejected');
+});
+
+test('DiffSchema: create_convoy_under_initiative REJECTS empty parent_acceptance_criteria', () => {
+  const result = DiffSchema.safeParse(makeConvoyDiff({ parent_acceptance_criteria: [] }));
+  assert.equal(result.success, false, 'empty parent_acceptance_criteria must be rejected');
+});
+
+test('DiffSchema: create_convoy_under_initiative REJECTS slice id containing a space', () => {
+  const result = DiffSchema.safeParse(
+    makeConvoyDiff({ slices: [makeSlice({ id: 'bad id' })] }),
+  );
+  assert.equal(result.success, false, 'slice id must match /^[a-zA-Z0-9_-]+$/');
+});
+
+test('DiffSchema: create_convoy_under_initiative REJECTS > 12 slices', () => {
+  const slices = Array.from({ length: 13 }, (_, i) => makeSlice({ id: `slice_${i}` }));
+  const result = DiffSchema.safeParse(makeConvoyDiff({ slices }));
+  assert.equal(result.success, false, 'slices.max(12) must reject 13');
+});
+
+test('DiffSchema: create_convoy_under_initiative REJECTS parent AC shorter than 10 chars', () => {
+  const result = DiffSchema.safeParse(makeConvoyDiff({ parent_acceptance_criteria: ['short'] }));
+  assert.equal(result.success, false, 'parent_acceptance_criteria items must be >= 10 chars');
+});

--- a/src/lib/mcp/shared.ts
+++ b/src/lib/mcp/shared.ts
@@ -298,6 +298,48 @@ export const DiffSchema = z.discriminatedUnion('kind', [
     priority: z.enum(['low', 'normal', 'high']).optional(),
   }),
   z.object({
+    // PM convoy mandate (slice 1/7): decompose-flow proposals emit a
+    // single create_convoy_under_initiative diff carrying the slice DAG
+    // rather than a flat list of create_task_under_initiative diffs.
+    // Schema only here — apply-pass, trigger_kind gating, and UX land in
+    // later slices behind MC_PM_CONVOY_MANDATE. See
+    // docs/proposals/pm-convoy-mandate.md.
+    kind: z.literal('create_convoy_under_initiative'),
+    initiative_id: z.string().min(1),
+    // Symbolic-ref placeholders ($0..$N) for create_child_initiative in
+    // the same proposal still resolve here, mirroring the current pattern.
+
+    // Parent-level acceptance criteria the convoy must satisfy before the
+    // parent task can transition from `review` to `done`. These are
+    // operator-facing, feature-level — NOT the per-slice contract criteria.
+    // Example: "Operator clicks Cancel on any InFlightProposalCard surface
+    // → card disappears + late agent reply doesn't resurrect."
+    parent_acceptance_criteria: z.array(z.string().min(10).max(500)).min(1),
+
+    // The DAG. Mirrors plan_convoy's slice schema (same fields the
+    // coordinator-driven path uses today) so a single apply-pass helper
+    // serves both entry points.
+    slices: z.array(z.object({
+      id: z.string().min(1).max(40).regex(/^[a-zA-Z0-9_-]+$/),
+      role: z.string().min(1).optional(),
+      peer_agent_id: z.string().min(1).optional(),
+      peer_gateway_id: z.string().min(1).optional(),
+      slice: z.string().min(10).max(500),
+      message: z.string().min(1).max(10000),
+      expected_deliverables: z.array(z.object({
+        title: z.string().min(1).max(200),
+        kind: z.enum(['file', 'note', 'report']),
+      })).min(1),
+      acceptance_criteria: z.array(z.string().min(10).max(500)).min(1),
+      expected_duration_minutes: z.number().int().min(5).max(240),
+      checkin_interval_minutes: z.number().int().min(5).max(60).optional(),
+      depends_on: z.array(z.string().min(1).max(40)).optional(),
+      // Per-slice evidence gate override; default ['test_full'] for tester
+      // slices, none for others. Inherits today's convoy_subtasks behavior.
+      required_evidence_gates: z.array(z.string()).optional(),
+    })).min(1).max(12),
+  }),
+  z.object({
     // PM may close out a task that's already in a late workflow state
     // when concrete evidence (audit proposal, commit, PR) confirms it
     // shipped. The apply pass routes through `transitionTaskStatus` so


### PR DESCRIPTION
## Summary

Slice 1/7 of the PM convoy mandate ([`docs/proposals/pm-convoy-mandate.md`](../blob/main/docs/proposals/pm-convoy-mandate.md)). Schema only — no behavior change shipped. Apply-pass, `trigger_kind` gating, parent `review → done` AC gate, and UX land in later slices behind `MC_PM_CONVOY_MANDATE`.

## Changes

- `src/lib/mcp/shared.ts` — new `create_convoy_under_initiative` variant on the `DiffSchema` discriminated union, placed right after `create_task_under_initiative` so PM-decomposition diffs stay grouped. Field shape copied verbatim from the spec: `parent_acceptance_criteria` (min 1, each 10-500 chars), `slices` (1-12 items, ids match `/^[a-zA-Z0-9_-]+$/`, each with deliverables / ACs / duration / optional `depends_on` / optional `required_evidence_gates`).
- `src/lib/db/migrations.ts` — migration `095` `pm_convoy_mandate_convoys_acceptance_criteria` adds a nullable `convoys.acceptance_criteria TEXT` column (JSON-encoded `string[]`). NULL = coordinator-spawned (back-compat); populated = PM-emitted. Idempotent `PRAGMA table_info` guard so partial re-runs skip cleanly. No code reads the column yet — slice 2 wires it in.
- `src/lib/mcp/diff-schema.test.ts` — extended with 7 zod regression tests for the new diff kind (positive: minimal + multi-slice depends_on; negative: empty slices, empty parent ACs, slice id with whitespace, > 12 slices, parent AC < 10 chars). DAG cycle / unknown-ref validation is out of scope here — runtime check in slice 2's apply pass.
- `src/lib/db/migration-095.test.ts` — new file confirming the column exists, is nullable, and the migration is idempotent (a second raw `ALTER` would error with `duplicate column name`, which the migration's PRAGMA guard prevents).

## Test plan

- [x] `yarn test src/lib/mcp` — passes; 7 new `create_convoy_under_initiative` tests green alongside existing diff-schema tests.
- [x] `yarn test src/lib/db` — passes; 3 new migration-095 tests green; migration runs cleanly during test-template build.
- [x] `tsc --noEmit` — clean (project has no `typecheck` yarn script; ran the compiler directly).
- [ ] No preview-smoke run — schema/migration-only change, no MCP-tool or UI surface to exercise yet (those land in slices 2-7).

No pre-existing test failures encountered.