### PR TITLE
feat(pm): convoy mandate phase 3 — Task Board collapse + coordinator SOUL shrink

### DIFF
--- a/agent-templates/coordinator/AGENTS.md
+++ b/agent-templates/coordinator/AGENTS.md
@@ -1,20 +1,20 @@
 # AGENTS.md — Coordinator Operating Instructions
 
-## You are a spawned subagent (with delegation authority)
+## You are a spawned subagent (monitor + accept + escalate)
 
-The dispatch briefing is authoritative. It carries your `agent_id`, the parent `task_id`, the role section above, the task body, prior notes, and the `next_status` to advance to once all your delegated slices close (typically `done` or `review`). Don't try to read SOUL/IDENTITY from disk — they're inlined. The `coordinator` role grants you `spawn_subtask` authority for the lifetime of this task; authz rejects it from any other role.
+The dispatch briefing is authoritative. It carries your `agent_id`, the parent `task_id`, the role section above, the task body, prior notes, and the `next_status` to advance to once all the convoy's slices close (typically `done` or `review`). Don't try to read SOUL/IDENTITY from disk — they're inlined. The `coordinator` role grants you `spawn_subtask` authority for the lifetime of this task as a **fallback** (mid-flight appends only — see SOUL.md); authz rejects sub-delegation from any other role.
 
-## Coordination workflow
+Under the PM convoy mandate (`docs/reference/pm-convoy-mandate.md`), the slice plan for this convoy was already emitted by the workspace PM at proposal-accept time. You inherit it intact. Your job is to monitor it through to completion.
 
-1. **Intake.** `get_task({ task_id })` to confirm parent state. `read_notes({ task_id })` for upstream breadcrumbs.
-2. **Decompose.** Break the parent into discrete slices. Each one needs a single accountable peer, explicit deliverables, and acceptance criteria.
-3. **Discover peers.** `list_peers({ agent_id })` returns the workspace roster. Filter to `dispatchable: true` for peers you can delegate to (role templates). The workspace PM and the org runner come back as `dispatchable: false` — they're mailable, not delegation targets.
-4. **Delegate.** One `spawn_subtask` per slice (see contract below). Prefer `role:` addressing.
-5. **Track.** `list_my_subtasks({ task_id })` returns derived per-row state. Re-poll after major events; don't loop tightly.
-6. **Accept / reject / cancel.** Each delivered slice gets one `update_subtask` call with `action: 'accept'` (success), `action: 'reject'` (loop back with revision), or `action: 'cancel'` (dead branch).
-7. **Close.** When all slices close, follow the briefing's `next_status`.
+## Monitoring workflow
 
-## `spawn_subtask` contract
+1. **Intake.** `get_task({ task_id })` to confirm parent state. `read_notes({ task_id })` for upstream breadcrumbs and the PM's decomposition rationale.
+2. **Pull convoy state.** `list_my_subtasks({ task_id })` returns derived per-row state. Re-poll after major events; don't loop tightly.
+3. **Accept / reject / cancel.** Each delivered slice gets one `update_subtask` call with `action: 'accept'` (success), `action: 'reject'` (loop back with revision), or `action: 'cancel'` (dead branch).
+4. **Append (rare).** If a builder reports a missing prerequisite the PM's plan didn't anticipate, `spawn_subtask` (single slice) or `plan_convoy` (multi-slice dependency cluster) is available — see contract below. If you find yourself reaching for these as the **primary** decomposition path, stop and verify (per SOUL.md).
+5. **Close.** When all slices close, follow the briefing's `next_status`.
+
+## `spawn_subtask` contract (mid-flight appends only)
 
 Exactly one of `role`, `peer_agent_id`, or `peer_gateway_id` must be supplied. Every other field is required — the tool 400s on partials.
 

--- a/agent-templates/coordinator/SOUL.md
+++ b/agent-templates/coordinator/SOUL.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-You are a Mission Control **Coordinator** subagent. You're spawned for a single parent task that needs to be split across multiple specialist peers. Your job is to decompose it, delegate the slices via `spawn_subtask`, monitor progress, and aggregate the result. You are NOT a persistent gateway agent — Mission Control creates a fresh coordinator subagent per task that needs one.
+You are a Mission Control **Coordinator** subagent. The parent task you've been spawned against arrived with its convoy already planned by the workspace **PM** — slices, deps, deliverables, and acceptance criteria are pre-materialized via the `create_convoy_under_initiative` diff (see `docs/reference/pm-convoy-mandate.md`). Your job is to **monitor** those slices, **accept** delivered work, **reject** misses with revisions, and **escalate** failures you can't resolve. Decomposition is the PM's responsibility, not yours.
 
 ## Personality
 
@@ -13,42 +13,40 @@ You are a Mission Control **Coordinator** subagent. You're spawned for a single 
 
 ## Core Responsibilities
 
-- Decompose the parent task into discrete, individually-reviewable slices
-- Match each slice to the right peer role using `list_peers`
-- Delegate via `spawn_subtask` with explicit acceptance criteria, expected deliverables, and an SLO duration
-- Monitor progress via `list_my_subtasks` — proactively `update_subtask({action: 'cancel'})` dead branches, `update_subtask({action: 'reject'})` work that doesn't meet criteria
-- Accept finished slices via `update_subtask({action: 'accept'})`; the parent convoy auto-completes when all slices close
-- Keep `take_note(kind: 'breadcrumb')` running so future stages and the operator can see what was delegated and why
+- **Monitor** convoy slices via `list_my_subtasks` — proactively `update_subtask({action: 'cancel'})` dead branches, watch for drift and overdue states
+- **Accept** delivered slices via `update_subtask({action: 'accept'})`; the parent convoy auto-promotes when all slices close
+- **Reject** misses via `update_subtask({action: 'reject', reason, new_acceptance_criteria?})` — the peer sees your reason on re-dispatch
+- **Escalate** failures you can't resolve (two consecutive rejections on the same slice, unreachable peer, scope mismatch between operator intent and a slice's brief) by mailing the workspace PM via `send_mail`. Don't loop silently.
+- **Keep notes flowing** — `take_note(kind: 'breadcrumb', audience: 'pm')` for high-level observations so the PM's next decomposition learns from this one.
+
+### Mid-flight slice appends (secondary tool surface)
+
+`spawn_subtask` and `plan_convoy` remain available, but they are no longer the primary entry point. Use them only when:
+
+- A delivered slice reports a missing dependency the original plan didn't anticipate (e.g. a builder discovers a config flag needs to land first), and adding the slice mid-flight is cheaper than failing the convoy.
+- The parent task came in via a non-PM path (manual task creation, an audit follow-up) and arrived **without** a convoy, so there's nothing to monitor yet.
+
+If you find yourself emitting `plan_convoy` for the **initial** decomposition of a parent task that came from PM decomposition, **STOP** and verify. PM-emitted convoys should be intact at dispatch time; needing to re-decompose suggests the PM emitted a stub or the parent isn't PM-managed. Document why you're decomposing in a `take_note(audience: 'pm', kind: 'breadcrumb', importance: 2)` so the PM can correct the upstream pattern.
 
 ## Rules
 
-- **ALWAYS** declare every required field on `spawn_subtask` (slice, message, expected_deliverables, acceptance_criteria, expected_duration_minutes). The tool rejects partial calls.
-- **NEVER** chat directly to peer sessions. The convoy IS the channel — your delegations + their state changes are the conversation.
-- **NEVER** `sessions_spawn` (openclaw native). Subagent spawning is reserved for the workspace PM via the META envelope flow; coordinators delegate via `spawn_subtask` (which goes through Mission Control, not openclaw).
-- **PREFER `plan_convoy` for the initial fan-out.** It takes the full DAG in a single call — slices reference each other by symbolic id via `depends_on`, MC validates topology (no cycles, all peers resolvable) before any briefing fires, and dependent slices stay queued (`inbox`, no chat.send) until their prerequisites are accepted. Use `spawn_subtask` only for single slices or for follow-ups discovered after monitoring. Mission Control honors `depends_on` (in `plan_convoy`) and `depends_on_subtask_ids` (in `spawn_subtask`) as a HARD gate. Prose like "Prerequisites: wait for the builder" inside a `message` field is **not enforced** — the subagent will receive the briefing immediately and start work. Example:
-  ```
-  plan_convoy({
-    slices: [
-      { id: 'builder',  role: 'builder',  slice: '...', ... },
-      { id: 'tester',   role: 'tester',   slice: '...', ..., depends_on: ['builder'] },
-      { id: 'reviewer', role: 'reviewer', slice: '...', ..., depends_on: ['builder'] },
-    ],
-  })
-  ```
+- **NEVER** chat directly to peer sessions. The convoy IS the channel — their state changes and your `accept` / `reject` calls are the conversation.
+- **NEVER** `sessions_spawn` (openclaw native). Subagent spawning is reserved for the workspace PM via the META envelope flow; coordinators only `spawn_subtask` (which goes through Mission Control, not openclaw) and only for mid-flight appends per the section above.
 - **FLAG** scope creep immediately. If the parent task balloons, mail the workspace PM (`send_mail`) — don't quietly add slices.
+- **ALWAYS** declare every required field on `spawn_subtask` when you do append a slice (slice, message, expected_deliverables, acceptance_criteria, expected_duration_minutes). The tool rejects partial calls.
+- **PREFER** `plan_convoy` over a sequence of `spawn_subtask` calls when an append needs more than one slice with dependencies between them. It validates the topology atomically before any briefing fires; symbolic `depends_on` references between the new slices resolve correctly.
 
-## Coordination process
+## Monitoring process
 
-1. **Read the parent.** `get_task({ task_id })` + `read_notes({ task_id })` to ground in operator intent and prior stage breadcrumbs.
-2. **Decompose.** Identify discrete slices. Each one should have its own success criteria and a single accountable peer.
-3. **Discover peers.** `list_peers({ agent_id })` returns the workspace roster. Each peer carries a `dispatchable` flag and an `addressing` object. `dispatchable: true` means the peer is delegable via `spawn_subtask`; those are the role templates (builder, tester, reviewer, …) — address them with `spawn_subtask({ role: '<role>' })`. The workspace PM and the org runner come back with `dispatchable: false` (they're mailable, not delegable).
-4. **Delegate.** One `spawn_subtask` per slice. Prefer `role:` addressing — it picks the workspace's primary live agent for that role and lets MC route the chat through the org runner with the role's SOUL attached. Be specific about what "done" looks like — the peer's evidence gate enforces deliverables, not your trust.
-5. **Monitor.** `list_my_subtasks({ task_id })` returns derived state (dispatched / in_progress / drifting / overdue / delivered). Drifting peers (silent past 2× check-in interval) need an intervention.
-6. **Accept or reject.** When a peer marks a slice delivered, `update_subtask({action: 'accept'})` (success) or `update_subtask({action: 'reject', reason})` (with an actionable revision request). MC handles the loopback.
-7. **Close.** When all slices close, the convoy auto-promotes the parent. Your final `update_task_status` follows the briefing's `next_status` (typically `done`).
+1. **Read the parent.** `get_task({ task_id })` + `read_notes({ task_id })` to ground in operator intent, the PM's decomposition rationale, and any prior stage breadcrumbs.
+2. **Pull the current convoy state.** `list_my_subtasks({ task_id })` returns derived per-row state (dispatched / in_progress / drifting / overdue / delivered).
+3. **Respond to deliveries.** When a peer marks a slice delivered, evaluate against its `acceptance_criteria`. `update_subtask({action: 'accept'})` on a pass, `update_subtask({action: 'reject', reason})` on a miss.
+4. **Intervene on drift.** Drifting peers (silent past 1× check-in interval) need an observation note; overdue peers (past 1.5× expected duration) need `update_subtask({action: 'cancel'})` or a sharper re-brief.
+5. **Escalate.** Mail the PM on patterns you can't fix locally: repeated rejections on the same slice, a peer who keeps missing the same kind of criterion, conflict between the PM's plan and the operator's actual intent surfacing in chat.
+6. **Close.** When all slices close, the convoy auto-promotes the parent (see [`checkConvoyCompletion`](../../src/lib/convoy.ts)). Your final `update_task_status` follows the briefing's `next_status` (typically `done`).
 
 ## How you fit in Mission Control
 
-You're a spawned subagent like any other — the difference is the `coordinator` role grants you `spawn_subtask` authority for the duration of this task. Authz rejects sub-delegation from non-coordinators. When the parent task closes, your session ends. You don't carry state between tasks; rely on `take_note(audience: 'pm')` for anything the workspace PM should learn for the long term.
+You're a spawned subagent like any other — the difference is the `coordinator` role grants you `spawn_subtask` authority for the duration of this task, kept only as a fallback for mid-flight slice appends. Authz rejects sub-delegation from non-coordinators. When the parent task closes, your session ends. You don't carry state between tasks; rely on `take_note(audience: 'pm')` for anything the workspace PM should learn for the long term.
 
-There are exactly two gateway-bound openclaw agents you'll see in `list_peers`: the **workspace PM** (one per workspace) and the **org runner** (one org-wide). Every other peer (builder, tester, reviewer, researcher, writer, learner, auditor) is a role-template row with `gateway_agent_id: null` — they have no openclaw session of their own. When you `spawn_subtask({ role: 'builder' })`, MC creates a child task assigned to the workspace's builder template, then dispatches it through the org runner with `builder/SOUL.md` attached. Don't try to address role templates by gateway id — they don't have one.
+There are exactly two gateway-bound openclaw agents you'll see in `list_peers`: the **workspace PM** (one per workspace) and the **org runner** (one org-wide). Every other peer (builder, tester, reviewer, researcher, writer, learner, auditor) is a role-template row with `gateway_agent_id: null` — they have no openclaw session of their own. When the PM's convoy planned a slice with `role: 'builder'`, MC created the child task assigned to the workspace's builder template and dispatched it through the org runner with `builder/SOUL.md` attached. You inherit that assignment as-is.

--- a/docs/reference/pm-convoy-mandate.md
+++ b/docs/reference/pm-convoy-mandate.md
@@ -7,12 +7,17 @@ code-anchors:
   - src/lib/db/pm-proposals.ts
   - src/lib/agents/pm-agent.ts
   - src/lib/convoy.ts
+  - src/lib/convoy-board-render.ts
   - src/lib/mcp/groups/work.ts:1565-1872
   - src/lib/services/task-status.ts:78-192
   - src/app/api/pm/proposals/[id]/accept/route.ts
+  - src/app/api/tasks/route.ts
   - src/components/DecomposeWithPmModal.tsx
   - src/components/DecomposeStoryToTasksModal.tsx
   - src/components/PlanWithPmPanel.tsx
+  - src/components/MissionQueue.tsx
+  - agent-templates/coordinator/SOUL.md
+  - agent-templates/coordinator/AGENTS.md
 mcp-tools: [propose_changes, plan_convoy, spawn_subtask]
 db-tables: [pm_proposals, convoys, convoy_subtasks, tasks, initiatives]
 related-specs:
@@ -27,9 +32,9 @@ related-specs:
 
 ## Status
 
-Current. Phases 1 and 2 have shipped across PRs #353–#357 (slices 1–6 of 7). The mandate replaces the previous `decompose_story` / `decompose_initiative` / `plan_initiative` output shape (an array of `create_task_under_initiative` diffs) with a `create_convoy_under_initiative` diff carrying a slice DAG. The wholistic fix to two locality bugs we kept re-hitting.
+Current. All 7 slices have shipped (PRs #353–#357 + this PR). The mandate replaces the previous `decompose_story` / `decompose_initiative` / `plan_initiative` output shape (an array of `create_task_under_initiative` diffs) with a `create_convoy_under_initiative` diff carrying a slice DAG. The wholistic fix to two locality bugs we kept re-hitting.
 
-Phase 3 (Task Board collapse for 1-slice convoys, coordinator SOUL shrink) is queued as slice 7.
+Phase 3 (Task Board collapse for 1-slice convoys, coordinator SOUL shrink) has shipped as slice 7 — the final piece of the mandate.
 
 ## Shipped state (as of 2026-05-14)
 
@@ -38,7 +43,8 @@ Phase 3 (Task Board collapse for 1-slice convoys, coordinator SOUL shrink) is qu
 - Slice 3 (PR #353) — PM SOUL + [`docs/reference/pm-chat-prompt.md`](pm-chat-prompt.md) updated with the decompose-flow output contract and DAG smell checklist.
 - Slice 4 (PR #356) — DAG approval UX in [`src/components/ConvoyDiffPreview.tsx`](../../src/components/ConvoyDiffPreview.tsx) and the three decompose modals.
 - Slice 5 — AC gate at parent `review → done` + migration 096 (`task_ac_acknowledgements`) + `AcAckModal`. Endpoint: `GET/POST /api/tasks/[id]/ac-ack`.
-- Slice 6 (this PR) — the `MC_PM_CONVOY_MANDATE=1` flag now causes [`validateProposedChanges`](../../src/lib/db/pm-proposals.ts) to REJECT `create_task_under_initiative` diffs from `decompose_story` / `decompose_initiative` / `plan_initiative` proposals, and to require at least one `create_convoy_under_initiative` in those flows. Carve-outs preserved for `notes_intake`, `manual`, and other tactical kinds. Proposal promoted to `docs/reference/`. Reference-spec edits land in the same PR.
+- Slice 6 — the `MC_PM_CONVOY_MANDATE=1` flag now causes [`validateProposedChanges`](../../src/lib/db/pm-proposals.ts) to REJECT `create_task_under_initiative` diffs from `decompose_story` / `decompose_initiative` / `plan_initiative` proposals, and to require at least one `create_convoy_under_initiative` in those flows. Carve-outs preserved for `notes_intake`, `manual`, and other tactical kinds. Proposal promoted to `docs/reference/`. Reference-spec edits land in the same PR.
+- Slice 7 (this PR) — Task Board ([`MissionQueue.tsx`](../../src/components/MissionQueue.tsx)) collapses 1-slice convoys via [`filterTasksForBoard`](../../src/lib/convoy-board-render.ts) so single-slice decompositions present as a plain parent task. Multi-slice convoy parents pick up a "Convoy · N slices · M done" badge. GET /api/tasks now joins `convoys` so the per-card aggregates land without a second fetch. Coordinator [`SOUL.md`](../../agent-templates/coordinator/SOUL.md) + [`AGENTS.md`](../../agent-templates/coordinator/AGENTS.md) shrink to monitor + accept + escalate; `spawn_subtask` / `plan_convoy` remain as fallback for mid-flight slice appends.
 
 ### Flag default
 

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -17,6 +17,13 @@ export async function GET(request: NextRequest) {
     const workspaceId = searchParams.get('workspace_id');
     const assignedAgentId = searchParams.get('assigned_agent_id');
 
+    // PM convoy mandate slice 7/7: also join the convoy aggregates so the
+    // Task Board can render the parent-row badge ("Convoy · N · M done") and
+    // collapse 1-slice convoys without a second round-trip per task.
+    //   - `parent_convoy_*` columns are populated when this task IS a parent
+    //     with an active convoy underneath.
+    //   - `child_convoy_total` is populated when this task is itself a
+    //     subtask; it's the slice count of the owning convoy.
     let sql = `
       SELECT
         t.*,
@@ -24,10 +31,18 @@ export async function GET(request: NextRequest) {
         aa.avatar_emoji as assigned_agent_emoji,
         aa.status as assigned_agent_status,
         aa.role as assigned_agent_role,
-        ca.name as created_by_agent_name
+        ca.name as created_by_agent_name,
+        pc.id as parent_convoy_id,
+        pc.total_subtasks as parent_convoy_total,
+        pc.completed_subtasks as parent_convoy_completed,
+        pc.failed_subtasks as parent_convoy_failed,
+        pc.status as parent_convoy_status,
+        cc.total_subtasks as child_convoy_total
       FROM tasks t
       LEFT JOIN agents aa ON t.assigned_agent_id = aa.id
       LEFT JOIN agents ca ON t.created_by_agent_id = ca.id
+      LEFT JOIN convoys pc ON pc.parent_task_id = t.id AND pc.status = 'active'
+      LEFT JOIN convoys cc ON cc.id = t.convoy_id
       WHERE 1=1
     `;
     const params: unknown[] = [];
@@ -64,6 +79,12 @@ export async function GET(request: NextRequest) {
       assigned_agent_status?: string;
       assigned_agent_role?: string;
       created_by_agent_name?: string;
+      parent_convoy_id?: string | null;
+      parent_convoy_total?: number | null;
+      parent_convoy_completed?: number | null;
+      parent_convoy_failed?: number | null;
+      parent_convoy_status?: string | null;
+      child_convoy_total?: number | null;
     }>(sql, params);
 
     // Transform to include nested agent info. `status` and `role` are needed
@@ -80,6 +101,16 @@ export async function GET(request: NextRequest) {
             role: task.assigned_agent_role,
           }
         : undefined,
+      convoy_summary: task.parent_convoy_id
+        ? {
+            convoy_id: task.parent_convoy_id,
+            total_subtasks: task.parent_convoy_total ?? 0,
+            completed_subtasks: task.parent_convoy_completed ?? 0,
+            failed_subtasks: task.parent_convoy_failed ?? 0,
+            status: task.parent_convoy_status ?? 'active',
+          }
+        : null,
+      convoy_total_subtasks: task.is_subtask ? task.child_convoy_total ?? null : null,
     }));
 
     return NextResponse.json(transformedTasks);

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -11,6 +11,7 @@ import { TaskModal } from './TaskModal';
 import { BlockedBadge } from './BlockedBadge';
 import { Time } from '@/components/Time';
 import { AcAckModal, type AcStatus } from './AcAckModal';
+import { filterTasksForBoard, convoyBadgeText } from '@/lib/convoy-board-render';
 
 interface MissionQueueProps {
   workspaceId?: string;
@@ -115,15 +116,21 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
   // synchronously while the modal also revalidates on open.
   const [acGate, setAcGate] = useState<{ task: Task; acs: AcStatus[] } | null>(null);
 
+  // PM convoy mandate slice 7/7: filter out subtasks of 1-slice convoys so
+  // single-slice decompositions present as a plain parent task on the board.
+  // Multi-slice convoy subtasks are kept (first-class rows in their status
+  // columns) and the parent row picks up a "Convoy · N · M done" badge.
+  const visibleTasks = filterTasksForBoard(tasks);
+
   const getTasksByStatus = (status: TaskStatus) =>
-    tasks.filter(
+    visibleTasks.filter(
       (task) =>
         task.status === status &&
         (showArchived || !task.is_archived),
     );
 
   const getTasksForColumn = (column: Column) =>
-    tasks.filter(
+    visibleTasks.filter(
       (task) =>
         column.matches.includes(task.status) &&
         (showArchived || !task.is_archived),
@@ -671,7 +678,13 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
         {isConvoyActive && (
           <div className={`flex items-center gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-cyan-500/10 rounded-md border border-cyan-500/20`}>
             <div className="w-2 h-2 bg-cyan-400 rounded-full animate-pulse shrink-0" />
-            <span className="text-xs text-cyan-300 font-medium">Convoy active — sub-tasks running</span>
+            <span className="text-xs text-cyan-300 font-medium">
+              {/* PM convoy mandate slice 7/7: show slice progress when the
+                  convoy has more than one slice. 1-slice convoys never
+                  reach this branch — they're collapsed by filterTasksForBoard
+                  upstream, so we'd be rendering the parent alone. */}
+              {convoyBadgeText(task) ?? 'Convoy active — sub-tasks running'}
+            </span>
           </div>
         )}
 

--- a/src/lib/convoy-board-render.test.ts
+++ b/src/lib/convoy-board-render.test.ts
@@ -1,0 +1,172 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  shouldHideSubtaskForCollapse,
+  filterTasksForBoard,
+  convoyBadgeText,
+} from './convoy-board-render';
+import type { Task } from './types';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: overrides.id ?? 't-' + Math.random().toString(36).slice(2, 8),
+    title: 'mock',
+    status: 'inbox',
+    priority: 'normal',
+    assigned_agent_id: null,
+    created_by_agent_id: null,
+    workspace_id: 'w-1',
+    business_id: 'default',
+    created_at: '2026-05-14T00:00:00Z',
+    updated_at: '2026-05-14T00:00:00Z',
+    ...overrides,
+  };
+}
+
+test('plain task: not collapsed', () => {
+  const t = makeTask({ id: 'plain', is_subtask: 0 });
+  assert.equal(shouldHideSubtaskForCollapse(t), false);
+});
+
+test('subtask in 1-slice convoy: collapsed (hidden)', () => {
+  const t = makeTask({
+    id: 'sub-1',
+    is_subtask: 1,
+    convoy_id: 'c1',
+    convoy_total_subtasks: 1,
+  });
+  assert.equal(shouldHideSubtaskForCollapse(t), true);
+});
+
+test('subtask in 3-slice convoy: NOT collapsed (first-class)', () => {
+  const t = makeTask({
+    id: 'sub-3a',
+    is_subtask: 1,
+    convoy_id: 'c2',
+    convoy_total_subtasks: 3,
+  });
+  assert.equal(shouldHideSubtaskForCollapse(t), false);
+});
+
+test('subtask with null convoy_total_subtasks: not collapsed (defensive)', () => {
+  const t = makeTask({
+    id: 'sub-orphan',
+    is_subtask: 1,
+    convoy_id: 'c-missing',
+    convoy_total_subtasks: null,
+  });
+  assert.equal(shouldHideSubtaskForCollapse(t), false);
+});
+
+test('filterTasksForBoard: 1-slice convoy parent stays, subtask drops', () => {
+  const parent = makeTask({
+    id: 'parent-1s',
+    status: 'convoy_active',
+    convoy_summary: {
+      convoy_id: 'c1',
+      total_subtasks: 1,
+      completed_subtasks: 0,
+      failed_subtasks: 0,
+      status: 'active',
+    },
+  });
+  const sub = makeTask({
+    id: 'sub-1s',
+    is_subtask: 1,
+    convoy_id: 'c1',
+    convoy_total_subtasks: 1,
+  });
+  const plain = makeTask({ id: 'plain' });
+
+  const rows = filterTasksForBoard([parent, sub, plain]);
+  assert.deepEqual(rows.map(r => r.id).sort(), ['parent-1s', 'plain']);
+});
+
+test('filterTasksForBoard: 3-slice convoy parent + all 3 subtasks visible', () => {
+  const parent = makeTask({
+    id: 'parent-3s',
+    status: 'convoy_active',
+    convoy_summary: {
+      convoy_id: 'c2',
+      total_subtasks: 3,
+      completed_subtasks: 1,
+      failed_subtasks: 0,
+      status: 'active',
+    },
+  });
+  const subs = [1, 2, 3].map(i =>
+    makeTask({ id: `s${i}`, is_subtask: 1, convoy_id: 'c2', convoy_total_subtasks: 3 }),
+  );
+  const rows = filterTasksForBoard([parent, ...subs]);
+  assert.equal(rows.length, 4);
+});
+
+test('convoyBadgeText: multi-slice returns badge', () => {
+  const t = makeTask({
+    convoy_summary: {
+      convoy_id: 'c',
+      total_subtasks: 3,
+      completed_subtasks: 1,
+      failed_subtasks: 0,
+      status: 'active',
+    },
+  });
+  assert.equal(convoyBadgeText(t), 'Convoy · 3 slices · 1 done');
+});
+
+test('convoyBadgeText: failures surfaced', () => {
+  const t = makeTask({
+    convoy_summary: {
+      convoy_id: 'c',
+      total_subtasks: 4,
+      completed_subtasks: 2,
+      failed_subtasks: 1,
+      status: 'active',
+    },
+  });
+  assert.equal(convoyBadgeText(t), 'Convoy · 4 slices · 2 done · 1 failed');
+});
+
+test('convoyBadgeText: 1-slice convoy returns null (collapsed)', () => {
+  const t = makeTask({
+    convoy_summary: {
+      convoy_id: 'c',
+      total_subtasks: 1,
+      completed_subtasks: 0,
+      failed_subtasks: 0,
+      status: 'active',
+    },
+  });
+  assert.equal(convoyBadgeText(t), null);
+});
+
+test('convoyBadgeText: no convoy returns null', () => {
+  const t = makeTask();
+  assert.equal(convoyBadgeText(t), null);
+});
+
+test('convoy in done status still renders correctly', () => {
+  // Parent auto-promoted to review/done; convoy_summary may still exist
+  // until cleanup. The collapse rule is structural, not status-driven.
+  const parent = makeTask({
+    id: 'p-done',
+    status: 'review',
+    convoy_summary: {
+      convoy_id: 'c',
+      total_subtasks: 1,
+      completed_subtasks: 1,
+      failed_subtasks: 0,
+      status: 'done',
+    },
+  });
+  const sub = makeTask({
+    id: 's-done',
+    status: 'done',
+    is_subtask: 1,
+    convoy_id: 'c',
+    convoy_total_subtasks: 1,
+  });
+  const rows = filterTasksForBoard([parent, sub]);
+  // 1-slice convoy: parent visible, single subtask elided.
+  assert.deepEqual(rows.map(r => r.id), ['p-done']);
+});

--- a/src/lib/convoy-board-render.ts
+++ b/src/lib/convoy-board-render.ts
@@ -1,0 +1,70 @@
+/**
+ * PM convoy mandate slice 7/7 — Task Board render helpers.
+ *
+ * The board renders convoy subtasks as first-class rows (they already had
+ * `is_subtask = 1` cards before this slice). What this helper adds is the
+ * "single-slice convoys are UI-collapsed" rule from the mandate spec:
+ *
+ *   docs/reference/pm-convoy-mandate.md (~lines 72-76):
+ *   > A story that genuinely is "one builder owns this end-to-end"
+ *   > decomposes to a 1-slice convoy. Convoy machinery underneath, plain-task
+ *   > surface above. The Task Board renders 1-slice convoys as if they were
+ *   > the parent task; the Convoy tab elides the ceremony.
+ *
+ * So we treat the convoy as ceremony and elide it whenever:
+ *
+ *   - the task is a convoy subtask (`is_subtask === 1`)
+ *   - AND the owning convoy has exactly one slice (`convoy_total_subtasks === 1`)
+ *
+ * In that case the subtask card is hidden; the parent task in `convoy_active`
+ * carries the operator-facing identity. Clicking the parent drills into the
+ * convoy view where the single slice is still reachable.
+ *
+ * Multi-slice convoys are unchanged: parent stays visible AND the subtask
+ * cards continue to render in their respective status columns. The parent
+ * row gets a small "Convoy · N · M done" badge (rendered inline in
+ * MissionQueue) so the operator can see progress at a glance.
+ *
+ * Tasks fed in here must have come from the GET /api/tasks endpoint, which
+ * populates `convoy_summary` and `convoy_total_subtasks` via LEFT JOIN on
+ * `convoys`. The helper has no DB access of its own — it's a pure transform
+ * over the in-memory task list so the Zustand store can stay the source of
+ * truth.
+ */
+
+import type { Task } from './types';
+
+/**
+ * Returns true when this subtask row should be hidden because its convoy
+ * has exactly one slice (the parent task represents it instead).
+ */
+export function shouldHideSubtaskForCollapse(task: Task): boolean {
+  if (!task.is_subtask) return false;
+  return task.convoy_total_subtasks === 1;
+}
+
+/**
+ * Filter a task list down to the rows the Task Board should render.
+ * - Plain tasks: kept.
+ * - Convoy parents: kept (badged via `task.convoy_summary` at render time).
+ * - Multi-slice convoy subtasks: kept (first-class).
+ * - Single-slice convoy subtasks: filtered out (collapsed under parent).
+ */
+export function filterTasksForBoard(tasks: Task[]): Task[] {
+  return tasks.filter(t => !shouldHideSubtaskForCollapse(t));
+}
+
+/**
+ * Convoy badge text for parent-task cards. NULL when the task has no active
+ * convoy or the convoy is a single-slice (collapsed) convoy where the badge
+ * would be redundant ceremony.
+ */
+export function convoyBadgeText(task: Task): string | null {
+  const s = task.convoy_summary;
+  if (!s) return null;
+  // Single-slice convoys collapse to plain-task surface; no badge.
+  if (s.total_subtasks <= 1) return null;
+  const failed = s.failed_subtasks ?? 0;
+  const base = `Convoy · ${s.total_subtasks} slices · ${s.completed_subtasks} done`;
+  return failed > 0 ? `${base} · ${failed} failed` : base;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -155,6 +155,28 @@ export interface Task {
   // Joined fields
   assigned_agent?: Agent;
   created_by_agent?: Agent;
+  /**
+   * PM convoy mandate slice 7/7: when this task is the PARENT of an active
+   * convoy, this aggregate lets the board render a "Convoy · N · M done"
+   * badge without a second fetch. NULL when the task has no active convoy.
+   */
+  convoy_summary?: ConvoyBoardSummary | null;
+  /**
+   * PM convoy mandate slice 7/7: when this task IS a convoy subtask
+   * (`is_subtask === 1`), this is the total slice count of the owning convoy.
+   * Used to collapse 1-slice convoys on the Task Board — operators see only
+   * the parent, the lone subtask is hidden as ceremony. NULL when the task
+   * isn't a subtask or its convoy disappeared.
+   */
+  convoy_total_subtasks?: number | null;
+}
+
+export interface ConvoyBoardSummary {
+  convoy_id: string;
+  total_subtasks: number;
+  completed_subtasks: number;
+  failed_subtasks: number;
+  status: string;
 }
 
 export interface TaskImage {


### PR DESCRIPTION
## Summary

**Slice 7 of 7 — the final piece of the PM convoy mandate.** This PR ships the Phase 3 cleanup from `docs/reference/pm-convoy-mandate.md` (lines ~244-249 + 72-76):

- Task Board collapses 1-slice convoys to a plain parent-task surface (operator sees one row; the lone subtask is hidden as ceremony).
- Multi-slice convoy parents pick up a "Convoy · N slices · M done" badge so progress is visible at a glance.
- Coordinator SOUL + AGENTS shrink to **monitor + accept + escalate**. `spawn_subtask` / `plan_convoy` remain available as a **fallback** for mid-flight slice appends, but they're no longer the primary decomposition path — the PM emits the convoy at proposal-accept time.

Out of scope (deferred follow-up): full `invertDiff` for `create_convoy_under_initiative`. Slice 6 noted this as a follow-up and that remains the case.

## Changes

### Task Board collapse
- `src/lib/convoy-board-render.ts` (new) — pure transform: `filterTasksForBoard`, `shouldHideSubtaskForCollapse`, `convoyBadgeText`.
- `src/lib/convoy-board-render.test.ts` (new) — 11 unit tests covering the 1-slice / 3-slice / no-convoy / done-status / orphan cases.
- `src/app/api/tasks/route.ts` — LEFT JOIN `convoys` so each task row carries `convoy_summary` (parent aggregate) and `convoy_total_subtasks` (child slice count). No second fetch per card.
- `src/lib/types.ts` — adds `convoy_summary?: ConvoyBoardSummary | null` and `convoy_total_subtasks?: number | null` to `Task`.
- `src/components/MissionQueue.tsx` — wires `filterTasksForBoard` into `getTasksForColumn` so single-slice subtasks are hidden in both desktop and mobile views; `convoyBadgeText` replaces the plain "Convoy active — sub-tasks running" string on `convoy_active` parent cards.

### Coordinator SOUL shrink
- `agent-templates/coordinator/SOUL.md` — rewrites the Role + Core Responsibilities + Rules sections to lead with **monitor → accept → escalate**. `spawn_subtask` / `plan_convoy` documented as fallback for mid-flight appends only, with a "STOP and verify if you find yourself re-decomposing a PM-emitted convoy" guardrail.
- `agent-templates/coordinator/AGENTS.md` — workflow renumbered (intake → pull convoy state → accept/reject/cancel → append (rare) → close); `spawn_subtask` contract section retitled "mid-flight appends only".

### Spec
- `docs/reference/pm-convoy-mandate.md` — Status section updated to "all 7 slices shipped"; slice 7 entry added under "Shipped state"; new code anchors (`convoy-board-render.ts`, `MissionQueue.tsx`, coordinator templates, `api/tasks/route.ts`); `last-verified` stays 2026-05-14.

## Test plan

- [x] `yarn docs:check` — 0 violations (verified all new code anchors exist).
- [x] `yarn test src/lib/convoy-board-render.test.ts` — 11 / 11 passing.
- [x] `yarn test` (full suite) — runs to completion. Two failures (`POST: happy path threads note + audit-run provenance into chat metadata`, `schedule-runner: produces a brief and advances run_count`) reproduce on plain `main` (sha `796d26b`) — pre-existing, unrelated to this slice.
- [x] `npx tsc --noEmit` — no errors.

## Verification

Preview-verified against the dev DB (`./mission-control.db`) at `localhost:4010`.

GET `/api/tasks?workspace_id=default` now returns 14 task rows; `filterTasksForBoard` reduces that to 12 — the two filtered rows are the lone subtasks of the two 1-slice convoys present in dev data:

```
hidden: [
  { id: "5c102844", title: "Implement POST /api/pm/proposals/[id]/cancel endpo..." },
  { id: "92b7b092", title: "Implement alert() replacements, alert-shim heurist..." },
]
```

The 3-slice convoy under `5d1b2a73` keeps all three subtask rows visible (`Wire UI surface`, `End-to-end test`, `Wire backend endpoint`), as expected.

Task Board render confirmed via DOM scan on `/workspace/default`:

```
has_1slice_5c1_visible: false   # collapsed
has_1slice_92b_visible: false   # collapsed
multi_3slice_subs_visible: ["Wire UI surface","End-to-end test","Wire backend endpoint"]
```

`preview_logs` (`level=error`): no server errors.

The "Convoy · N slices · M done" badge variant is exercised by `convoy-board-render.test.ts` (multi-slice returns `Convoy · 3 slices · 1 done`; failures append `· 1 failed`; 1-slice convoys return `null` and fall through to the legacy string — which is now only reachable for orphan / no-summary edge cases since the filter elides them).

---

🦞 Slice 7 of 7 — the convoy mandate is now end-to-end. PM emits convoys at decompose time → operator approves the DAG → apply-pass materializes parent + subtasks → coordinator monitors → AC gate at parent review → done. Phase 3 cleanup completes the loop.