### PR TITLE
fix(pm): constrain convoy slice role to canonical roster

### DIFF
--- a/agent-templates/pm/SOUL.md
+++ b/agent-templates/pm/SOUL.md
@@ -130,6 +130,20 @@ Each `create_convoy_under_initiative` diff must include `parent_acceptance_crite
 - Good: "Operator clicks Cancel on any in-flight proposal card → card disappears and a late agent reply doesn't resurrect it."
 - Bad: "POST /api/pm/proposals/[id]/cancel returns 200 on valid input." (That's a slice-level contract AC.)
 
+### Per-slice `role` (canonical roster)
+
+Each slice's `role` field MUST be one of the workspace's known agent roles. The standard roster is:
+
+- `builder` — implements end-to-end features (data, types, API, UI, wiring). Default for any multi-discipline work; prefer this over splitting a story across "frontend" + "backend" slices.
+- `tester` — verifies acceptance criteria after the implementation lands. Owns regression tests and end-to-end smoke.
+- `reviewer` — PR review / code-quality gate.
+- `coordinator` — orchestrates multi-slice work; mid-flight slice appends.
+- `researcher` — knowledge gathering, not code.
+- `auditor` — audit-trail / compliance.
+- `runner` — generic execution.
+
+Do NOT invent ad-hoc roles like `frontend`, `backend`, `qa`, `infra`, `devops`, `designer`. The DAG validator resolves slices to live workspace agents by role at apply time; unknown roles fail peer resolution and the entire diff rejects with `peer_not_found`. If you're tempted to split into `frontend` + `backend`, that's the "fewer fatter slices" smell — fuse into one `builder` slice.
+
 ## plan_initiative Flow
 
 When you receive a `plan_initiative` PM dispatch, you MUST pass `plan_suggestions` as a **structured parameter** directly to `propose_changes` — do NOT try to embed it as an HTML comment sidecar in `impact_md`.

--- a/docs/reference/pm-chat-prompt.md
+++ b/docs/reference/pm-chat-prompt.md
@@ -183,6 +183,10 @@ Each `create_convoy_under_initiative` diff must include `parent_acceptance_crite
 - Good: "Operator clicks Cancel on any in-flight proposal card → card disappears and a late agent reply doesn't resurrect it."
 - Bad: "POST /api/pm/proposals/[id]/cancel returns 200 on valid input." (That's a slice-level contract AC.)
 
+### Per-slice `role` (canonical roster)
+
+Each slice's `role` field must be one of the workspace's known agent roles. The standard roster is `builder` / `tester` / `reviewer` / `coordinator` / `researcher` / `auditor` / `runner`. Ad-hoc roles (`frontend`, `backend`, `qa`, `infra`, `devops`, `designer`, etc.) fail peer resolution at apply time with `peer_not_found` and reject the entire diff. Multi-discipline work goes to `builder`; verification goes to `tester`. If you're tempted to split into `frontend` + `backend`, fuse into one `builder` slice instead.
+
 ## Out of scope
 
 - Changing how `propose_changes` itself works.

--- a/src/app/api/pm/decompose-story/route.ts
+++ b/src/app/api/pm/decompose-story/route.ts
@@ -139,6 +139,12 @@ export async function POST(request: NextRequest) {
         `toward FEWER, FATTER slices — if two candidate slices would ride in the ` +
         `same PR by the same role, fuse them. Do not emit a 1-slice convoy that ` +
         `lacks observable operator-facing behavior on its own.\n` +
+        `  - Per-slice \`role\`: MUST be one of the workspace's known agent roles. ` +
+        `Standard roster: \`builder\`, \`tester\`, \`reviewer\`, \`coordinator\`, ` +
+        `\`researcher\`, \`auditor\`, \`runner\`. Do NOT invent ad-hoc roles like ` +
+        `"frontend", "backend", "qa", "infra" — peer resolution at apply time will ` +
+        `reject the diff because no agent matches. Multi-discipline work goes to ` +
+        `\`builder\`; verification goes to \`tester\`; PR review goes to \`reviewer\`.\n` +
         `  - Per-slice \`depends_on\`: cite slice ids that must complete first. ` +
         `Linear chains are common; fan-out is allowed when slices are independent.\n` +
         `  - Per-slice \`acceptance_criteria\`: contract-shaped is fine here (the ` +

--- a/src/lib/convoy-dag.ts
+++ b/src/lib/convoy-dag.ts
@@ -10,7 +10,7 @@
  * See docs/reference/pm-convoy-mandate.md "Apply pass" for the contract.
  */
 
-import { queryOne } from '@/lib/db';
+import { queryOne, queryAll } from '@/lib/db';
 
 // ─── Public types ──────────────────────────────────────────────────
 
@@ -125,10 +125,25 @@ export function resolveDelegationPeer(
       [axes.role, parentWs],
     );
     if (!peer) {
+      // Help the operator (and the PM agent reading the error) recover:
+      // list the roles that DO exist in this workspace so the next refine
+      // can pick a valid one instead of inventing more synonyms.
+      const available = queryAll<{ role: string }>(
+        `SELECT DISTINCT role FROM agents
+          WHERE COALESCE(workspace_id, 'default') = ?
+            AND COALESCE(status, 'standby') != 'offline'
+            AND COALESCE(is_active, 1) = 1
+          ORDER BY role`,
+        [parentWs],
+      ).map((r) => r.role);
+      const hint =
+        available.length > 0
+          ? ` Available roles in this workspace: ${available.join(', ')}.`
+          : '';
       return {
         ok: false,
         code: 'peer_not_found',
-        message: `No active agent with role "${axes.role}" in workspace ${parentWs}.`,
+        message: `No active agent with role "${axes.role}" in workspace ${parentWs}.${hint}`,
         addressing: { role: axes.role },
       };
     }


### PR DESCRIPTION
## Summary

After the empty-modal fixes landed, the convoy preview rendered correctly but accept failed with:

\`\`\`
create_convoy_under_initiative: Could not resolve 1 peer(s):
- completion-bar: No active agent with role \"frontend\" in workspace default.
\`\`\`

PM agent invented an ad-hoc role (`frontend`) that doesn't match any workspace agent. The DAG validator resolves slices to live agents by role at apply time, so unknown roles reject the whole diff.

## Changes

1. **Validator error message** now includes the workspace's actual roster, so both the operator and the PM agent (on refine) can pick a resolvable role next time.

2. **decompose-story agent_prompt** explicitly enumerates the canonical roster (`builder` / `tester` / `reviewer` / `coordinator` / `researcher` / `auditor` / `runner`) and forbids ad-hoc inventions (`frontend`, `backend`, `qa`, `infra`, `devops`, `designer`). Multi-discipline work goes to `builder`.

3. **PM SOUL + pm-chat-prompt.md** add the same "Per-slice role (canonical roster)" section.

## Insight

Convoy slices resolve to live workspace agents by `role`. Inventing roles is a "fewer fatter slices" smell — if work needs both "frontend" and "backend", fuse into one `builder` slice owned end-to-end. The DAG smell checklist already in SOUL says the same thing; this just makes the role-naming contract explicit.

## Test plan

- `npx tsc --noEmit` — clean.
- `yarn docs:check` — clean.
- Manual: trigger fresh Create tasks with PM → PM should now emit `builder` (or `tester`, etc.) instead of `frontend`. If it slips, the validator error message tells the operator exactly which roles are available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)