### PR TITLE
fix(pm): wire InFlightProposalCard.onReplaced(newId) → modal refetch

### DIFF
--- a/src/components/DecomposeStoryToTasksModal.tsx
+++ b/src/components/DecomposeStoryToTasksModal.tsx
@@ -18,7 +18,7 @@ import { formatApiError } from '@/lib/format-api-error';
  *   - POST /api/pm/proposals/[id]/accept    (apply transactionally)
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Sparkles, Send, RefreshCw, RotateCw, Plus, Trash2, ArrowUp, ArrowDown, X } from 'lucide-react';
 import { InFlightProposalCard } from '@/components/InFlightProposalCard';
 import { ConvoyDiffPreview, pickConvoyDiffs, type ConvoyDiff } from '@/components/ConvoyDiffPreview';
@@ -142,45 +142,48 @@ export default function DecomposeStoryToTasksModal({
     };
   }, [initiative.id, initiative.workspace_id, initialHint, agentId]);
 
-  // SSE: when the named-agent reply lands, swap the synth placeholder for
-  // the agent's row. Mirrors DecomposeWithPmModal.
+  /**
+   * Fetch a specific proposal by id and hydrate modal state. Used by:
+   *   (a) the InFlightProposalCard's `onReplaced(newId)` callback after
+   *       the named-agent's row supersedes the synth placeholder;
+   *   (b) future callers needing a direct proposal swap.
+   *
+   * Prefer this over a resume-by-initiative lookup — that endpoint
+   * filters by `status='draft' AND json_extract(trigger_text, ...)`
+   * which has historically raced with the supersede transaction's
+   * commit order. The per-proposal GET has no filter, no race.
+   */
+  const fetchById = useCallback(async (newId: string) => {
+    try {
+      const res = await fetch(`/api/pm/proposals/${encodeURIComponent(newId)}`);
+      if (!res.ok) return;
+      const proposal = await res.json() as ProposalRow | null;
+      if (!proposal || !proposal.id) return;
+      setProposalId(proposal.id);
+      setProposalCreatedAt(proposal.created_at);
+      setImpactMd(proposal.impact_md);
+      setTasks(proposal.proposed_changes);
+      setDispatchState(proposal.dispatch_state ?? null);
+    } catch {
+      // best-effort
+    }
+  }, []);
+
+  // SSE: listen for `pm_proposal_dispatch_state_changed` so the named-
+  // agent timeout (synth_only fallback) flips the modal out of the
+  // in-flight render path. Replacement events arrive through
+  // InFlightProposalCard's onReplaced callback (see render below) —
+  // single source of truth for the agent-finished signal.
   useEffect(() => {
     if (!proposalId) return;
-    if (dispatchState !== 'pending_agent') return;
     const es = new EventSource('/api/events/stream');
     let cancelled = false;
-    /**
-     * Fetch a specific proposal by id and hydrate modal state. Prefer
-     * this over a resume-by-initiative lookup (which has filter logic
-     * — status='draft', json_extract — that can race with the
-     * supersede transaction's commit order). The SSE payload carries
-     * the new_id directly, so address it directly.
-     */
-    const fetchById = async (newId: string) => {
-      try {
-        const res = await fetch(`/api/pm/proposals/${encodeURIComponent(newId)}`);
-        if (!res.ok) return;
-        const proposal = await res.json() as ProposalRow | null;
-        if (cancelled || !proposal || !proposal.id) return;
-        setProposalId(proposal.id);
-        setProposalCreatedAt(proposal.created_at);
-        setImpactMd(proposal.impact_md);
-        setTasks(proposal.proposed_changes);
-        setDispatchState(proposal.dispatch_state ?? null);
-      } catch {
-        // best-effort
-      }
-    };
     es.onmessage = (ev) => {
       if (cancelled) return;
       let parsed: { type?: string; payload?: Record<string, unknown> } | null = null;
       try { parsed = JSON.parse(ev.data); } catch { return; }
       if (!parsed || !parsed.type) return;
-      if (parsed.type === 'pm_proposal_replaced') {
-        const oldId = parsed.payload?.old_id as string | undefined;
-        const newId = parsed.payload?.new_id as string | undefined;
-        if (oldId === proposalId && newId) void fetchById(newId);
-      } else if (parsed.type === 'pm_proposal_dispatch_state_changed') {
+      if (parsed.type === 'pm_proposal_dispatch_state_changed') {
         const id = parsed.payload?.proposal_id as string | undefined;
         const next = parsed.payload?.dispatch_state as 'pending_agent' | 'agent_complete' | 'synth_only' | undefined;
         if (id === proposalId && next) setDispatchState(next);
@@ -190,7 +193,7 @@ export default function DecomposeStoryToTasksModal({
       cancelled = true;
       es.close();
     };
-  }, [proposalId, dispatchState, initiative.id, initiative.workspace_id]);
+  }, [proposalId]);
 
   // Stash onClose in a ref so the keydown subscription doesn't churn
   // on every parent render — same fix as Drawer.tsx.
@@ -420,6 +423,7 @@ export default function DecomposeStoryToTasksModal({
               onUseSynthFallback={() => {
                 setDispatchState('synth_only');
               }}
+              onReplaced={(newId) => { void fetchById(newId); }}
             />
           ) : (() => {
             // Convoy mandate (slice 4): split diffs by kind so convoy DAGs

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -31,7 +31,7 @@ import { formatApiError } from '@/lib/format-api-error';
  * superseded chain — the modal swaps in the new proposal's diffs.
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Sparkles, Send, RefreshCw, RotateCw, Plus, Trash2, ArrowUp, ArrowDown, X } from 'lucide-react';
 import { InFlightProposalCard } from '@/components/InFlightProposalCard';
 import { ConvoyDiffPreview, pickConvoyDiffs, type ConvoyDiff } from '@/components/ConvoyDiffPreview';
@@ -156,48 +156,47 @@ export default function DecomposeWithPmModal({
     };
   }, [initiative.id, initiative.workspace_id, initialHint]);
 
-  // Tier 3 of pm-dispatch-async. While the synth placeholder is pending the
-  // named-agent reply, listen for `pm_proposal_replaced` SSE events. When
-  // the agent's row supersedes the placeholder, swap to the new id and
-  // refetch its content (now resolvable because supersede also copies
-  // trigger_text). Mirrors the PlanWithPmPanel hookup.
+  /**
+   * Fetch a specific proposal by id and hydrate modal state. Called by
+   * the InFlightProposalCard's `onReplaced(newId)` callback once the
+   * named-agent's row supersedes the synth placeholder.
+   *
+   * Prefer this over a resume-by-initiative lookup — that endpoint
+   * filters by `status='draft' AND json_extract(trigger_text, ...)`
+   * which has raced with the supersede transaction's commit in
+   * practice. The per-proposal GET has no filter, no race.
+   */
+  const fetchById = useCallback(async (newId: string) => {
+    try {
+      const res = await fetch(`/api/pm/proposals/${encodeURIComponent(newId)}`);
+      if (!res.ok) return;
+      const proposal = await res.json() as ProposalRow | null;
+      if (!proposal || !proposal.id) return;
+      setProposalId(proposal.id);
+      setProposalCreatedAt(proposal.created_at);
+      setImpactMd(proposal.impact_md);
+      setChildren(proposal.proposed_changes);
+      setDispatchState(proposal.dispatch_state ?? null);
+    } catch {
+      // Best-effort — operator can refresh manually.
+    }
+  }, []);
+
+  // SSE: listen for `pm_proposal_dispatch_state_changed` so the named-
+  // agent timeout (synth_only fallback) flips the modal out of the
+  // in-flight render path. Replacement events arrive through
+  // InFlightProposalCard's onReplaced callback — single source of
+  // truth for the agent-finished signal.
   useEffect(() => {
     if (!proposalId) return;
-    if (dispatchState !== 'pending_agent') return;
     const es = new EventSource('/api/events/stream');
     let cancelled = false;
-    /**
-     * Fetch a specific proposal by id and hydrate modal state. Prefer
-     * this over a resume-by-initiative lookup which has filter logic
-     * (status='draft', json_extract on trigger_text) that can race
-     * with the supersede transaction's commit. The SSE payload
-     * carries new_id directly, so address it directly.
-     */
-    const fetchById = async (newId: string) => {
-      try {
-        const res = await fetch(`/api/pm/proposals/${encodeURIComponent(newId)}`);
-        if (!res.ok) return;
-        const proposal = await res.json() as ProposalRow | null;
-        if (cancelled || !proposal || !proposal.id) return;
-        setProposalId(proposal.id);
-        setProposalCreatedAt(proposal.created_at);
-        setImpactMd(proposal.impact_md);
-        setChildren(proposal.proposed_changes);
-        setDispatchState(proposal.dispatch_state ?? null);
-      } catch {
-        // Best-effort — operator can refresh manually.
-      }
-    };
     es.onmessage = (ev) => {
       if (cancelled) return;
       let parsed: { type?: string; payload?: Record<string, unknown> } | null = null;
       try { parsed = JSON.parse(ev.data); } catch { return; }
       if (!parsed || !parsed.type) return;
-      if (parsed.type === 'pm_proposal_replaced') {
-        const oldId = parsed.payload?.old_id as string | undefined;
-        const newId = parsed.payload?.new_id as string | undefined;
-        if (oldId === proposalId && newId) void fetchById(newId);
-      } else if (parsed.type === 'pm_proposal_dispatch_state_changed') {
+      if (parsed.type === 'pm_proposal_dispatch_state_changed') {
         const id = parsed.payload?.proposal_id as string | undefined;
         const next = parsed.payload?.dispatch_state as 'pending_agent' | 'agent_complete' | 'synth_only' | undefined;
         if (id === proposalId && next) setDispatchState(next);
@@ -207,7 +206,7 @@ export default function DecomposeWithPmModal({
       cancelled = true;
       es.close();
     };
-  }, [proposalId, dispatchState, initiative.id, initiative.workspace_id]);
+  }, [proposalId]);
 
   // Esc to close. Stash onClose in a ref so the keydown subscription
   // doesn't churn on every parent render (caller-supplied onClose is
@@ -443,6 +442,7 @@ export default function DecomposeWithPmModal({
                 // appears with the synth template populated.
                 setDispatchState('synth_only');
               }}
+              onReplaced={(newId) => { void fetchById(newId); }}
             />
           ) : (() => {
             // Convoy mandate (slice 4): split convoy DAGs from

--- a/src/components/InFlightProposalCard.tsx
+++ b/src/components/InFlightProposalCard.tsx
@@ -38,9 +38,11 @@ export interface InFlightProposalCardProps {
   onCancel: () => void;
   /** Callback when the operator clicks "Use Synth Fallback" in synth_only state. */
   onUseSynthFallback?: () => void;
-  /** Optional: called when the card transitions to replaced so the parent can
-   *  clean up any in-flight state. */
-  onReplaced?: () => void;
+  /** Optional: called when the card transitions to replaced so the parent
+   *  can refetch / clean up. The new proposal id from the
+   *  `pm_proposal_replaced` SSE payload is passed through, so the parent
+   *  can GET the agent's row directly without re-deriving it. */
+  onReplaced?: (newProposalId: string) => void;
   /** Optional: additional metadata row to show in the card body. */
   extraContent?: React.ReactNode;
 }
@@ -113,10 +115,11 @@ export function InFlightProposalCard({
       // pm_proposal_replaced: fade out and hand off.
       if (parsed.type === 'pm_proposal_replaced') {
         const oldId = parsed.payload?.old_id as string | undefined;
+        const newId = parsed.payload?.new_id as string | undefined;
         if (oldId === proposalId && parsed.payload?.workspace_id === workspaceId) {
           setFadeOut(true);
           setState('replaced');
-          onReplaced?.();
+          if (newId) onReplaced?.(newId);
         }
       }
 


### PR DESCRIPTION
## Summary

Operator hit the empty-modal symptom again even after #363's switch to fetch-by-new_id. The InFlightProposalCard caught the SSE replace frame correctly (fade-to-opacity-0), but the modal's own SSE handler never fired — closure-deps race, or effect-tear-down beat the event. Two SSE listeners on the same channel for the same signal is structural noise.

## Fix

Single source of truth: the InFlightProposalCard owns the replacement signal.

- `InFlightProposalCard.onReplaced?: (newProposalId: string) => void` — passes the new id through from the same SSE payload it already reads for the fade-out transition.
- Both decompose modals now expose a `fetchById(newId)` useCallback that hydrates state from `GET /api/pm/proposals/[id]`. The card binds onReplaced to it. Moment the card sees the replace frame, the modal refetches.
- Modals' own SSE effects shrink to just `pm_proposal_dispatch_state_changed` (the synth_only fallback signal). Replacement is no longer modal business.

## Files

- `src/components/InFlightProposalCard.tsx` — onReplaced signature + payload destructuring
- `src/components/DecomposeStoryToTasksModal.tsx` — fetchById useCallback + onReplaced wiring + SSE shrink
- `src/components/DecomposeWithPmModal.tsx` — same

## Test plan

- `npx tsc --noEmit` — clean.
- Manual: fresh "Create tasks with PM" on a story → in-flight card streams tool calls (PR #363) → agent finishes → card fades out AND the convoy preview renders without "empty modal".

🤖 Generated with [Claude Code](https://claude.com/claude-code)