### PR TITLE
feat(pm): flip MC_PM_CONVOY_MANDATE flag + promote proposal to reference + spec edits (convoy mandate slice 6/7)

### DIFF
--- a/docs/proposals/subagent-orchestration.md
+++ b/docs/proposals/subagent-orchestration.md
@@ -1,6 +1,6 @@
 ---
 status: aspirational
-last-verified: 2026-05-11
+last-verified: 2026-05-14
 audience: ai-subagents-primary, operator-secondary
 code-anchors:
   - src/lib/agents/dispatch-subagent.ts

--- a/docs/reference/agent-model-cleanup.md
+++ b/docs/reference/agent-model-cleanup.md
@@ -1,5 +1,18 @@
 # Agent model cleanup — drop residual N-gateway assumptions
 
+> **Addendum (2026-05-14, PM convoy mandate slice 6/7).** The
+> coordinator role described below is being narrowed. Under the PM
+> convoy mandate ([pm-convoy-mandate.md](pm-convoy-mandate.md)),
+> decomposition happens at PM-emit time via the
+> `create_convoy_under_initiative` diff — the coordinator no longer
+> "decomposes the parent task". Its job becomes **monitor + accept +
+> escalate**: watch convoy slices via `list_my_subtasks`, accept
+> delivered slices via `update_subtask({action: 'accept'})`, escalate
+> failures via `escalate_to_parent`. `spawn_subtask` and `plan_convoy`
+> remain available for mid-flight slice appends but are no longer the
+> primary decomposition path. Slice 7 of the mandate will land the
+> matching coordinator SOUL shrink.
+
 ## Background
 
 Mission Control's agent topology was collapsed some time ago. The current intended model:

--- a/docs/reference/audit-pipeline.md
+++ b/docs/reference/audit-pipeline.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last-verified: 2026-05-11
+last-verified: 2026-05-14
 audience: ai-subagents-primary, operator-secondary
 code-anchors:
   - src/lib/agents/audit-prompt.ts
@@ -42,9 +42,21 @@ related-specs:
   - research-area.md — research notes also flow through agent_notes and feed audit briefings
   - jobs-in-progress.md — agent_runs spine the InitiativeRunsStrip filters
   - subagent-orchestration.md — convoy substrate explicitly NOT used by this pipeline
+  - pm-convoy-mandate.md — audit follow-ups bypass the convoy mandate (carve-out)
 ---
 
 # Audit Pipeline
+
+> **PM convoy mandate carve-out.** Audit follow-ups bypass the
+> decompose-flow convoy mandate documented in
+> [pm-convoy-mandate.md](pm-convoy-mandate.md). Audit-spawned proposals
+> use `trigger_kind = 'notes_intake'` (via `propose_from_notes`) and
+> emit `create_task_under_initiative` diffs for tactical follow-ups —
+> the mandate's required convoy shape only applies to strategic
+> decomposition (`decompose_story` / `decompose_initiative` /
+> `plan_initiative`). Future readers should not infer the mandate
+> applies universally.
+
 
 Canonical reference for the **initiative-audit** capability in Mission
 Control. Supersedes `subtree-audit-proposals-spec.md`,

--- a/docs/reference/autonomous-flow-tightening-spec.md
+++ b/docs/reference/autonomous-flow-tightening-spec.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last-verified: 2026-05-11
+last-verified: 2026-05-14
 audience: ai-subagents-primary, operator-secondary
 code-anchors:
   - src/lib/task-governance.ts:30

--- a/docs/reference/pm-chat-prompt.md
+++ b/docs/reference/pm-chat-prompt.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last-verified: 2026-05-13
+last-verified: 2026-05-14
 code-anchors:
   - agent-templates/pm/SOUL.md
   - src/lib/agents/pm-dispatch.ts

--- a/docs/reference/pm-convoy-mandate.md
+++ b/docs/reference/pm-convoy-mandate.md
@@ -1,6 +1,6 @@
 ---
-status: aspirational
-last-verified: 2026-05-13
+status: current
+last-verified: 2026-05-14
 audience: ai-subagents-primary, operator-secondary
 code-anchors:
   - src/lib/mcp/shared.ts:285-299
@@ -27,7 +27,26 @@ related-specs:
 
 ## Status
 
-Aspirational. The mandate replaces the current `decompose_story` / `decompose_initiative` / `plan_initiative` output shape (an array of `create_task_under_initiative` diffs) with a `create_convoy_under_initiative` diff carrying a slice DAG. The wholistic fix to two locality bugs we keep re-hitting.
+Current. Phases 1 and 2 have shipped across PRs #353–#357 (slices 1–6 of 7). The mandate replaces the previous `decompose_story` / `decompose_initiative` / `plan_initiative` output shape (an array of `create_task_under_initiative` diffs) with a `create_convoy_under_initiative` diff carrying a slice DAG. The wholistic fix to two locality bugs we kept re-hitting.
+
+Phase 3 (Task Board collapse for 1-slice convoys, coordinator SOUL shrink) is queued as slice 7.
+
+## Shipped state (as of 2026-05-14)
+
+- Slice 1 (PR #354) — `create_convoy_under_initiative` zod variant + migration 095 (`convoys.acceptance_criteria`).
+- Slice 2 (PR #355) — apply-pass in [`src/lib/db/pm-proposals.ts`](../../src/lib/db/pm-proposals.ts) materializes the diff via shared [`src/lib/convoy-dag.ts`](../../src/lib/convoy-dag.ts). Parent task auto-created with `status=convoy_active`; topologically-ordered slices dispatched via `dispatchReadyConvoySubtasks`.
+- Slice 3 (PR #353) — PM SOUL + [`docs/reference/pm-chat-prompt.md`](pm-chat-prompt.md) updated with the decompose-flow output contract and DAG smell checklist.
+- Slice 4 (PR #356) — DAG approval UX in [`src/components/ConvoyDiffPreview.tsx`](../../src/components/ConvoyDiffPreview.tsx) and the three decompose modals.
+- Slice 5 — AC gate at parent `review → done` + migration 096 (`task_ac_acknowledgements`) + `AcAckModal`. Endpoint: `GET/POST /api/tasks/[id]/ac-ack`.
+- Slice 6 (this PR) — the `MC_PM_CONVOY_MANDATE=1` flag now causes [`validateProposedChanges`](../../src/lib/db/pm-proposals.ts) to REJECT `create_task_under_initiative` diffs from `decompose_story` / `decompose_initiative` / `plan_initiative` proposals, and to require at least one `create_convoy_under_initiative` in those flows. Carve-outs preserved for `notes_intake`, `manual`, and other tactical kinds. Proposal promoted to `docs/reference/`. Reference-spec edits land in the same PR.
+
+### Flag default
+
+`MC_PM_CONVOY_MANDATE` is **off by default** in both dev and prod containers. The mandate is opt-in via env var rather than always-on so operators can verify the PM is reliably emitting convoy-shaped diffs before the schema starts rejecting fallbacks. When the operator is confident enough to flip it on, set `MC_PM_CONVOY_MANDATE=1` in the container env. Slice 7 will revisit defaulting it on.
+
+### Revert semantics — current state
+
+`invertDiff` for `create_convoy_under_initiative` returns the `limited` marker today: revert is not yet implemented for this diff kind ([`src/lib/pm/invertDiff.ts`](../../src/lib/pm/invertDiff.ts) line ~251). Full revert (cancel-convoy-if-no-slice-done + delete unscheduled child tasks; refuse if any slice has reached `done`) is queued as a follow-up — see [`pm-revertable-proposals.md`](pm-revertable-proposals.md) for the planned semantics.
 
 ## Problem
 

--- a/docs/reference/pm-diff-conventions.md
+++ b/docs/reference/pm-diff-conventions.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last-verified: 2026-05-11
+last-verified: 2026-05-14
 audience: ai-subagents-primary, operator-secondary
 code-anchors:
   - src/lib/db/pm-proposals.ts
@@ -14,6 +14,7 @@ mcp-tools: [propose_changes]
 db-tables: [pm_proposals]
 related-specs:
   - roadmap-and-pm-spec.md — original PM design (Phase 5)
+  - pm-convoy-mandate.md — create_convoy_under_initiative diff + decompose-flow mandate
   - pm-revertable-proposals.md — revert pipeline + capture pattern
   - audit-action-recommended.md — audit_verdict bridge (note kind, not diff kind)
   - autonomous-flow-tightening-spec.md — async dispatch overlay
@@ -67,7 +68,17 @@ Each variant is an intersection of a literal-`kind`-tagged shape with
 the `PmDiffCapture` interface ([:58-90](../src/lib/db/pm-proposals.ts))
 so capture fields are uniformly optional across all kinds.
 
-**Current `kind` values (10 total):**
+**Current `kind` values (11 total):**
+
+> **Decompose-flow restriction (PM convoy mandate).** When
+> `MC_PM_CONVOY_MANDATE=1`, proposals with `trigger_kind` ∈
+> {`decompose_story`, `decompose_initiative`, `plan_initiative`} MUST
+> emit at least one `create_convoy_under_initiative` diff and MUST NOT
+> emit `create_task_under_initiative`. The `notes_intake`, `manual`,
+> and audit-follow-up paths are unaffected. See
+> [pm-convoy-mandate.md](pm-convoy-mandate.md) and the enforcement at
+> [src/lib/db/pm-proposals.ts](../../src/lib/db/pm-proposals.ts)
+> (`validateProposedChanges`, mandate block near the top).
 
 | kind | line | mutable target | revert support |
 |---|---|---|---|
@@ -80,6 +91,7 @@ so capture fields are uniformly optional across all kinds.
 | `update_status_check` | [:128-132](../src/lib/db/pm-proposals.ts) | `initiatives.status_check_md` | full |
 | `create_child_initiative` | [:133-151](../src/lib/db/pm-proposals.ts) | `initiatives` (INSERT) | tombstone (status=cancelled) |
 | `create_task_under_initiative` | [:152-164](../src/lib/db/pm-proposals.ts) | `tasks` (INSERT) | tombstone (status=cancelled) |
+| `create_convoy_under_initiative` | [:187-204](../src/lib/db/pm-proposals.ts) | `tasks` (parent) + `convoys` + `convoy_subtasks` (INSERT) — decompose-flow only | **limited** (full revert deferred — see [pm-convoy-mandate.md](pm-convoy-mandate.md)) |
 | `set_task_status` | [:165-188](../src/lib/db/pm-proposals.ts) | `tasks.status` | full (revert proposals only on the forward path) |
 | `confirm_task_done` | [:189-201](../src/lib/db/pm-proposals.ts) | `tasks.status` (via `transitionTaskStatus`) | full |
 
@@ -575,7 +587,8 @@ proposal row may be created with `dispatch_state: 'synth_only'` or
 | `reorder_initiatives` | manual, decompose_initiative | UPDATE initiatives.sort_order | yes (`prev_child_ids_in_order`) | yes | original Phase 5 |
 | `update_status_check` | status_check_investigation, notes_intake | UPDATE initiatives.status_check_md | yes (`prev_status_check_md`) | yes | original Phase 5 |
 | `create_child_initiative` | decompose_initiative | INSERT initiatives | yes (`created_initiative_id`) | tombstone via set_initiative_status='cancelled' | Polish B (migration 047) |
-| `create_task_under_initiative` | notes_intake, decompose_story | INSERT tasks | yes (`created_task_id`) | tombstone via set_task_status='cancelled' | migration 054 / 063 |
+| `create_task_under_initiative` | notes_intake, manual, audit follow-ups, child-initiative stubs (NOT decompose flows when MC_PM_CONVOY_MANDATE=1) | INSERT tasks | yes (`created_task_id`) | tombstone via set_task_status='cancelled' | migration 054 / 063 |
+| `create_convoy_under_initiative` | decompose_story, decompose_initiative, plan_initiative | INSERT tasks (parent) + convoys + convoy_subtasks | yes (`convoy_id`, `parent_task_id`, `subtask_id_map`) | **limited** — full revert deferred (slice 7) | migration 095 / pm-convoy-mandate.md |
 | `set_task_status` | revert only on forward path (`'cancelled'` allowed on forward; arbitrary on revert) | UPDATE tasks.status | yes (`prev_task_status`) | yes | revert pipeline (migration 062) |
 | `confirm_task_done` | notes_intake, disruption_event | UPDATE tasks.status via `transitionTaskStatus` + emit event | yes (`prev_task_status`) | yes (→ set_task_status with prev) | PR #325 |
 

--- a/docs/reference/pm-revertable-proposals.md
+++ b/docs/reference/pm-revertable-proposals.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last-verified: 2026-05-11
+last-verified: 2026-05-14
 audience: ai-subagents-primary, operator-secondary
 code-anchors:
   - src/lib/pm/invertDiff.ts
@@ -16,6 +16,7 @@ related-specs:
   - pm-diff-conventions.md — PmDiff kinds enumerated here are inverted
   - audit-action-recommended.md — audit-spawned proposals flow through this revert surface
   - roadmap-and-pm-spec.md — broader PM mutation model
+  - pm-convoy-mandate.md — adds create_convoy_under_initiative (revert support deferred — see §"create_convoy_under_initiative — current revert state" below)
 ---
 
 # PM action audit log + revertable proposals
@@ -77,6 +78,35 @@ Add a `revert_proposal` action: given an accepted proposal, synthesize the inver
 | `create_child_initiative` | `set_initiative_status: 'cancelled'` on the created row (we don't delete). The created child's id must be captured back into the diff record at apply time so revert can target it. |
 | `create_task_under_initiative` | `set_task_status: 'cancelled'` (if that diff kind exists; if not, add it). Same id-capture pattern. |
 | `add_availability` | Mark the row inactive or mirror with a removal diff. Audit current `add_availability` apply path; choose the cleanest inverse. |
+| `create_convoy_under_initiative` | **Limited (deferred — see below).** Planned inverse: cancel the convoy + delete unscheduled child tasks; refuse revert if any slice has reached `done`. |
+
+### `create_convoy_under_initiative` — current revert state
+
+The PM convoy mandate ([pm-convoy-mandate.md](pm-convoy-mandate.md))
+added `create_convoy_under_initiative` as a new diff kind. Its
+`invertDiff` case at
+[`src/lib/pm/invertDiff.ts`](../../src/lib/pm/invertDiff.ts) (~line
+251) currently returns the `limited` marker — the UI shows "Revert
+(limited)" with a tooltip and no actionable inverse.
+
+**Planned semantics for the follow-up** (not yet implemented; tracked
+as part of slice 7 / a separate follow-up PR):
+
+- If no slice has reached `done`: emit a `set_task_status: 'cancelled'`
+  on the parent task plus tombstones for any subtasks that are still
+  in `inbox` / `assigned`. The convoy row stays for audit; its status
+  flips to `failed`.
+- If any slice has reached `done`: refuse the revert at validation
+  time with a structured error pointing the operator to per-slice
+  manual rollback. The "all-or-nothing" inverse is unsafe once
+  downstream artifacts may exist.
+- Capture state required at apply time (already populated by slice 2):
+  `convoy_id`, `parent_task_id`, `subtask_id_map`. No new capture
+  fields needed.
+
+Until the follow-up lands, operators revert convoy-shaped proposals by
+cancelling the parent task manually (the dependency / cascade rules
+already handle the rest).
 
 **The "captured at apply time" pattern is critical:** each forward apply should persist enough state into the diff record (or a sibling table) that the inverse is a pure function of the diff row alone. Don't recompute from current DB state at revert time — it'll have drifted.
 

--- a/docs/reference/review-stage-robustness-spec.md
+++ b/docs/reference/review-stage-robustness-spec.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last-verified: 2026-05-11
+last-verified: 2026-05-14
 audience: ai-subagents-primary, operator-secondary
 code-anchors:
   - src/lib/authz/agent-task.ts
@@ -20,6 +20,7 @@ related-specs:
   - ../docs/archive/coordinator-delegation-via-convoy-spec.md — defines spawn_subtask path being tightened
   - agent-health.md — heartbeat/stall infrastructure extended here
   - ../docs/archive/convoy-mode-spec.md — convoy-subtask gate behavior modified
+  - pm-convoy-mandate.md — parent-task review→done AC gate (composes with the evidence gate below)
 ---
 
 # Review-Stage Robustness
@@ -128,6 +129,46 @@ Extend `scanStalledTasks` (and the per-stage timer in `agent-health.ts`) with:
 PM and builder soul-prompts get a one-paragraph addition: when you receive `agent_not_coordinator` (or any `next_action: escalate_to_parent`), your only valid next call is `escalate_to_parent`. Doing the work yourself is a protocol violation.
 
 This is a belt-and-braces redundant rail — A.2's soft-lock makes it impossible at the system level — but worth keeping aligned.
+
+### G. Parent-task `review → done` AC gate (PM convoy mandate, slice 5)
+
+Layered on top of the evidence gate above. When the PM emits a
+`create_convoy_under_initiative` diff (decompose-flow output — see
+[pm-convoy-mandate.md](pm-convoy-mandate.md)), the resulting convoy
+carries operator-facing parent acceptance criteria in
+`convoys.acceptance_criteria` (JSON array; mig 095). The parent task
+sits in `convoy_active` while slices run, gets auto-promoted to
+`review` by `checkConvoyCompletion` once all subtasks are `done`, and
+then must clear the AC gate before transitioning to `done`.
+
+**Composition order in `transitionTaskStatus`:**
+
+1. **Evidence gate first** — `STAGE_REQUIRED_EVIDENCE[review]` (today's
+   rail). If evidence is missing, return the existing
+   `evidence_required` error. No AC check runs.
+2. **AC gate second** — if the parent has a convoy with
+   `acceptance_criteria` populated and is being transitioned to
+   `done`, the service looks up `task_ac_acknowledgements` (mig 096).
+   Each AC must have an `acknowledged_at` row keyed by the operator
+   before the transition is allowed; otherwise return
+   `parent_ac_check_pending`.
+3. **`board_override: true` bypasses both gates** — operator escape
+   hatch, mirroring the existing evidence-gate bypass.
+
+**UI:** the parent task's detail page surfaces an `AcAckModal` when
+the task is in `review` and the convoy has uncherished ACs. The
+endpoint `GET/POST /api/tasks/[id]/ac-ack` writes the ack rows
+operator-by-operator. See
+[`src/components/AcAckModal.tsx`](../../src/components/AcAckModal.tsx)
+and the convoy-mandate spec for the wiring.
+
+**Why it composes cleanly:** the evidence gate is per-slice; the AC
+gate is per-feature. A parent that genuinely shipped will satisfy
+both (each subtask has its `test_full` evidence + operator has
+acked the parent ACs). A parent whose subtasks gamed evidence but
+whose feature isn't really done will fail the AC gate, surfacing the
+"locally green, globally wrong" failure mode the mandate was designed
+to catch.
 
 ## Decisions (formerly open questions)
 

--- a/docs/reference/roadmap-and-pm-spec.md
+++ b/docs/reference/roadmap-and-pm-spec.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last-verified: 2026-05-11
+last-verified: 2026-05-14
 audience: ai-subagents-primary, operator-secondary
 code-anchors:
   - src/lib/agents/pm-agent.ts
@@ -21,6 +21,7 @@ db-tables: [initiatives, initiative_dependencies, pm_proposals, owner_availabili
 > - [audit-action-recommended.md](audit-action-recommended.md) — `audit_verdict` note kind + opt-in auto-spawn (PR #326).
 > - [pm-diff-conventions.md](pm-diff-conventions.md) — canonical contract for adding new PmDiff kinds (sibling reference).
 > - [pm-chat-prompt.md](pm-chat-prompt.md) — PR A SOUL/UI changes layered on top.
+> - [pm-convoy-mandate.md](pm-convoy-mandate.md) — decompose-flow output shape changed to `create_convoy_under_initiative` DAGs (see §9.5 below).
 > - [pm-steer-abort.md](pm-steer-abort.md) — aspirational steer/abort/in-flight visibility.
 > - Archived: [pm-confirm-task-done.md](../docs/archive/pm-confirm-task-done.md), [pm-dispatch-async.md](../docs/archive/pm-dispatch-async.md), [roadmap-navigation-polish.md](../docs/archive/roadmap-navigation-polish.md).
 
@@ -501,6 +502,14 @@ In addition to the reactive disruption flow, the PM has two operator-driven guid
 **New diff kind** — `create_child_initiative`. Only emitted from `decompose_initiative` proposals. Validation rejects `child_kind='theme'` or `'milestone'`.
 
 UI surface: a "Plan with PM" button next to Save in the initiative edit drawer; a "Decompose with PM" entry in the `⋮` action menu (epic/milestone rows) and a button on `/initiatives/[id]` for the same kinds. Both flows use the existing refine endpoint.
+
+#### Decompose-to-task output: `create_convoy_under_initiative` (PM convoy mandate)
+
+Originally `decompose_story` / `decompose_initiative` / `plan_initiative` proposals emitted flat lists of `create_task_under_initiative` diffs. Two locality bugs surfaced from that shape (layer-sliced narrow tasks; no sibling ordering at the PM layer), so the output was upgraded to a slice DAG.
+
+When `MC_PM_CONVOY_MANDATE=1`, decompose-flow proposals MUST emit at least one `create_convoy_under_initiative` diff and MUST NOT emit `create_task_under_initiative` (the schema in [`src/lib/db/pm-proposals.ts`](../../src/lib/db/pm-proposals.ts) `validateProposedChanges` rejects mismatches up front). On accept, the apply pass in [`src/lib/convoy-dag.ts`](../../src/lib/convoy-dag.ts) auto-creates the parent task (`status=convoy_active`, mirroring `promote_initiative_to_task`), the `convoys` row carrying `acceptance_criteria` (parent-level operator-facing criteria), and per-slice `convoy_subtasks` in topological order, then fires root slices.
+
+Carve-outs preserved: `notes_intake`, `manual`, audit-follow-ups, and `create_child_initiative` stub tasks continue to use `create_task_under_initiative`. See [pm-convoy-mandate.md](pm-convoy-mandate.md) for the full contract, including the parent-task `review → done` AC gate (slice 5).
 
 ---
 

--- a/docs/reference/task-delegation-and-convoys.md
+++ b/docs/reference/task-delegation-and-convoys.md
@@ -1,9 +1,10 @@
 ---
 status: current
-last-verified: 2026-05-11
+last-verified: 2026-05-14
 audience: ai-subagents-primary, operator-secondary
 code-anchors:
   - src/lib/convoy.ts
+  - src/lib/convoy-dag.ts
   - src/lib/workspace-isolation.ts
   - src/lib/mcp/groups/work.ts
   - src/lib/mcp/groups/core.ts
@@ -38,6 +39,7 @@ related-specs:
   - review-stage-robustness-spec.md — role gating, convoy-subtask evidence gate, capability-denial soft-lock, escalate_to_parent
   - agent-health.md — generic stall semantics; convoy SLO clock is the per-subtask layer above it
   - subagent-orchestration.md — different capability (read-only subagents); cross-reference, do not merge
+  - pm-convoy-mandate.md — PM-emit convoy entry point (decompose-flow proposals materialize convoys at accept time)
 ---
 
 # Task Delegation and Convoys
@@ -85,6 +87,37 @@ The legacy `delegate` MCP tool has been removed. The MCP test suite
 asserts this (`src/lib/mcp/mcp.test.ts:90`:
 `assert.ok(!names.has('delegate'), 'delegate tool should be removed')`).
 
+### Two convoy entry points (post-PM-convoy-mandate)
+
+Convoys now have **two distinct entry points** for the same underlying
+machinery:
+
+1. **PM-emit at proposal-accept time.** When the PM produces a
+   decompose-flow proposal (`trigger_kind` ∈ {`decompose_story`,
+   `decompose_initiative`, `plan_initiative`}), it emits one or more
+   `create_convoy_under_initiative` diffs. On accept, the apply pass in
+   [`src/lib/db/pm-proposals.ts`](../../src/lib/db/pm-proposals.ts) calls
+   the shared DAG materializer in
+   [`src/lib/convoy-dag.ts`](../../src/lib/convoy-dag.ts) to create the
+   parent task (status=`convoy_active`), the `convoys` row (with
+   `acceptance_criteria` populated), and per-slice `convoy_subtasks`
+   rows in topological order, then fires
+   `dispatchReadyConvoySubtasks`. See
+   [pm-convoy-mandate.md](pm-convoy-mandate.md).
+2. **Coordinator-emit mid-flight.** A coordinator with an active task
+   calls `spawn_subtask` or `plan_convoy` to append slices to an
+   existing convoy (or lazy-create the first one). Same underlying
+   helpers (`spawnDelegationSubtask`,
+   `dispatchReadyConvoySubtasks`). The coordinator's role has shifted
+   from *decomposer* to *monitor + accept + escalate*: decomposition
+   happens at PM-emit time; `spawn_subtask` / `plan_convoy` remain
+   available for follow-up work discovered mid-flight (e.g. a builder
+   reports a missing slice).
+
+The PM mandate is gated by `MC_PM_CONVOY_MANDATE`. When the flag is on,
+the schema rejects `create_task_under_initiative` from decompose-flow
+proposals.
+
 ---
 
 ## 2. Data model
@@ -106,6 +139,7 @@ migration 037 (`migrations.ts:2075-2167`).
 | `completed_subtasks`     | Recomputed by `updateConvoyProgress` (`convoy.ts:191`)                |
 | `failed_subtasks`        | Same recompute pass                                                   |
 | `created_at`, `updated_at` | ISO timestamps                                                      |
+| `acceptance_criteria`    | JSON array of strings (mig 095). Populated when the convoy is spawned from a PM `create_convoy_under_initiative` diff; NULL for coordinator-spawned convoys. Gates the parent task's `review → done` transition — see [pm-convoy-mandate.md](pm-convoy-mandate.md) + `task_ac_acknowledgements` table. |
 
 Indexes: `idx_convoys_parent_active(parent_task_id, status)` replaces the
 pre-037 `idx_convoys_parent` (see `migrations.ts:2161-2164`).
@@ -328,16 +362,22 @@ that spec for the full rail.
    └────────┘
 ```
 
-- **Creation.** Three entry points all converge on
+- **Creation.** Four entry points all converge on
   `INSERT INTO convoys`:
   1. `createConvoy()` — operator-driven manual / AI / planning flows
      (`convoy.ts:83`). Rejects a second active convoy on the same
      parent (`convoy.ts:97`).
-  2. `spawnDelegationSubtask()` — lazy create from `spawn_subtask`
-     (`convoy.ts:560-574`).
+  2. `spawnDelegationSubtask()` — lazy create from coordinator
+     `spawn_subtask` / `plan_convoy` (`convoy.ts:560-574`).
   3. AI decomposition route at `src/app/api/tasks/[id]/convoy/route.ts`
      (unchanged from the original convoy-mode-spec; preserved for the
      operator path).
+  4. **PM-emit** via `create_convoy_under_initiative` diff — the apply
+     pass in [`src/lib/db/pm-proposals.ts`](../../src/lib/db/pm-proposals.ts)
+     materializes the parent task + convoy + slice DAG through
+     [`src/lib/convoy-dag.ts`](../../src/lib/convoy-dag.ts), populating
+     `convoys.acceptance_criteria`. See
+     [pm-convoy-mandate.md](pm-convoy-mandate.md).
 - **Active.** Parent task sits in `convoy_active`. Each subtask runs
   the normal task lifecycle (`assigned → in_progress → testing → review →
   done`). `dispatchReadyConvoySubtasks` (`convoy.ts:321`) iterates

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -337,6 +337,44 @@ export function validateProposedChanges(
     return ['proposed_changes must be an array'];
   }
 
+  // PM convoy mandate (slice 6/7): when MC_PM_CONVOY_MANDATE=1, decompose-flow
+  // proposals (decompose_story / decompose_initiative / plan_initiative) MUST
+  // emit at least one create_convoy_under_initiative diff and MUST NOT emit
+  // any create_task_under_initiative diffs. Carve-outs for notes_intake,
+  // manual, and other tactical kinds are preserved (the mandate only applies
+  // to strategic decomposition output). See docs/reference/pm-convoy-mandate.md.
+  const mandateOn = process.env.MC_PM_CONVOY_MANDATE === '1';
+  const decomposeFlowKinds = new Set<PmProposalTriggerKind>([
+    'decompose_story',
+    'decompose_initiative',
+    'plan_initiative',
+  ]);
+  if (
+    mandateOn &&
+    options.trigger_kind &&
+    decomposeFlowKinds.has(options.trigger_kind)
+  ) {
+    const flatTaskDiffs = changes.filter(
+      (d) => d && typeof d === 'object' && (d as { kind?: string }).kind === 'create_task_under_initiative',
+    );
+    const convoyDiffs = changes.filter(
+      (d) => d && typeof d === 'object' && (d as { kind?: string }).kind === 'create_convoy_under_initiative',
+    );
+    if (flatTaskDiffs.length > 0) {
+      errors.push(
+        `[MC_PM_CONVOY_MANDATE] Decompose-flow proposals (trigger_kind=${options.trigger_kind}) MUST use create_convoy_under_initiative, not create_task_under_initiative. Got ${flatTaskDiffs.length} flat-task diff(s). See docs/reference/pm-convoy-mandate.md.`,
+      );
+    }
+    if (convoyDiffs.length === 0) {
+      errors.push(
+        `[MC_PM_CONVOY_MANDATE] Decompose-flow proposals (trigger_kind=${options.trigger_kind}) MUST emit at least one create_convoy_under_initiative diff. None found. See docs/reference/pm-convoy-mandate.md.`,
+      );
+    }
+    if (errors.length > 0) {
+      return errors;
+    }
+  }
+
   // Build a placeholder set so create_task_under_initiative diffs can
   // reference initiatives created earlier in the SAME proposal. Both
   // ordinal `$N` (where N is the position of a create_child_initiative)

--- a/src/lib/mcp/pm-convoy-mandate.test.ts
+++ b/src/lib/mcp/pm-convoy-mandate.test.ts
@@ -1,0 +1,202 @@
+/**
+ * PM convoy mandate (slice 6/7) — schema-level rejection of
+ * `create_task_under_initiative` in decompose-flow proposals when
+ * `MC_PM_CONVOY_MANDATE=1`.
+ *
+ * Asserts only the trigger_kind ↔ allowed-diff-kinds matrix from
+ * docs/reference/pm-convoy-mandate.md (the "Carve-outs" table). DAG
+ * structural validity is covered by diff-schema.test.ts.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { run } from '@/lib/db';
+import {
+  validateProposedChanges,
+  type PmDiff,
+} from '@/lib/db/pm-proposals';
+import { createInitiative } from '@/lib/db/initiatives';
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at)
+     VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function withMandate<T>(on: boolean, fn: () => T): T {
+  const prev = process.env.MC_PM_CONVOY_MANDATE;
+  if (on) process.env.MC_PM_CONVOY_MANDATE = '1';
+  else delete process.env.MC_PM_CONVOY_MANDATE;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env.MC_PM_CONVOY_MANDATE;
+    else process.env.MC_PM_CONVOY_MANDATE = prev;
+  }
+}
+
+function makeFlatTaskDiff(initiativeId: string): PmDiff {
+  return {
+    kind: 'create_task_under_initiative',
+    initiative_id: initiativeId,
+    title: 'Wire up the cancel endpoint',
+  } as PmDiff;
+}
+
+function makeConvoyDiff(initiativeId: string): PmDiff {
+  return {
+    kind: 'create_convoy_under_initiative',
+    initiative_id: initiativeId,
+    parent_acceptance_criteria: [
+      'Operator clicks Cancel on any in-flight proposal card and the card disappears.',
+    ],
+    slices: [
+      {
+        id: 'slice_a',
+        role: 'builder',
+        slice: 'Build the cancel endpoint and wire it through.',
+        message: 'Implement and ship the cancel endpoint per the AC list.',
+        expected_deliverables: [{ title: 'cancel route handler', kind: 'file' }],
+        acceptance_criteria: ['Endpoint returns 200 on a valid cancel request body.'],
+        expected_duration_minutes: 60,
+      },
+    ],
+  } as PmDiff;
+}
+
+// ─── mandate OFF: back-compat baseline ─────────────────────────────
+
+test('mandate OFF: flat-task diff under decompose_story is allowed', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Cancel feature' });
+  const errors = withMandate(false, () =>
+    validateProposedChanges(ws, [makeFlatTaskDiff(init.id)], {
+      trigger_kind: 'decompose_story',
+    }),
+  );
+  assert.deepEqual(errors, [], 'back-compat: mandate OFF must permit flat-task decompose output');
+});
+
+// ─── mandate ON: decompose flows rejected ──────────────────────────
+
+test('mandate ON: flat-task diff under decompose_story is REJECTED', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Cancel feature' });
+  const errors = withMandate(true, () =>
+    validateProposedChanges(ws, [makeFlatTaskDiff(init.id)], {
+      trigger_kind: 'decompose_story',
+    }),
+  );
+  assert.ok(errors.length > 0, 'expected at least one error');
+  assert.ok(
+    errors.some((e) => e.includes('MC_PM_CONVOY_MANDATE') && e.includes('create_task_under_initiative')),
+    `expected mandate violation, got: ${errors.join(' | ')}`,
+  );
+});
+
+test('mandate ON: flat-task diff under decompose_initiative is REJECTED', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'X' });
+  const errors = withMandate(true, () =>
+    validateProposedChanges(ws, [makeFlatTaskDiff(init.id)], {
+      trigger_kind: 'decompose_initiative',
+    }),
+  );
+  assert.ok(errors.some((e) => e.includes('MC_PM_CONVOY_MANDATE')));
+});
+
+test('mandate ON: flat-task diff under plan_initiative is REJECTED', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'X' });
+  const errors = withMandate(true, () =>
+    validateProposedChanges(ws, [makeFlatTaskDiff(init.id)], {
+      trigger_kind: 'plan_initiative',
+    }),
+  );
+  assert.ok(errors.some((e) => e.includes('MC_PM_CONVOY_MANDATE')));
+});
+
+// ─── mandate ON: carve-outs preserved ──────────────────────────────
+
+test('mandate ON: flat-task diff under notes_intake is ALLOWED (carve-out)', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'X' });
+  const errors = withMandate(true, () =>
+    validateProposedChanges(ws, [makeFlatTaskDiff(init.id)], {
+      trigger_kind: 'notes_intake',
+    }),
+  );
+  assert.deepEqual(errors, []);
+});
+
+test('mandate ON: flat-task diff under manual is ALLOWED (carve-out)', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'X' });
+  const errors = withMandate(true, () =>
+    validateProposedChanges(ws, [makeFlatTaskDiff(init.id)], {
+      trigger_kind: 'manual',
+    }),
+  );
+  assert.deepEqual(errors, []);
+});
+
+// ─── mandate ON: convoy diffs accepted ─────────────────────────────
+
+test('mandate ON: decompose_story with only convoy diffs is ALLOWED', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Cancel feature' });
+  const errors = withMandate(true, () =>
+    validateProposedChanges(ws, [makeConvoyDiff(init.id)], {
+      trigger_kind: 'decompose_story',
+    }),
+  );
+  assert.deepEqual(errors, [], `expected no errors, got: ${errors.join(' | ')}`);
+});
+
+test('mandate ON: decompose_story with convoy + child-initiative is ALLOWED', () => {
+  const ws = freshWorkspace();
+  const parent = createInitiative({ workspace_id: ws, kind: 'epic', title: 'Parent' });
+  const errors = withMandate(true, () =>
+    validateProposedChanges(
+      ws,
+      [
+        {
+          kind: 'create_child_initiative',
+          parent_initiative_id: parent.id,
+          title: 'Child story',
+          child_kind: 'story',
+        } as PmDiff,
+        makeConvoyDiff('$0'),
+      ],
+      { trigger_kind: 'decompose_story' },
+    ),
+  );
+  assert.deepEqual(errors, [], `expected no errors, got: ${errors.join(' | ')}`);
+});
+
+test('mandate ON: decompose_story with ZERO convoy diffs is REJECTED', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'epic', title: 'X' });
+  const errors = withMandate(true, () =>
+    validateProposedChanges(
+      ws,
+      [
+        {
+          kind: 'set_initiative_status',
+          initiative_id: init.id,
+          status: 'at_risk',
+        } as PmDiff,
+      ],
+      { trigger_kind: 'decompose_story' },
+    ),
+  );
+  assert.ok(
+    errors.some((e) => e.includes('MC_PM_CONVOY_MANDATE') && e.includes('at least one')),
+    `expected missing-convoy error, got: ${errors.join(' | ')}`,
+  );
+});


### PR DESCRIPTION
## Summary

Slice 6 of 7 of the PM convoy mandate. Three things in one PR:

1. **Flip the switch.** When `MC_PM_CONVOY_MANDATE=1`, `validateProposedChanges` in `src/lib/db/pm-proposals.ts` REJECTS `create_task_under_initiative` diffs from decompose-flow proposals (`decompose_story` / `decompose_initiative` / `plan_initiative`) and requires at least one `create_convoy_under_initiative` diff. Carve-outs preserved for `notes_intake`, `manual`, audit follow-ups, and child-initiative stubs. Flag is **off by default** — operators flip it on per-container when confident the PM emits convoy-shaped diffs reliably.

2. **Spec edits across 10 reference docs** per the proposal table (see "Spec edits" below).

3. **Proposal promoted.** `docs/proposals/pm-convoy-mandate.md` → `docs/reference/pm-convoy-mandate.md`; `status: aspirational` → `current`; `last-verified` bumped to today; Status section rewritten to reflect phases 1+2 shipped (PRs #353–#357) and phase 3 (slice 7) queued. Added a "Shipped state (as of 2026-05-14)" subsection that documents the flag default and the current `invertDiff` `limited` behavior.

## Changes

- `src/lib/db/pm-proposals.ts` — mandate enforcement block at the top of `validateProposedChanges`, reading `process.env.MC_PM_CONVOY_MANDATE`. Errors flow through the existing `PmProposalValidationError` shape so the PM agent sees a structured `validation_failed` tool-result and can self-correct.
- `src/lib/mcp/pm-convoy-mandate.test.ts` — 9 tests covering:
  - mandate OFF: flat-task under `decompose_story` allowed (back-compat baseline)
  - mandate ON: flat-task under each of the 3 decompose kinds REJECTED
  - mandate ON: flat-task under `notes_intake` / `manual` ALLOWED (carve-outs)
  - mandate ON: decompose with only convoy diffs ALLOWED
  - mandate ON: decompose with convoy + child-initiative ALLOWED
  - mandate ON: decompose with ZERO convoy diffs REJECTED

## Spec edits

| Spec | Edit | Severity |
|---|---|---|
| `docs/reference/pm-convoy-mandate.md` | Promoted from `proposals/`. `status: current`. New "Shipped state" subsection. | Promotion |
| `docs/reference/pm-diff-conventions.md` | Added `create_convoy_under_initiative` row to the diff-kind table; added mandate callout; updated Appendix A inventory. | Material |
| `docs/reference/task-delegation-and-convoys.md` | New §"Two convoy entry points" in overview; added `acceptance_criteria` column row to `convoys` schema table; updated §4 Creation list to include the PM-emit path. | Material |
| `docs/reference/roadmap-and-pm-spec.md` | New §9.5 subsection on the convoy-shaped decompose output; added pm-convoy-mandate to post-merge addenda list. | Material |
| `docs/reference/pm-revertable-proposals.md` | Added `create_convoy_under_initiative` row to inverse-mapping table; new "current revert state" subsection documenting `limited` behavior + planned semantics. | Material (doc of current state; full revert deferred) |
| `docs/reference/review-stage-robustness-spec.md` | New §G "Parent-task `review → done` AC gate" describing composition with evidence gate + `board_override` bypass. | Material |
| `docs/reference/agent-model-cleanup.md` | Top-of-file addendum noting coordinator role shift to monitor + accept + escalate. | Light |
| `docs/reference/audit-pipeline.md` | Top-of-file carve-out note. | Light |
| `docs/reference/autonomous-flow-tightening-spec.md` | Re-verify bump only — no content change (per-slice evidence gates are unaffected). | Re-verify |
| `docs/proposals/subagent-orchestration.md` | Re-verify bump only — orthogonal layer (context offloading), no overlap. | Re-verify |
| `docs/reference/pm-chat-prompt.md` | Re-verify bump (slice 3 had already updated content). | Bump |

## Test plan

- [x] `yarn test src/lib/mcp` — all 9 new tests pass; no existing-test regressions.
- [x] `yarn test src/lib/db` — no regressions.
- [x] `yarn docs:check` — 40 doc files checked, 39 with frontmatter, 0 violations.
- [x] `npx tsc --noEmit` — passes clean.

### `invertDiff` decision (option A vs B)

Chose **option B — kept the `limited` marker and documented current behavior** in `pm-revertable-proposals.md`. Full revert (cancel-convoy-if-no-slice-done + delete unscheduled child tasks; refuse if any slice has reached `done`) is queued as a follow-up. Rationale: keeps this PR focused on the mandate flip + spec sweep; full revert is a separate, testable surface that deserves its own PR.

### Pre-existing failures

Not surfaced in the test slices I ran. (If you suspect any unrelated pre-existing failure in the full suite, surface it in a separate cleanup — none of the tests I touched flagged anything.)

### Preview verification

Skipped — the flag is OFF by default and the gating is server-side schema-only. The schema-OFF/ON test coverage in `pm-convoy-mandate.test.ts` is the primary signal. UI verification was done end-to-end on `main` for slices 2+4+5 before this PR.

## Notes for the next slice (7/7)

- Task Board: collapse 1-slice convoys to plain-task surface.
- Coordinator SOUL: shrink to monitor + accept + escalate (matching `agent-model-cleanup.md` addendum here).
- `invertDiff` for `create_convoy_under_initiative`: implement the planned semantics per `pm-revertable-proposals.md`.
- Consider defaulting `MC_PM_CONVOY_MANDATE=1` in dev (and later prod) once operator confidence is high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)