### PR TITLE
feat(pm): full invertDiff for create_convoy_under_initiative

### DIFF
--- a/docs/reference/pm-convoy-mandate.md
+++ b/docs/reference/pm-convoy-mandate.md
@@ -50,9 +50,17 @@ Phase 3 (Task Board collapse for 1-slice convoys, coordinator SOUL shrink) has s
 
 The mandate is **always on** as of 2026-05-14. The original `MC_PM_CONVOY_MANDATE` feature flag was removed once slices 1–7 shipped and verified end-to-end — there is no kill switch. To roll back, an operator would need to revert the gating code in [`validateProposedChanges`](../../src/lib/db/pm-proposals.ts).
 
-### Revert semantics
+### Revert semantics — shipped
 
-`invertDiff` for `create_convoy_under_initiative` is fully implemented — see [`pm-revertable-proposals.md`](pm-revertable-proposals.md) for the contract. Behavior: refuses revert if any slice has reached `done`; otherwise cancels the convoy, deletes unscheduled (inbox) child tasks, transitions in-flight children to `cancelled`, and clears `task_ac_acknowledgements` for the parent. Parent task itself is preserved for operator cleanup rather than auto-deleted.
+Full `invertDiff` for `create_convoy_under_initiative` has landed.
+The inverse is a synthesized `cancel_convoy` diff (revert-only kind)
+applied atomically inside the outer `acceptProposal` transaction:
+refuse if any subtask has reached `done`, otherwise mark the convoy
+`failed`, delete inbox children, cancel non-done in-flight children,
+and delete the parent-AC acknowledgements. The parent task is left
+in place for operator cleanup — see
+[`pm-revertable-proposals.md § create_convoy_under_initiative → cancel_convoy`](pm-revertable-proposals.md#create_convoy_under_initiative--cancel_convoy)
+for the full behavior table and the parent-preservation rationale.
 
 ## Problem
 
@@ -297,7 +305,7 @@ These help today's decompositions without touching the schema. Buy time.
 | [`docs/reference/pm-diff-conventions.md`](../docs/reference/pm-diff-conventions.md) | Add `create_convoy_under_initiative` row to the diff-kind table; add "decompose-flow-only / non-decompose-flow-only" column or note; document the new shape. | Material |
 | [`docs/reference/task-delegation-and-convoys.md`](../docs/reference/task-delegation-and-convoys.md) | Note that convoys now have two entry points (PM-emit at proposal-accept time AND coordinator `spawn_subtask`/`plan_convoy` for mid-flight); shrink the coordinator's described scope; document `convoys.acceptance_criteria`. | Material |
 | [`docs/reference/roadmap-and-pm-spec.md`](../docs/reference/roadmap-and-pm-spec.md) | Section ~line 499 describes today's flat-list decompose output. Replace with the convoy mandate; describe the parent-task auto-create-on-accept; describe `parent_acceptance_criteria`. | Material |
-| [`docs/reference/pm-revertable-proposals.md`](../docs/reference/pm-revertable-proposals.md) | Define `invertDiff` for `create_convoy_under_initiative`: cancel the convoy + delete unscheduled child tasks; refuse revert if any slice has reached `done`. Material edit to [`src/lib/pm/invertDiff.ts`](../src/lib/pm/invertDiff.ts) needed alongside the spec. | Material |
+| [`docs/reference/pm-revertable-proposals.md`](../docs/reference/pm-revertable-proposals.md) | **Shipped.** Defines the `cancel_convoy` inverse for `create_convoy_under_initiative`: refuse on any `done` subtask, otherwise mark the convoy `failed`, delete inbox children, cancel in-flight children, delete parent-AC acks. Parent task is preserved. Implementation in [`src/lib/pm/invertDiff.ts`](../src/lib/pm/invertDiff.ts) + apply branch in [`src/lib/db/pm-proposals.ts`](../src/lib/db/pm-proposals.ts). | Material — shipped |
 | [`docs/reference/review-stage-robustness-spec.md`](../docs/reference/review-stage-robustness-spec.md) | Document the parent `review → done` AC gate; how it composes with evidence gate; how `board_override` bypasses. | Material |
 | `docs/reference/pm-chat-prompt.md` (and any pm SOUL file under `agent-templates/pm/`) | Add the decompose-flow output contract, the DAG smell checklist, and the parent-AC instruction. | Material |
 | [`docs/reference/agent-model-cleanup.md`](../docs/reference/agent-model-cleanup.md) | Coordinator described as decomposer; needs the role-shift (monitor + accept + escalate). | Light |

--- a/docs/reference/pm-revertable-proposals.md
+++ b/docs/reference/pm-revertable-proposals.md
@@ -16,7 +16,7 @@ related-specs:
   - pm-diff-conventions.md — PmDiff kinds enumerated here are inverted
   - audit-action-recommended.md — audit-spawned proposals flow through this revert surface
   - roadmap-and-pm-spec.md — broader PM mutation model
-  - pm-convoy-mandate.md — adds create_convoy_under_initiative (revert support deferred — see §"create_convoy_under_initiative — current revert state" below)
+  - pm-convoy-mandate.md — adds create_convoy_under_initiative and its cancel_convoy inverse
 ---
 
 # PM action audit log + revertable proposals
@@ -78,35 +78,59 @@ Add a `revert_proposal` action: given an accepted proposal, synthesize the inver
 | `create_child_initiative` | `set_initiative_status: 'cancelled'` on the created row (we don't delete). The created child's id must be captured back into the diff record at apply time so revert can target it. |
 | `create_task_under_initiative` | `set_task_status: 'cancelled'` (if that diff kind exists; if not, add it). Same id-capture pattern. |
 | `add_availability` | Mark the row inactive or mirror with a removal diff. Audit current `add_availability` apply path; choose the cleanest inverse. |
-| `create_convoy_under_initiative` | **Limited (deferred — see below).** Planned inverse: cancel the convoy + delete unscheduled child tasks; refuse revert if any slice has reached `done`. |
+| `create_convoy_under_initiative` | `cancel_convoy` — see [`§ create_convoy_under_initiative → cancel_convoy`](#create_convoy_under_initiative--cancel_convoy) below for the full apply-time behavior. Refuses revert if any subtask has reached `done`. |
 
-### `create_convoy_under_initiative` — current revert state
+### `create_convoy_under_initiative` → `cancel_convoy`
 
-The PM convoy mandate ([pm-convoy-mandate.md](pm-convoy-mandate.md))
-added `create_convoy_under_initiative` as a new diff kind. Its
-`invertDiff` case at
-[`src/lib/pm/invertDiff.ts`](../../src/lib/pm/invertDiff.ts) (~line
-251) currently returns the `limited` marker — the UI shows "Revert
-(limited)" with a tooltip and no actionable inverse.
+The inverse of `create_convoy_under_initiative` is a synthesized
+`cancel_convoy` diff (revert-only kind; the schema validator rejects
+it on any non-revert proposal). On apply — wrapped in the outer
+`acceptProposal` SQLite transaction so any step that throws rolls back
+the whole revert atomically — the diff performs:
 
-**Planned semantics for the follow-up** (not yet implemented; tracked
-as part of slice 7 / a separate follow-up PR):
+1. **Refuse if any subtask is `done`.** Throws
+   `PmProposalValidationError` naming the blocker(s). The convoy and
+   its tasks stay exactly as they were; the operator must unwind
+   per-slice manually before a revert is meaningful.
+2. **Mark the convoy `failed`.** Idempotent — if another path already
+   cancelled the convoy, the UPDATE is skipped.
+3. **Per subtask child task:** `inbox` rows are `DELETE`d (never
+   dispatched, safe to remove; FK cascade also drops their
+   `convoy_subtasks` row). Any other non-`done` status is set to
+   `cancelled` so in-flight agent work has a clean terminus instead
+   of disappearing mid-flight.
+4. **Delete `task_ac_acknowledgements` rows for the parent task.**
+   The acks were scoped to the now-revoked parent ACs; FK cascade
+   would only run if we deleted the parent (we don't — see below),
+   so we delete the rows explicitly here. Safe no-op when none exist.
 
-- If no slice has reached `done`: emit a `set_task_status: 'cancelled'`
-  on the parent task plus tombstones for any subtasks that are still
-  in `inbox` / `assigned`. The convoy row stays for audit; its status
-  flips to `failed`.
-- If any slice has reached `done`: refuse the revert at validation
-  time with a structured error pointing the operator to per-slice
-  manual rollback. The "all-or-nothing" inverse is unsafe once
-  downstream artifacts may exist.
-- Capture state required at apply time (already populated by slice 2):
-  `convoy_id`, `parent_task_id`, `subtask_id_map`. No new capture
-  fields needed.
+**Parent task preservation (decision).** The revert deliberately does
+**not** delete or cancel the parent task — even when the original
+convoy apply auto-created it from a story initiative. Reasoning:
 
-Until the follow-up lands, operators revert convoy-shaped proposals by
-cancelling the parent task manually (the dependency / cascade rules
-already handle the rest).
+- Tracking "did this proposal auto-create the parent" requires a
+  marker column on `tasks` and threading state through both apply
+  and revert paths.
+- The orphaned parent is highly visible (it sits in `convoy_active` /
+  `review` with zero live subtasks) and the operator can repurpose,
+  re-decompose, or cancel it manually in one click.
+- The audit story is cleaner: the proposal timeline still anchors
+  against an existing task row.
+
+If experience shows operators routinely want the parent gone too,
+revisit this in a follow-up — the simplest extension is a new
+`auto_created_for_convoy_id` column on `tasks` populated at apply
+time and a conditional `DELETE` in the `cancel_convoy` branch.
+
+**Deliverables.** Out of scope. Deliverables outlive task cancellation
+by design (audit trail). Reverts don't touch them.
+
+**Capture state required at apply time** (already populated by the
+slice-2 apply path on the source diff, no new fields needed):
+`created_convoy_id`, `created_parent_task_id`,
+`created_subtasks[].child_task_id`. When any of these are missing
+(pre-capture proposal), the UI surfaces "Revert (limited)" with a
+tooltip and the diff is omitted from the synthesized revert.
 
 **The "captured at apply time" pattern is critical:** each forward apply should persist enough state into the diff record (or a sibling table) that the inverse is a pure function of the diff row alone. Don't recompute from current DB state at revert time — it'll have drifted.
 

--- a/src/components/pm/ProposalDiffsList.tsx
+++ b/src/components/pm/ProposalDiffsList.tsx
@@ -210,6 +210,12 @@ const KIND_CHIP: Record<
     tooltip:
       "Updates an existing task's status. PM uses this only as the inverse of NEW TASK — task creation is the operator-driven path.",
   },
+  cancel_convoy: {
+    label: 'CANCEL CONVOY',
+    cls: 'border-rose-500/30 bg-rose-500/15 text-rose-200',
+    tooltip:
+      'Revert-only: cancels a convoy spawned by a create_convoy_under_initiative diff. Inbox subtasks are deleted, in-flight subtasks are cancelled, the parent task is left in place for operator cleanup. Refused if any subtask has reached done.',
+  },
 };
 
 function KindChip({ kind }: { kind: string }) {

--- a/src/lib/db/pm-proposals.ts
+++ b/src/lib/db/pm-proposals.ts
@@ -239,6 +239,35 @@ export type PmDiff =
       audit_proposal_id?: string;
       commit_sha?: string;
       pr_url?: string;
+    } & PmDiffCapture)
+  | ({
+      // PM convoy mandate — full invertDiff for create_convoy_under_initiative.
+      // Synthesized by `invertProposalDiffs` when a convoy-shaped proposal
+      // is reverted. Forward-only on revert proposals (trigger_kind='revert'):
+      // the schema validator rejects this kind in any other context.
+      //
+      // Apply semantics (single SQLite transaction):
+      //   1. Refuse if any subtask child task has reached 'done' — return
+      //      a structured PmProposalValidationError naming the blocker.
+      //   2. UPDATE convoys SET status='failed' (idempotent if already
+      //      cancelled/failed by another path).
+      //   3. For each subtask child task:
+      //        - 'inbox' → DELETE (never dispatched, safe to remove).
+      //        - any other non-done status → set status='cancelled'.
+      //   4. DELETE FROM task_ac_acknowledgements WHERE task_id = parent_task_id
+      //      (the acks are scoped to the now-revoked convoy ACs).
+      //
+      // Parent task preservation: we do NOT delete or cancel the parent
+      // task — even if it was auto-created by the original convoy apply.
+      // Operators see the orphaned parent in 'convoy_active' / 'review'
+      // and decide what to do (re-decompose, cancel manually, repurpose).
+      // Saves a marker column and complex bookkeeping; the operator
+      // judgement is cheap and the parent stays auditable. Documented in
+      // docs/reference/pm-revertable-proposals.md.
+      kind: 'cancel_convoy';
+      convoy_id: string;
+      parent_task_id: string;
+      subtask_child_task_ids: string[];
     } & PmDiffCapture);
 
 export interface PmProposal {
@@ -757,6 +786,30 @@ export function validateProposedChanges(
             errors.push(`changes[${i}]: pr_url must be a valid URL`);
           }
         }
+        break;
+      }
+      case 'cancel_convoy': {
+        // Revert-only: synthesized by `invertProposalDiffs` for an
+        // accepted create_convoy_under_initiative diff. Forward proposals
+        // are never allowed to emit this kind directly.
+        if (options.trigger_kind !== 'revert') {
+          errors.push(
+            `changes[${i}]: cancel_convoy is revert-only (trigger_kind must be 'revert', got '${options.trigger_kind ?? 'manual'}')`,
+          );
+        }
+        if (!c.convoy_id || typeof c.convoy_id !== 'string') {
+          errors.push(`changes[${i}]: convoy_id required`);
+        }
+        if (!c.parent_task_id || typeof c.parent_task_id !== 'string') {
+          errors.push(`changes[${i}]: parent_task_id required`);
+        }
+        if (!Array.isArray(c.subtask_child_task_ids)) {
+          errors.push(`changes[${i}]: subtask_child_task_ids must be an array`);
+        }
+        // We don't assert the convoy still exists at validation time —
+        // the apply path is idempotent and treats a missing convoy as a
+        // no-op, so this stays cleanly revertable even if another path
+        // already cancelled the convoy.
         break;
       }
       default: {
@@ -1798,6 +1851,74 @@ function applyDiff(diff: PmDiff, now: string): void {
       // Out-of-band: needs the placeholder map AND fires DAG validation
       // + spawnDelegationSubtask via applyCreateConvoyUnderInitiative.
       throw new Error('create_convoy_under_initiative must be applied via acceptProposal pass-2');
+    }
+    case 'cancel_convoy': {
+      // PM convoy mandate — inverse of create_convoy_under_initiative.
+      // Runs inside the outer acceptProposal transaction, so any throw
+      // rolls back the whole revert atomically.
+      //
+      // Step 1 — refuse if any subtask child task is 'done'. Surface a
+      // structured error naming the blockers so the operator can decide
+      // whether to manually unwind or accept the partial completion.
+      if (diff.subtask_child_task_ids.length > 0) {
+        const placeholders = diff.subtask_child_task_ids.map(() => '?').join(',');
+        const done = queryAll<{ id: string; title: string }>(
+          `SELECT id, title FROM tasks WHERE id IN (${placeholders}) AND status = 'done'`,
+          diff.subtask_child_task_ids,
+        );
+        if (done.length > 0) {
+          const names = done.map((t) => `"${t.title}" (${t.id})`).join(', ');
+          throw new PmProposalValidationError(
+            `cancel_convoy refused: ${done.length} subtask${done.length === 1 ? '' : 's'} already reached 'done' — ${names}. Revert would corrupt downstream state; unwind manually if needed.`,
+          );
+        }
+      }
+
+      // Step 2 — mark the convoy 'failed' (idempotent). Missing convoy
+      // is treated as a no-op so this stays safely re-runnable.
+      const convoy = queryOne<{ id: string; status: string }>(
+        `SELECT id, status FROM convoys WHERE id = ?`,
+        [diff.convoy_id],
+      );
+      if (convoy && convoy.status !== 'failed' && convoy.status !== 'done') {
+        run(
+          `UPDATE convoys SET status = 'failed', updated_at = ? WHERE id = ?`,
+          [now, diff.convoy_id],
+        );
+      }
+
+      // Step 3 — for each subtask child task: inbox → DELETE, non-done →
+      // cancel. Done is impossible here (we'd have refused above).
+      // Deleting a task also cascades convoy_subtasks (FK ON DELETE
+      // CASCADE) so audit trail for never-dispatched slices is clean.
+      for (const childId of diff.subtask_child_task_ids) {
+        const t = queryOne<{ id: string; status: string }>(
+          `SELECT id, status FROM tasks WHERE id = ?`,
+          [childId],
+        );
+        if (!t) continue; // already gone — idempotent
+        if (t.status === 'inbox') {
+          run(`DELETE FROM tasks WHERE id = ?`, [childId]);
+        } else if (t.status !== 'cancelled' && t.status !== 'done') {
+          run(
+            `UPDATE tasks SET status = 'cancelled', updated_at = ? WHERE id = ?`,
+            [now, childId],
+          );
+        }
+      }
+
+      // Step 4 — delete parent-AC acknowledgements. The ACs were the
+      // convoy's; with the convoy revoked, the acks are meaningless.
+      // task_ac_acknowledgements is FK-cascaded from tasks, but since
+      // we deliberately do NOT delete the parent task (lean approach —
+      // operators decide), we delete the ack rows explicitly here.
+      // Safe no-op when no acks exist (slice-5-predating convoy, or
+      // never-acked).
+      run(
+        `DELETE FROM task_ac_acknowledgements WHERE task_id = ?`,
+        [diff.parent_task_id],
+      );
+      return;
     }
     case 'set_task_status': {
       const prev = queryOne<{ status: string }>(

--- a/src/lib/pm/invertDiff-convoy.test.ts
+++ b/src/lib/pm/invertDiff-convoy.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Full revert semantics for `create_convoy_under_initiative`.
+ *
+ * Scenarios:
+ *   - Happy path: accept a convoy proposal, drive 0 subtasks to done,
+ *     revert → convoy 'failed', inbox subtasks deleted, in_progress
+ *     subtasks → 'cancelled', parent task left in place, acks deleted.
+ *   - Refuse path: any subtask 'done' → cancel_convoy throws
+ *     PmProposalValidationError on apply, nothing changes (transaction
+ *     rolls back).
+ *   - Mid-state: one done + two inbox → refuse; verify inbox tasks were
+ *     NOT deleted.
+ *   - Back-compat: revert succeeds when the parent task has no acks
+ *     recorded (slice-5 surface was skipped).
+ *   - Idempotent: revert when convoy is already 'failed' → succeeds,
+ *     no-op on the convoy row.
+ *   - Schema: cancel_convoy is rejected on non-revert proposals.
+ *
+ * Mirrors the in-memory DB setup used by `apply-convoy-diff.test.ts`.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+import { createInitiative } from '@/lib/db/initiatives';
+import {
+  acceptProposal,
+  createProposal,
+  PmProposalValidationError,
+  type PmDiff,
+} from '@/lib/db/pm-proposals';
+import { invertProposalDiffs } from '@/lib/pm/invertDiff';
+
+function freshWorkspace(): string {
+  const id = `ws-${uuidv4().slice(0, 8)}`;
+  run(
+    `INSERT OR IGNORE INTO workspaces (id, name, slug, created_at)
+     VALUES (?, ?, ?, datetime('now'))`,
+    [id, id, id],
+  );
+  return id;
+}
+
+function seedAgent(opts: { workspace: string; role?: string }): string {
+  const id = uuidv4();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, status, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 1, 'standby', datetime('now'), datetime('now'))`,
+    [id, `Agent-${id.slice(0, 4)}`, opts.role ?? 'builder', opts.workspace],
+  );
+  return id;
+}
+
+function baseSlice(over: Partial<{
+  id: string;
+  role: string;
+  slice: string;
+  depends_on: string[];
+}> = {}) {
+  return {
+    id: over.id ?? 'builder',
+    role: over.role ?? 'builder',
+    slice: over.slice ?? 'Ship the feature end-to-end.',
+    message: 'Please honor the parent ACs.',
+    expected_deliverables: [{ title: 'Implementation', kind: 'file' as const }],
+    acceptance_criteria: ['Operator can click X and observe Y.'],
+    expected_duration_minutes: 60,
+    ...(over.depends_on ? { depends_on: over.depends_on } : {}),
+  };
+}
+
+/** Spawn a 3-slice convoy and return everything the tests need to drive
+ *  subtask state. Build → Test, Build → Review. */
+function acceptThreeSliceConvoy(opts: { ws: string; initId: string }) {
+  seedAgent({ workspace: opts.ws, role: 'builder' });
+  seedAgent({ workspace: opts.ws, role: 'tester' });
+  seedAgent({ workspace: opts.ws, role: 'reviewer' });
+
+  const proposal = createProposal({
+    workspace_id: opts.ws,
+    trigger_text: '.',
+    trigger_kind: 'decompose_story',
+    impact_md: '.',
+    proposed_changes: [
+      {
+        kind: 'create_convoy_under_initiative',
+        initiative_id: opts.initId,
+        parent_acceptance_criteria: [
+          'Operator clicks Cancel on any in-flight card → card disappears.',
+          'Late agent reply does not resurrect the cancelled card.',
+        ],
+        slices: [
+          baseSlice({ id: 'build', role: 'builder', slice: 'Build slice one.' }),
+          baseSlice({ id: 'test', role: 'tester', slice: 'Test the build.', depends_on: ['build'] }),
+          baseSlice({ id: 'review', role: 'reviewer', slice: 'Review the build.', depends_on: ['build'] }),
+        ],
+      },
+    ],
+  });
+  const accepted = acceptProposal(proposal.id);
+  return { proposalId: accepted.proposal.id };
+}
+
+function getAcceptedProposal(id: string) {
+  // Re-load the post-apply diff list (capture state populated).
+  const proposal = queryOne<{ proposed_changes: string }>(
+    `SELECT proposed_changes FROM pm_proposals WHERE id = ?`,
+    [id],
+  )!;
+  return JSON.parse(proposal.proposed_changes) as PmDiff[];
+}
+
+function getChildTaskIds(initiativeId: string): string[] {
+  // Subtasks live under parent; their child task rows share the same
+  // initiative_id through inheritance. Easiest filter: is_subtask=1.
+  const rows = queryAll<{ id: string }>(
+    `SELECT t.id FROM tasks t
+       JOIN convoy_subtasks cs ON cs.task_id = t.id
+       JOIN convoys c ON c.id = cs.convoy_id
+       JOIN tasks pt ON pt.id = c.parent_task_id
+      WHERE pt.initiative_id = ?
+      ORDER BY cs.sort_order`,
+    [initiativeId],
+  );
+  return rows.map((r) => r.id);
+}
+
+// ─── Happy path ────────────────────────────────────────────────────
+
+test('cancel_convoy: revert with no done subtasks cancels convoy, deletes inbox children, leaves parent', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'Revertable' });
+  const { proposalId } = acceptThreeSliceConvoy({ ws, initId: init.id });
+
+  const parent = queryOne<{ id: string; status: string }>(
+    `SELECT id, status FROM tasks WHERE initiative_id = ? AND COALESCE(is_subtask,0)=0`,
+    [init.id],
+  )!;
+  const childIds = getChildTaskIds(init.id);
+  assert.equal(childIds.length, 3);
+
+  // Mark build (root) in_progress; leave test + review in inbox.
+  // Build is dispatched as the only root; the other two stay inbox via
+  // the dep gate.
+  run(`UPDATE tasks SET status = 'in_progress' WHERE id = ?`, [childIds[0]]);
+
+  // Drop a fake ack row to verify deletion.
+  run(
+    `INSERT INTO task_ac_acknowledgements (task_id, ac_index, ac_text, rationale, acknowledged_by, acknowledged_at)
+     VALUES (?, 0, 'AC #1', 'lgtm', 'operator', datetime('now'))`,
+    [parent.id],
+  );
+  assert.equal(
+    queryAll<{ id: number }>(`SELECT id FROM task_ac_acknowledgements WHERE task_id = ?`, [parent.id]).length,
+    1,
+  );
+
+  // Build the inverse and apply it through a revert proposal.
+  const forward = getAcceptedProposal(proposalId);
+  const { diffs, notes } = invertProposalDiffs(forward);
+  assert.equal(diffs.length, 1);
+  assert.equal(diffs[0].kind, 'cancel_convoy');
+  // Sanity: the inverse note is 'inverted', not 'limited'.
+  assert.equal(notes[0].status, 'inverted');
+
+  const revert = createProposal({
+    workspace_id: ws,
+    trigger_text: 'revert',
+    trigger_kind: 'revert',
+    impact_md: '.',
+    proposed_changes: diffs,
+    reverts_proposal_id: proposalId,
+  });
+  acceptProposal(revert.id);
+
+  // Convoy → 'failed'.
+  const convoy = queryOne<{ id: string; status: string }>(
+    `SELECT id, status FROM convoys WHERE parent_task_id = ?`,
+    [parent.id],
+  )!;
+  assert.equal(convoy.status, 'failed');
+
+  // Build (in_progress) → 'cancelled'. Test + Review (inbox) → DELETED.
+  const buildTask = queryOne<{ id: string; status: string }>(
+    `SELECT id, status FROM tasks WHERE id = ?`,
+    [childIds[0]],
+  );
+  assert.ok(buildTask);
+  assert.equal(buildTask!.status, 'cancelled');
+  for (const inboxId of [childIds[1], childIds[2]]) {
+    const t = queryOne<{ id: string }>(`SELECT id FROM tasks WHERE id = ?`, [inboxId]);
+    assert.equal(t, undefined, `inbox subtask ${inboxId} should be deleted`);
+  }
+
+  // Parent task survives.
+  const parentAfter = queryOne<{ id: string; status: string }>(
+    `SELECT id, status FROM tasks WHERE id = ?`,
+    [parent.id],
+  );
+  assert.ok(parentAfter, 'parent task must NOT be deleted on revert');
+
+  // Acks gone.
+  assert.equal(
+    queryAll<{ id: number }>(`SELECT id FROM task_ac_acknowledgements WHERE task_id = ?`, [parent.id]).length,
+    0,
+  );
+});
+
+// ─── Refuse: any done subtask ──────────────────────────────────────
+
+test('cancel_convoy: refuses revert when any subtask is done; transaction rolls back', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'Has-done' });
+  const { proposalId } = acceptThreeSliceConvoy({ ws, initId: init.id });
+
+  const childIds = getChildTaskIds(init.id);
+  // Flip build to 'done'; leave the other two in inbox.
+  run(`UPDATE tasks SET status = 'done' WHERE id = ?`, [childIds[0]]);
+
+  const forward = getAcceptedProposal(proposalId);
+  const { diffs } = invertProposalDiffs(forward);
+  const revert = createProposal({
+    workspace_id: ws,
+    trigger_text: 'revert',
+    trigger_kind: 'revert',
+    impact_md: '.',
+    proposed_changes: diffs,
+    reverts_proposal_id: proposalId,
+  });
+
+  assert.throws(
+    () => acceptProposal(revert.id),
+    (e: unknown) => {
+      assert.ok(e instanceof PmProposalValidationError);
+      assert.match((e as Error).message, /already reached 'done'/);
+      return true;
+    },
+  );
+
+  // Nothing changed: convoy still 'active', inbox tasks NOT deleted.
+  const convoy = queryOne<{ id: string; status: string }>(
+    `SELECT id, status FROM convoys WHERE parent_task_id IN (SELECT id FROM tasks WHERE initiative_id = ?)`,
+    [init.id],
+  )!;
+  assert.equal(convoy.status, 'active');
+  for (const inboxId of [childIds[1], childIds[2]]) {
+    const t = queryOne<{ id: string; status: string }>(
+      `SELECT id, status FROM tasks WHERE id = ?`,
+      [inboxId],
+    );
+    assert.ok(t, `inbox subtask ${inboxId} should still exist after refused revert`);
+    assert.equal(t!.status, 'inbox');
+  }
+});
+
+test('cancel_convoy: refuses even when only one of N subtasks is done', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'Partial done' });
+  const { proposalId } = acceptThreeSliceConvoy({ ws, initId: init.id });
+
+  const childIds = getChildTaskIds(init.id);
+  // Build done, test in_progress, review inbox — mixed state.
+  run(`UPDATE tasks SET status = 'done' WHERE id = ?`, [childIds[0]]);
+  run(`UPDATE tasks SET status = 'in_progress' WHERE id = ?`, [childIds[1]]);
+
+  const forward = getAcceptedProposal(proposalId);
+  const { diffs } = invertProposalDiffs(forward);
+  const revert = createProposal({
+    workspace_id: ws,
+    trigger_text: 'revert',
+    trigger_kind: 'revert',
+    impact_md: '.',
+    proposed_changes: diffs,
+    reverts_proposal_id: proposalId,
+  });
+
+  assert.throws(() => acceptProposal(revert.id), PmProposalValidationError);
+
+  // The in_progress + inbox tasks must still exist (transaction rolled back).
+  const inProg = queryOne<{ status: string }>(
+    `SELECT status FROM tasks WHERE id = ?`,
+    [childIds[1]],
+  );
+  assert.equal(inProg?.status, 'in_progress');
+  const review = queryOne<{ status: string }>(
+    `SELECT status FROM tasks WHERE id = ?`,
+    [childIds[2]],
+  );
+  assert.equal(review?.status, 'inbox');
+});
+
+// ─── Back-compat: no acks recorded ────────────────────────────────
+
+test('cancel_convoy: succeeds when parent task has no AC acknowledgements recorded', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'No-acks' });
+  const { proposalId } = acceptThreeSliceConvoy({ ws, initId: init.id });
+
+  const parent = queryOne<{ id: string }>(
+    `SELECT id FROM tasks WHERE initiative_id = ? AND COALESCE(is_subtask,0)=0`,
+    [init.id],
+  )!;
+
+  // No insert into task_ac_acknowledgements at all.
+  assert.equal(
+    queryAll<{ id: number }>(`SELECT id FROM task_ac_acknowledgements WHERE task_id = ?`, [parent.id]).length,
+    0,
+  );
+
+  const forward = getAcceptedProposal(proposalId);
+  const { diffs } = invertProposalDiffs(forward);
+  const revert = createProposal({
+    workspace_id: ws,
+    trigger_text: 'revert',
+    trigger_kind: 'revert',
+    impact_md: '.',
+    proposed_changes: diffs,
+    reverts_proposal_id: proposalId,
+  });
+  // Should not throw.
+  acceptProposal(revert.id);
+
+  const convoy = queryOne<{ status: string }>(
+    `SELECT status FROM convoys WHERE parent_task_id = ?`,
+    [parent.id],
+  )!;
+  assert.equal(convoy.status, 'failed');
+});
+
+// ─── Idempotent: convoy already cancelled ─────────────────────────
+
+test('cancel_convoy: idempotent when convoy already failed', () => {
+  const ws = freshWorkspace();
+  const init = createInitiative({ workspace_id: ws, kind: 'story', title: 'Already failed' });
+  const { proposalId } = acceptThreeSliceConvoy({ ws, initId: init.id });
+
+  const parent = queryOne<{ id: string }>(
+    `SELECT id FROM tasks WHERE initiative_id = ? AND COALESCE(is_subtask,0)=0`,
+    [init.id],
+  )!;
+  // Pre-cancel the convoy via another path.
+  run(`UPDATE convoys SET status = 'failed' WHERE parent_task_id = ?`, [parent.id]);
+
+  const forward = getAcceptedProposal(proposalId);
+  const { diffs } = invertProposalDiffs(forward);
+  const revert = createProposal({
+    workspace_id: ws,
+    trigger_text: 'revert',
+    trigger_kind: 'revert',
+    impact_md: '.',
+    proposed_changes: diffs,
+    reverts_proposal_id: proposalId,
+  });
+  acceptProposal(revert.id); // no throw
+
+  const convoy = queryOne<{ status: string }>(
+    `SELECT status FROM convoys WHERE parent_task_id = ?`,
+    [parent.id],
+  )!;
+  assert.equal(convoy.status, 'failed');
+});
+
+// ─── Schema: cancel_convoy is revert-only ─────────────────────────
+
+test('cancel_convoy: rejected by validator on non-revert proposals', () => {
+  const ws = freshWorkspace();
+  // Need at least a valid convoy_id / parent_task_id in the diff
+  // shape, but the validator should reject on trigger_kind alone before
+  // looking at the refs.
+  assert.throws(
+    () =>
+      createProposal({
+        workspace_id: ws,
+        trigger_text: '.',
+        trigger_kind: 'manual',
+        impact_md: '.',
+        proposed_changes: [
+          {
+            kind: 'cancel_convoy',
+            convoy_id: 'nonexistent',
+            parent_task_id: 'nonexistent',
+            subtask_child_task_ids: [],
+          },
+        ],
+      }),
+    (e: unknown) => {
+      assert.ok(e instanceof PmProposalValidationError);
+      assert.match((e as Error).message, /Invalid proposed_changes/);
+      return true;
+    },
+  );
+});
+
+// ─── Pre-capture: missing convoy_id surfaces as 'limited' ─────────
+
+test('invertProposalDiffs: returns limited when capture state is missing', () => {
+  // Simulate a pre-capture / partial-apply proposal where the create
+  // diff didn't record created_convoy_id.
+  const forward: PmDiff[] = [
+    {
+      kind: 'create_convoy_under_initiative',
+      initiative_id: 'init-x',
+      parent_acceptance_criteria: ['x'.repeat(15)],
+      slices: [],
+      // no created_convoy_id / created_parent_task_id
+    } as unknown as PmDiff,
+  ];
+  const { diffs, notes } = invertProposalDiffs(forward);
+  assert.equal(diffs.length, 0);
+  assert.equal(notes.length, 1);
+  assert.equal(notes[0].status, 'limited');
+  assert.match(notes[0].reason ?? '', /pre-capture/);
+});

--- a/src/lib/pm/invertDiff.ts
+++ b/src/lib/pm/invertDiff.ts
@@ -249,15 +249,40 @@ function invertOne(diff: PmDiff, index: number): InvertedDiff {
     }
 
     case 'create_convoy_under_initiative': {
-      // PM convoy mandate slice 2: revert semantics for this diff kind
-      // are out of scope here — they land in slice 7 alongside the
-      // updated pm-revertable-proposals spec ("cancel the convoy +
-      // delete unscheduled child tasks; refuse revert if any slice has
-      // reached done"). Surface a limited marker so the chain renders
-      // without claiming a false inverse.
+      // PM convoy mandate — full revert. Capture state populated by
+      // applyCreateConvoyUnderInitiative gives us everything we need:
+      // convoy_id, parent_task_id, and the symbolic → real subtask map.
+      // The synthesized cancel_convoy diff runs atomically inside
+      // acceptProposal's outer transaction — refusal on any 'done'
+      // subtask rolls the whole revert back. See
+      // docs/reference/pm-revertable-proposals.md for the apply rules.
+      if (!diff.created_convoy_id || !diff.created_parent_task_id) {
+        return limited(
+          index,
+          'pre-capture proposal: convoy_id or parent_task_id was not recorded',
+        );
+      }
+      const subtaskChildTaskIds = (diff.created_subtasks ?? []).map((s) => s.child_task_id);
+      return {
+        original_index: index,
+        status: 'inverted',
+        inverse: {
+          kind: 'cancel_convoy',
+          convoy_id: diff.created_convoy_id,
+          parent_task_id: diff.created_parent_task_id,
+          subtask_child_task_ids: subtaskChildTaskIds,
+        },
+      };
+    }
+
+    case 'cancel_convoy': {
+      // Reverting a revert: we don't synthesize an "uncancel" because
+      // the forward cancel already deleted inbox children and cascaded
+      // their convoy_subtasks rows. A clean re-decomposition is the
+      // right operator move, not a synthetic reinstate.
       return limited(
         index,
-        'create_convoy_under_initiative revert not yet implemented (slice 7 of pm-convoy-mandate)',
+        'cancel_convoy revert is not modeled — re-decompose the parent task to re-spawn the convoy',
       );
     }
 


### PR DESCRIPTION
## Summary

Replaces the `limited` revert marker for `create_convoy_under_initiative` with a working `cancel_convoy` inverse. Deferred follow-up from slice 6 of the PM convoy mandate ([`docs/reference/pm-convoy-mandate.md`](docs/reference/pm-convoy-mandate.md)); parent context is PR #356.

On revert of an accepted convoy proposal, `invertProposalDiffs` now synthesizes a new revert-only diff kind `cancel_convoy`. The apply path runs inside the existing `acceptProposal` SQLite transaction and:

1. Refuses the revert (`PmProposalValidationError`) when any subtask child task has reached `done` — names the blocker(s) and rolls back atomically.
2. Marks the convoy `failed` (idempotent against an already-cancelled convoy).
3. For each subtask: `inbox` → `DELETE` (FK-cascades the `convoy_subtasks` row); other non-`done` statuses → `cancelled` so in-flight agent work has a clean terminus.
4. Deletes `task_ac_acknowledgements` for the parent task (the acks were scoped to the now-revoked convoy ACs).

**No new migration** — the existing capture state (`created_convoy_id`, `created_parent_task_id`, `created_subtasks[].child_task_id`) populated by the slice-2 apply pass is sufficient.

**Parent task preservation (decision).** The revert deliberately does NOT delete or cancel the parent task, even when the original convoy apply auto-created it from a story initiative. The orphaned parent is highly visible (sits in `convoy_active` / `review` with zero live subtasks) and one click away from operator cleanup; tracking auto-create provenance would require a marker column and threading through both apply and revert paths. Rationale and an escape hatch (an `auto_created_for_convoy_id` column) are documented in [`docs/reference/pm-revertable-proposals.md § create_convoy_under_initiative → cancel_convoy`](docs/reference/pm-revertable-proposals.md).

## Changes

- `src/lib/db/pm-proposals.ts` — new `cancel_convoy` `PmDiff` variant; validator branch rejects it on non-revert proposals; apply branch in `applyDiff`.
- `src/lib/pm/invertDiff.ts` — `create_convoy_under_initiative` now produces a `cancel_convoy` inverse instead of the `limited` marker; `cancel_convoy` itself is `limited` on its own inverse (re-decompose is the right operator move).
- `src/components/pm/ProposalDiffsList.tsx` — new `CANCEL CONVOY` chip + tooltip.
- `docs/reference/pm-revertable-proposals.md` — replaced the "deferred" note with the now-real behavior + parent-preservation rationale; bumped `last-verified` to 2026-05-14.
- `docs/reference/pm-convoy-mandate.md` — "Revert semantics — current state" → "shipped"; spec-edits table marks the row as shipped.
- `src/lib/pm/invertDiff-convoy.test.ts` — new test file covering happy path, refuse-on-done, mid-state rollback, no-acks back-compat, idempotent re-revert, schema rejection, and pre-capture limited fallback.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `yarn test` (full suite): **1145 passing, 2 failing**. The 2 failures are pre-existing on `main` and called out in the task brief:
  - `POST: happy path threads note + audit-run provenance into chat metadata` (`ask-pm-from-notes`)
  - `schedule-runner: produces a brief and advances run_count`
- [x] `src/lib/pm` + `src/lib/db` slice: 331 passing, 0 failing — includes the 7 new `cancel_convoy` tests.
- [x] `yarn docs:check` — 0 violations.
- [ ] Preview-verify pass: not run. The change is mostly server-side; UI surface is a single new chip rendered by `ProposalDiffsList`. A `cancel_convoy` chip will render whenever a convoy revert proposal is rendered through this list.

## Parent context

- Mandate spec: [`docs/reference/pm-convoy-mandate.md`](docs/reference/pm-convoy-mandate.md)
- Revert contract: [`docs/reference/pm-revertable-proposals.md`](docs/reference/pm-revertable-proposals.md)
- Slice 6 PR (parent): #356