### PR TITLE
fix(pm): subscribe to openclaw session.tool events for live tool calls

### DIFF
--- a/src/components/DecomposeStoryToTasksModal.tsx
+++ b/src/components/DecomposeStoryToTasksModal.tsx
@@ -149,18 +149,24 @@ export default function DecomposeStoryToTasksModal({
     if (dispatchState !== 'pending_agent') return;
     const es = new EventSource('/api/events/stream');
     let cancelled = false;
-    const refetch = async () => {
+    /**
+     * Fetch a specific proposal by id and hydrate modal state. Prefer
+     * this over a resume-by-initiative lookup (which has filter logic
+     * — status='draft', json_extract — that can race with the
+     * supersede transaction's commit order). The SSE payload carries
+     * the new_id directly, so address it directly.
+     */
+    const fetchById = async (newId: string) => {
       try {
-        const url = `/api/pm/decompose-story?workspace_id=${encodeURIComponent(initiative.workspace_id)}&initiative_id=${encodeURIComponent(initiative.id)}`;
-        const res = await fetch(url);
+        const res = await fetch(`/api/pm/proposals/${encodeURIComponent(newId)}`);
         if (!res.ok) return;
-        const body = await res.json() as { proposal?: ProposalRow | null };
-        if (cancelled || !body?.proposal) return;
-        setProposalId(body.proposal.id);
-        setProposalCreatedAt(body.proposal.created_at);
-        setImpactMd(body.proposal.impact_md);
-        setTasks(body.proposal.proposed_changes);
-        setDispatchState(body.proposal.dispatch_state ?? null);
+        const proposal = await res.json() as ProposalRow | null;
+        if (cancelled || !proposal || !proposal.id) return;
+        setProposalId(proposal.id);
+        setProposalCreatedAt(proposal.created_at);
+        setImpactMd(proposal.impact_md);
+        setTasks(proposal.proposed_changes);
+        setDispatchState(proposal.dispatch_state ?? null);
       } catch {
         // best-effort
       }
@@ -172,7 +178,8 @@ export default function DecomposeStoryToTasksModal({
       if (!parsed || !parsed.type) return;
       if (parsed.type === 'pm_proposal_replaced') {
         const oldId = parsed.payload?.old_id as string | undefined;
-        if (oldId === proposalId) void refetch();
+        const newId = parsed.payload?.new_id as string | undefined;
+        if (oldId === proposalId && newId) void fetchById(newId);
       } else if (parsed.type === 'pm_proposal_dispatch_state_changed') {
         const id = parsed.payload?.proposal_id as string | undefined;
         const next = parsed.payload?.dispatch_state as 'pending_agent' | 'agent_complete' | 'synth_only' | undefined;

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -166,18 +166,24 @@ export default function DecomposeWithPmModal({
     if (dispatchState !== 'pending_agent') return;
     const es = new EventSource('/api/events/stream');
     let cancelled = false;
-    const refetch = async () => {
+    /**
+     * Fetch a specific proposal by id and hydrate modal state. Prefer
+     * this over a resume-by-initiative lookup which has filter logic
+     * (status='draft', json_extract on trigger_text) that can race
+     * with the supersede transaction's commit. The SSE payload
+     * carries new_id directly, so address it directly.
+     */
+    const fetchById = async (newId: string) => {
       try {
-        const url = `/api/pm/decompose-initiative?workspace_id=${encodeURIComponent(initiative.workspace_id)}&initiative_id=${encodeURIComponent(initiative.id)}`;
-        const res = await fetch(url);
+        const res = await fetch(`/api/pm/proposals/${encodeURIComponent(newId)}`);
         if (!res.ok) return;
-        const body = await res.json() as { proposal?: ProposalRow | null };
-        if (cancelled || !body?.proposal) return;
-        setProposalId(body.proposal.id);
-        setProposalCreatedAt(body.proposal.created_at);
-        setImpactMd(body.proposal.impact_md);
-        setChildren(body.proposal.proposed_changes);
-        setDispatchState(body.proposal.dispatch_state ?? null);
+        const proposal = await res.json() as ProposalRow | null;
+        if (cancelled || !proposal || !proposal.id) return;
+        setProposalId(proposal.id);
+        setProposalCreatedAt(proposal.created_at);
+        setImpactMd(proposal.impact_md);
+        setChildren(proposal.proposed_changes);
+        setDispatchState(proposal.dispatch_state ?? null);
       } catch {
         // Best-effort — operator can refresh manually.
       }
@@ -189,7 +195,8 @@ export default function DecomposeWithPmModal({
       if (!parsed || !parsed.type) return;
       if (parsed.type === 'pm_proposal_replaced') {
         const oldId = parsed.payload?.old_id as string | undefined;
-        if (oldId === proposalId) void refetch();
+        const newId = parsed.payload?.new_id as string | undefined;
+        if (oldId === proposalId && newId) void fetchById(newId);
       } else if (parsed.type === 'pm_proposal_dispatch_state_changed') {
         const id = parsed.payload?.proposal_id as string | undefined;
         const next = parsed.payload?.dispatch_state as 'pending_agent' | 'agent_complete' | 'synth_only' | undefined;

--- a/src/lib/agents/pm-dispatch.ts
+++ b/src/lib/agents/pm-dispatch.ts
@@ -766,21 +766,37 @@ function extractAgentReplyText(
 function summariseAgentEvent(
   event: AgentEvent,
 ): { tool: string; phase?: string; note?: string } | null {
-  const pickStr = (...keys: string[]): string | undefined => {
+  // openclaw's tool events carry the canonical shape:
+  //   { runId, stream: 'tool', sessionKey, data: { phase, name, toolCallId, args } }
+  // …so peek into `data` first. Older / non-tool agent_events may have
+  // these fields at the top level, which we still honor as a fallback.
+  const data = (event as { data?: Record<string, unknown> }).data ?? {};
+  const pickStrFrom = (
+    source: Record<string, unknown>,
+    ...keys: string[]
+  ): string | undefined => {
     for (const k of keys) {
-      const v = event[k];
+      const v = source[k];
       if (typeof v === 'string' && v.trim()) return v.trim();
     }
     return undefined;
   };
-  const tool = pickStr('tool', 'name', 'function', 'event', 'kind');
+
+  const tool =
+    pickStrFrom(data, 'name', 'tool', 'function') ??
+    pickStrFrom(event as Record<string, unknown>, 'tool', 'name', 'function', 'event', 'kind');
   if (!tool) return null;
 
-  const phase = pickStr('phase', 'step', 'state', 'status');
+  const phase =
+    pickStrFrom(data, 'phase', 'step', 'state', 'status') ??
+    pickStrFrom(event as Record<string, unknown>, 'phase', 'step', 'state', 'status');
 
   // Pull a short note from anything resembling a body / message /
-  // text field. Capped so we never broadcast a huge payload.
-  const noteRaw = pickStr('note', 'message', 'text', 'body', 'summary', 'description');
+  // text field. Tool-end events carry the result text in `data.text`
+  // or `data.summary`. Capped so we never broadcast a huge payload.
+  const noteRaw =
+    pickStrFrom(data, 'note', 'summary', 'text', 'message', 'body', 'description') ??
+    pickStrFrom(event as Record<string, unknown>, 'note', 'message', 'text', 'body', 'summary', 'description');
   const note = noteRaw ? noteRaw.slice(0, 200) : undefined;
 
   return { tool, phase, note };

--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -326,6 +326,24 @@ export class OpenClawClient extends EventEmitter {
                 metadata: { seq: data.seq, event: data.event },
               });
             }
+            // Tool lifecycle frames are broadcast on a dedicated channel
+            // when the gateway has session.* subscribers (we register
+            // via `sessions.subscribe` post-auth). The payload shape
+            // mirrors the `agent` channel so we re-emit it as the same
+            // `agent_event` for downstream consumers (pm-dispatch's
+            // onAgentEvent tap, etc.).
+            if (data.type === 'event' && data.event === 'session.tool' && data.payload) {
+              this.emit('agent_event', data.payload);
+              const sessionKey = (data.payload as { sessionKey?: string })?.sessionKey ?? null;
+              logDebugEvent({
+                type: 'agent.event',
+                direction: 'inbound',
+                taskId: extractTaskIdFromSessionKey(sessionKey),
+                sessionKey,
+                responseBody: data.payload,
+                metadata: { seq: data.seq, event: data.event, channel: 'session.tool' },
+              });
+            }
             if (data.type === 'event' && data.event === 'chat' && data.payload) {
               this.emit('chat_event', data.payload);
               const sessionKey = (data.payload as { sessionKey?: string })?.sessionKey ?? null;
@@ -420,6 +438,22 @@ export class OpenClawClient extends EventEmitter {
                       device_id: this.deviceIdentity?.deviceId ?? null,
                     },
                   });
+                  // Subscribe to session.* events (incl. session.tool) so
+                  // the gateway forwards live tool-call frames. Without
+                  // this, only the generic `agent` channel arrives —
+                  // which the gateway routes ONLY to clients that
+                  // registered as run-scoped tool recipients or session
+                  // subscribers (see openclaw server-chat.ts ~line 656).
+                  // Fire-and-forget: if it fails we still get chat
+                  // deltas via the unconditional `chat` broadcast.
+                  this.call('sessions.subscribe').then(
+                    () => {
+                      console.log('[OpenClaw] Subscribed to session events (tool calls + results)');
+                    },
+                    (err) => {
+                      console.warn('[OpenClaw] sessions.subscribe failed (tool events will be missing):', err instanceof Error ? err.message : err);
+                    },
+                  );
                   resolve();
                 },
                 reject: (error: Error) => {


### PR DESCRIPTION
## Summary

The InFlightProposalCard activity panel was silent during PM dispatches even when openclaw's webchat clearly showed the agent calling tools (operator-confirmed by watching the gateway session URL while the dispatch ran).

## Root cause

From openclaw's `server-chat.ts` ~L644-680: when `evt.stream === "tool"`, the gateway broadcasts to:

(a) connections registered as run-scoped tool-event recipients, or  
(b) connections that subscribed via `sessions.subscribe` (channel: `session.tool`).

The unconditional `broadcast("agent", ...)` call only fires for non-tool agent events. MC's client did neither (a) nor (b), so it saw thinking + item events but never tool starts / ends.

## Changes

1. **Post-auth `sessions.subscribe` in `src/lib/openclaw/client.ts`** — fire-and-forget RPC immediately after auth resolves. Fail-soft: chat deltas still arrive via the unconditional `chat` broadcast even if subscribe fails.

2. **Re-emit `session.tool` frames as `agent_event`** so downstream consumers (pm-dispatch's `onAgentEvent` tap, the `pm_dispatch_in_flight` broadcaster, the InFlightProposalCard subscription) don't need new code paths. Same DTO shape; just an additional source channel.

3. **`summariseAgentEvent` now peeks into `event.data`** for tool metadata. openclaw's shape is `{ runId, stream: 'tool', sessionKey, data: { phase, name, toolCallId, args } }` — name/phase live one level deeper than the old heuristic expected. Top-level fallback preserved for back-compat with other agent_event shapes.

## Test plan

- `npx tsc --noEmit` — clean.
- Manual: after a fresh dev-server restart, open Create tasks with PM on a story. The in-flight card should now stream `→ read_notes (start)`, `→ propose_changes (start)`, etc. matching what the openclaw webchat URL shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)