### PR TITLE
feat(pm): inline role editor on each convoy slice in the proposal modal

### DIFF
--- a/src/components/ConvoyDiffPreview.tsx
+++ b/src/components/ConvoyDiffPreview.tsx
@@ -113,18 +113,51 @@ function peerLabel(s: ConvoySliceInput): string {
   return '∅';
 }
 
+/**
+ * Workspace's canonical agent roster. Slices' `role` field must match
+ * one of these for peer resolution to succeed at apply time. The PM
+ * agent is instructed (in pm/SOUL.md + decompose-story prompt) to pick
+ * from this list; the inline editor below offers it as a dropdown so
+ * the operator can fix ad-hoc inventions without going through Refine.
+ */
+const CANONICAL_ROLES = [
+  'builder',
+  'tester',
+  'reviewer',
+  'coordinator',
+  'researcher',
+  'auditor',
+  'runner',
+] as const;
+
 function SliceRow({
   slice,
   index,
   defaultExpanded,
+  onEdit,
 }: {
   slice: ConvoySliceInput;
   index: number;
   defaultExpanded: boolean;
+  /** When provided, the role pill becomes an inline dropdown editor. */
+  onEdit?: (sliceId: string, patch: Partial<ConvoySliceInput>) => void;
 }) {
   const [expanded, setExpanded] = React.useState(defaultExpanded);
   const deps = slice.depends_on ?? [];
   const evidenceGates = slice.required_evidence_gates ?? [];
+  // If the slice's current role is non-canonical (e.g. agent emitted
+  // "frontend"), surface it in the dropdown alongside the canonical
+  // roles so the operator can see what was inferred and pick a
+  // resolvable value.
+  const currentRole = slice.role ?? '';
+  const roleOptions = React.useMemo(() => {
+    const base = [...CANONICAL_ROLES];
+    if (currentRole && !base.includes(currentRole as typeof CANONICAL_ROLES[number])) {
+      return [currentRole, ...base];
+    }
+    return base;
+  }, [currentRole]);
+  const isCanonical = (CANONICAL_ROLES as readonly string[]).includes(currentRole);
   return (
     <li className="rounded border border-mc-border bg-mc-bg p-3 space-y-1.5">
       <div className="flex items-center gap-2 flex-wrap">
@@ -134,9 +167,33 @@ function SliceRow({
         <span className="font-mono text-xs text-mc-text shrink-0" title="Slice symbolic id">
           {slice.id}
         </span>
-        <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded-sm border border-violet-500/30 bg-violet-500/15 text-violet-200 shrink-0">
-          {peerLabel(slice)}
-        </span>
+        {onEdit ? (
+          <select
+            value={currentRole}
+            onChange={(e) => onEdit(slice.id, { role: e.target.value })}
+            title={
+              isCanonical
+                ? 'Reassign to a different canonical role'
+                : `"${currentRole}" is not in the workspace roster — pick a canonical role so the convoy can dispatch.`
+            }
+            className={
+              'text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded-sm border shrink-0 cursor-pointer bg-mc-bg ' +
+              (isCanonical
+                ? 'border-violet-500/30 bg-violet-500/15 text-violet-200 hover:border-violet-500/60'
+                : 'border-red-500/40 bg-red-500/15 text-red-200 hover:border-red-500/60')
+            }
+          >
+            {roleOptions.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded-sm border border-violet-500/30 bg-violet-500/15 text-violet-200 shrink-0">
+            {peerLabel(slice)}
+          </span>
+        )}
         <span className="text-[11px] text-mc-text-secondary shrink-0">
           ~{slice.expected_duration_minutes}min
         </span>
@@ -239,10 +296,25 @@ export interface ConvoyDiffPreviewProps {
    * operator clicks "More" per row (modal mode).
    */
   expanded?: boolean;
+  /**
+   * When provided, the role pill on each slice becomes an inline
+   * dropdown editor. The callback receives the slice id and a partial
+   * patch — currently only `{ role }` — for the parent modal to apply
+   * to its local diff state. The modal's existing PUT /diffs flow on
+   * accept persists the change.
+   *
+   * Pass `undefined` to keep the preview read-only (detail page).
+   */
+  onSliceEdit?: (sliceId: string, patch: Partial<ConvoySliceInput>) => void;
   className?: string;
 }
 
-export function ConvoyDiffPreview({ diff, expanded = false, className }: ConvoyDiffPreviewProps) {
+export function ConvoyDiffPreview({
+  diff,
+  expanded = false,
+  onSliceEdit,
+  className,
+}: ConvoyDiffPreviewProps) {
   const ordered = React.useMemo(() => topoOrderSlices(diff.slices), [diff.slices]);
   return (
     <div className={className ?? 'space-y-4'}>
@@ -271,6 +343,7 @@ export function ConvoyDiffPreview({ diff, expanded = false, className }: ConvoyD
               slice={slice}
               index={i}
               defaultExpanded={expanded}
+              onEdit={onSliceEdit}
             />
           ))}
         </ul>

--- a/src/components/DecomposeStoryToTasksModal.tsx
+++ b/src/components/DecomposeStoryToTasksModal.tsx
@@ -21,7 +21,12 @@ import { formatApiError } from '@/lib/format-api-error';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Sparkles, Send, RefreshCw, RotateCw, Plus, Trash2, ArrowUp, ArrowDown, X } from 'lucide-react';
 import { InFlightProposalCard } from '@/components/InFlightProposalCard';
-import { ConvoyDiffPreview, pickConvoyDiffs, type ConvoyDiff } from '@/components/ConvoyDiffPreview';
+import {
+  ConvoyDiffPreview,
+  pickConvoyDiffs,
+  type ConvoyDiff,
+  type ConvoySliceInput,
+} from '@/components/ConvoyDiffPreview';
 
 interface InitiativeLite {
   id: string;
@@ -141,6 +146,30 @@ export default function DecomposeStoryToTasksModal({
       cancelled = true;
     };
   }, [initiative.id, initiative.workspace_id, initialHint, agentId]);
+
+  /**
+   * Apply a per-slice edit (currently just `role`) to whichever
+   * `create_convoy_under_initiative` diff in `tasks` owns the slice.
+   * The modal's existing accept flow persists `tasks` via PUT /diffs
+   * before POSTing accept, so this just needs to mutate local state.
+   */
+  const editConvoySlice = useCallback(
+    (sliceId: string, patch: Partial<ConvoySliceInput>) => {
+      setTasks((prev) =>
+        prev.map((diff) => {
+          if (diff.kind !== 'create_convoy_under_initiative') return diff;
+          const convoy = diff as ConvoyDiff;
+          return {
+            ...convoy,
+            slices: convoy.slices.map((s) =>
+              s.id === sliceId ? { ...s, ...patch } : s,
+            ),
+          } as typeof diff;
+        }),
+      );
+    },
+    [],
+  );
 
   /**
    * Fetch a specific proposal by id and hydrate modal state. Used by:
@@ -461,7 +490,12 @@ export default function DecomposeStoryToTasksModal({
               {convoyDiffs.length > 0 && (
                 <div className="shrink-0 max-h-[40vh] overflow-y-auto pr-1">
                   {convoyDiffs.map((d, i) => (
-                    <ConvoyDiffPreview key={i} diff={d} className="space-y-3 mb-3" />
+                    <ConvoyDiffPreview
+                      key={i}
+                      diff={d}
+                      onSliceEdit={editConvoySlice}
+                      className="space-y-3 mb-3"
+                    />
                   ))}
                 </div>
               )}
@@ -486,7 +520,7 @@ export default function DecomposeStoryToTasksModal({
                 {tasks.length === 0 ? (
                   <p className="text-sm text-mc-text-secondary">No tasks proposed. Add one manually above or refine below.</p>
                 ) : flatTasks.length === 0 ? (
-                  <p className="text-sm text-mc-text-secondary">Convoy plan is read-only here — use Refine to revise.</p>
+                  <p className="text-sm text-mc-text-secondary">Click a slice&apos;s role badge to reassign; use Refine for deeper changes.</p>
                 ) : (
                   <ul className="flex-1 min-h-0 overflow-y-auto space-y-2 pr-1">
                     {tasks.map((c, i) => {

--- a/src/components/DecomposeWithPmModal.tsx
+++ b/src/components/DecomposeWithPmModal.tsx
@@ -34,7 +34,12 @@ import { formatApiError } from '@/lib/format-api-error';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Sparkles, Send, RefreshCw, RotateCw, Plus, Trash2, ArrowUp, ArrowDown, X } from 'lucide-react';
 import { InFlightProposalCard } from '@/components/InFlightProposalCard';
-import { ConvoyDiffPreview, pickConvoyDiffs, type ConvoyDiff } from '@/components/ConvoyDiffPreview';
+import {
+  ConvoyDiffPreview,
+  pickConvoyDiffs,
+  type ConvoyDiff,
+  type ConvoySliceInput,
+} from '@/components/ConvoyDiffPreview';
 
 interface InitiativeLite {
   id: string;
@@ -155,6 +160,30 @@ export default function DecomposeWithPmModal({
       cancelled = true;
     };
   }, [initiative.id, initiative.workspace_id, initialHint]);
+
+  /**
+   * Apply a per-slice edit (currently just `role`) to whichever
+   * `create_convoy_under_initiative` diff in `children` owns the slice.
+   * The modal's existing accept flow persists `children` via PUT /diffs
+   * before POSTing accept, so this just needs to mutate local state.
+   */
+  const editConvoySlice = useCallback(
+    (sliceId: string, patch: Partial<ConvoySliceInput>) => {
+      setChildren((prev) =>
+        prev.map((diff) => {
+          if (diff.kind !== 'create_convoy_under_initiative') return diff;
+          const convoy = diff as ConvoyDiff;
+          return {
+            ...convoy,
+            slices: convoy.slices.map((s) =>
+              s.id === sliceId ? { ...s, ...patch } : s,
+            ),
+          } as typeof diff;
+        }),
+      );
+    },
+    [],
+  );
 
   /**
    * Fetch a specific proposal by id and hydrate modal state. Called by
@@ -473,7 +502,12 @@ export default function DecomposeWithPmModal({
               {convoyDiffs.length > 0 && (
                 <div className="shrink-0 max-h-[40vh] overflow-y-auto pr-1">
                   {convoyDiffs.map((d, i) => (
-                    <ConvoyDiffPreview key={i} diff={d} className="space-y-3 mb-3" />
+                    <ConvoyDiffPreview
+                      key={i}
+                      diff={d}
+                      onSliceEdit={editConvoySlice}
+                      className="space-y-3 mb-3"
+                    />
                   ))}
                 </div>
               )}
@@ -498,7 +532,7 @@ export default function DecomposeWithPmModal({
                 {children.length === 0 ? (
                   <p className="text-sm text-mc-text-secondary">No children proposed. Add one manually above or refine below.</p>
                 ) : childInitiatives.length === 0 ? (
-                  <p className="text-sm text-mc-text-secondary">Convoy plan is read-only here — use Refine to revise.</p>
+                  <p className="text-sm text-mc-text-secondary">Click a slice&apos;s role badge to reassign; use Refine for deeper changes.</p>
                 ) : (
                   <ul className="flex-1 min-h-0 overflow-y-auto space-y-2 pr-1">
                     {children.map((c, i) => {


### PR DESCRIPTION
## Summary

Operator wants to manually reassign a slice's agent role without re-rolling the proposal via Discard & regenerate. Common case: PM emitted an ad-hoc role (\`frontend\`) that fails peer resolution at apply time — flip to \`builder\` in place and accept.

## Changes

- **ConvoyDiffPreview**: new \`onSliceEdit?: (sliceId, patch) => void\` prop. When provided, each slice's role pill becomes an inline dropdown. The canonical roster (\`builder\`, \`tester\`, \`reviewer\`, \`coordinator\`, \`researcher\`, \`auditor\`, \`runner\`) is the option set. Any non-canonical role already on the slice is included too, red-tinted, so the operator can see what the agent invented before picking a resolvable value. Tooltip explains the action.

- **DecomposeStoryToTasksModal + DecomposeWithPmModal**: \`editConvoySlice(sliceId, patch)\` useCallback mutates the local diff list. The existing accept flow already persists that list via PUT \`/api/pm/proposals/[id]/diffs\` before POSTing accept, so no new persistence wiring.

- **Detail page** (\`/pm/proposals/[id]\`): keeps the read-only preview (deep-review context; not an accept surface).

- Copy "Convoy plan is read-only here — use Refine to revise." → "Click a slice's role badge to reassign; use Refine for deeper changes."

## Test plan

- \`npx tsc --noEmit\` — clean.
- Manual: open Create tasks with PM → click the role badge on any slice → pick \`builder\` (or any canonical role) → Accept dispatches without peer-resolution rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)