### PR TITLE
fix(pm): belt-and-suspenders SSE listener in decompose modals

### DIFF
--- a/src/components/DecomposeStoryToTasksModal.tsx
+++ b/src/components/DecomposeStoryToTasksModal.tsx
@@ -169,13 +169,21 @@ export default function DecomposeStoryToTasksModal({
     }
   }, []);
 
-  // SSE: listen for `pm_proposal_dispatch_state_changed` so the named-
-  // agent timeout (synth_only fallback) flips the modal out of the
-  // in-flight render path. Replacement events arrive through
-  // InFlightProposalCard's onReplaced callback (see render below) —
-  // single source of truth for the agent-finished signal.
+  // SSE listener:
+  //   - `pm_proposal_dispatch_state_changed` → flips the modal out of
+  //     the in-flight render path on synth_only timeout.
+  //   - `pm_proposal_replaced` → belt-and-suspenders fallback to the
+  //     InFlightProposalCard's onReplaced callback. The card-driven path
+  //     should fire first; if the card has unmounted, churned its
+  //     EventSource between cleanup and resubscribe, or otherwise missed
+  //     the frame, this independent listener still triggers fetchById.
+  //
+  // proposalIdRef avoids re-running the effect every time proposalId
+  // changes — otherwise we'd churn the EventSource and risk missing the
+  // very replace frame we're listening for.
+  const proposalIdRef = useRef<string | null>(null);
+  proposalIdRef.current = proposalId;
   useEffect(() => {
-    if (!proposalId) return;
     const es = new EventSource('/api/events/stream');
     let cancelled = false;
     es.onmessage = (ev) => {
@@ -183,17 +191,25 @@ export default function DecomposeStoryToTasksModal({
       let parsed: { type?: string; payload?: Record<string, unknown> } | null = null;
       try { parsed = JSON.parse(ev.data); } catch { return; }
       if (!parsed || !parsed.type) return;
+      const currentId = proposalIdRef.current;
+      if (!currentId) return;
       if (parsed.type === 'pm_proposal_dispatch_state_changed') {
         const id = parsed.payload?.proposal_id as string | undefined;
         const next = parsed.payload?.dispatch_state as 'pending_agent' | 'agent_complete' | 'synth_only' | undefined;
-        if (id === proposalId && next) setDispatchState(next);
+        if (id === currentId && next) setDispatchState(next);
+      } else if (parsed.type === 'pm_proposal_replaced') {
+        const oldId = parsed.payload?.old_id as string | undefined;
+        const newId = parsed.payload?.new_id as string | undefined;
+        if (oldId === currentId && newId) {
+          void fetchById(newId);
+        }
       }
     };
     return () => {
       cancelled = true;
       es.close();
     };
-  }, [proposalId]);
+  }, [fetchById]);
 
   // Stash onClose in a ref so the keydown subscription doesn't churn
   // on every parent render — same fix as Drawer.tsx.

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -182,13 +182,14 @@ export default function DecomposeWithPmModal({
     }
   }, []);
 
-  // SSE: listen for `pm_proposal_dispatch_state_changed` so the named-
-  // agent timeout (synth_only fallback) flips the modal out of the
-  // in-flight render path. Replacement events arrive through
-  // InFlightProposalCard's onReplaced callback — single source of
-  // truth for the agent-finished signal.
+  // SSE listener: same belt-and-suspenders pattern as
+  // DecomposeStoryToTasksModal — handle both dispatch_state_changed and
+  // pm_proposal_replaced here as a fallback to the card's onReplaced.
+  // proposalIdRef avoids effect churn that would otherwise risk missing
+  // the replace frame.
+  const proposalIdRef = useRef<string | null>(null);
+  proposalIdRef.current = proposalId;
   useEffect(() => {
-    if (!proposalId) return;
     const es = new EventSource('/api/events/stream');
     let cancelled = false;
     es.onmessage = (ev) => {
@@ -196,17 +197,25 @@ export default function DecomposeWithPmModal({
       let parsed: { type?: string; payload?: Record<string, unknown> } | null = null;
       try { parsed = JSON.parse(ev.data); } catch { return; }
       if (!parsed || !parsed.type) return;
+      const currentId = proposalIdRef.current;
+      if (!currentId) return;
       if (parsed.type === 'pm_proposal_dispatch_state_changed') {
         const id = parsed.payload?.proposal_id as string | undefined;
         const next = parsed.payload?.dispatch_state as 'pending_agent' | 'agent_complete' | 'synth_only' | undefined;
-        if (id === proposalId && next) setDispatchState(next);
+        if (id === currentId && next) setDispatchState(next);
+      } else if (parsed.type === 'pm_proposal_replaced') {
+        const oldId = parsed.payload?.old_id as string | undefined;
+        const newId = parsed.payload?.new_id as string | undefined;
+        if (oldId === currentId && newId) {
+          void fetchById(newId);
+        }
       }
     };
     return () => {
       cancelled = true;
       es.close();
     };
-  }, [proposalId]);
+  }, [fetchById]);
 
   // Esc to close. Stash onClose in a ref so the keydown subscription
   // doesn't churn on every parent render (caller-supplied onClose is


### PR DESCRIPTION
## Summary

After PR #364, the empty-modal symptom still reproduced. The InFlightProposalCard clearly received the pm_proposal_replaced frame (visible "Proposal replaced" + opacity-0 transition), but the modal's fetchById never ran — so dispatchState stayed 'pending_agent' and the in-flight card stayed in the render path.

## Hypothesis

The card's SSE useEffect has `onReplaced` in its deps. The parent modal passes a fresh inline arrow `(newId) => fetchById(newId)` on every render, so the card's EventSource churns: cleanup → new subscribe → cleanup → new subscribe. Across the brief window where the replace frame arrives, the listener instance that DID see the event was a stale closure with a stale onReplaced reference, OR the cleanup happened mid-handler. The visible state transition came from a different effect instance than the one that should have called the callback.

## Fix

Restore an independent SSE listener inside each modal — gated on a `proposalIdRef.current` ref instead of reactive state. The ref keeps the effect deps stable (`[fetchById]` only, and fetchById is a useCallback with `[]`), so the listener mounts once and survives the entire in-flight phase. No churn, no stale closure window.

The card's onReplaced is left in place as the primary path; this is a belt-and-suspenders fallback that handles both `pm_proposal_replaced` and `pm_proposal_dispatch_state_changed`.

## Files

- `src/components/DecomposeStoryToTasksModal.tsx`
- `src/components/DecomposeWithPmModal.tsx`

## Test plan

- `npx tsc --noEmit` — clean.
- Manual: trigger fresh **Create tasks with PM** → expect the in-flight card → agent reply → modal renders the agent's convoy without "empty body".

🤖 Generated with [Claude Code](https://claude.com/claude-code)