### PR TITLE
fix(agent-health): treat MCP tool activity as proof-of-life

### DIFF
--- a/src/lib/agent-health.test.ts
+++ b/src/lib/agent-health.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for `checkAgentHealth` proof-of-life sources.
+ *
+ * Regression: previously the watcher only inspected `task_activities` to
+ * decide if an agent was alive — but `register_deliverable` and
+ * `take_note` (the most common MCP call sites for "I am working") write
+ * to `task_deliverables` / `task_notes` instead. An agent actively
+ * registering deliverables would be flagged `stalled` → `stuck` and the
+ * stall watcher would re-dispatch, stomping on its in-flight progress.
+ *
+ * These tests pin the behavior: any of the three signals (activity,
+ * deliverable, note) within the threshold window keeps the agent
+ * `working`.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { run } from '@/lib/db';
+import { checkAgentHealth } from './agent-health';
+
+function uuid(): string {
+  return (globalThis.crypto ?? require('node:crypto')).randomUUID();
+}
+
+function seedWorkingAgent(): string {
+  const id = uuid();
+  run(
+    `INSERT INTO agents (id, name, role, workspace_id, is_active, status, created_at, updated_at)
+       VALUES (?, 'A', 'builder', 'default', 1, 'working', datetime('now'), datetime('now'))`,
+    [id],
+  );
+  return id;
+}
+
+function seedActiveTask(agentId: string, ageMinutes: number): string {
+  const id = uuid();
+  const past = new Date(Date.now() - ageMinutes * 60_000).toISOString();
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, assigned_agent_id, created_at, updated_at)
+       VALUES (?, 't', 'in_progress', 'normal', 'default', 'default', ?, ?, ?)`,
+    [id, agentId, past, past],
+  );
+  // Active openclaw_session row so the early-return doesn't tag 'zombie'
+  run(
+    `INSERT INTO openclaw_sessions (id, agent_id, openclaw_session_id, task_id, status, channel, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'active', 'mission-control', ?, ?)`,
+    [uuid(), agentId, `mc-${id}`, id, past, past],
+  );
+  return id;
+}
+
+function insertActivity(taskId: string, agentId: string, agoMinutes: number, message = 'real activity'): void {
+  const past = new Date(Date.now() - agoMinutes * 60_000).toISOString();
+  run(
+    `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, created_at)
+       VALUES (?, ?, ?, 'progress', ?, ?)`,
+    [uuid(), taskId, agentId, message, past],
+  );
+}
+
+function insertDeliverable(taskId: string, agoMinutes: number): void {
+  const past = new Date(Date.now() - agoMinutes * 60_000).toISOString();
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, storage_scheme, created_at)
+       VALUES (?, ?, 'file', 'd', 'inline', ?)`,
+    [uuid(), taskId, past],
+  );
+}
+
+function insertNote(taskId: string, agoMinutes: number): void {
+  const past = new Date(Date.now() - agoMinutes * 60_000).toISOString();
+  // agent_notes is what the take_note MCP tool writes to. Required cols:
+  // workspace_id, scope_key, role, run_group_id, kind (CHECK list), body.
+  run(
+    `INSERT INTO agent_notes (
+        id, workspace_id, agent_id, task_id, scope_key, role, run_group_id, kind, body, created_at
+      ) VALUES (?, 'default', NULL, ?, 'test-scope', 'builder', 'test-run', 'discovery', 'note body', ?)`,
+    [uuid(), taskId, past],
+  );
+}
+
+test('checkAgentHealth: recent task_activities row keeps agent working', () => {
+  const agentId = seedWorkingAgent();
+  const taskId = seedActiveTask(agentId, 30);
+  insertActivity(taskId, agentId, 1);
+  assert.equal(checkAgentHealth(agentId), 'working');
+});
+
+test('checkAgentHealth: recent task_deliverables row keeps agent working (regression)', () => {
+  const agentId = seedWorkingAgent();
+  const taskId = seedActiveTask(agentId, 30);
+  // No task_activities row at all — only a deliverable. Pre-fix this
+  // returned 'stuck' (taskAge > STUCK_THRESHOLD) because the watcher
+  // only looked at task_activities.
+  insertDeliverable(taskId, 1);
+  assert.equal(checkAgentHealth(agentId), 'working');
+});
+
+test('checkAgentHealth: recent task_notes row keeps agent working', () => {
+  const agentId = seedWorkingAgent();
+  const taskId = seedActiveTask(agentId, 30);
+  insertNote(taskId, 1);
+  assert.equal(checkAgentHealth(agentId), 'working');
+});
+
+test('checkAgentHealth: stale activity, fresh deliverable → working (max wins)', () => {
+  const agentId = seedWorkingAgent();
+  const taskId = seedActiveTask(agentId, 30);
+  insertActivity(taskId, agentId, 60); // way past stuck threshold
+  insertDeliverable(taskId, 1);
+  assert.equal(checkAgentHealth(agentId), 'working');
+});
+
+test('checkAgentHealth: all signals stale → stuck', () => {
+  const agentId = seedWorkingAgent();
+  const taskId = seedActiveTask(agentId, 60);
+  insertActivity(taskId, agentId, 60);
+  insertDeliverable(taskId, 60);
+  insertNote(taskId, 60);
+  assert.equal(checkAgentHealth(agentId), 'stuck');
+});
+
+test('checkAgentHealth: all signals between stall and stuck thresholds → stalled', () => {
+  const agentId = seedWorkingAgent();
+  const taskId = seedActiveTask(agentId, 10);
+  insertDeliverable(taskId, 10); // > 5min stall, < 15min stuck
+  assert.equal(checkAgentHealth(agentId), 'stalled');
+});
+
+test('checkAgentHealth: heartbeat-style activities (Agent health: …) ignored as proof-of-life', () => {
+  const agentId = seedWorkingAgent();
+  const taskId = seedActiveTask(agentId, 30);
+  // Heartbeat row, not real activity.
+  insertActivity(taskId, agentId, 1, 'Agent health: stalled');
+  // No other signals → should fall through to taskAge-based check → stuck.
+  assert.equal(checkAgentHealth(agentId), 'stuck');
+});

--- a/src/lib/agent-health.ts
+++ b/src/lib/agent-health.ts
@@ -49,14 +49,51 @@ export function checkAgentHealth(agentId: string): AgentHealthState {
     if (!anySession) return 'zombie';
   }
 
-  // Check last REAL activity (exclude health check logs — they reset the clock and prevent stuck detection)
-  const lastActivity = queryOne<{ created_at: string }>(
-    `SELECT created_at FROM task_activities WHERE task_id = ? AND message NOT LIKE 'Agent health:%' ORDER BY created_at DESC LIMIT 1`,
+  // Check last REAL activity. "Real" means the agent did something
+  // operator-visible since the last health-check tick — anything that
+  // proves the LLM is mid-run, not just the heartbeat ping cadence.
+  //
+  // Sources we consider proof-of-life (max timestamp across all):
+  //   1. task_activities (excluding our own 'Agent health: …' log lines
+  //      and the heartbeat-ping rows, which would reset the clock and
+  //      hide a real stall)
+  //   2. task_deliverables — every register_deliverable MCP call lands
+  //      a row here. Without including this, an agent that's actively
+  //      registering deliverables (the most concrete proof-of-life
+  //      signal we have) gets misclassified as `stalled`/`stuck` and
+  //      stomped by a stall-watcher re-dispatch.
+  //   3. agent_notes — take_note MCP calls write breadcrumbs here;
+  //      same "agent is alive and progressing" signal.
+  //
+  // The check is `MAX(created_at)` across the three tables; we then
+  // compare to the threshold the same way as before.
+  const lastActivityRow = queryOne<{ created_at: string }>(
+    `SELECT created_at FROM task_activities
+       WHERE task_id = ?
+         AND message NOT LIKE 'Agent health:%'
+       ORDER BY created_at DESC LIMIT 1`,
     [activeTask.id]
   );
+  const lastDeliverableRow = queryOne<{ created_at: string }>(
+    `SELECT created_at FROM task_deliverables
+       WHERE task_id = ?
+       ORDER BY created_at DESC LIMIT 1`,
+    [activeTask.id]
+  );
+  const lastNoteRow = queryOne<{ created_at: string }>(
+    `SELECT created_at FROM agent_notes
+       WHERE task_id = ?
+         AND archived_at IS NULL
+       ORDER BY created_at DESC LIMIT 1`,
+    [activeTask.id]
+  );
+  const candidates = [lastActivityRow, lastDeliverableRow, lastNoteRow]
+    .map((r) => (r ? new Date(r.created_at).getTime() : 0))
+    .filter((t) => t > 0);
+  const lastActivityAt = candidates.length > 0 ? Math.max(...candidates) : null;
 
-  if (lastActivity) {
-    const minutesSince = (Date.now() - new Date(lastActivity.created_at).getTime()) / 60000;
+  if (lastActivityAt !== null) {
+    const minutesSince = (Date.now() - lastActivityAt) / 60000;
     if (minutesSince > STUCK_THRESHOLD_MINUTES) return 'stuck';
     if (minutesSince > STALL_THRESHOLD_MINUTES) return 'stalled';
   } else {


### PR DESCRIPTION
## Summary

The stall watcher was misclassifying actively-running agents as `stalled` / `stuck` because it only looked at `task_activities`. The most common MCP-driven proof-of-life signals — `register_deliverable` and `take_note` — write to `task_deliverables` and `agent_notes` respectively. An agent mid-run that's registering deliverables every minute would still get tagged stuck after the 15-min threshold, and the watcher would re-dispatch on top of its in-flight work.

## Observed in dogfood

The completion-percentage-bar builder ran 37 minutes, registered 7 deliverables, made 7 MC tool calls per turn, finished its work cleanly. The stall watcher logged "Agent health: stalled" / "stuck" rows every 2 minutes the whole time. When I manually reset the task to test the new briefing it stomped the agent's actual progress and forced redundant deliverable registrations.

## Fix

`checkAgentHealth` now computes `lastActivityAt = MAX(created_at)` across three sources:

- `task_activities` (excluding `Agent health: …` heartbeat rows — same exclusion as before)
- `task_deliverables` (all rows)
- `agent_notes` (excluding archived)

Stall/stuck thresholds compare against that max, so any of the three signals proves the agent is alive.

## Tests

New `src/lib/agent-health.test.ts` with 7 tests:

- Recent task_activities row → working
- Recent task_deliverables row → working (regression for the dogfood bug)
- Recent agent_notes row → working
- Stale activity + fresh deliverable → working (max wins)
- All signals stale → stuck
- All signals between stall and stuck thresholds → stalled
- Heartbeat-style activity rows ignored (no other signal → stuck via task-age)

`yarn test src/lib` — all 7 pass. Pre-existing `schedule-runner` failure unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)