### PR TITLE
feat(pm): apply-pass for create_convoy_under_initiative

### DIFF
--- a/src/lib/convoy-dag.ts
+++ b/src/lib/convoy-dag.ts
@@ -1,0 +1,311 @@
+/**
+ * Shared convoy-DAG validator.
+ *
+ * Pulled out of `src/lib/mcp/groups/work.ts` (plan_convoy) so the
+ * PM-driven apply pass for `create_convoy_under_initiative` diffs can
+ * reuse the same Kahn topological sort + peer resolution. One place to
+ * fix validation rules; two entry points (coordinator's plan_convoy MCP
+ * tool + operator's proposal-accept).
+ *
+ * See docs/proposals/pm-convoy-mandate.md "Apply pass" for the contract.
+ */
+
+import { queryOne } from '@/lib/db';
+
+// ─── Public types ──────────────────────────────────────────────────
+
+/**
+ * The minimal slice shape the validator needs. Both call sites pass
+ * richer objects (with `slice`, `message`, `expected_deliverables`,
+ * etc.); the validator only looks at `id`, the addressing axes, and
+ * `depends_on`. Keeping the input type narrow lets each caller forward
+ * its own slice array without an extra mapping pass.
+ */
+export interface ConvoyDagSliceInput {
+  id: string;
+  role?: string;
+  peer_agent_id?: string;
+  peer_gateway_id?: string;
+  depends_on?: string[];
+}
+
+export interface DelegationPeerRow {
+  id: string;
+  name: string;
+  role: string | null;
+  gateway_agent_id: string | null;
+}
+
+export interface ResolvedPeer {
+  peer: DelegationPeerRow;
+  resolvedVia: 'role' | 'peer_agent_id' | 'peer_gateway_id';
+}
+
+export interface PeerResolutionError {
+  slice_id: string;
+  code: string;
+  message: string;
+}
+
+export type ConvoyDagValidationResult =
+  | {
+      ok: true;
+      /** Topological order of slice symbolic ids. */
+      topo: string[];
+      /** Resolved peer per symbolic id. */
+      resolved: Map<string, ResolvedPeer>;
+    }
+  | {
+      ok: false;
+      /** Single error code identifying the first structural failure. */
+      code:
+        | 'duplicate_slice_id'
+        | 'unknown_dep'
+        | 'self_dependency'
+        | 'cycle_detected'
+        | 'peer_resolution_failed';
+      message: string;
+      /** Structured detail for the failure. */
+      details: Record<string, unknown>;
+    };
+
+// ─── Peer resolution ───────────────────────────────────────────────
+
+type ResolvePeerOk = {
+  ok: true;
+  peer: DelegationPeerRow;
+  resolvedVia: 'role' | 'peer_agent_id' | 'peer_gateway_id';
+};
+type ResolvePeerErr = {
+  ok: false;
+  code: string;
+  message: string;
+  addressing: Record<string, string>;
+};
+
+/**
+ * Resolve one slice's peer addressing (exactly one of role /
+ * peer_agent_id / peer_gateway_id) against the workspace roster.
+ *
+ * Lifted verbatim from `resolveDelegationPeer` in
+ * `src/lib/mcp/groups/work.ts` (PR #344-era code path). Identical
+ * semantics — including the mc-runner / mc-runner-dev cross-workspace
+ * carve-out and the role-active filter.
+ */
+export function resolveDelegationPeer(
+  axes: { role?: string; peer_agent_id?: string; peer_gateway_id?: string },
+  parentWs: string,
+): ResolvePeerOk | ResolvePeerErr {
+  const provided = [axes.role, axes.peer_agent_id, axes.peer_gateway_id]
+    .filter((v): v is string => typeof v === 'string' && v.length > 0);
+  if (provided.length === 0) {
+    return {
+      ok: false,
+      code: 'peer_addressing_missing',
+      message: 'Specify exactly one of role / peer_agent_id / peer_gateway_id.',
+      addressing: {},
+    };
+  }
+  if (provided.length > 1) {
+    return {
+      ok: false,
+      code: 'peer_addressing_conflict',
+      message: 'role / peer_agent_id / peer_gateway_id are mutually exclusive.',
+      addressing: {},
+    };
+  }
+  if (axes.role) {
+    const peer = queryOne<DelegationPeerRow>(
+      `SELECT id, name, role, gateway_agent_id FROM agents
+        WHERE role = ?
+          AND COALESCE(workspace_id, 'default') = ?
+          AND COALESCE(status, 'standby') != 'offline'
+          AND COALESCE(is_active, 1) = 1
+        ORDER BY updated_at DESC LIMIT 1`,
+      [axes.role, parentWs],
+    );
+    if (!peer) {
+      return {
+        ok: false,
+        code: 'peer_not_found',
+        message: `No active agent with role "${axes.role}" in workspace ${parentWs}.`,
+        addressing: { role: axes.role },
+      };
+    }
+    return { ok: true, peer, resolvedVia: 'role' };
+  }
+  if (axes.peer_agent_id) {
+    const peer = queryOne<DelegationPeerRow & { workspace_id: string | null }>(
+      `SELECT id, name, role, gateway_agent_id, workspace_id FROM agents WHERE id = ? LIMIT 1`,
+      [axes.peer_agent_id],
+    );
+    if (!peer) {
+      return {
+        ok: false,
+        code: 'peer_not_found',
+        message: `No agent with id "${axes.peer_agent_id}".`,
+        addressing: { peer_agent_id: axes.peer_agent_id },
+      };
+    }
+    const isOrgRunner =
+      peer.gateway_agent_id === 'mc-runner' || peer.gateway_agent_id === 'mc-runner-dev';
+    const peerWs = peer.workspace_id ?? 'default';
+    if (peerWs !== parentWs && !isOrgRunner) {
+      return {
+        ok: false,
+        code: 'peer_not_in_workspace',
+        message: `Peer "${peer.name}" is in workspace ${peerWs}, not ${parentWs}.`,
+        addressing: { peer_agent_id: axes.peer_agent_id },
+      };
+    }
+    return {
+      ok: true,
+      peer: {
+        id: peer.id,
+        name: peer.name,
+        role: peer.role,
+        gateway_agent_id: peer.gateway_agent_id,
+      },
+      resolvedVia: 'peer_agent_id',
+    };
+  }
+  const gwId = axes.peer_gateway_id as string;
+  const isOrgRunner = gwId === 'mc-runner' || gwId === 'mc-runner-dev';
+  const peer = isOrgRunner
+    ? queryOne<DelegationPeerRow>(
+        `SELECT id, name, role, gateway_agent_id FROM agents WHERE gateway_agent_id = ? LIMIT 1`,
+        [gwId],
+      )
+    : queryOne<DelegationPeerRow>(
+        `SELECT id, name, role, gateway_agent_id FROM agents WHERE gateway_agent_id = ? AND COALESCE(workspace_id, 'default') = ? LIMIT 1`,
+        [gwId, parentWs],
+      );
+  if (!peer) {
+    return {
+      ok: false,
+      code: 'peer_not_found',
+      message: `No agent with gateway_agent_id "${gwId}" in workspace ${parentWs}.`,
+      addressing: { peer_gateway_id: gwId },
+    };
+  }
+  return { ok: true, peer, resolvedVia: 'peer_gateway_id' };
+}
+
+// ─── DAG validator ─────────────────────────────────────────────────
+
+/**
+ * Validate a convoy slice DAG. Returns either a successful result with
+ * the topological order + resolved peers, or a single structured error.
+ *
+ * Steps (atomic — first failure short-circuits):
+ *   1. Duplicate slice ids.
+ *   2. Unknown / self-referencing depends_on.
+ *   3. Kahn's topological sort; surfaces cycles.
+ *   4. Peer resolution for every slice (aggregates all peer errors so
+ *      the caller can show one combined diagnostic instead of N retries).
+ *
+ * Caller decides what to do with the result — `plan_convoy` writes
+ * `convoy_subtasks` directly; the proposal-accept pass writes through
+ * `spawnDelegationSubtask`. Neither path mutates the DB inside the
+ * validator.
+ */
+export function validateConvoyDag(
+  slices: ConvoyDagSliceInput[],
+  parentWs: string,
+): ConvoyDagValidationResult {
+  // ── 1. duplicate ids ─────────────────────────────────────────────
+  const ids = new Set<string>();
+  for (const s of slices) {
+    if (ids.has(s.id)) {
+      return {
+        ok: false,
+        code: 'duplicate_slice_id',
+        message: `Duplicate slice id "${s.id}".`,
+        details: { id: s.id },
+      };
+    }
+    ids.add(s.id);
+  }
+
+  // ── 2. unknown / self deps ───────────────────────────────────────
+  for (const s of slices) {
+    for (const dep of s.depends_on ?? []) {
+      if (!ids.has(dep)) {
+        return {
+          ok: false,
+          code: 'unknown_dep',
+          message: `Slice "${s.id}" depends on unknown id "${dep}".`,
+          details: { slice_id: s.id, dep },
+        };
+      }
+      if (dep === s.id) {
+        return {
+          ok: false,
+          code: 'self_dependency',
+          message: `Slice "${s.id}" depends on itself.`,
+          details: { slice_id: s.id },
+        };
+      }
+    }
+  }
+
+  // ── 3. Kahn topo sort ────────────────────────────────────────────
+  const inDegree = new Map<string, number>();
+  const outEdges = new Map<string, string[]>();
+  for (const s of slices) {
+    inDegree.set(s.id, (s.depends_on ?? []).length);
+    for (const dep of s.depends_on ?? []) {
+      const arr = outEdges.get(dep) ?? [];
+      arr.push(s.id);
+      outEdges.set(dep, arr);
+    }
+  }
+  const ready: string[] = [];
+  for (const [id, deg] of inDegree) if (deg === 0) ready.push(id);
+  const topo: string[] = [];
+  while (ready.length > 0) {
+    const id = ready.shift()!;
+    topo.push(id);
+    for (const next of outEdges.get(id) ?? []) {
+      const d = (inDegree.get(next) ?? 0) - 1;
+      inDegree.set(next, d);
+      if (d === 0) ready.push(next);
+    }
+  }
+  if (topo.length !== slices.length) {
+    const stuck = slices.filter((s) => !topo.includes(s.id)).map((s) => s.id);
+    return {
+      ok: false,
+      code: 'cycle_detected',
+      message: `Cycle detected: slices ${stuck.join(', ')} form a dependency loop.`,
+      details: { stuck },
+    };
+  }
+
+  // ── 4. peer resolution (aggregate all failures) ──────────────────
+  const resolved = new Map<string, ResolvedPeer>();
+  const peerErrors: PeerResolutionError[] = [];
+  for (const s of slices) {
+    const r = resolveDelegationPeer(
+      { role: s.role, peer_agent_id: s.peer_agent_id, peer_gateway_id: s.peer_gateway_id },
+      parentWs,
+    );
+    if (!r.ok) {
+      peerErrors.push({ slice_id: s.id, code: r.code, message: r.message });
+    } else {
+      resolved.set(s.id, { peer: r.peer, resolvedVia: r.resolvedVia });
+    }
+  }
+  if (peerErrors.length > 0) {
+    return {
+      ok: false,
+      code: 'peer_resolution_failed',
+      message: `Could not resolve ${peerErrors.length} peer(s):\n${peerErrors
+        .map((e) => `- ${e.slice_id}: ${e.message}`)
+        .join('\n')}`,
+      details: { failures: peerErrors },
+    };
+  }
+
+  return { ok: true, topo, resolved };
+}

--- a/src/lib/db/apply-convoy-diff.test.ts
+++ b/src/lib/db/apply-convoy-diff.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Apply-pass for `create_convoy_under_initiative` (PM convoy mandate slice 2).
+ *
+ *   - Happy path: a single-slice convoy materializes with parent ACs on
+ *     the convoys row and a root subtask ready for dispatch.
+ *   - Multi-slice DAG: 3 slices, A → B,C. Topological order respected;
+ *     B and C carry depends_on pointing at A's subtask id.
+ *   - Initiative placeholder: a `create_child_initiative` + a
+ *     `create_convoy_under_initiative` referencing `$0` both materialize.
+ *   - Find-or-create parent: a story initiative without an existing
+ *     task gets one auto-created and the convoy attaches to it.
+ *   - Atomic fail — cycle: apply rejects; no convoy row, no tasks.
+ *   - Atomic fail — unknown depends_on: same.
+ *   - ACs persisted as JSON-encoded array on `convoys.acceptance_criteria`.
+ *
+ * Dispatch firing in the apply path is fire-and-forget (loopback fetch
+ * that nothing answers in tests); these tests assert state up to the
+ * INSERTed rows, not the dispatched HTTP call.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+import { createInitiative } from './initiatives';
+import {
+  createProposal,
+  acceptProposal,
+  PmProposalValidationError,
+  type PmDiff,
+} from './pm-proposals';
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at)
+     VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function seedAgent(opts: { workspace: string; role?: string; name?: string } ): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, status, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 1, 'standby', datetime('now'), datetime('now'))`,
+    [id, opts.name ?? `Agent-${id.slice(0, 4)}`, opts.role ?? 'builder', opts.workspace],
+  );
+  return id;
+}
+
+function baseSlice(over: Partial<{
+  id: string;
+  role: string;
+  slice: string;
+  message: string;
+  depends_on: string[];
+}> = {}) {
+  return {
+    id: over.id ?? 'builder',
+    role: over.role ?? 'builder',
+    slice: over.slice ?? 'Build the feature end-to-end.',
+    message: over.message ?? 'Please ship the feature; honor the parent ACs.',
+    expected_deliverables: [{ title: 'Implementation', kind: 'file' as const }],
+    acceptance_criteria: ['Operator can click X and observe Y.'],
+    expected_duration_minutes: 60,
+    ...(over.depends_on ? { depends_on: over.depends_on } : {}),
+  };
+}
+
+// ─── Happy path ────────────────────────────────────────────────────
+
+test('create_convoy_under_initiative: single-slice happy path materializes convoy + subtask', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: 'builder' });
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'Ship feature' });
+
+  const proposal = createProposal({
+    workspace_id: ws,
+    trigger_text: 'decompose this story',
+    trigger_kind: 'decompose_story',
+    impact_md: '.',
+    proposed_changes: [
+      {
+        kind: 'create_convoy_under_initiative',
+        initiative_id: init.id,
+        parent_acceptance_criteria: [
+          'Operator can click X and observe Y end-to-end.',
+        ],
+        slices: [baseSlice()],
+      },
+    ],
+  });
+
+  const r = acceptProposal(proposal.id);
+  assert.equal(r.changes_applied, 1);
+  assert.equal(r.proposal.status, 'accepted');
+
+  // Parent task auto-created (story initiative had no prior task).
+  const parent = queryOne<{ id: string; status: string; initiative_id: string }>(
+    `SELECT id, status, initiative_id FROM tasks WHERE initiative_id = ? AND COALESCE(is_subtask, 0) = 0`,
+    [init.id],
+  );
+  assert.ok(parent, 'parent task should exist');
+  assert.equal(parent!.initiative_id, init.id);
+  // spawnDelegationSubtask flips parent into convoy_active on first spawn.
+  assert.equal(parent!.status, 'convoy_active');
+
+  // Convoy row carries the ACs as JSON.
+  const convoy = queryOne<{ id: string; acceptance_criteria: string | null; total_subtasks: number }>(
+    `SELECT id, acceptance_criteria, total_subtasks FROM convoys WHERE parent_task_id = ?`,
+    [parent!.id],
+  );
+  assert.ok(convoy, 'convoy row should exist');
+  assert.equal(convoy!.total_subtasks, 1);
+  assert.ok(convoy!.acceptance_criteria, 'parent ACs persisted');
+  const acs = JSON.parse(convoy!.acceptance_criteria!) as string[];
+  assert.deepEqual(acs, ['Operator can click X and observe Y end-to-end.']);
+
+  // Subtask row exists with proper SLO fields.
+  const subtasks = queryAll<{ id: string; slice: string; depends_on: string | null }>(
+    `SELECT id, slice, depends_on FROM convoy_subtasks WHERE convoy_id = ?`,
+    [convoy!.id],
+  );
+  assert.equal(subtasks.length, 1);
+  assert.equal(subtasks[0].depends_on, null, 'root slice has no deps');
+});
+
+// ─── Multi-slice DAG ───────────────────────────────────────────────
+
+test('create_convoy_under_initiative: multi-slice DAG resolves depends_on into subtask uuids', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: 'builder' });
+  seedAgent({ workspace: ws, role: 'tester' });
+  seedAgent({ workspace: ws, role: 'reviewer' });
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'Multi-slice' });
+
+  const proposal = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    trigger_kind: 'decompose_story',
+    impact_md: '.',
+    proposed_changes: [
+      {
+        kind: 'create_convoy_under_initiative',
+        initiative_id: init.id,
+        parent_acceptance_criteria: ['Feature ships green.'],
+        slices: [
+          baseSlice({ id: 'build', role: 'builder', slice: 'Build slice one.' }),
+          baseSlice({ id: 'test', role: 'tester', slice: 'Test the build.', depends_on: ['build'] }),
+          baseSlice({ id: 'review', role: 'reviewer', slice: 'Review the build.', depends_on: ['build'] }),
+        ],
+      },
+    ],
+  });
+
+  acceptProposal(proposal.id);
+
+  const parent = queryOne<{ id: string }>(
+    `SELECT id FROM tasks WHERE initiative_id = ? AND COALESCE(is_subtask, 0) = 0`,
+    [init.id],
+  )!;
+  const convoy = queryOne<{ id: string; total_subtasks: number }>(
+    `SELECT id, total_subtasks FROM convoys WHERE parent_task_id = ?`,
+    [parent.id],
+  )!;
+  assert.equal(convoy.total_subtasks, 3);
+
+  const rows = queryAll<{
+    id: string;
+    slice: string;
+    depends_on: string | null;
+    sort_order: number;
+    task_id: string;
+  }>(
+    `SELECT id, slice, depends_on, sort_order, task_id FROM convoy_subtasks WHERE convoy_id = ? ORDER BY sort_order`,
+    [convoy.id],
+  );
+  assert.equal(rows.length, 3);
+
+  // The root (build) has no deps; the other two each depend on it.
+  const build = rows.find((r) => r.slice.includes('one'))!;
+  const test_ = rows.find((r) => r.slice.includes('Test'))!;
+  const review = rows.find((r) => r.slice.includes('Review'))!;
+  assert.equal(build.depends_on, null);
+  const testDeps = JSON.parse(test_.depends_on!) as string[];
+  const reviewDeps = JSON.parse(review.depends_on!) as string[];
+  assert.deepEqual(testDeps, [build.id]);
+  assert.deepEqual(reviewDeps, [build.id]);
+
+  // Dependents stay in inbox until build is done (the dep gate from PR #344).
+  const testTaskStatus = queryOne<{ status: string }>(
+    `SELECT status FROM tasks WHERE id = ?`,
+    [test_.task_id],
+  )!;
+  assert.equal(testTaskStatus.status, 'inbox');
+});
+
+// ─── Initiative placeholder ($N) ───────────────────────────────────
+
+test('create_convoy_under_initiative: resolves $N placeholder against same-proposal create_child_initiative', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: 'builder' });
+  const parentInit = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Epic parent' });
+
+  const proposal = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    trigger_kind: 'decompose_initiative',
+    impact_md: '.',
+    proposed_changes: [
+      {
+        kind: 'create_child_initiative',
+        parent_initiative_id: parentInit.id,
+        title: 'Child story',
+        child_kind: 'story',
+      },
+      {
+        kind: 'create_convoy_under_initiative',
+        initiative_id: '$0',
+        parent_acceptance_criteria: ['Child ships.'],
+        slices: [baseSlice()],
+      },
+    ],
+  });
+
+  acceptProposal(proposal.id);
+
+  // Child initiative materialized.
+  const child = queryOne<{ id: string; title: string }>(
+    `SELECT id, title FROM initiatives WHERE parent_initiative_id = ?`,
+    [parentInit.id],
+  );
+  assert.ok(child);
+  assert.equal(child!.title, 'Child story');
+
+  // Parent task attached to the new child initiative.
+  const parentTask = queryOne<{ id: string; initiative_id: string }>(
+    `SELECT id, initiative_id FROM tasks WHERE initiative_id = ? AND COALESCE(is_subtask, 0) = 0`,
+    [child!.id],
+  );
+  assert.ok(parentTask);
+  // Convoy attached.
+  const convoy = queryOne<{ id: string }>(
+    `SELECT id FROM convoys WHERE parent_task_id = ?`,
+    [parentTask!.id],
+  );
+  assert.ok(convoy);
+});
+
+// ─── Find-or-create parent task ────────────────────────────────────
+
+test('create_convoy_under_initiative: auto-creates parent task for story initiative without one', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: 'builder' });
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'No task yet' });
+
+  // Sanity: no parent task exists.
+  const before = queryAll<{ id: string }>(
+    `SELECT id FROM tasks WHERE initiative_id = ?`,
+    [init.id],
+  );
+  assert.equal(before.length, 0);
+
+  const proposal = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    trigger_kind: 'decompose_story',
+    impact_md: '.',
+    proposed_changes: [
+      {
+        kind: 'create_convoy_under_initiative',
+        initiative_id: init.id,
+        parent_acceptance_criteria: ['Done means done.'],
+        slices: [baseSlice()],
+      },
+    ],
+  });
+
+  acceptProposal(proposal.id);
+
+  const parent = queryOne<{ id: string; title: string; status: string }>(
+    `SELECT id, title, status FROM tasks WHERE initiative_id = ? AND COALESCE(is_subtask, 0) = 0`,
+    [init.id],
+  );
+  assert.ok(parent, 'parent task auto-created from story initiative');
+  assert.equal(parent!.title, 'No task yet');
+});
+
+// ─── Atomic fail: cycle ────────────────────────────────────────────
+
+test('create_convoy_under_initiative: rejects DAG cycle and leaves DB untouched', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: 'builder' });
+  seedAgent({ workspace: ws, role: 'tester' });
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'Cycle' });
+
+  // createProposal's structural validator doesn't catch cycles (it only
+  // checks unknown refs); the apply pass surfaces them via
+  // validateConvoyDag. Build a 2-slice loop and ensure no writes leak.
+  const cycle: Extract<PmDiff, { kind: 'create_convoy_under_initiative' }> = {
+    kind: 'create_convoy_under_initiative',
+    initiative_id: init.id,
+    parent_acceptance_criteria: ['Never reached.'],
+    slices: [
+      { ...baseSlice({ id: 'a', role: 'builder' }), depends_on: ['b'] },
+      { ...baseSlice({ id: 'b', role: 'tester' }), depends_on: ['a'] },
+    ],
+  };
+
+  const proposal = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    trigger_kind: 'decompose_story',
+    impact_md: '.',
+    proposed_changes: [cycle],
+  });
+
+  assert.throws(() => acceptProposal(proposal.id), PmProposalValidationError);
+
+  // No convoy, no subtasks, no parent task.
+  const convoys = queryAll<{ id: string }>(
+    `SELECT id FROM convoys WHERE parent_task_id IN (SELECT id FROM tasks WHERE initiative_id = ?)`,
+    [init.id],
+  );
+  assert.equal(convoys.length, 0, 'cycle must roll back convoy insert');
+  const tasks = queryAll<{ id: string }>(
+    `SELECT id FROM tasks WHERE initiative_id = ?`,
+    [init.id],
+  );
+  assert.equal(tasks.length, 0, 'cycle must roll back parent-task auto-create');
+});
+
+// ─── Atomic fail: unknown depends_on ──────────────────────────────
+
+test('create_convoy_under_initiative: rejects unknown depends_on ref at proposal-create time', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: 'builder' });
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'Bad ref' });
+
+  assert.throws(
+    () =>
+      createProposal({
+        workspace_id: ws,
+        trigger_text: '.',
+        trigger_kind: 'decompose_story',
+        impact_md: '.',
+        proposed_changes: [
+          {
+            kind: 'create_convoy_under_initiative',
+            initiative_id: init.id,
+            parent_acceptance_criteria: ['x'.repeat(15)],
+            slices: [
+              { ...baseSlice(), depends_on: ['no-such-slice'] },
+            ],
+          },
+        ],
+      }),
+    PmProposalValidationError,
+  );
+});
+
+// ─── ACs persisted exactly ─────────────────────────────────────────
+
+test('create_convoy_under_initiative: parent ACs persist as JSON-encoded string array', () => {
+  const ws = freshWorkspace();
+  seedAgent({ workspace: ws, role: 'builder' });
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'ACs' });
+
+  const acs = [
+    'Operator clicks Cancel on any in-flight proposal card and the card disappears.',
+    'A late agent reply does not resurrect the cancelled card.',
+  ];
+
+  const proposal = createProposal({
+    workspace_id: ws,
+    trigger_text: '.',
+    trigger_kind: 'decompose_story',
+    impact_md: '.',
+    proposed_changes: [
+      {
+        kind: 'create_convoy_under_initiative',
+        initiative_id: init.id,
+        parent_acceptance_criteria: acs,
+        slices: [baseSlice()],
+      },
+    ],
+  });
+
+  acceptProposal(proposal.id);
+
+  const convoy = queryOne<{ acceptance_criteria: string | null }>(
+    `SELECT c.acceptance_criteria FROM convoys c
+       JOIN tasks t ON t.id = c.parent_task_id
+      WHERE t.initiative_id = ?`,
+    [init.id],
+  )!;
+  assert.ok(convoy.acceptance_criteria);
+  assert.deepEqual(JSON.parse(convoy.acceptance_criteria!), acs);
+});

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -31,6 +31,8 @@ import { getDb, queryAll, queryOne, run } from '@/lib/db';
 import { createTaskFromInitiative } from './promotion';
 import { transitionTaskStatus } from '@/lib/services/task-status';
 import { broadcast } from '@/lib/events';
+import { validateConvoyDag } from '@/lib/convoy-dag';
+import { spawnDelegationSubtask } from '@/lib/convoy';
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -82,6 +84,13 @@ export interface PmDiffCapture {
   created_initiative_id?: string;
   /** Set by the create_task_under_initiative apply pass — id of the new task. */
   created_task_id?: string;
+  /** Set by the create_convoy_under_initiative apply pass — id of the convoy row. */
+  created_convoy_id?: string;
+  /** Set by the create_convoy_under_initiative apply pass — id of the parent task
+   *  the convoy was attached to (existing or auto-created from a story initiative). */
+  created_parent_task_id?: string;
+  /** Set by the create_convoy_under_initiative apply pass — symbolic→real subtask map. */
+  created_subtasks?: Array<{ symbolic_id: string; subtask_id: string; child_task_id: string }>;
   /** Set by `applyDiff` for `add_availability` — id of the inserted row. */
   created_availability_id?: string;
   /** Set by `applyDiff` for `set_task_status` AND by the
@@ -162,6 +171,36 @@ export type PmDiff =
       status_check_md?: string | null;
       assigned_agent_id?: string | null;
       priority?: 'low' | 'normal' | 'high';
+    } & PmDiffCapture)
+  | ({
+      // PM convoy mandate (slice 2). Decompose-flow proposals emit a
+      // single convoy DAG instead of a flat task list. Apply pass:
+      //   1. resolve `initiative_id` against placeholders or workspace,
+      //   2. find-or-create the parent task for that initiative,
+      //   3. validate the DAG (Kahn + peer resolution) atomically,
+      //   4. INSERT convoys + convoy_subtasks via spawnDelegationSubtask,
+      //   5. fire-and-forget dispatchReadyConvoySubtasks for roots.
+      // No flag gates the apply itself — the diff materializes wherever
+      // it appears. Flag MC_PM_CONVOY_MANDATE gates the schema-level
+      // REJECTION of create_task_under_initiative in decompose flows
+      // (slice 6).
+      kind: 'create_convoy_under_initiative';
+      initiative_id: string;
+      parent_acceptance_criteria: string[];
+      slices: Array<{
+        id: string;
+        role?: string;
+        peer_agent_id?: string;
+        peer_gateway_id?: string;
+        slice: string;
+        message: string;
+        expected_deliverables: Array<{ title: string; kind: 'file' | 'note' | 'report' }>;
+        acceptance_criteria: string[];
+        expected_duration_minutes: number;
+        checkin_interval_minutes?: number;
+        depends_on?: string[];
+        required_evidence_gates?: string[];
+      }>;
     } & PmDiffCapture)
   | ({
       // Slice 2 of revertable PM proposals. Used as the inverse of
@@ -462,6 +501,102 @@ export function validateProposedChanges(
         }
         break;
       }
+      case 'create_convoy_under_initiative': {
+        if (!c.initiative_id) {
+          errors.push(`changes[${i}]: initiative_id required`);
+          break;
+        }
+        // Same placeholder semantics as create_task_under_initiative.
+        if (validPlaceholders.has(c.initiative_id)) {
+          // Resolved at apply time.
+        } else if (c.initiative_id.startsWith('$')) {
+          errors.push(
+            `changes[${i}]: placeholder ${c.initiative_id} does not match any create_child_initiative diff`,
+          );
+        } else {
+          assertInitiativeInWorkspace(workspaceId, c.initiative_id, errors, initiativeCache);
+        }
+        if (!Array.isArray(c.parent_acceptance_criteria) || c.parent_acceptance_criteria.length === 0) {
+          errors.push(`changes[${i}]: parent_acceptance_criteria must be a non-empty array`);
+        } else {
+          for (const ac of c.parent_acceptance_criteria) {
+            if (typeof ac !== 'string' || ac.length < 10 || ac.length > 500) {
+              errors.push(
+                `changes[${i}]: each parent_acceptance_criteria entry must be a string of 10..500 chars`,
+              );
+              break;
+            }
+          }
+        }
+        if (!Array.isArray(c.slices) || c.slices.length === 0 || c.slices.length > 12) {
+          errors.push(`changes[${i}]: slices must be a non-empty array (max 12)`);
+        } else {
+          // Cheap structural checks; full DAG (cycle / peer) validation
+          // happens in the apply pass against live workspace state.
+          const sliceIds = new Set<string>();
+          for (let j = 0; j < c.slices.length; j++) {
+            const s = c.slices[j];
+            if (!s || typeof s !== 'object') {
+              errors.push(`changes[${i}].slices[${j}]: must be an object`);
+              continue;
+            }
+            if (!s.id || typeof s.id !== 'string' || !/^[a-zA-Z0-9_-]{1,40}$/.test(s.id)) {
+              errors.push(`changes[${i}].slices[${j}]: id required (alphanum/_/-, 1..40 chars)`);
+            } else if (sliceIds.has(s.id)) {
+              errors.push(`changes[${i}].slices[${j}]: duplicate slice id "${s.id}"`);
+            } else {
+              sliceIds.add(s.id);
+            }
+            const addressing = [s.role, s.peer_agent_id, s.peer_gateway_id].filter(
+              (v) => typeof v === 'string' && v.length > 0,
+            );
+            if (addressing.length === 0) {
+              errors.push(
+                `changes[${i}].slices[${j}]: specify exactly one of role / peer_agent_id / peer_gateway_id`,
+              );
+            } else if (addressing.length > 1) {
+              errors.push(
+                `changes[${i}].slices[${j}]: role / peer_agent_id / peer_gateway_id are mutually exclusive`,
+              );
+            }
+            if (typeof s.slice !== 'string' || s.slice.length < 10 || s.slice.length > 500) {
+              errors.push(`changes[${i}].slices[${j}]: slice required (10..500 chars)`);
+            }
+            if (typeof s.message !== 'string' || s.message.length < 1 || s.message.length > 10000) {
+              errors.push(`changes[${i}].slices[${j}]: message required (1..10000 chars)`);
+            }
+            if (!Array.isArray(s.expected_deliverables) || s.expected_deliverables.length === 0) {
+              errors.push(`changes[${i}].slices[${j}]: expected_deliverables required`);
+            }
+            if (!Array.isArray(s.acceptance_criteria) || s.acceptance_criteria.length === 0) {
+              errors.push(`changes[${i}].slices[${j}]: acceptance_criteria required`);
+            }
+            if (
+              typeof s.expected_duration_minutes !== 'number' ||
+              s.expected_duration_minutes < 5 ||
+              s.expected_duration_minutes > 240
+            ) {
+              errors.push(`changes[${i}].slices[${j}]: expected_duration_minutes required (5..240)`);
+            }
+          }
+          // depends_on refs must point at sibling slice ids.
+          for (let j = 0; j < c.slices.length; j++) {
+            const s = c.slices[j];
+            if (!Array.isArray(s?.depends_on)) continue;
+            for (const dep of s.depends_on) {
+              if (!sliceIds.has(dep)) {
+                errors.push(
+                  `changes[${i}].slices[${j}]: depends_on "${dep}" is not a sibling slice id`,
+                );
+              }
+              if (dep === s.id) {
+                errors.push(`changes[${i}].slices[${j}]: slice cannot depend on itself`);
+              }
+            }
+          }
+        }
+        break;
+      }
       case 'create_child_initiative': {
         if (!c.parent_initiative_id) {
           errors.push(`changes[${i}]: parent_initiative_id required`);
@@ -677,6 +812,7 @@ export function inferTargetInitiativeId(changes: PmDiff[]): string | null {
       case 'add_dependency':
       case 'update_status_check':
       case 'create_task_under_initiative':
+      case 'create_convoy_under_initiative':
         id = c.initiative_id;
         break;
       case 'create_child_initiative':
@@ -1176,11 +1312,11 @@ export function acceptProposal(
     for (let idx = 0; idx < existing.proposed_changes.length; idx++) {
       if (!filter.has(idx)) continue;
       const c = existing.proposed_changes[idx];
-      if (c.kind !== 'create_task_under_initiative') continue;
+      if (c.kind !== 'create_task_under_initiative' && c.kind !== 'create_convoy_under_initiative') continue;
       const refIdx = placeholderToOwner.get(c.initiative_id);
       if (refIdx !== undefined && !filter.has(refIdx)) {
         throw new PmProposalValidationError(
-          `changes[${idx}]: create_task_under_initiative refers to placeholder "${c.initiative_id}" but the create_child_initiative at index ${refIdx} is not in the accepted set. Either accept both or neither.`,
+          `changes[${idx}]: ${c.kind} refers to placeholder "${c.initiative_id}" but the create_child_initiative at index ${refIdx} is not in the accepted set. Either accept both or neither.`,
         );
       }
     }
@@ -1226,6 +1362,12 @@ export function acceptProposal(
   // client-side by populating the create-initiative form. Keeps the
   // refine + audit chain intact without touching real state.
   const isAdvisory = existing.trigger_kind === 'plan_initiative';
+
+  // Convoy ids whose root slices should be fired AFTER the apply
+  // transaction commits. dispatch fires HTTP loopback through
+  // internalDispatch — we don't want it racing with the outer tx, and
+  // a dispatch failure must not roll back the materialized convoy.
+  const convoysToDispatch: string[] = [];
 
   db.transaction(() => {
     if (!isAdvisory) {
@@ -1309,6 +1451,33 @@ export function acceptProposal(
           });
           // Capture the new task id so revert can cancel that exact row.
           change.created_task_id = created.id;
+          changesApplied++;
+          continue;
+        }
+        if (change.kind === 'create_convoy_under_initiative') {
+          // PM convoy mandate slice 2: materialize the DAG atomically.
+          // We're already inside `db.transaction(...)`, so any throw
+          // from this branch rolls back ALL pass-1 / pass-2 writes,
+          // honoring the all-or-nothing apply invariant.
+          const mapped = placeholderMap.get(change.initiative_id);
+          const realInit = mapped ?? (change.initiative_id.startsWith('$')
+            ? undefined
+            : change.initiative_id);
+          if (!realInit) {
+            throw new PmProposalValidationError(
+              `create_convoy_under_initiative: unresolved placeholder "${change.initiative_id}"`,
+            );
+          }
+          const parentTaskId = applyCreateConvoyUnderInitiative({
+            workspaceId: existing.workspace_id,
+            initiativeId: realInit,
+            diff: change,
+            now,
+            appliedByAgentId: applied_by_agent_id,
+            proposalId: id,
+          });
+          convoysToDispatch.push(change.created_convoy_id!);
+          change.created_parent_task_id = parentTaskId;
           changesApplied++;
           continue;
         }
@@ -1397,6 +1566,30 @@ export function acceptProposal(
       now,
     );
   })();
+
+  // After-commit: fire root slices for every freshly-materialized
+  // convoy. Lazy-imported so this module stays decoupled from the
+  // dispatch / fetch surface — keeps test setup light and avoids a
+  // circular import between pm-proposals and convoy.
+  if (convoysToDispatch.length > 0) {
+    import('@/lib/convoy')
+      .then(({ dispatchReadyConvoySubtasks }) => {
+        for (const convoyId of convoysToDispatch) {
+          dispatchReadyConvoySubtasks(convoyId).catch((err) => {
+            console.warn(
+              '[acceptProposal] dispatchReadyConvoySubtasks failed:',
+              (err as Error).message,
+            );
+          });
+        }
+      })
+      .catch((err) => {
+        console.warn(
+          '[acceptProposal] failed to load convoy dispatcher:',
+          (err as Error).message,
+        );
+      });
+  }
 
   const updated = getProposal(id)!;
   const rejected_indexes = filter
@@ -1566,6 +1759,11 @@ function applyDiff(diff: PmDiff, now: string): void {
       // initiative_id placeholders can resolve from the same proposal.
       throw new Error('create_task_under_initiative must be applied via acceptProposal pass-2');
     }
+    case 'create_convoy_under_initiative': {
+      // Out-of-band: needs the placeholder map AND fires DAG validation
+      // + spawnDelegationSubtask via applyCreateConvoyUnderInitiative.
+      throw new Error('create_convoy_under_initiative must be applied via acceptProposal pass-2');
+    }
     case 'set_task_status': {
       const prev = queryOne<{ status: string }>(
         `SELECT status FROM tasks WHERE id = ?`,
@@ -1640,6 +1838,188 @@ function applyCreateChildInitiative(
     ],
   );
   return childId;
+}
+
+/**
+ * Apply one `create_convoy_under_initiative` diff.
+ *
+ *   1. Validate the DAG (Kahn topo sort + peer resolution) against the
+ *      live workspace. Atomic: any error throws and the outer
+ *      transaction rolls back.
+ *   2. Find-or-create the parent task for the initiative. Story-kind
+ *      initiatives without an existing task get one in 'inbox' via
+ *      `createTaskFromInitiative` + an immediate `inbox` flip so the
+ *      convoy can attach.
+ *   3. INSERT the `convoys` row (via spawnDelegationSubtask's lazy
+ *      create-on-first-spawn path) populated with the parent ACs as a
+ *      JSON-encoded array.
+ *   4. INSERT per-slice tasks + convoy_subtasks in topological order
+ *      with resolved `depends_on_subtask_ids`. Reuses
+ *      `spawnDelegationSubtask` so the SLO contract fields
+ *      (acceptance_criteria, expected_deliverables, evidence gates)
+ *      land on the row identically to coordinator-spawned subtasks.
+ *
+ * The caller wires up dispatch fire-and-forget AFTER the outer tx
+ * commits — see `convoysToDispatch` in `acceptProposal`.
+ *
+ * Mutates the diff in place to record `created_convoy_id` and
+ * `created_subtasks` for revert.
+ *
+ * @returns the parent task id the convoy was attached to.
+ */
+function applyCreateConvoyUnderInitiative(input: {
+  workspaceId: string;
+  initiativeId: string;
+  diff: Extract<PmDiff, { kind: 'create_convoy_under_initiative' }>;
+  now: string;
+  appliedByAgentId: string | null;
+  proposalId: string;
+}): string {
+  const { workspaceId, initiativeId, diff, now, appliedByAgentId, proposalId } = input;
+
+  // ── DAG validation pre-pass (atomic — first failure throws) ──────
+  const dag = validateConvoyDag(diff.slices, workspaceId);
+  if (!dag.ok) {
+    throw new PmProposalValidationError(
+      `create_convoy_under_initiative: ${dag.message}`,
+    );
+  }
+
+  // ── Find-or-create the parent task ──────────────────────────────
+  // Reuses `promote_initiative_to_task` semantics: story-kind
+  // initiatives without a task row get one created here. We prefer
+  // the most-recent non-terminal task on the initiative so a convoy
+  // re-decompose attaches to live work rather than spawning a second
+  // parent. Terminal-state rows (done / cancelled) are skipped so a
+  // re-plan after completion creates a fresh parent.
+  const initiative = queryOne<{ id: string; kind: string; title: string; description: string | null }>(
+    'SELECT id, kind, title, description FROM initiatives WHERE id = ?',
+    [initiativeId],
+  );
+  if (!initiative) {
+    throw new PmProposalValidationError(
+      `create_convoy_under_initiative: initiative ${initiativeId} not found`,
+    );
+  }
+  const existingTask = queryOne<{ id: string; status: string }>(
+    `SELECT id, status FROM tasks
+       WHERE initiative_id = ? AND COALESCE(is_subtask, 0) = 0
+         AND status NOT IN ('done', 'cancelled')
+       ORDER BY datetime(created_at) DESC LIMIT 1`,
+    [initiativeId],
+  );
+
+  let parentTaskId: string;
+  if (existingTask) {
+    parentTaskId = existingTask.id;
+    // If the parent is in 'draft', flip to 'inbox' so spawnDelegationSubtask
+    // and convoy_active transitions are valid.
+    if (existingTask.status === 'draft') {
+      run(
+        `UPDATE tasks SET status = 'inbox', updated_at = ? WHERE id = ?`,
+        [now, parentTaskId],
+      );
+    }
+  } else {
+    // Auto-create. Requires the initiative to be story-kind per the
+    // promote_initiative_to_task contract; the PM SOUL is responsible
+    // for not emitting decompose-flow convoys against theme / milestone
+    // / epic initiatives, but we keep the guard so a buggy emit
+    // surfaces an actionable error rather than orphaned rows.
+    if (initiative.kind !== 'story') {
+      throw new PmProposalValidationError(
+        `create_convoy_under_initiative: initiative ${initiativeId} is kind='${initiative.kind}' — only story-kind initiatives can auto-create a parent task. Promote the initiative first.`,
+      );
+    }
+    const created = createTaskFromInitiative({
+      initiative_id: initiativeId,
+      workspace_id: workspaceId,
+      title: initiative.title,
+      description: initiative.description ?? null,
+      created_by_agent_id: appliedByAgentId,
+      reason: `parent task auto-created for convoy from PM proposal #${proposalId}`,
+    });
+    parentTaskId = created.id;
+    // createTaskFromInitiative inserts 'draft'; flip to 'inbox' so the
+    // convoy can attach (spawnDelegationSubtask transitions parent to
+    // 'convoy_active' on first spawn, which expects a non-draft state).
+    run(
+      `UPDATE tasks SET status = 'inbox', updated_at = ? WHERE id = ?`,
+      [now, parentTaskId],
+    );
+  }
+
+  // ── Spawn each slice in topological order ───────────────────────
+  // spawnDelegationSubtask lazy-creates the convoy on the first call
+  // and appends to it on subsequent calls — exactly the shape we need.
+  const slicesById = new Map(diff.slices.map((s) => [s.id, s] as const));
+  const symbolicToSubtaskId = new Map<string, string>();
+  const symbolicToChildTaskId = new Map<string, string>();
+  const created: Array<{ symbolic_id: string; subtask_id: string; child_task_id: string }> = [];
+  let convoyId: string | null = null;
+
+  for (const symId of dag.topo) {
+    const s = slicesById.get(symId)!;
+    const r = dag.resolved.get(symId)!;
+    const checkin = s.checkin_interval_minutes ?? 15;
+    const depSubtaskIds = (s.depends_on ?? [])
+      .map((d) => symbolicToSubtaskId.get(d)!)
+      .filter(Boolean);
+    const peerRoleForLog = r.peer.role ?? s.role ?? 'builder';
+
+    const spawn = spawnDelegationSubtask({
+      parentTaskId,
+      parentAgentId: appliedByAgentId ?? r.peer.id,
+      peerAgentId: r.peer.id,
+      peerGatewayId: r.peer.gateway_agent_id ?? '',
+      suggestedRole: peerRoleForLog,
+      slice: s.slice,
+      message: s.message,
+      expectedDeliverables: s.expected_deliverables,
+      acceptanceCriteria: s.acceptance_criteria,
+      expectedDurationMinutes: s.expected_duration_minutes,
+      checkinIntervalMinutes: checkin,
+      dependsOnSubtaskIds: depSubtaskIds.length > 0 ? depSubtaskIds : undefined,
+    });
+    convoyId = spawn.convoyId;
+    symbolicToSubtaskId.set(symId, spawn.subtaskId);
+    symbolicToChildTaskId.set(symId, spawn.childTaskId);
+    created.push({
+      symbolic_id: symId,
+      subtask_id: spawn.subtaskId,
+      child_task_id: spawn.childTaskId,
+    });
+
+    // Per-slice required_evidence_gates override (spawnDelegationSubtask
+    // defaults to ['test_full']; the diff can override). Only fire the
+    // UPDATE when the diff explicitly sets it — otherwise the default
+    // stays.
+    if (Array.isArray(s.required_evidence_gates)) {
+      run(
+        `UPDATE convoy_subtasks SET required_evidence_gates = ? WHERE id = ?`,
+        [JSON.stringify(s.required_evidence_gates), spawn.subtaskId],
+      );
+    }
+  }
+
+  if (!convoyId) {
+    // Unreachable — validateConvoyDag would have rejected an empty
+    // slice list — but guard for safety.
+    throw new PmProposalValidationError(
+      'create_convoy_under_initiative: no convoy materialized',
+    );
+  }
+
+  // Populate convoys.acceptance_criteria with the parent ACs. Column
+  // was added by migration 095; we JSON-encode the string[].
+  run(
+    `UPDATE convoys SET acceptance_criteria = ?, updated_at = ? WHERE id = ?`,
+    [JSON.stringify(diff.parent_acceptance_criteria), now, convoyId],
+  );
+
+  diff.created_convoy_id = convoyId;
+  diff.created_subtasks = created;
+  return parentTaskId;
 }
 
 // ─── Reject / refine ────────────────────────────────────────────────

--- a/src/lib/mcp/groups/work.ts
+++ b/src/lib/mcp/groups/work.ts
@@ -25,6 +25,11 @@ import { saveKnowledge, searchKnowledge } from '@/lib/services/knowledge';
 import { getUnreadMail } from '@/lib/mailbox';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { spawnDelegationSubtask, dispatchReadyConvoySubtasks } from '@/lib/convoy';
+import {
+  validateConvoyDag,
+  resolveDelegationPeer as resolveDelegationPeerShared,
+  type DelegationPeerRow as SharedDelegationPeerRow,
+} from '@/lib/convoy-dag';
 import { internalDispatch } from '@/lib/internal-dispatch';
 import { upsertSession, type ScopeType } from '@/lib/db/mc-sessions';
 import {
@@ -228,82 +233,14 @@ async function cancelSubtaskImpl(args: { agent_id: string; subtask_id: string; r
   });
 }
 
-// Peer-resolution helper shared by spawn_subtask + plan_convoy. Returns
-// either the resolved agent row + addressing axis, or a structured error
-// describing why it couldn't resolve. Mirrors the inline resolver in the
-// spawn_subtask handler exactly — kept terse because plan_convoy needs
-// to aggregate errors across many slices rather than short-circuit on
-// the first one. (spawn_subtask still uses its own inline copy because
-// its error text is hand-tuned for the single-slice case.)
-type DelegationPeerRow = {
-  id: string;
-  name: string;
-  role: string | null;
-  gateway_agent_id: string | null;
-};
-type ResolvePeerOk = {
-  ok: true;
-  peer: DelegationPeerRow;
-  resolvedVia: 'role' | 'peer_agent_id' | 'peer_gateway_id';
-};
-type ResolvePeerErr = {
-  ok: false;
-  code: string;
-  message: string;
-  addressing: Record<string, string>;
-};
-function resolveDelegationPeer(
-  axes: { role?: string; peer_agent_id?: string; peer_gateway_id?: string },
-  parentWs: string,
-): ResolvePeerOk | ResolvePeerErr {
-  const provided = [axes.role, axes.peer_agent_id, axes.peer_gateway_id]
-    .filter((v): v is string => typeof v === 'string' && v.length > 0);
-  if (provided.length === 0) {
-    return { ok: false, code: 'peer_addressing_missing', message: 'Specify exactly one of role / peer_agent_id / peer_gateway_id.', addressing: {} };
-  }
-  if (provided.length > 1) {
-    return { ok: false, code: 'peer_addressing_conflict', message: 'role / peer_agent_id / peer_gateway_id are mutually exclusive.', addressing: {} };
-  }
-  if (axes.role) {
-    const peer = queryOne<DelegationPeerRow>(
-      `SELECT id, name, role, gateway_agent_id FROM agents
-        WHERE role = ?
-          AND COALESCE(workspace_id, 'default') = ?
-          AND COALESCE(status, 'standby') != 'offline'
-          AND COALESCE(is_active, 1) = 1
-        ORDER BY updated_at DESC LIMIT 1`,
-      [axes.role, parentWs],
-    );
-    if (!peer) {
-      return { ok: false, code: 'peer_not_found', message: `No active agent with role "${axes.role}" in workspace ${parentWs}.`, addressing: { role: axes.role } };
-    }
-    return { ok: true, peer, resolvedVia: 'role' };
-  }
-  if (axes.peer_agent_id) {
-    const peer = queryOne<DelegationPeerRow & { workspace_id: string | null }>(
-      `SELECT id, name, role, gateway_agent_id, workspace_id FROM agents WHERE id = ? LIMIT 1`,
-      [axes.peer_agent_id],
-    );
-    if (!peer) {
-      return { ok: false, code: 'peer_not_found', message: `No agent with id "${axes.peer_agent_id}".`, addressing: { peer_agent_id: axes.peer_agent_id } };
-    }
-    const isOrgRunner = peer.gateway_agent_id === 'mc-runner' || peer.gateway_agent_id === 'mc-runner-dev';
-    const peerWs = peer.workspace_id ?? 'default';
-    if (peerWs !== parentWs && !isOrgRunner) {
-      return { ok: false, code: 'peer_not_in_workspace', message: `Peer "${peer.name}" is in workspace ${peerWs}, not ${parentWs}.`, addressing: { peer_agent_id: axes.peer_agent_id } };
-    }
-    return { ok: true, peer: { id: peer.id, name: peer.name, role: peer.role, gateway_agent_id: peer.gateway_agent_id }, resolvedVia: 'peer_agent_id' };
-  }
-  const gwId = axes.peer_gateway_id as string;
-  const isOrgRunner = gwId === 'mc-runner' || gwId === 'mc-runner-dev';
-  const peer = isOrgRunner
-    ? queryOne<DelegationPeerRow>(`SELECT id, name, role, gateway_agent_id FROM agents WHERE gateway_agent_id = ? LIMIT 1`, [gwId])
-    : queryOne<DelegationPeerRow>(`SELECT id, name, role, gateway_agent_id FROM agents WHERE gateway_agent_id = ? AND COALESCE(workspace_id, 'default') = ? LIMIT 1`, [gwId, parentWs]);
-  if (!peer) {
-    return { ok: false, code: 'peer_not_found', message: `No agent with gateway_agent_id "${gwId}" in workspace ${parentWs}.`, addressing: { peer_gateway_id: gwId } };
-  }
-  return { ok: true, peer, resolvedVia: 'peer_gateway_id' };
-}
+// Peer-resolution helper shared by spawn_subtask + plan_convoy. The
+// implementation lives in `@/lib/convoy-dag` so the PM-driven apply
+// pass for `create_convoy_under_initiative` diffs can reuse the same
+// rules (extracted in slice 2 of the PM convoy mandate). Local
+// aliases below preserve the existing call-site names so the handler
+// bodies didn't need to be rewritten.
+type DelegationPeerRow = SharedDelegationPeerRow;
+const resolveDelegationPeer = resolveDelegationPeerShared;
 
 export function registerWorkTools(server: McpServer): void {
   // get_task ──────────────────────────────────────────────────────
@@ -1744,71 +1681,21 @@ export function registerWorkTools(server: McpServer): void {
       }
       const parentWs = parent.workspace_id ?? 'default';
 
-      // ── DAG validation ─────────────────────────────────────────
-      const ids = new Set<string>();
-      for (const s of args.slices) {
-        if (ids.has(s.id)) {
-          return { isError: true, content: [{ type: 'text', text: `Duplicate slice id "${s.id}".` }], structuredContent: { error: 'duplicate_slice_id', id: s.id } };
-        }
-        ids.add(s.id);
-      }
-      for (const s of args.slices) {
-        for (const dep of s.depends_on ?? []) {
-          if (!ids.has(dep)) {
-            return { isError: true, content: [{ type: 'text', text: `Slice "${s.id}" depends on unknown id "${dep}".` }], structuredContent: { error: 'unknown_dep', slice_id: s.id, dep } };
-          }
-          if (dep === s.id) {
-            return { isError: true, content: [{ type: 'text', text: `Slice "${s.id}" depends on itself.` }], structuredContent: { error: 'self_dependency', slice_id: s.id } };
-          }
-        }
-      }
-      // Topological sort via Kahn's algorithm. Surfaces cycles before
-      // any row is written.
-      const inDegree = new Map<string, number>();
-      const outEdges = new Map<string, string[]>();
-      for (const s of args.slices) {
-        inDegree.set(s.id, (s.depends_on ?? []).length);
-        for (const dep of s.depends_on ?? []) {
-          const arr = outEdges.get(dep) ?? [];
-          arr.push(s.id);
-          outEdges.set(dep, arr);
-        }
-      }
-      const ready: string[] = [];
-      for (const [id, deg] of inDegree) if (deg === 0) ready.push(id);
-      const topo: string[] = [];
-      while (ready.length > 0) {
-        const id = ready.shift()!;
-        topo.push(id);
-        for (const next of outEdges.get(id) ?? []) {
-          const d = (inDegree.get(next) ?? 0) - 1;
-          inDegree.set(next, d);
-          if (d === 0) ready.push(next);
-        }
-      }
-      if (topo.length !== args.slices.length) {
-        const stuck = args.slices.filter(s => !topo.includes(s.id)).map(s => s.id);
-        return { isError: true, content: [{ type: 'text', text: `Cycle detected: slices ${stuck.join(', ')} form a dependency loop.` }], structuredContent: { error: 'cycle_detected', stuck } };
-      }
-
-      // ── Peer resolution pre-pass (collect ALL errors before writes) ─
-      const resolved = new Map<string, { peer: DelegationPeerRow; resolvedVia: 'role' | 'peer_agent_id' | 'peer_gateway_id' }>();
-      const peerErrors: Array<{ slice_id: string; code: string; message: string }> = [];
-      for (const s of args.slices) {
-        const r = resolveDelegationPeer(
-          { role: s.role, peer_agent_id: s.peer_agent_id, peer_gateway_id: s.peer_gateway_id },
-          parentWs,
-        );
-        if (!r.ok) peerErrors.push({ slice_id: s.id, code: r.code, message: r.message });
-        else resolved.set(s.id, { peer: r.peer, resolvedVia: r.resolvedVia });
-      }
-      if (peerErrors.length > 0) {
+      // ── DAG validation (shared with the PM convoy-mandate apply pass) ─
+      //    Slice 2 of pm-convoy-mandate: the Kahn topo sort + peer
+      //    resolution moved to `@/lib/convoy-dag`. Same rules, single
+      //    source of truth. The structured `error` codes returned to
+      //    the MCP client are preserved for back-compat — only the
+      //    code path changed.
+      const dag = validateConvoyDag(args.slices, parentWs);
+      if (!dag.ok) {
         return {
           isError: true,
-          content: [{ type: 'text', text: `Could not resolve ${peerErrors.length} peer(s):\n${peerErrors.map(e => `- ${e.slice_id}: ${e.message}`).join('\n')}` }],
-          structuredContent: { error: 'peer_resolution_failed', failures: peerErrors },
+          content: [{ type: 'text', text: dag.message }],
+          structuredContent: { error: dag.code, ...dag.details },
         };
       }
+      const { topo, resolved } = dag;
 
       // ── Create rows in topological order so depends_on_subtask_ids
       //    resolves cleanly per slice.

--- a/src/lib/pm/invertDiff.ts
+++ b/src/lib/pm/invertDiff.ts
@@ -248,6 +248,19 @@ function invertOne(diff: PmDiff, index: number): InvertedDiff {
       };
     }
 
+    case 'create_convoy_under_initiative': {
+      // PM convoy mandate slice 2: revert semantics for this diff kind
+      // are out of scope here — they land in slice 7 alongside the
+      // updated pm-revertable-proposals spec ("cancel the convoy +
+      // delete unscheduled child tasks; refuse revert if any slice has
+      // reached done"). Surface a limited marker so the chain renders
+      // without claiming a false inverse.
+      return limited(
+        index,
+        'create_convoy_under_initiative revert not yet implemented (slice 7 of pm-convoy-mandate)',
+      );
+    }
+
     default: {
       const exhaustive: never = diff;
       return {


### PR DESCRIPTION
## Summary

Slice **2 of 7** of the PM convoy mandate (see [`docs/proposals/pm-convoy-mandate.md`](docs/proposals/pm-convoy-mandate.md)). Wires up the apply pass that materializes a `create_convoy_under_initiative` diff on proposal accept — convoy row, per-slice tasks, parent ACs, and dep-gated dispatch all land atomically. The schema variant + migration already shipped in slices 1 and 3; this is the code path that makes the diff actually do something.

This slice ENABLES the new diff to materialize convoys but does **NOT yet** gate or reject `create_task_under_initiative` diffs from decompose flows. That's the `MC_PM_CONVOY_MANDATE` flag flip in **slice 6**. No UX changes here either (slice 4); no parent `review → done` AC gate (slice 5).

## Changes

- **`src/lib/convoy-dag.ts`** (new). Shared Kahn topological-sort + peer-resolution validator. Lifted from `plan_convoy`'s inline body so both entry points — the coordinator's `plan_convoy` MCP tool AND the new operator-driven proposal-accept path — share one source of truth. Took **option A** (extraction) per the spec brief; `plan_convoy` now delegates to `validateConvoyDag(...)`. The MCP tool's structured `error` codes (`duplicate_slice_id`, `unknown_dep`, `self_dependency`, `cycle_detected`, `peer_resolution_failed`) are preserved for back-compat.
- **`src/lib/db/pm-proposals.ts`**:
  - New `PmDiff` variant `create_convoy_under_initiative` (matches the zod variant from slice 1).
  - `validateProposedChanges` handles the new kind with structural checks (placeholder resolution, slice id format, deps point at siblings, parent ACs are non-empty strings ≤500 chars, ≤12 slices).
  - `acceptProposal` pass-2 branch: resolve `initiative_id` (real or `$N` placeholder), find-or-create the parent task (mirrors `promote_initiative_to_task` semantics; story-kind requirement when auto-creating), validate the DAG, spawn slices via `spawnDelegationSubtask` in topo order, persist parent ACs as JSON on `convoys.acceptance_criteria`, capture revert metadata.
  - Dispatch firing for root slices runs **after** the outer `db.transaction(...)` commits — lazy-imported `dispatchReadyConvoySubtasks` fire-and-forget so a dispatch HTTP failure can't roll back the materialized convoy.
  - Cross-diff placeholder safety check extended to cover the new kind.
- **`src/lib/mcp/groups/work.ts`**: `plan_convoy`'s inline DAG validation collapses to `validateConvoyDag(...)`. Local `resolveDelegationPeer` removed (now imported from `@/lib/convoy-dag`). No behavior change in the MCP tool.
- **`src/lib/pm/invertDiff.ts`**: `create_convoy_under_initiative` returns a `limited` revert marker. Real revert semantics (cancel convoy + delete unscheduled child tasks; refuse if any slice reached `done`) land in slice 7 alongside the `pm-revertable-proposals` spec edits.
- **`src/lib/db/apply-convoy-diff.test.ts`** (new). 7 scenarios — see Test plan.

Atomic invariant: any failure inside the apply pass (cycle, unknown ref, peer resolution miss, find-or-create error) throws inside the outer transaction and nothing materializes. `convoys.acceptance_criteria` is `JSON.stringify(parent_acceptance_criteria)`.

## Test plan

- [x] `yarn test src/lib/db src/lib/mcp src/lib/pm src/lib/convoy.ts` — green
- [x] `npx tsc --noEmit` — clean
- [x] New tests in `src/lib/db/apply-convoy-diff.test.ts` cover:
  - happy path single-slice convoy materializes (convoy row, ACs JSON, root subtask)
  - multi-slice DAG (3 slices, build → test, build → review) resolves `depends_on_subtask_ids` and leaves dependents in `inbox`
  - `$0` placeholder against same-proposal `create_child_initiative` resolves end-to-end
  - find-or-create: story initiative without a parent task gets one auto-created
  - atomic fail — DAG cycle: no convoy / task / parent rows leak
  - atomic fail — unknown `depends_on` ref rejected at proposal-create time
  - parent ACs persist as JSON-encoded `string[]` on `convoys.acceptance_criteria`
- [x] No preview run for this slice — pure backend, no UI surface yet (UI lands in slice 4).
- One **pre-existing** test failure unrelated to this slice: `schedule-runner: produces a brief and advances run_count` in `src/lib/research/eval/schedule-runner.test.ts` fails on plain `main` (verified with `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)