### PR TITLE
feat(initiatives): completion percentage bar (xx/yy children)

### DIFF
--- a/src/app/(app)/initiatives/page.tsx
+++ b/src/app/(app)/initiatives/page.tsx
@@ -52,6 +52,7 @@ import PlanWithPmPanel, { type PlanInitiativeSuggestions } from '@/components/Pl
 import DecomposeWithPmModal from '@/components/DecomposeWithPmModal';
 import { showAlertDialog } from '@/lib/show-alert';
 import { useCurrentWorkspaceId } from '@/components/shell/workspace-context';
+import { CompletionPercentageBar } from '@/components/CompletionPercentageBar';
 
 // Local types (kept separate from src/lib/types.ts so Phase 1 doesn't touch
 // the central type module — Phase 2 can promote these once the broader API
@@ -1407,6 +1408,13 @@ function InitiativeRow({
                 <ClipboardList className="w-3 h-3" />
                 {node.pending_proposal_count} pending
               </span>
+            )}
+            {isContainer && (
+              <CompletionPercentageBar
+                initiativeId={node.id}
+                variant="compact"
+                size="sm"
+              />
             )}
           </div>
           <div

--- a/src/components/CompletionPercentageBar.tsx
+++ b/src/components/CompletionPercentageBar.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCompletionPercentage } from '@/hooks/useCompletionPercentage';
+
+/**
+ * Completion percentage bar — displays "X/Y done" with a visual progress
+ * bar.  Reusable on initiative cards (tree rows) and detail pages.
+ *
+ * Props:
+ *   - initiativeId: the initiative whose children to count
+ *   - variant: "compact" (inline, no bar) or "full" (bar + label)
+ *   - size: "sm" (tree row) or "md" (detail page)
+ *   - className: additional Tailwind classes
+ */
+
+interface CompletionPercentageBarProps {
+  initiativeId: string;
+  /** Render style. "compact" shows just the label; "full" shows bar + label. */
+  variant?: 'compact' | 'full';
+  /** Visual size. "sm" for tree rows, "md" for detail pages. */
+  size?: 'sm' | 'md';
+  /** Extra Tailwind classes applied to the root element. */
+  className?: string;
+}
+
+const VARIANT_STYLES: Record<'compact' | 'full', string> = {
+  compact: '',
+  full: 'flex items-center gap-2',
+};
+
+interface SizeStyle {
+  barHeight: string;
+  label: string;
+  barWidth: string;
+}
+
+const SIZE_STYLES: Record<'sm' | 'md', SizeStyle> = {
+  sm: {
+    barHeight: 'h-1',
+    label: 'text-[10px] text-mc-text-secondary',
+    barWidth: 'w-16',
+  },
+  md: {
+    barHeight: 'h-2',
+    label: 'text-xs text-mc-text-secondary',
+    barWidth: 'w-24',
+  },
+};
+
+export function CompletionPercentageBar({
+  initiativeId,
+  variant = 'full',
+  size = 'md',
+  className = '',
+}: CompletionPercentageBarProps) {
+  const { done, total, percentage, label } = useCompletionPercentage(initiativeId);
+  const barStyle = SIZE_STYLES[size];
+
+  // Edge case: zero children → show "0/0" with an empty bar.
+  const barWidthPercent = total === 0 ? 0 : percentage;
+
+  return (
+    <div className={`${VARIANT_STYLES[variant]} ${className}`}>
+      {variant === 'full' && (
+        <div
+          className={`${barStyle.barWidth} ${barStyle.barHeight} bg-mc-bg-tertiary rounded-full overflow-hidden`}
+        >
+          <div
+            className={`h-full rounded-full ${
+              done === total && total > 0
+                ? 'bg-green-500'
+                : done > 0
+                  ? 'bg-blue-500'
+                  : 'bg-mc-text-secondary/30'
+            }`}
+            style={{ width: `${barWidthPercent}%` }}
+          />
+        </div>
+      )}
+      <span className={barStyle.label} title={`${done} of ${total} children completed`}>
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/src/components/InitiativeDetailView.tsx
+++ b/src/components/InitiativeDetailView.tsx
@@ -62,6 +62,7 @@ import {
   InlineDate,
 } from '@/components/inline/InlineEdit';
 import { SplitToolbarButton } from '@/components/inline/SplitToolbarButton';
+import { CompletionPercentageBar } from '@/components/CompletionPercentageBar';
 // Reuse the action modals defined alongside the list page — Move / Convert /
 // AddDep / History still make sense as focused dialogs since they have
 // non-trivial side effects beyond a simple field write.
@@ -985,7 +986,14 @@ or "carve out the onboarding flow as its own story first"`}
 
         {/* Children */}
         {initiative.children && initiative.children.length > 0 && (
-          <Section id="children" title={`Children (${initiative.children.length})`}>
+          <Section id="children" title="Children">
+            <div className="mb-3">
+              <CompletionPercentageBar
+                initiativeId={initiative.id}
+                variant="full"
+                size="md"
+              />
+            </div>
             <ul className="space-y-1">
               {initiative.children.map(c => (
                 <li

--- a/src/hooks/useCompletionPercentage.ts
+++ b/src/hooks/useCompletionPercentage.ts
@@ -1,0 +1,75 @@
+'use client';
+
+/**
+ * Data hook for computing initiative completion percentage.
+ *
+ * Reads children of a given initiative and counts how many are `done`
+ * (ignores `cancelled` and all other statuses).
+ *
+ * Returns:
+ *   - `done`: number of children with status === 'done'
+ *   - `total`: total number of non-archived children
+ *   - `percentage`: integer 0–100 (0 when total === 0)
+ *   - `label`: human-readable string like "3/7 done"
+ *
+ * Real-time updates: TODO. MC doesn't currently broadcast
+ * `initiative_created` / `_updated` / `_deleted` SSE events, so the
+ * hook can't subscribe to a live feed today. The label refreshes on
+ * mount and whenever `initiativeId` changes; for in-place updates the
+ * parent surface needs to re-key/re-mount, or this hook needs to
+ * subscribe to a future initiative-level SSE channel. Either path is a
+ * separate piece of work — track via the initiative-events build plan.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+
+export interface CompletionResult {
+  done: number;
+  total: number;
+  percentage: number;
+  label: string;
+}
+
+function computeLabel(done: number, total: number): string {
+  if (total === 0) return '0/0';
+  return `${done}/${total} done`;
+}
+
+function computePercentage(done: number, total: number): number {
+  if (total === 0) return 0;
+  return Math.round((done / total) * 100);
+}
+
+export function useCompletionPercentage(initiativeId: string | null): CompletionResult {
+  const [done, setDone] = useState(0);
+  const [total, setTotal] = useState(0);
+
+  const fetchChildren = useCallback(async (id: string) => {
+    try {
+      const res = await fetch(`/api/initiatives/${encodeURIComponent(id)}?include=children`);
+      if (!res.ok) return;
+      const data = await res.json();
+      const children = (data.children ?? []) as Array<{ id: string; status: string }>;
+      setTotal(children.length);
+      setDone(children.filter((c) => c.status === 'done').length);
+    } catch {
+      // Non-fatal — leave stale values until the next mount / id change.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!initiativeId) {
+      setDone(0);
+      setTotal(0);
+      return;
+    }
+    fetchChildren(initiativeId);
+  }, [initiativeId, fetchChildren]);
+
+  return {
+    done,
+    total,
+    percentage: computePercentage(done, total),
+    label: computeLabel(done, total),
+  };
+}


### PR DESCRIPTION
## Summary

Salvages the work that the stalled-builder dispatch produced for the "Initiative completion percentage bar (xx/yy children)" task. The agent's logic was sound but two bugs blocked it from shipping cleanly — and it never registered the deliverables, which is what stalled the convoy in the first place (separate fix in #368 means future builders won't repeat that).

## Triage of the 5 uncommitted files

| File | Verdict |
|---|---|
| `src/components/CompletionPercentageBar.tsx` | Keep, fix typing |
| `src/hooks/useCompletionPercentage.ts` | Keep, drop broken SSE listener |
| `src/hooks/useSSE.ts` | **Revert** — added cases for non-existent SSE event types |
| `src/app/(app)/initiatives/page.tsx` | Keep wiring (badge in InitiativeRow) |
| `src/components/InitiativeDetailView.tsx` | Keep wiring (badge in Children section) |

## Fixes

- `SIZE_STYLES` and `VARIANT_STYLES` were declared `Record<string, string>` but hold objects — TS errored on every consumer. Now properly typed.
- `useCompletionPercentage` was listening for `initiative_created` / `initiative_updated` / `initiative_deleted` SSE events that MC doesn't broadcast. Dropped the listener; hook is now fetch-on-mount with a TODO for real-time updates (would need MC to emit initiative-level SSE first).

## Followup

Real-time refresh of the bar is a separate piece of work — needs initiative-level SSE events broadcast on initiative status changes. Today the bar refreshes when its parent surface re-mounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)