### PR TITLE
fix(dispatch): convoy children transition to 'done' (not 'review' / 'testing')

### DIFF
--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -513,7 +513,26 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const isBuilder = !isCoordinator && (!currentStage || currentStage.role === 'builder' || task.status === 'assigned');
     const isTester = !isCoordinator && currentStage?.role === 'tester';
     const isVerifier = !isCoordinator && (currentStage?.role === 'verifier' || currentStage?.role === 'reviewer');
-    const nextStatus = nextStage?.status || 'review';
+    // Convoy-child detection. When workflow_template_id is NULL (PR #346
+    // strips it on convoy children) the task lifecycle is owned by the
+    // convoy machinery, not a stage template. The slice completes by
+    // transitioning straight to `done`; checkConvoyCompletion in
+    // src/lib/convoy.ts auto-promotes the parent task to `review` when
+    // every sibling subtask is `done`. If the briefing says `review` (the
+    // null-workflow fallback) the agent might transition there
+    // prematurely, breaking the auto-promote rail. Worse, observed in
+    // dogfood: the LLM can ignore the briefing entirely and guess
+    // `testing` from generic SDLC intuition — which has no consumer in a
+    // convoy and leaves the task pinging the same builder forever.
+    const isConvoyChild = Boolean(
+      queryOne<{ task_id: string }>(
+        `SELECT task_id FROM convoy_subtasks WHERE task_id = ? LIMIT 1`,
+        [id],
+      ),
+    );
+    const nextStatus = isConvoyChild
+      ? 'done'
+      : nextStage?.status || 'review';
     const failEndpoint = `POST ${missionControlUrl}/api/tasks/${task.id}/fail`;
 
     // Prescribed verification commands (slice 2 of the autonomous-flow
@@ -996,6 +1015,7 @@ ${criteria.length > 0 ? criteria.map(c => `  - ${c}`).join('\n') : '  - (none de
 - **Expected duration:** ${contract.expected_duration_minutes} minutes (due at ${contract.due_at ?? 'unset'})
 - **Check-in cadence:** call \`log_activity\` at least every ${contract.checkin_interval_minutes ?? 15} minutes with a substantive note. Silence past 2\u00D7 cadence = drift alert to coordinator.
 - **Your \`subtask_id\`:** \`${contract.id}\` — referenced automatically by register_deliverable and fail_task.
+- **Terminal status for THIS slice is \`done\`** (NOT \`testing\`, NOT \`review\`). The convoy machinery (\`checkConvoyCompletion\` in src/lib/convoy.ts) auto-promotes the parent task to \`review\` once every sibling subtask is \`done\`. Step 3 of your closing sequence MUST use \`status: "done"\`.
 
 **If the slice is wrong:** do not sub-delegate, do not improvise. Call \`fail_task\` with \`reason: "redecompose: <specific ask>"\`, optionally mail the coordinator with suggestions, and stop. The coordinator will re-plan.
 `;


### PR DESCRIPTION
## What happened

After #368 fixed the namespaced-tool issue, the stalled convoy actually progressed for the first time:

- Builder ran 37 minutes, called 7 MC tools (read_notes, register_deliverable ×3, log_activity, get_task, update_task_status). ✅ #368 working.
- But it transitioned the task to **`testing`** instead of `done`. The convoy never closes.
- Stall watcher kept re-dispatching the same builder against `status='testing'` because no other agent picks up the slice.

## Root cause (two compounding bugs)

1. **Briefing fallback was wrong for convoy children.** `workflow_template_id` is NULL (PR #346 strips it on convoy children) → `nextStage` is undefined → the briefing's fallback was `nextStatus = 'review'`. But the convoy machinery (`checkConvoyCompletion` in `src/lib/convoy.ts`) only auto-promotes the parent to `review` when every sibling subtask is **`done`**. A subtask transitioning to `review` itself never trips the rail.

2. **The agent ignored the briefing anyway** and went with `'testing'` from generic SDLC intuition. Nothing in the prompt told the LLM that `done` is the ONLY allowed terminal for a convoy slice.

## Fix

- `isConvoyChild` computed once per dispatch (single-row `convoy_subtasks` query). When true, `nextStatus = 'done'`.
- Delegation contract section now includes an explicit bullet: "**Terminal status for THIS slice is `done`** (NOT `testing`, NOT `review`)" with a pointer to `checkConvoyCompletion` as the auto-promote rail. Belt-and-suspenders against the LLM guessing.

## Test plan

- `npx tsc --noEmit` — clean.
- I manually reset the stuck task `7a2eb552` from `testing` → `in_progress`. Next stall-watcher tick (~16 min) re-dispatches with the new briefing; the builder should transition to `done`, the convoy should close, and the parent should auto-promote to `review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)