### PR TITLE
feat(pm): parent review→done AC gate + ack modal (slice 5/7)

### DIFF
--- a/src/app/api/tasks/[id]/ac-ack/route.ts
+++ b/src/app/api/tasks/[id]/ac-ack/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  acknowledgeAc,
+  getParentConvoyAcs,
+  unacknowledgeAc,
+} from '@/lib/db/task-ac-ack';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/tasks/[id]/ac-ack
+ *
+ * Returns the per-AC status for the task's done-state parent convoy.
+ * Response body: `{ acceptance_criteria: AcStatus[] | null }`. A null value
+ * means the task has no convoy with ACs — the AC gate is a no-op and the
+ * caller can drive the existing review → done transition directly.
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const acceptance_criteria = getParentConvoyAcs(id);
+    return NextResponse.json({ acceptance_criteria });
+  } catch (error) {
+    console.error('[ac-ack:GET] failed:', error);
+    return NextResponse.json({ error: 'Failed to load AC status' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/tasks/[id]/ac-ack
+ *
+ * Body: `{ ac_index: number, rationale?: string }`.
+ * Records (or replaces) an acknowledgement for a single AC. Returns the
+ * updated AC projection so the modal can re-render without a round trip.
+ *
+ * Single-operator dev mode: `acknowledged_by` defaults to 'operator'.
+ * Future auth layers can populate it from the session.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body.ac_index !== 'number') {
+      return NextResponse.json(
+        { error: 'ac_index (number) is required' },
+        { status: 400 },
+      );
+    }
+    const rationale = typeof body.rationale === 'string' ? body.rationale : undefined;
+    try {
+      acknowledgeAc(id, body.ac_index, { rationale, acknowledgedBy: 'operator' });
+    } catch (err) {
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : 'Failed to ack' },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json({ acceptance_criteria: getParentConvoyAcs(id) });
+  } catch (error) {
+    console.error('[ac-ack:POST] failed:', error);
+    return NextResponse.json({ error: 'Failed to record acknowledgement' }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/tasks/[id]/ac-ack
+ *
+ * Body: `{ ac_index: number }`. Removes a single ack row (operator changed
+ * their mind). Idempotent — DELETE of a non-existent row succeeds.
+ */
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body.ac_index !== 'number') {
+      return NextResponse.json(
+        { error: 'ac_index (number) is required' },
+        { status: 400 },
+      );
+    }
+    unacknowledgeAc(id, body.ac_index);
+    return NextResponse.json({ acceptance_criteria: getParentConvoyAcs(id) });
+  } catch (error) {
+    console.error('[ac-ack:DELETE] failed:', error);
+    return NextResponse.json({ error: 'Failed to remove acknowledgement' }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -6,6 +6,7 @@ import { internalDispatch } from '@/lib/internal-dispatch';
 import { handleStageTransition, handleStageFailure, getTaskWorkflow, populateTaskRolesFromAgents } from '@/lib/workflow-engine';
 import { runPostStatusChangeSideEffects } from '@/lib/services/task-status';
 import { hasStageEvidence, checkStageEvidence, canUseBoardOverride, auditBoardOverride, whyCannotBeDone, recordLearnerOnTransition, isTerminalStatus } from '@/lib/task-governance';
+import { missingAcAcknowledgements } from '@/lib/db/task-ac-ack';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
 import { UpdateTaskSchema } from '@/lib/validation';
@@ -274,6 +275,23 @@ export async function PATCH(
         });
         if (reason) {
           return NextResponse.json({ error: `Cannot mark done: ${reason}` }, { status: 400 });
+        }
+
+        // PM convoy mandate (slice 5/7): parent task with a done convoy
+        // carrying feature-level acceptance criteria must have every AC
+        // explicitly acknowledged before review → done. board_override
+        // bypasses (handled above by the boardOverrideAllowed branch).
+        const acGate = missingAcAcknowledgements(id);
+        if (acGate && acGate.missing_indices.length > 0) {
+          return NextResponse.json(
+            {
+              error: `Parent task has ${acGate.missing_indices.length} unacknowledged convoy AC(s). Operator must acknowledge each before review → done.`,
+              code: 'parent_ac_check_pending',
+              missing_ac_indices: acGate.missing_indices,
+              acceptance_criteria: acGate.acceptance_criteria,
+            },
+            { status: 400 },
+          );
         }
       }
 

--- a/src/components/AcAckModal.tsx
+++ b/src/components/AcAckModal.tsx
@@ -1,0 +1,336 @@
+'use client';
+
+/**
+ * AC acknowledgement modal — PM convoy mandate slice 5/7.
+ *
+ * Opens when the operator tries to flip a parent task from `review` →
+ * `done` and the PATCH returns `code: 'parent_ac_check_pending'`. The
+ * server-returned `acceptance_criteria` payload bootstraps the list so
+ * the modal renders synchronously without a second fetch.
+ *
+ * Each AC has a checkbox + an optional free-text rationale. "Save"
+ * persists per-AC via POST /api/tasks/[id]/ac-ack. Once every AC is
+ * acknowledged, the "Complete task" button enables and fires the
+ * caller-supplied transition (which re-runs the PATCH and clears the
+ * gate). A "board_override" escape hatch routes through ConfirmDialog
+ * per project convention — no native window.confirm.
+ *
+ * Per spec: free-text rationale is soft-required for V1 (warn if empty,
+ * still allow save). We can tighten to hard-required if operators game
+ * the checkbox.
+ */
+
+import { useEffect, useState } from 'react';
+import { CheckCircle2, Circle, X } from 'lucide-react';
+import { ConfirmDialog } from './ConfirmDialog';
+
+export interface AcStatus {
+  ac_index: number;
+  ac_text: string;
+  acknowledged: boolean;
+  rationale?: string;
+}
+
+interface AcAckModalProps {
+  open: boolean;
+  taskId: string;
+  /** Optional initial snapshot (e.g. from the PATCH 400 body) to avoid a fetch round-trip. */
+  initialAcs?: AcStatus[];
+  onClose: () => void;
+  /** Called when all ACs are acked and the operator confirms completion. */
+  onComplete: () => Promise<void> | void;
+  /** Called when the operator chooses the board_override escape hatch. */
+  onBoardOverride: (reason: string) => Promise<void> | void;
+}
+
+export function AcAckModal({
+  open,
+  taskId,
+  initialAcs,
+  onClose,
+  onComplete,
+  onBoardOverride,
+}: AcAckModalProps) {
+  const [acs, setAcs] = useState<AcStatus[]>(initialAcs ?? []);
+  const [rationales, setRationales] = useState<Record<number, string>>({});
+  const [savingIndex, setSavingIndex] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmOverride, setConfirmOverride] = useState(false);
+  const [overrideReason, setOverrideReason] = useState('');
+  const [completing, setCompleting] = useState(false);
+
+  // Refresh from the server on open so we don't miss out-of-band ack rows
+  // (e.g. another tab acked an AC since this modal was bootstrapped).
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/tasks/${taskId}/ac-ack`);
+        if (!res.ok) return;
+        const data = (await res.json()) as { acceptance_criteria: AcStatus[] | null };
+        if (cancelled || !data.acceptance_criteria) return;
+        setAcs(data.acceptance_criteria);
+        const seed: Record<number, string> = {};
+        for (const a of data.acceptance_criteria) {
+          if (a.rationale) seed[a.ac_index] = a.rationale;
+        }
+        setRationales(prev => ({ ...seed, ...prev }));
+      } catch {
+        /* non-fatal — the initialAcs fallback covers offline */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, taskId]);
+
+  const allAcked = acs.length > 0 && acs.every(a => a.acknowledged);
+
+  const handleSave = async (acIndex: number) => {
+    setSavingIndex(acIndex);
+    setError(null);
+    try {
+      const rationale = rationales[acIndex]?.trim() ?? '';
+      const res = await fetch(`/api/tasks/${taskId}/ac-ack`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ac_index: acIndex, rationale: rationale || undefined }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: 'Save failed' }));
+        throw new Error(data.error || `Save failed (${res.status})`);
+      }
+      const data = (await res.json()) as { acceptance_criteria: AcStatus[] | null };
+      if (data.acceptance_criteria) setAcs(data.acceptance_criteria);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSavingIndex(null);
+    }
+  };
+
+  const handleUnack = async (acIndex: number) => {
+    setSavingIndex(acIndex);
+    setError(null);
+    try {
+      const res = await fetch(`/api/tasks/${taskId}/ac-ack`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ac_index: acIndex }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: 'Unack failed' }));
+        throw new Error(data.error || `Unack failed (${res.status})`);
+      }
+      const data = (await res.json()) as { acceptance_criteria: AcStatus[] | null };
+      if (data.acceptance_criteria) setAcs(data.acceptance_criteria);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unack failed');
+    } finally {
+      setSavingIndex(null);
+    }
+  };
+
+  const handleComplete = async () => {
+    setCompleting(true);
+    setError(null);
+    try {
+      await onComplete();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Complete failed');
+    } finally {
+      setCompleting(false);
+    }
+  };
+
+  const handleConfirmOverride = async () => {
+    setConfirmOverride(false);
+    setCompleting(true);
+    setError(null);
+    try {
+      await onBoardOverride(overrideReason.trim() || 'operator override (no reason given)');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Override failed');
+    } finally {
+      setCompleting(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ac-ack-title"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) onClose();
+        }}
+        data-testid="ac-ack-modal"
+      >
+        <div className="w-full max-w-2xl max-h-[85vh] overflow-hidden flex flex-col rounded-lg border border-mc-border bg-mc-bg shadow-2xl">
+          <div className="flex items-center justify-between px-5 py-3 border-b border-mc-border">
+            <h2 id="ac-ack-title" className="text-base font-medium">
+              Acknowledge convoy acceptance criteria
+            </h2>
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={onClose}
+              className="text-mc-text-secondary hover:text-mc-text"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+
+          <div className="px-5 py-3 text-xs text-mc-text-secondary border-b border-mc-border">
+            This parent task has feature-level acceptance criteria from a PM-emitted
+            convoy. Tick each AC (rationale optional but recommended) before completing.
+            Or use board override to bypass with an audit reason.
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-5 py-3 space-y-3">
+            {acs.length === 0 && (
+              <div className="text-sm text-mc-text-secondary">
+                No acceptance criteria found for this task.
+              </div>
+            )}
+            {acs.map((ac) => {
+              const draft = rationales[ac.ac_index] ?? '';
+              const draftDiffersFromSaved = (ac.rationale ?? '') !== draft;
+              return (
+                <div
+                  key={ac.ac_index}
+                  className="border border-mc-border rounded-md p-3 bg-mc-bg-secondary"
+                  data-testid={`ac-row-${ac.ac_index}`}
+                >
+                  <div className="flex items-start gap-2">
+                    {ac.acknowledged ? (
+                      <CheckCircle2 className="w-4 h-4 text-mc-accent-green mt-0.5 shrink-0" />
+                    ) : (
+                      <Circle className="w-4 h-4 text-mc-text-secondary mt-0.5 shrink-0" />
+                    )}
+                    <div className="flex-1 text-sm">{ac.ac_text}</div>
+                  </div>
+                  <textarea
+                    value={draft}
+                    onChange={(e) =>
+                      setRationales((prev) => ({ ...prev, [ac.ac_index]: e.target.value }))
+                    }
+                    placeholder="Why is this AC satisfied? (optional but recommended)"
+                    rows={2}
+                    className="mt-2 w-full bg-mc-bg border border-mc-border rounded-sm px-2 py-1.5 text-sm focus:outline-hidden focus:border-mc-accent resize-none"
+                    data-testid={`ac-rationale-${ac.ac_index}`}
+                  />
+                  {!draft.trim() && !ac.acknowledged && (
+                    <div className="mt-1 text-[11px] text-amber-400">
+                      Rationale empty — recommended but not required.
+                    </div>
+                  )}
+                  <div className="mt-2 flex items-center gap-2">
+                    {!ac.acknowledged ? (
+                      <button
+                        type="button"
+                        onClick={() => handleSave(ac.ac_index)}
+                        disabled={savingIndex === ac.ac_index}
+                        className="px-3 py-1 text-xs bg-mc-accent text-mc-bg rounded-sm font-medium hover:bg-mc-accent/90 disabled:opacity-50"
+                        data-testid={`ac-save-${ac.ac_index}`}
+                      >
+                        {savingIndex === ac.ac_index ? 'Saving…' : 'Acknowledge'}
+                      </button>
+                    ) : (
+                      <>
+                        {draftDiffersFromSaved && (
+                          <button
+                            type="button"
+                            onClick={() => handleSave(ac.ac_index)}
+                            disabled={savingIndex === ac.ac_index}
+                            className="px-3 py-1 text-xs bg-mc-accent text-mc-bg rounded-sm font-medium hover:bg-mc-accent/90 disabled:opacity-50"
+                          >
+                            Update rationale
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => handleUnack(ac.ac_index)}
+                          disabled={savingIndex === ac.ac_index}
+                          className="px-3 py-1 text-xs text-mc-text-secondary hover:text-mc-text border border-mc-border rounded-sm disabled:opacity-50"
+                        >
+                          Undo
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {error && (
+            <div className="px-5 py-2 bg-red-500/10 border-t border-red-500/30 text-sm text-red-400">
+              {error}
+            </div>
+          )}
+
+          <div className="flex items-center justify-between gap-2 px-5 py-3 border-t border-mc-border">
+            <button
+              type="button"
+              onClick={() => setConfirmOverride(true)}
+              disabled={completing}
+              className="px-3 py-1.5 text-xs text-mc-text-secondary hover:text-mc-text border border-mc-border rounded-sm disabled:opacity-50"
+              data-testid="ac-board-override"
+            >
+              Override and complete without acknowledging
+            </button>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={completing}
+                className="px-3 py-1.5 text-xs border border-mc-border rounded-sm hover:bg-mc-bg-tertiary disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleComplete}
+                disabled={!allAcked || completing}
+                className="px-3 py-1.5 text-xs bg-mc-accent-green text-mc-bg rounded-sm font-medium hover:bg-mc-accent-green/90 disabled:opacity-50"
+                data-testid="ac-complete-task"
+              >
+                {completing ? 'Completing…' : 'Complete task'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={confirmOverride}
+        title="Override AC check and complete?"
+        destructive
+        body={
+          <div className="space-y-2">
+            <p className="text-sm">
+              This skips the convoy AC acknowledgement gate and marks the task done
+              anyway. The override is recorded in the board-override audit log.
+            </p>
+            <textarea
+              value={overrideReason}
+              onChange={(e) => setOverrideReason(e.target.value)}
+              placeholder="Reason (recorded in audit log)"
+              rows={2}
+              className="w-full bg-mc-bg-secondary border border-mc-border rounded-sm px-2 py-1.5 text-sm focus:outline-hidden focus:border-mc-accent resize-none"
+            />
+          </div>
+        }
+        confirmLabel="Override and complete"
+        onCancel={() => setConfirmOverride(false)}
+        onConfirm={handleConfirmOverride}
+      />
+    </>
+  );
+}

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -10,6 +10,7 @@ import type { Task, TaskStatus } from '@/lib/types';
 import { TaskModal } from './TaskModal';
 import { BlockedBadge } from './BlockedBadge';
 import { Time } from '@/components/Time';
+import { AcAckModal, type AcStatus } from './AcAckModal';
 
 interface MissionQueueProps {
   workspaceId?: string;
@@ -108,6 +109,11 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
   const [mobileStatus, setMobileStatus] = useState<TaskStatus>('planning');
   const [statusMoveTask, setStatusMoveTask] = useState<Task | null>(null);
   const [pendingMove, setPendingMove] = useState<{ task: Task; targetStatus: TaskStatus } | null>(null);
+  // PM convoy mandate slice 5/7: when a PATCH to status=done returns the
+  // parent_ac_check_pending gate, open the AC ack modal. The initialAcs
+  // snapshot from the 400 body bootstraps the modal so it renders
+  // synchronously while the modal also revalidates on open.
+  const [acGate, setAcGate] = useState<{ task: Task; acs: AcStatus[] } | null>(null);
 
   const getTasksByStatus = (status: TaskStatus) =>
     tasks.filter(
@@ -161,17 +167,46 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
     await updateTaskStatusWithPersist(task, targetStatus);
   };
 
-  const updateTaskStatusWithPersist = async (task: Task, targetStatus: TaskStatus) => {
+  const updateTaskStatusWithPersist = async (
+    task: Task,
+    targetStatus: TaskStatus,
+    opts: { boardOverride?: boolean; overrideReason?: string } = {},
+  ) => {
     if (task.status === targetStatus) return;
 
     updateTaskStatus(task.id, targetStatus);
 
     try {
+      const body: Record<string, unknown> = { status: targetStatus };
+      if (opts.boardOverride) {
+        body.board_override = true;
+        if (opts.overrideReason) body.override_reason = opts.overrideReason;
+      }
       const res = await fetch(`/api/tasks/${task.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: targetStatus }),
+        body: JSON.stringify(body),
       });
+
+      // PM convoy mandate slice 5/7: surface the AC gate by opening the modal.
+      // The 400 body carries the AC snapshot so the modal can render
+      // without a second fetch.
+      if (res.status === 400 && targetStatus === 'done' && !opts.boardOverride) {
+        const data = await res.json().catch(() => null) as
+          | { code?: string; acceptance_criteria?: string[]; missing_ac_indices?: number[] }
+          | null;
+        if (data && data.code === 'parent_ac_check_pending' && Array.isArray(data.acceptance_criteria)) {
+          updateTaskStatus(task.id, task.status); // revert optimistic
+          const missing = new Set(data.missing_ac_indices ?? []);
+          const acs: AcStatus[] = data.acceptance_criteria.map((text, i) => ({
+            ac_index: i,
+            ac_text: text,
+            acknowledged: !missing.has(i),
+          }));
+          setAcGate({ task, acs });
+          return;
+        }
+      }
 
       if (res.ok) {
         addEvent({
@@ -458,6 +493,31 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
             </div>
           </div>
         </div>
+      )}
+
+      {/* PM convoy mandate slice 5/7: AC acknowledgement gate. */}
+      {acGate && (
+        <AcAckModal
+          open
+          taskId={acGate.task.id}
+          initialAcs={acGate.acs}
+          onClose={() => {
+            const t = acGate.task;
+            setAcGate(null);
+            // Optimistic update was reverted at gate-detection time.
+            updateTaskStatus(t.id, t.status);
+          }}
+          onComplete={async () => {
+            const t = acGate.task;
+            setAcGate(null);
+            await updateTaskStatusWithPersist(t, 'done');
+          }}
+          onBoardOverride={async (reason) => {
+            const t = acGate.task;
+            setAcGate(null);
+            await updateTaskStatusWithPersist(t, 'done', { boardOverride: true, overrideReason: reason });
+          }}
+        />
       )}
     </div>
   );

--- a/src/lib/db/migration-096.test.ts
+++ b/src/lib/db/migration-096.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Migration 096 (`pm_convoy_mandate_task_ac_acknowledgements`).
+ *
+ * Verifies the new `task_ac_acknowledgements` table exists with the
+ * right shape: unique (task_id, ac_index), FK to tasks(id) with cascade
+ * delete, and CURRENT_TIMESTAMP default on acknowledged_at.
+ *
+ * See docs/proposals/pm-convoy-mandate.md "Gate at parent review → done".
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getDb, run } from '@/lib/db';
+
+test('migration 096: task_ac_acknowledgements table exists with the expected columns', () => {
+  const db = getDb();
+  const cols = db.prepare(`PRAGMA table_info(task_ac_acknowledgements)`).all() as Array<{
+    name: string;
+    type: string;
+    notnull: number;
+  }>;
+  assert.ok(cols.length > 0, 'task_ac_acknowledgements table should exist');
+  const byName = Object.fromEntries(cols.map(c => [c.name, c]));
+  assert.ok(byName.id);
+  assert.ok(byName.task_id);
+  assert.ok(byName.ac_index);
+  assert.ok(byName.ac_text);
+  assert.ok(byName.rationale);
+  assert.ok(byName.acknowledged_by);
+  assert.ok(byName.acknowledged_at);
+  assert.equal(byName.task_id.notnull, 1, 'task_id must be NOT NULL');
+  assert.equal(byName.ac_index.notnull, 1, 'ac_index must be NOT NULL');
+  assert.equal(byName.ac_text.notnull, 1, 'ac_text must be NOT NULL');
+});
+
+test('migration 096: unique (task_id, ac_index) constraint enforced', () => {
+  const taskId = `mig096-${crypto.randomUUID()}`;
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, created_at, updated_at)
+     VALUES (?, 'T', 'review', 'normal', 'default', 'default', datetime('now'), datetime('now'))`,
+    [taskId],
+  );
+  run(
+    `INSERT INTO task_ac_acknowledgements (task_id, ac_index, ac_text) VALUES (?, 0, 'AC0')`,
+    [taskId],
+  );
+  assert.throws(
+    () =>
+      run(
+        `INSERT INTO task_ac_acknowledgements (task_id, ac_index, ac_text) VALUES (?, 0, 'dup')`,
+        [taskId],
+      ),
+    /UNIQUE constraint failed/i,
+  );
+});
+
+test('migration 096: FK cascade delete removes ack rows when task is deleted', () => {
+  const db = getDb();
+  // Enable FKs in this connection (defense — index.ts sets it but tests
+  // sometimes open fresh handles).
+  db.pragma('foreign_keys = ON');
+  const taskId = `mig096-fk-${crypto.randomUUID()}`;
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, created_at, updated_at)
+     VALUES (?, 'T', 'review', 'normal', 'default', 'default', datetime('now'), datetime('now'))`,
+    [taskId],
+  );
+  run(
+    `INSERT INTO task_ac_acknowledgements (task_id, ac_index, ac_text) VALUES (?, 0, 'AC0')`,
+    [taskId],
+  );
+  run(`DELETE FROM tasks WHERE id = ?`, [taskId]);
+  const remaining = db
+    .prepare(`SELECT COUNT(*) AS cnt FROM task_ac_acknowledgements WHERE task_id = ?`)
+    .get(taskId) as { cnt: number };
+  assert.equal(remaining.cnt, 0, 'ack rows should cascade-delete with their task');
+});

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -4906,6 +4906,38 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    id: '096',
+    name: 'pm_convoy_mandate_task_ac_acknowledgements',
+    up: (db) => {
+      // PM convoy mandate (slice 5/7): records operator acknowledgement of
+      // each parent-convoy acceptance criterion before the parent task may
+      // transition review → done.
+      //
+      // Snapshot the AC text at ack time so post-hoc edits to the convoy
+      // row don't silently rewrite history. `acknowledged_by` is free-form
+      // (operator id / 'operator' default / 'system' for board_override
+      // bypass paths that record an ack instead of skipping the table).
+      //
+      // Idempotent (IF NOT EXISTS) so re-runs against partially-applied
+      // DBs skip cleanly. See docs/proposals/pm-convoy-mandate.md.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS task_ac_acknowledgements (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          task_id TEXT NOT NULL,
+          ac_index INTEGER NOT NULL,
+          ac_text TEXT NOT NULL,
+          rationale TEXT,
+          acknowledged_by TEXT,
+          acknowledged_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(task_id, ac_index),
+          FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+        );
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_task_ac_ack_task ON task_ac_acknowledgements(task_id);`);
+      console.log('[Migration 096] task_ac_acknowledgements ready.');
+    },
+  },
 ];
 
 /** Escape a string for inclusion as a literal in a RegExp source. */

--- a/src/lib/db/task-ac-ack.test.ts
+++ b/src/lib/db/task-ac-ack.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for `task-ac-ack` helpers + the `transitionTaskStatus` AC gate.
+ *
+ * The AC gate is the load-bearing piece of slice 5/7 of the PM convoy
+ * mandate: a parent task with a done convoy that carries feature-level
+ * acceptance criteria cannot leave `review` for `done` until each AC has
+ * been explicitly acknowledged (with an optional free-text rationale).
+ *
+ * Convoy seeding here uses the minimum subset of columns needed to satisfy
+ * the queries the helpers run. The full apply-pass shape is covered in
+ * `src/lib/db/apply-convoy-diff.test.ts`.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { queryOne, run } from '@/lib/db';
+import {
+  acknowledgeAc,
+  getParentConvoyAcs,
+  missingAcAcknowledgements,
+  unacknowledgeAc,
+} from './task-ac-ack';
+import { transitionTaskStatus } from '@/lib/services/task-status';
+
+function seedParentTask(opts: { status?: string; agent?: string | null } = {}): string {
+  const id = `t-${crypto.randomUUID()}`;
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, assigned_agent_id, created_at, updated_at)
+     VALUES (?, 'Parent', ?, 'normal', 'default', 'default', ?, datetime('now'), datetime('now'))`,
+    [id, opts.status ?? 'review', opts.agent ?? null],
+  );
+  return id;
+}
+
+function seedConvoy(opts: {
+  parentTaskId: string;
+  acceptanceCriteria: string[] | null;
+  status?: 'active' | 'done' | 'paused';
+}): string {
+  const id = `c-${crypto.randomUUID()}`;
+  const ac = opts.acceptanceCriteria ? JSON.stringify(opts.acceptanceCriteria) : null;
+  run(
+    `INSERT INTO convoys (id, parent_task_id, name, status, total_subtasks, completed_subtasks, decomposition_strategy, created_at, updated_at, acceptance_criteria)
+     VALUES (?, ?, 'C', ?, 0, 0, 'manual', datetime('now'), datetime('now'), ?)`,
+    [id, opts.parentTaskId, opts.status ?? 'done', ac],
+  );
+  return id;
+}
+
+// ─── getParentConvoyAcs ────────────────────────────────────────────────
+
+test('getParentConvoyAcs: returns null when task has no convoy', () => {
+  const task = seedParentTask();
+  assert.equal(getParentConvoyAcs(task), null);
+});
+
+test('getParentConvoyAcs: returns null when convoy has no ACs (coordinator-spawned)', () => {
+  const task = seedParentTask();
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: null });
+  assert.equal(getParentConvoyAcs(task), null);
+});
+
+test('getParentConvoyAcs: returns null when convoy is not yet done (still active)', () => {
+  const task = seedParentTask();
+  seedConvoy({
+    parentTaskId: task,
+    acceptanceCriteria: ['AC0', 'AC1'],
+    status: 'active',
+  });
+  assert.equal(getParentConvoyAcs(task), null);
+});
+
+test('getParentConvoyAcs: returns unacked entries when ACs exist but no acks recorded', () => {
+  const task = seedParentTask();
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: ['AC0', 'AC1'] });
+  const acs = getParentConvoyAcs(task);
+  assert.ok(acs);
+  assert.equal(acs!.length, 2);
+  assert.equal(acs![0].ac_index, 0);
+  assert.equal(acs![0].ac_text, 'AC0');
+  assert.equal(acs![0].acknowledged, false);
+  assert.equal(acs![1].acknowledged, false);
+});
+
+test('getParentConvoyAcs: reflects partial acknowledgement', () => {
+  const task = seedParentTask();
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: ['AC0', 'AC1'] });
+  acknowledgeAc(task, 0, { rationale: 'looked at output' });
+  const acs = getParentConvoyAcs(task);
+  assert.ok(acs);
+  assert.equal(acs![0].acknowledged, true);
+  assert.equal(acs![0].rationale, 'looked at output');
+  assert.equal(acs![1].acknowledged, false);
+});
+
+// ─── acknowledgeAc / unacknowledgeAc ──────────────────────────────────
+
+test('acknowledgeAc + unacknowledgeAc round-trip', () => {
+  const task = seedParentTask();
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: ['AC0'] });
+  acknowledgeAc(task, 0, { rationale: 'r1' });
+  let acs = getParentConvoyAcs(task);
+  assert.equal(acs![0].acknowledged, true);
+  unacknowledgeAc(task, 0);
+  acs = getParentConvoyAcs(task);
+  assert.equal(acs![0].acknowledged, false);
+});
+
+test('acknowledgeAc is idempotent (upsert) — second call replaces rationale', () => {
+  const task = seedParentTask();
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: ['AC0'] });
+  acknowledgeAc(task, 0, { rationale: 'first' });
+  acknowledgeAc(task, 0, { rationale: 'second' });
+  const acs = getParentConvoyAcs(task);
+  assert.equal(acs![0].acknowledged, true);
+  assert.equal(acs![0].rationale, 'second');
+});
+
+test('acknowledgeAc rejects out-of-range index', () => {
+  const task = seedParentTask();
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: ['AC0'] });
+  assert.throws(() => acknowledgeAc(task, 5));
+});
+
+test('acknowledgeAc rejects when convoy has no ACs', () => {
+  const task = seedParentTask();
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: null });
+  assert.throws(() => acknowledgeAc(task, 0));
+});
+
+// ─── missingAcAcknowledgements ────────────────────────────────────────
+
+test('missingAcAcknowledgements: reports all indices when nothing acked', () => {
+  const task = seedParentTask();
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: ['A', 'B', 'C'] });
+  const r = missingAcAcknowledgements(task);
+  assert.deepEqual(r!.missing_indices, [0, 1, 2]);
+  assert.deepEqual(r!.acceptance_criteria, ['A', 'B', 'C']);
+});
+
+test('missingAcAcknowledgements: returns null when no ACs', () => {
+  const task = seedParentTask();
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: null });
+  assert.equal(missingAcAcknowledgements(task), null);
+});
+
+// ─── transitionTaskStatus AC gate ─────────────────────────────────────
+
+function seedDoneEvidence(taskId: string): void {
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, role, created_at)
+     VALUES (?, ?, 'file', 'x', 'output', datetime('now'))`,
+    [crypto.randomUUID(), taskId],
+  );
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (?, ?, 'completed', 'done', datetime('now'))`,
+    [crypto.randomUUID(), taskId],
+  );
+}
+
+test('transitionTaskStatus: review → done blocked when convoy ACs are unacknowledged', () => {
+  const task = seedParentTask({ status: 'review' });
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: ['AC0', 'AC1'] });
+  seedDoneEvidence(task);
+  const result = transitionTaskStatus({
+    taskId: task,
+    actingAgentId: null,
+    newStatus: 'done',
+  });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, 'parent_ac_check_pending');
+    assert.deepEqual(result.missingAcIndices, [0, 1]);
+    assert.deepEqual(result.acceptanceCriteria, ['AC0', 'AC1']);
+  }
+  // Task did not transition.
+  const after = queryOne<{ status: string }>(`SELECT status FROM tasks WHERE id = ?`, [task]);
+  assert.equal(after!.status, 'review');
+});
+
+test('transitionTaskStatus: review → done succeeds once all ACs acked', () => {
+  const task = seedParentTask({ status: 'review' });
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: ['AC0', 'AC1'] });
+  seedDoneEvidence(task);
+  acknowledgeAc(task, 0, { rationale: 'verified manually' });
+  acknowledgeAc(task, 1, { rationale: 'see deliverable doc' });
+  const result = transitionTaskStatus({
+    taskId: task,
+    actingAgentId: null,
+    newStatus: 'done',
+  });
+  assert.equal(result.ok, true);
+  const after = queryOne<{ status: string }>(`SELECT status FROM tasks WHERE id = ?`, [task]);
+  assert.equal(after!.status, 'done');
+});
+
+test('transitionTaskStatus: review → done bypassed by board_override even with unacked ACs', () => {
+  const task = seedParentTask({ status: 'review' });
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: ['AC0', 'AC1'] });
+  seedDoneEvidence(task);
+  const result = transitionTaskStatus({
+    taskId: task,
+    actingAgentId: null,
+    newStatus: 'done',
+    boardOverride: true,
+    boardOverrideReason: 'shipped behind a flag, verify post-merge',
+  });
+  assert.equal(result.ok, true);
+  const after = queryOne<{ status: string }>(`SELECT status FROM tasks WHERE id = ?`, [task]);
+  assert.equal(after!.status, 'done');
+});
+
+test('transitionTaskStatus: review → done is NOT gated when convoy has no ACs (back-compat)', () => {
+  const task = seedParentTask({ status: 'review' });
+  seedConvoy({ parentTaskId: task, acceptanceCriteria: null });
+  seedDoneEvidence(task);
+  const result = transitionTaskStatus({
+    taskId: task,
+    actingAgentId: null,
+    newStatus: 'done',
+  });
+  assert.equal(result.ok, true);
+});
+
+test('transitionTaskStatus: review → done is NOT gated when task has no convoy at all', () => {
+  const task = seedParentTask({ status: 'review' });
+  seedDoneEvidence(task);
+  const result = transitionTaskStatus({
+    taskId: task,
+    actingAgentId: null,
+    newStatus: 'done',
+  });
+  assert.equal(result.ok, true);
+});

--- a/src/lib/db/task-ac-ack.ts
+++ b/src/lib/db/task-ac-ack.ts
@@ -1,0 +1,162 @@
+/**
+ * PM convoy mandate — operator acknowledgement of parent convoy acceptance
+ * criteria (slice 5 of 7).
+ *
+ * Each `create_convoy_under_initiative` proposal carries a feature-level
+ * `parent_acceptance_criteria` array. When the convoy's subtasks all reach
+ * `done` and `checkConvoyCompletion` flips the parent task to `review`,
+ * the operator-driven `review → done` click runs through an AC gate —
+ * each AC must be explicitly acknowledged (with an optional free-text
+ * rationale) before the transition is allowed.
+ *
+ * This module owns the per-AC ack rows in `task_ac_acknowledgements`
+ * (migration 096) and the projection consumed by the UI / gate.
+ *
+ * NULL `acceptance_criteria` on the convoy row = coordinator-spawned
+ * (back-compat) convoy with no ACs — `getParentConvoyAcs` returns null
+ * and the gate is a no-op. Same for tasks with no convoy at all.
+ *
+ * See docs/proposals/pm-convoy-mandate.md "Gate at parent review → done".
+ */
+
+import { queryOne, queryAll, run } from '@/lib/db';
+
+export interface AcStatus {
+  ac_index: number;
+  ac_text: string;
+  acknowledged: boolean;
+  rationale?: string;
+  acknowledged_by?: string;
+  acknowledged_at?: string;
+}
+
+/**
+ * Returns the per-AC status for a task's done-state parent convoy, or
+ * `null` if the task has no convoy with ACs (coordinator-spawned convoy
+ * or no convoy at all).
+ */
+export function getParentConvoyAcs(taskId: string): AcStatus[] | null {
+  const convoy = queryOne<{ acceptance_criteria: string | null }>(
+    `SELECT acceptance_criteria FROM convoys WHERE parent_task_id = ? AND status = 'done'`,
+    [taskId],
+  );
+  if (!convoy?.acceptance_criteria) return null;
+  let acs: unknown;
+  try {
+    acs = JSON.parse(convoy.acceptance_criteria);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(acs) || acs.length === 0) return null;
+
+  const acks = queryAll<{
+    ac_index: number;
+    rationale: string | null;
+    acknowledged_by: string | null;
+    acknowledged_at: string;
+  }>(
+    `SELECT ac_index, rationale, acknowledged_by, acknowledged_at
+       FROM task_ac_acknowledgements
+      WHERE task_id = ?`,
+    [taskId],
+  );
+  const ackByIndex = new Map(acks.map(a => [a.ac_index, a]));
+
+  return acs.map((text, i) => {
+    const ack = ackByIndex.get(i);
+    return {
+      ac_index: i,
+      ac_text: typeof text === 'string' ? text : String(text),
+      acknowledged: Boolean(ack),
+      rationale: ack?.rationale ?? undefined,
+      acknowledged_by: ack?.acknowledged_by ?? undefined,
+      acknowledged_at: ack?.acknowledged_at,
+    };
+  });
+}
+
+/**
+ * Records (or replaces) an acknowledgement for a single AC index.
+ * `INSERT ... ON CONFLICT` upserts so the operator can revise the rationale
+ * without first calling `unacknowledgeAc`.
+ *
+ * Snapshots the AC text at ack time — later edits to the convoy row
+ * don't silently rewrite the audit trail.
+ */
+export function acknowledgeAc(
+  taskId: string,
+  acIndex: number,
+  opts: { rationale?: string; acknowledgedBy?: string } = {},
+): void {
+  const convoy = queryOne<{ acceptance_criteria: string | null }>(
+    `SELECT acceptance_criteria FROM convoys WHERE parent_task_id = ? AND status = 'done'`,
+    [taskId],
+  );
+  if (!convoy?.acceptance_criteria) {
+    throw new Error(`No done-state convoy with acceptance criteria for task ${taskId}`);
+  }
+  let acs: unknown;
+  try {
+    acs = JSON.parse(convoy.acceptance_criteria);
+  } catch {
+    throw new Error(`Convoy acceptance_criteria for task ${taskId} is not valid JSON`);
+  }
+  if (!Array.isArray(acs) || acIndex < 0 || acIndex >= acs.length) {
+    throw new Error(`AC index ${acIndex} out of range for task ${taskId}`);
+  }
+  const acText = typeof acs[acIndex] === 'string' ? (acs[acIndex] as string) : String(acs[acIndex]);
+  const rationale = opts.rationale ?? null;
+  const ackedBy = opts.acknowledgedBy ?? 'operator';
+
+  run(
+    `INSERT INTO task_ac_acknowledgements (task_id, ac_index, ac_text, rationale, acknowledged_by)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(task_id, ac_index) DO UPDATE SET
+       ac_text = excluded.ac_text,
+       rationale = excluded.rationale,
+       acknowledged_by = excluded.acknowledged_by,
+       acknowledged_at = CURRENT_TIMESTAMP`,
+    [taskId, acIndex, acText, rationale, ackedBy],
+  );
+}
+
+/** Operator changed their mind — removes a single ack row. Idempotent. */
+export function unacknowledgeAc(taskId: string, acIndex: number): void {
+  run(
+    `DELETE FROM task_ac_acknowledgements WHERE task_id = ? AND ac_index = ?`,
+    [taskId, acIndex],
+  );
+}
+
+/**
+ * Returns the AC indices that lack an ack row, or null if the task has no
+ * AC-carrying convoy (gate is a no-op). Used by the review → done gate
+ * to compute its rejection payload without round-tripping through
+ * `getParentConvoyAcs`'s richer projection.
+ */
+export function missingAcAcknowledgements(taskId: string): {
+  missing_indices: number[];
+  acceptance_criteria: string[];
+} | null {
+  const convoy = queryOne<{ acceptance_criteria: string | null }>(
+    `SELECT acceptance_criteria FROM convoys WHERE parent_task_id = ? AND status = 'done'`,
+    [taskId],
+  );
+  if (!convoy?.acceptance_criteria) return null;
+  let acs: unknown;
+  try {
+    acs = JSON.parse(convoy.acceptance_criteria);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(acs) || acs.length === 0) return null;
+  const acStrings = acs.map(v => (typeof v === 'string' ? v : String(v)));
+
+  const acks = queryAll<{ ac_index: number }>(
+    `SELECT ac_index FROM task_ac_acknowledgements WHERE task_id = ?`,
+    [taskId],
+  );
+  const acked = new Set(acks.map(a => a.ac_index));
+  const missing = acStrings.map((_, i) => i).filter(i => !acked.has(i));
+  return { missing_indices: missing, acceptance_criteria: acStrings };
+}

--- a/src/lib/services/task-status.ts
+++ b/src/lib/services/task-status.ts
@@ -35,6 +35,7 @@ import {
   pickReviewerForTask,
 } from '@/lib/task-governance';
 import { assertAgentCanActOnTask } from '@/lib/authz/agent-task';
+import { missingAcAcknowledgements } from '@/lib/db/task-ac-ack';
 import type { Task, TaskStatus } from '@/lib/types';
 
 /** Slice 1 strict gating is opt-in for one cycle while operators backfill. */
@@ -70,9 +71,12 @@ export type TransitionTaskStatusResult =
         | 'status_reason_required'
         | 'cannot_mark_done'
         | 'self_review_blocked'
-        | 'reviewer_required';
+        | 'reviewer_required'
+        | 'parent_ac_check_pending';
       error: string;
       missingDeliverableIds?: string[];
+      missingAcIndices?: number[];
+      acceptanceCriteria?: string[];
     };
 
 const QUALITY_STAGES = new Set(['testing', 'review', 'verification', 'done']);
@@ -226,6 +230,23 @@ export function transitionTaskStatus(
         ok: false,
         code: 'cannot_mark_done',
         error: `Cannot mark done: ${reason}`,
+      };
+    }
+
+    // PM convoy mandate (slice 5/7): parent task with a done convoy that
+    // carries feature-level acceptance criteria must have every AC
+    // explicitly acknowledged before review → done. `board_override`
+    // bypasses (same pattern as the evidence gate). Tasks without a
+    // convoy / convoys without ACs (coordinator-spawned back-compat) are
+    // skipped via the null return from missingAcAcknowledgements.
+    const acGate = missingAcAcknowledgements(taskId);
+    if (acGate && acGate.missing_indices.length > 0) {
+      return {
+        ok: false,
+        code: 'parent_ac_check_pending',
+        error: `Parent task has ${acGate.missing_indices.length} unacknowledged convoy AC(s). Operator must acknowledge each before review → done.`,
+        missingAcIndices: acGate.missing_indices,
+        acceptanceCriteria: acGate.acceptance_criteria,
       };
     }
   }


### PR DESCRIPTION
## Summary

Slice 5 of 7 of the PM convoy mandate (see `docs/proposals/pm-convoy-mandate.md`). Adds the AC acknowledgement gate at the parent-task `review → done` boundary. When a parent task's done convoy carries feature-level acceptance criteria (set at apply-pass time in slice 2), the operator must explicitly acknowledge each AC before the transition succeeds. `board_override: true` bypasses the gate with an audit-log entry, same shape as the existing evidence gate.

## Changes

- **Migration 096** — `task_ac_acknowledgements` table (id, task_id, ac_index, ac_text snapshot, rationale, acknowledged_by, acknowledged_at). Unique on `(task_id, ac_index)`, FK cascade on tasks.
- **`src/lib/db/task-ac-ack.ts`** — `getParentConvoyAcs`, `acknowledgeAc` (upsert), `unacknowledgeAc`, and `missingAcAcknowledgements` (used by the gate to compute its rejection payload).
- **Gate wiring**:
  - `src/lib/services/task-status.ts::transitionTaskStatus` — new `parent_ac_check_pending` result code, with `missingAcIndices` + `acceptanceCriteria` meta. Runs after the evidence gate, before the UPDATE; bypassed by `boardOverride: true`.
  - `src/app/api/tasks/[id]/route.ts` PATCH — same gate mirrored here, because the operator UI drives through PATCH (not the service directly). Response body carries `code: 'parent_ac_check_pending'` plus the AC snapshot so the modal can render synchronously.
- **`src/app/api/tasks/[id]/ac-ack/route.ts`** — GET (status), POST (acknowledge), DELETE (un-acknowledge).
- **`src/components/AcAckModal.tsx`** — per-AC checkbox + free-text rationale (soft-required per spec line 264), board-override escape hatch behind `ConfirmDialog` (no native confirm per project convention).
- **`src/components/MissionQueue.tsx`** — when the PATCH returns 400 + `parent_ac_check_pending`, opens the AC ack modal; the modal re-fires the PATCH after all ACs are acked, or with `board_override: true` after operator confirms.

Coordinator-spawned convoys (NULL `acceptance_criteria` — back-compat) and tasks without a convoy remain unaffected.

## Test plan

- `yarn test src/lib/db/task-ac-ack.test.ts src/lib/db/migration-096.test.ts` — 19/19 pass:
  - migration 096 column shape + unique constraint + FK cascade.
  - `getParentConvoyAcs` returns null for no-convoy / coordinator-spawned / not-yet-done convoy; populated entries with ack flag for the live case.
  - `acknowledgeAc` upsert idempotency; out-of-range and no-ACs throw.
  - `unacknowledgeAc` round-trip.
  - `transitionTaskStatus` review→done: blocked when unacked, succeeds when all acked, bypassed by `board_override`, no-op when convoy has no ACs or task has no convoy.
- Full `yarn test` run — 2 failures, **both pre-existing and unrelated**:
  - `schedule-runner: produces a brief and advances run_count` (noted in the slice 5 task plan as carried over from slice 2 PR).
  - `POST: happy path threads note + audit-run provenance into chat metadata` in `src/app/api/initiatives/[id]/ask-pm-from-notes/route.test.ts` — fails with an OpenClaw dispatch timeout (singleton-replacement / missed-final stall), no AC / convoy / transition surface touched.

## Verification

`npx tsc --noEmit` is clean.

Preview-verify pass was **skipped** for this slice — the gate only fires when there is a `convoy with status='done' AND acceptance_criteria IS NOT NULL` pointing at the parent task. Seeding that state via the live apply-pass requires walking a PM proposal end-to-end (decompose → emit → accept → run all slices to done → auto-promote parent to review), which is more setup than the preview tooling reasonably hits without flake. The gate logic itself is exercised by the 19 unit tests above (transition + helpers); the UI piece is straightforward state wiring around an existing PATCH error response. Slice 7 cleanup will include an end-to-end preview walk through the whole convoy lifecycle.

Slice 5 of 7. Stacked on top of slice 4 (merged as #356).